### PR TITLE
Stop codecov checks from running

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,7 +1,5 @@
 name: PHP & JavaScript Code Coverage
 
-on: pull_request
-
 jobs:
     coverage:
         name: PHP and JS Test Coverage


### PR DESCRIPTION
More context [here](https://a8c.slack.com/archives/C07418EJ0/p1663841727880299)

Stops codecov checks from running as it seems that they produce a lot of noise. The related files are not removed in case we want to re-enable it in the future.