### PR TITLE
Add support to render html tags incoming from legacy questions

### DIFF
--- a/includes/class-sensei-wp-kses.php
+++ b/includes/class-sensei-wp-kses.php
@@ -80,6 +80,31 @@ class Sensei_Wp_Kses {
 		);
 	}
 
+
+
+	/**
+	 * Return all HTML formatting tags to be used with wp_kses
+	 * see https://www.w3schools.com/html/html_formatting.asp
+	 *
+	 * @access public
+	 * @since $$next-version$$
+	 *
+	 * @return array HTML formatting tags
+	 */public static function get_allowed_html_formatting_tags(): array {
+		return array(
+			'b'      => array(),
+			'strong' => array(),
+			'i'      => array(),
+			'em'     => array(),
+			'mark'   => array(),
+			'small'  => array(),
+			'del'    => array(),
+			'ins'    => array(),
+			'sub'    => array(),
+			'sup'    => array(),
+		);
+}
+
 	/**
 	 * Will act as a sanitization or an identity function, depending on HTML security settings.
 	 *

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -38,7 +38,7 @@ foreach ( $question_data['answer_options'] as $option ) {
 			/>
 
 		<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
-			<?php echo esc_html( apply_filters( 'sensei_answer_text', $option['answer'] ) ); ?>
+			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', $option['answer'] ) ); ?>
 		</label>
 	</li>
 <?php } ?>

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -22,28 +22,26 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 
 <ul class="answers">
 
-<?php
-$count = 0;
-foreach ( $question_data['answer_options'] as $option ) {
-	$count++;
+	<?php
+	$count = 0;
+	foreach ( $question_data['answer_options'] as $option ) {
+		$count++;
 
-	?>
+		?>
 
-	<li class="<?php echo esc_attr( $option['option_class'] ); ?>">
-		<input type="<?php echo esc_attr( $option['type'] ); ?>"
-			id="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>"
-			name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>[]"
-			value="<?php echo esc_attr( $option['answer'] ); ?>" <?php echo esc_attr( $option['checked'] ); ?>
-			<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
-			/>
+		<li class="<?php echo esc_attr( $option['option_class'] ); ?>">
+			<input type="<?php echo esc_attr( $option['type'] ); ?>" id="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>" name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>[]" value="<?php echo esc_attr( $option['answer'] ); ?>" <?php echo esc_attr( $option['checked'] ); ?> <?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?> />
 
-		<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
-			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', $option['answer'] ) ); ?>
-		</label>
-	</li>
-<?php } ?>
+			<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
+				<?php
+				echo wp_kses(
+					apply_filters( 'sensei_answer_text', $option['answer'] ),
+					Sensei_Wp_Kses::get_allowed_html_formatting_tags(),
+					array()
+				);
+				?>
+			</label>
+		</li>
+	<?php } ?>
 
 </ul>
-
-
-


### PR DESCRIPTION
Fixes partially #5730

### Changes proposed in this Pull Request
* Support render safe HTML tags on the question-type-multiple-choice


### Testing instructions
* Create a quiz
* Use HTML tags on the "Add Answer" field
*  Publish
* Check if the HTML was rendered correctly on the published version.

### Extra Notes
it is not enabled to use the Gutenberg rich formatting options (Bold, Italic buttons) because there are a lot of custom behaviors associated with the [Single Inline Input](https://github.com/Automattic/sensei/blob/98064e4f1edcfb2da46bdb591a94e8c2bbeff764/assets/shared/blocks/single-line-input/single-line-input.js#L59) that are not compatible with the Gutenberg RichText components. 
Enabling the HTML formatting on the editor requires further investigation. 

### Screenshots
<img width="1005" alt="Screen Shot 2022-09-21 at 17 05 08" src="https://user-images.githubusercontent.com/38718/191600104-2b3298ca-6175-44ea-9a8b-cafae0d71e4c.png">

<img width="1279" alt="Screen Shot 2022-09-21 at 17 05 13" src="https://user-images.githubusercontent.com/38718/191600095-ba2779e8-dd51-409e-a6fd-cdf92d4b39c8.png">




