### PR TITLE
Learning Mode - Show Sensei notices inside LM notices.

### DIFF
--- a/includes/blocks/course-theme/class-notices.php
+++ b/includes/blocks/course-theme/class-notices.php
@@ -49,7 +49,9 @@ class Notices {
 	 * @return string The block HTML.
 	 */
 	public function render( array $attributes = [] ) : string {
-		$notices_html = Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' )
+		$notices_html = Sensei_Context_Notices::instance( 'course_theme_lesson_regular' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' )
+			. Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' )
+			. Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' )
 			. Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' )
 			. Sensei_Context_Notices::instance( 'course_theme_quiz_grade' )->get_notices_html( 'course-theme/quiz-grade-notice.php' );
 

--- a/includes/blocks/course-theme/class-notices.php
+++ b/includes/blocks/course-theme/class-notices.php
@@ -52,7 +52,6 @@ class Notices {
 		$notices_html = Sensei_Context_Notices::instance( 'course_theme_lesson_regular' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' )
 			. Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' )
 			. Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' )
-			. Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' )
 			. Sensei_Context_Notices::instance( 'course_theme_quiz_grade' )->get_notices_html( 'course-theme/quiz-grade-notice.php' );
 
 		$wrapper_attr = get_block_wrapper_attributes();

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -76,17 +76,39 @@ class Sensei_Notices {
 	 * @return void
 	 */
 	public function add_notice( string $content, string $type = 'alert', string $key = null ) {
+		$notice = [
+			'content' => $content,
+			'type'    => $type,
+			'key'     => $key,
+		];
+
+		/**
+		 * Allows to modify a sensei notice that will be shown to the user.
+		 *
+		 * @since $$next-version$$
+		 * @hook sensei_notice
+		 *
+		 * @param array $notice {
+		 *     The notice data with the following properties.
+		 *
+		 *     @type string $content The message text of the notice.
+		 *     @type string $type    The type of the notice. Default: "alert".
+		 *     @type string $key     Optional. The identifier key for the notice.
+		 * }
+		 *
+		 * @return array|null The notice data. Or return null if you want to prevent the notice showing up.
+		 */
+		$notice = apply_filters( 'sensei_notice', $notice );
+
+		if ( empty( $notice ) ) {
+			return;
+		}
+
 		// append the new notice.
-		if ( null === $key ) {
-			$this->notices[] = [
-				'content' => $content,
-				'type'    => $type,
-			];
+		if ( empty( $notice['key'] ) ) {
+			$this->notices[] = $notice;
 		} else {
-			$this->notices[ $key ] = [
-				'content' => $content,
-				'type'    => $type,
-			];
+			$this->notices[ $notice['key'] ] = $notice;
 		}
 
 		// if a notice is added after we've printed print it immediately.

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -64,7 +64,7 @@ class Sensei_Course_Theme_Lesson {
 	public static function intercept_notice( array $notice ) {
 		// Do nothing if learning mode is not used.
 		$course_id = \Sensei_Utils::get_current_course();
-		if ( ! $course_id && ! Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {
+		if ( ! $course_id || ! Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {
 			return $notice;
 		}
 

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -57,6 +57,25 @@ class Sensei_Course_Theme_Lesson {
 	}
 
 	/**
+	 * Intercepts the notices and prints them out later via 'sensei-lms/course-theme-notices' block.
+	 *
+	 * @param array $notice The notice to intercept.
+	 */
+	public static function intercept_notice( array $notice ) {
+		// Do nothing if learning mode is not used.
+		$course_id = \Sensei_Utils::get_current_course();
+		if ( ! $course_id && ! Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {
+			return $notice;
+		}
+
+		// Add the notice to lesson notices.
+		$notices = \Sensei_Context_Notices::instance( 'course_theme_lesson_regular' );
+		$notices->add_notice( $notice['content'], $notice['content'], null, [], $notice['type'] );
+
+		return null;
+	}
+
+	/**
 	 * Maybe add lesson quiz results notice.
 	 */
 	private function maybe_add_quiz_results_notice() {

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -62,6 +62,12 @@ class Sensei_Course_Theme_Lesson {
 	 * @param array $notice The notice to intercept.
 	 */
 	public static function intercept_notice( array $notice ) {
+		// Do nothing if it is not lesson or quiz post.
+		$post_type = get_post_type();
+		if ( ! in_array( $post_type, [ 'lesson', 'quiz' ], true ) ) {
+			return $notice;
+		}
+
 		// Do nothing if learning mode is not used.
 		$course_id = \Sensei_Utils::get_current_course();
 		if ( ! $course_id || ! Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -85,6 +85,7 @@ class Sensei_Course_Theme {
 
 		// Initialize quiz and lesson specific functionality.
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
+		add_filter( 'sensei_notice', [ Sensei_Course_Theme_Lesson::instance(), 'intercept_notice' ], 10, 1 );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Quiz::instance(), 'init' ] );
 		add_filter( 'the_content', [ $this, 'add_lesson_video_to_content' ], 80, 1 );
 


### PR DESCRIPTION
Fixes #5679 

### Changes proposed in this Pull Request

* Intercepts the regular Sensei notices and prints them in Learning Mode notices block instead.

#### Discussion

Currently it is a minimal implementation that adds this logic to `Sensei_Course_Theme_Lesson`. We intercept the regular notices that is handled by `Sensei_Notices` and redirect it to `Sensei_Context_Notices`, which is printed by `sensei-lms/course-theme-notices` block in Learning Mode.

Ideally we should have a unified design for Sensei notices and have only one `Sensei_Notices` that manages it and use it to print notices in regular mode and in Learning Mode. The shortest pathway is probably to remove `Sensei_Context_Notices` and update `Sensei_Notices` to handle everything `Sensei_Context_Notices` offers.

Another change we might want to make is to combine `Sensei_Course_Theme_Lesson` and `Sensei_Course_Theme_Quiz` into one class and name it `Sensei_Course_Theme_Notices`. Because both of those classes deal with notices only. And then the new logic from this PR would also reside there.

#### Questions
- What do you think about this solution? Is this enough for the time being?
- Do you think it's worth to remove `Sensei_Context_Notices` and move it's functionality to `Sensei_Notices` in this PR?

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Set a course's access expiration to today for a user you're testing with.
* Visit any lesson/quiz page for that user.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

#### `sensei_notice`
```php
/**
 * Allows to modify a sensei notice that will be shown to the user.
 *
 * @since $$next-version$$
 * @hook sensei_notice
 *
 * @param array $notice {
 *     The notice data with the following properties.
 *
 *     @type string $content The message text of the notice.
 *     @type string $type    The type of the notice. Default: "alert".
 *     @type string $key     Optional. The identifier key for the notice.
 * }
 *
 * @return array|null The notice data. Or return null if you want to prevent the notice showing up.
 */

```

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Before
<img width="1818" alt="lesson-before" src="https://user-images.githubusercontent.com/2578542/191752969-861e3b09-160f-40b4-bf35-b7ea17b764b5.png">
<img width="1818" alt="quiz-before" src="https://user-images.githubusercontent.com/2578542/191752945-6a5f7645-8f0c-43fe-93a7-4bffa79468b7.png">

#### After

<img width="1774" alt="lesson-after" src="https://user-images.githubusercontent.com/2578542/191753051-032e45e9-a0fc-46a1-9145-66ba5801b3e7.png">
<img width="1818" alt="quiz-after" src="https://user-images.githubusercontent.com/2578542/191753100-2aab602f-fad5-4183-8bd8-16463926e0ca.png">
