### PR TITLE
Rename LM color variables

### DIFF
--- a/assets/course-theme/styles-probe.js
+++ b/assets/course-theme/styles-probe.js
@@ -30,9 +30,10 @@ export const StylesProbe = () => {
 		const { color: linkColor } = getComputedStyle( link );
 
 		const updates = {
-			'primary-color': linkColor,
-			'text-color': color,
-			'bg-color': backgroundColor,
+			'--sensei-primary-color': linkColor,
+			'--sensei-text-color': color,
+			'--sensei-background-color': backgroundColor,
+			'--sensei-primary-contrast-color': backgroundColor,
 		};
 
 		for ( const name in { ...updates } ) {
@@ -48,7 +49,7 @@ export const StylesProbe = () => {
 
 	function setVariables( updates ) {
 		for ( const [ name, value ] of Object.entries( updates ) ) {
-			root.style.setProperty( `--${ name }`, value );
+			root.style.setProperty( name, value );
 		}
 	}
 

--- a/assets/course-theme/supports-color.js
+++ b/assets/course-theme/supports-color.js
@@ -48,11 +48,11 @@ function getCSSVariables( attributes ) {
 
 	const vars = {};
 	if ( link ) {
-		vars[ '--primary-color' ] = compileStyleValue( link );
+		vars[ '--sensei-primary-color' ] = compileStyleValue( link );
 	}
 	if ( background ) {
-		vars[ '--bg-color' ] = background;
-		vars[ '--primary-contrast-color' ] = vars[ '--bg-color' ];
+		vars[ '--sensei-background-color' ] = background;
+		vars[ '--sensei-primary-contrast-color' ] = background;
 	}
 	return vars;
 }

--- a/assets/course-theme/themes/default-theme.scss
+++ b/assets/course-theme/themes/default-theme.scss
@@ -17,7 +17,7 @@ $breakpoint: 783px;
 		left: 0;
 		width: var(--sidebar-width);
 		border-right: 1px solid var(--border-color);
-		background-color: var(--bg-color);
+		background-color: var(--sensei-background-color);
 		overflow: auto;
 		overscroll-behavior: contain;
 		display: flex;

--- a/assets/css/sensei-course-theme/4-0-2/layout.scss
+++ b/assets/css/sensei-course-theme/4-0-2/layout.scss
@@ -6,7 +6,7 @@
 }
 
 body.sensei-course-theme {
-	background: var(--bg-color);
+	background: var(--sensei-background-color);
 	--top-offset: var(--sensei-wpadminbar-offset, 0px);
 	padding: 0!important;
 	margin: 0!important;
@@ -50,7 +50,7 @@ body.sensei-course-theme {
 }
 
 .sensei-course-theme {
-	background-color: var(--bg-color);
+	background-color: var(--sensei-background-color);
 
 	&__columns, &__header {
 		margin: 0 !important;
@@ -63,7 +63,7 @@ body.sensei-course-theme {
 		left: 0;
 		right: 0;
 		top: var(--top-offset);
-		background-color: var(--bg-color);
+		background-color: var(--sensei-background-color);
 		z-index: 100;
 	}
 
@@ -78,7 +78,7 @@ body.sensei-course-theme {
 		left: 0;
 		width: var(--sidebar-width);
 		border-right: 1px solid var(--border-color);
-		background-color: var(--bg-color);
+		background-color: var(--sensei-background-color);
 		overflow: auto;
 		overscroll-behavior: contain;
 		display: flex;

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -1,15 +1,16 @@
 $breakpoint: 783px;
 
 body {
-	--primary-color: var(--sensei-primary-color, var(--sensei-course-theme-primary-color, var(--wp--preset--color--primary, #307771)));
-	--bg-color: var(--sensei-background-color, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #ffffff)));
-	--primary-contrast-color: var(--bg-color, #FFFFFF);
+	// Try to pick up global styles, customizer or theme colors.
+	--sensei-primary-color: var(--sensei-primary-color, var(--sensei-course-theme-primary-color, var(--wp--preset--color--primary, #307771)));
+	--sensei-background-color: var(--sensei-background-color, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #ffffff)));
+	--sensei-primary-contrast-color: var(--sensei-background-color, #FFFFFF);
 
-	--text-color: var(--sensei-text-color, var(--sensei-course-theme-foreground-color, var(--wp--preset--color--text, var(--wp--preset--color--foreground, #1E1E1E))));
+	--sensei-text-color: var(--sensei-text-color, var(--sensei-course-theme-foreground-color, var(--wp--preset--color--text, var(--wp--preset--color--foreground, #1E1E1E))));
 	--border-color: rgba(125, 125, 125, 0.3);
 
-	background-color: var(--bg-color);
-	color: var(--text-color);
+	background-color: var(--sensei-background-color);
+	color: var(--sensei-text-color);
 }
 
 .sensei-course-theme__frame {
@@ -22,8 +23,8 @@ body {
 		text-decoration: none;
 
 		&:hover, &:hover * {
-			color: var(--primary-color);
-			fill: var(--primary-color);
+			color: var(--sensei-primary-color);
+			fill: var(--sensei-primary-color);
 			cursor: pointer;
 			background: none;
 		}

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -2,11 +2,10 @@ $breakpoint: 783px;
 
 body {
 	// Try to pick up global styles, customizer or theme colors.
-	--sensei-primary-color: var(--sensei-primary-color, var(--sensei-course-theme-primary-color, var(--wp--preset--color--primary, #307771)));
-	--sensei-background-color: var(--sensei-background-color, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #ffffff)));
-	--sensei-primary-contrast-color: var(--sensei-background-color, #FFFFFF);
-
-	--sensei-text-color: var(--sensei-text-color, var(--sensei-course-theme-foreground-color, var(--wp--preset--color--text, var(--wp--preset--color--foreground, #1E1E1E))));
+	--sensei-primary-color: var(--sensei-primary-color-global, var(--sensei-course-theme-primary-color, var(--wp--preset--color--primary, #307771)));
+	--sensei-background-color: var(--sensei-background-color-global, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #ffffff)));
+	--sensei-primary-contrast-color: var(--sensei-background-color-global, #FFFFFF);
+	--sensei-text-color: var(--sensei-text-color-global, var(--sensei-course-theme-foreground-color, var(--wp--preset--color--text, var(--wp--preset--color--foreground, #1E1E1E))));
 	--border-color: rgba(125, 125, 125, 0.3);
 
 	background-color: var(--sensei-background-color);

--- a/assets/css/sensei-course-theme/blockbase-ponyfill.scss
+++ b/assets/css/sensei-course-theme/blockbase-ponyfill.scss
@@ -190,7 +190,7 @@ a:hover, a:focus {
 }
 
 a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen-reader-shortcut):focus {
-	outline: 1px dashed var(--primary-color);
+	outline: 1px dashed var(--sensei-primary-color);
 	text-decoration: none;
 }
 
@@ -239,14 +239,14 @@ input[type="color"]:focus,
 textarea:focus {
 	border-color: var(--custom--form--color--border);
 	color: var(--wp--custom--form--color--text);
-	outline: 1px dashed var(--primary-color);
+	outline: 1px dashed var(--sensei-primary-color);
 	outline-offset: 2px;
 }
 
 input[type="checkbox"]:focus,
 input[type="submit"]:focus,
 button:focus {
-	outline: 1px dashed var(--primary-color);
+	outline: 1px dashed var(--sensei-primary-color);
 	outline-offset: 2px;
 }
 
@@ -720,7 +720,7 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-post-comments form .comment-form-cookies-consent input[type="checkbox"]:focus + ::before {
-	outline: 1px dashed var(--primary-color);
+	outline: 1px dashed var(--sensei-primary-color);
 	outline-offset: 2px;
 }
 

--- a/assets/css/sensei-course-theme/blocks/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/blocks/contact-teacher.scss
@@ -6,14 +6,14 @@
 
 .sensei-contact-teacher-form__submit {
 	padding: 10px 20px;
-	background-color: var(--primary-color);
-	color: var(--primary-contrast-color);
-	border: 1px solid var(--primary-color);
+	background-color: var(--sensei-primary-color);
+	color: var(--sensei-primary-contrast-color);
+	border: 1px solid var(--sensei-primary-color);
 	font-weight: 700;
 	font-size: 14px;
 	border-radius: 2px;
 	&:hover {
-		color: var(--primary-color);
+		color: var(--sensei-primary-color);
 		background-color: transparent;
 	}
 
@@ -49,13 +49,13 @@
 		z-index: -1;
 		opacity: 0;
 		transition: opacity 100ms ease-out;
-		background: var(--bg-color);
+		background: var(--sensei-background-color);
 
 		svg {
 			width: 42px;
 			height: 42px;
 			margin-bottom: 20px;
-			color: var(--primary-color);
+			color: var(--sensei-primary-color);
 		}
 
 		p {

--- a/assets/css/sensei-course-theme/blocks/course-navigation.scss
+++ b/assets/css/sensei-course-theme/blocks/course-navigation.scss
@@ -34,7 +34,7 @@
 		color: inherit !important;
 
 		&:hover {
-			color: var(--primary-color) !important;
+			color: var(--sensei-primary-color) !important;
 			text-decoration: underline;
 		}
 
@@ -50,7 +50,7 @@
 
 	&__title {
 		flex: 1;
-		color: var(--primary-color);
+		color: var(--sensei-primary-color);
 		font-weight: 600;
 		font-size: 18px;
 		line-height: 22px;

--- a/assets/css/sensei-course-theme/blocks/course-progress-bar.scss
+++ b/assets/css/sensei-course-theme/blocks/course-progress-bar.scss
@@ -6,6 +6,6 @@
 
 	&-inner {
 		height: 100%;
-		background-color: var(--primary-color);
+		background-color: var(--sensei-primary-color);
 	}
 }

--- a/assets/css/sensei-course-theme/blocks/prev-next-lesson.scss
+++ b/assets/css/sensei-course-theme/blocks/prev-next-lesson.scss
@@ -21,7 +21,7 @@
 		}
 
 		&:hover span {
-			color: var(--primary-color);
+			color: var(--sensei-primary-color);
 		}
 
 
@@ -38,7 +38,7 @@
 		&:hover svg {
 			path {
 				fill: transparent;
-				stroke: var(--primary-color);
+				stroke: var(--sensei-primary-color);
 			}
 		}
 

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -5,7 +5,7 @@
 		}
 		&:focus-visible {
 			transition: none;
-			outline: dashed 1px var(--primary-color);
+			outline: dashed 1px var(--sensei-primary-color);
 		}
 	}
 }
@@ -44,7 +44,7 @@
 	&.is-secondary,
 	&.wp-block-button > .wp-block-button__link {
 		padding: 8px 11px;
-		border: solid 1px var(--primary-color);
+		border: solid 1px var(--sensei-primary-color);
 		font-weight: 700;
 		text-decoration: none;
 		border-radius: 2px;
@@ -56,7 +56,7 @@
 			padding: 8px 11px;
 			display: block;
 			&:focus {
-				outline: dashed 1px var(--primary-color);
+				outline: dashed 1px var(--sensei-primary-color);
 				margin: -1px;
 				padding: 9px 12px;
 			}
@@ -66,24 +66,24 @@
 	&.is-primary,
 	&.wp-block-button:not(.is-style-outline, .is-style-link) {
 		&:not(:hover) {
-			background-color: var(--primary-color) !important;
-			color: var(--primary-contrast-color);
+			background-color: var(--sensei-primary-color) !important;
+			color: var(--sensei-primary-contrast-color);
 		}
 		&:hover {
-			color: var(--primary-color);
+			color: var(--sensei-primary-color);
 			background: none;
 		}
 	}
 
 	&.is-secondary,
 	&.wp-block-button.is-style-outline {
-		color: var(--primary-color);
-		--wp--custom--button--border--color: var(--primary-color);
+		color: var(--sensei-primary-color);
+		--wp--custom--button--border--color: var(--sensei-primary-color);
 		&:hover {
-			background-color: var(--primary-color) !important;
-			color: var(--primary-contrast-color);
+			background-color: var(--sensei-primary-color) !important;
+			color: var(--sensei-primary-contrast-color);
 			.wp-block-button__link {
-				border-color: var(--primary-color);
+				border-color: var(--sensei-primary-color);
 			}
 		}
 	}
@@ -97,7 +97,7 @@
 		color: inherit !important;
 
 		&:hover {
-			color: var(--primary-color) !important;;
+			color: var(--sensei-primary-color) !important;;
 		}
 	}
 

--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -1,9 +1,9 @@
 
 body {
-	--wp--custom--form--color--background: var(--bg-color);
+	--wp--custom--form--color--background: var(--sensei-background-color);
 	--wp--custom--form--border--width: 1.5px;
 	--wp--custom--form--border--style: solid;
-	--wp--custom--form--border--color: var(--text-color);
+	--wp--custom--form--border--color: var(--sensei-text-color);
 	--wp--custom--form--border--radius: 2px;
 	--wp--custom--form--color--text: inherit;
 	--wp--custom--form--padding: 6px 8px;

--- a/assets/css/sensei-course-theme/editor.scss
+++ b/assets/css/sensei-course-theme/editor.scss
@@ -5,7 +5,7 @@ body, .wp-site-blocks.is-root-container {
 body {
 	padding: 8px;
 	--wp--custom--gap--baseline: 0px;
-	--bg-color: none;
+	--sensei-background-color: none;
 }
 
 .wp-block {

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -9,7 +9,7 @@ $base: '.sensei-course-theme';
 		color: inherit !important;
 		line-height: 10px;
 		&:hover {
-			color: var(--primary-color) !important;
+			color: var(--sensei-primary-color) !important;
 		}
 
 		.sensei-course-theme__focus-mode-toggle-icon {

--- a/assets/css/sensei-course-theme/lesson-complete-transition.scss
+++ b/assets/css/sensei-course-theme/lesson-complete-transition.scss
@@ -13,7 +13,7 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	background-color: var(--bg-color);
+	background-color: var(--sensei-background-color);
 
 	&__text {
 		margin: 25px 0;
@@ -24,7 +24,7 @@
 	> svg {
 		width: 70px;
 		height: 70px;
-		color: var(--primary-color);
+		color: var(--sensei-primary-color);
 	}
 
 	.sensei-course-theme--focus-mode & {

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -89,7 +89,7 @@
 				bottom: 0;
 				left: 0;
 				right: 0;
-				background: var(--bg-color);
+				background: var(--sensei-background-color);
 				box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
 				transition: bottom 800ms ease-in;
 

--- a/assets/css/sensei-course-theme/modal.scss
+++ b/assets/css/sensei-course-theme/modal.scss
@@ -1,5 +1,5 @@
 [data-sensei-modal] [data-sensei-modal-content] {
-	background: var(--bg-color);
+	background: var(--sensei-background-color);
 	color: inherit;
 	border-color: var(--border-color);
 	textarea {

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -35,7 +35,7 @@ $tablet-breakpoint: 768px;
 	&__header {
 		position: sticky;
 		top: var(--top-offset);
-		background-color: var(--bg-color);
+		background-color: var(--sensei-background-color);
 		z-index: 100;
 
 		.wp-block-post-title {
@@ -89,7 +89,7 @@ $tablet-breakpoint: 768px;
 				left: 0;
 				right: 0;
 				z-index: 100;
-				background-color: var(--bg-color);
+				background-color: var(--sensei-background-color);
 				box-shadow: 2px 10px 30px 5px rgba(0,0,0, 0.1);
 			}
 
@@ -122,6 +122,6 @@ $tablet-breakpoint: 768px;
 	}
 
 	&__progress {
-		background-color: var(--primary-color);
+		background-color: var(--sensei-primary-color);
 	}
 }

--- a/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
+++ b/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
@@ -26,7 +26,7 @@ $breakpoint: 783px;
 	}
 
 	&:hover, &:focus {
-		color: var(--primary-color);
+		color: var(--sensei-primary-color);
 		background: none;
 	}
 }
@@ -53,7 +53,7 @@ $breakpoint: 783px;
 		&__sidebar {
 			position: fixed;
 			z-index: 90;
-			background: var(--bg-color, #fff);
+			background: var(--sensei-background-color, #fff);
 			top: var(--full-header-height);
 			bottom: 0;
 			left: 0 !important;

--- a/assets/css/sensei-course-theme/theme.scss
+++ b/assets/css/sensei-course-theme/theme.scss
@@ -2,7 +2,7 @@
 @import './global-styles';
 
 a {
-	color: var(--primary-color);
+	color: var(--sensei-primary-color);
 }
 
 input, textarea {
@@ -10,8 +10,8 @@ input, textarea {
 }
 
 ::selection {
-	background-color: var(--primary-color);
-	color: var(--primary-contrast-color);
+	background-color: var(--sensei-primary-color);
+	color: var(--sensei-primary-contrast-color);
 }
 .sensei-course-theme
 {

--- a/assets/css/sensei-course-theme/ui-blocks.scss
+++ b/assets/css/sensei-course-theme/ui-blocks.scss
@@ -37,7 +37,7 @@ body.sensei-course-theme {
 		right: 0;
 		height: var(--header-height);
 		top: var(--top-offset);
-		background-color: var(--bg-color);
+		background-color: var(--sensei-background-color);
 		z-index: 100;
 
 		img {

--- a/assets/css/sensei-modal.scss
+++ b/assets/css/sensei-modal.scss
@@ -21,7 +21,7 @@
 		top: 200%;
 		left: 50%;
 		transform: translate( -50%, -40% );
-		background-color: var(--bg-color, #fff);
+		background-color: var(--sensei-background-color, #fff);
 		border: 1px solid #ddd;
 		border-radius: 2px;
 		padding: 30px;

--- a/includes/course-theme/class-sensei-course-theme-styles.php
+++ b/includes/course-theme/class-sensei-course-theme-styles.php
@@ -79,7 +79,7 @@ class Sensei_Course_Theme_Styles {
 		}
 
 		$colors = self::get_colors( $styles );
-		return self::format_css_variables( $colors, 'sensei-' );
+		return self::format_css_variables( $colors );
 	}
 
 	/**
@@ -99,14 +99,14 @@ class Sensei_Course_Theme_Styles {
 
 		$element_colors = $styles['color'] ?? $styles['elements']['color'] ?? null;
 
-		$vars['text-color']             = $element_colors['text'] ?? $styles['textColor'] ?? null;
-		$vars['background-color']       = $element_colors['background'] ?? $styles['backgroundColor'] ?? null;
-		$vars['primary-contrast-color'] = $vars['--sensei-background-color'];
+		$vars['--sensei-text-color']             = $element_colors['text'] ?? $styles['textColor'] ?? null;
+		$vars['--sensei-background-color']       = $element_colors['background'] ?? $styles['backgroundColor'] ?? null;
+		$vars['--sensei-primary-contrast-color'] = $vars['--sensei-background-color'];
 
 		$link = $styles['elements']['link']['color'] ?? null;
 
 		if ( ! empty( $link ) ) {
-			$vars['primary-color'] = $link['text'];
+			$vars['--sensei-primary-color'] = $link['text'];
 		}
 
 		return $vars;
@@ -142,18 +142,14 @@ class Sensei_Course_Theme_Styles {
 	/**
 	 * Generate CSS variables.
 	 *
-	 * @param array  $variables Key-value pair of variable names and values.
-	 * @param string $prefix    Variable prefix.
+	 * @param array $variables Key-value pair of variable names and values.
 	 */
-	private static function format_css_variables( $variables, $prefix = '' ) {
+	private static function format_css_variables( $variables ) {
 		$css = [];
 
 		foreach ( $variables as $variable => $value ) {
-			if ( $prefix ) {
-				$variable = $prefix . $variable;
-			}
 			if ( $value ) {
-				$css[] = sprintf( '--%s: %s;', $variable, self::get_property_value( $value ) );
+				$css[] = sprintf( '%s: %s;', $variable, self::get_property_value( $value ) );
 			}
 		}
 
@@ -163,7 +159,7 @@ class Sensei_Course_Theme_Styles {
 	/**
 	 * Generate a style tag with the given CSS properties.
 	 *
-	 * @param string $css      CSS properties.
+	 * @param string $css CSS properties.
 	 */
 	private static function output_style( $css ) {
 		?>

--- a/includes/course-theme/class-sensei-course-theme-styles.php
+++ b/includes/course-theme/class-sensei-course-theme-styles.php
@@ -62,7 +62,8 @@ class Sensei_Course_Theme_Styles {
 		}
 
 		$styles = wp_get_global_styles();
-		$vars   = self::get_colors_as_css_variables( $styles );
+		$colors = self::get_colors( $styles );
+		$vars   = self::format_css_variables( $colors, '-global' );
 
 		if ( ! empty( $vars ) ) {
 			self::output_style( implode( "\n", $vars ) );
@@ -82,8 +83,6 @@ class Sensei_Course_Theme_Styles {
 			return [];
 		}
 
-		$colors = self::get_colors( $styles );
-		return self::format_css_variables( $colors );
 	}
 
 	/**
@@ -105,7 +104,7 @@ class Sensei_Course_Theme_Styles {
 
 		$vars['--sensei-text-color']             = $element_colors['text'] ?? $styles['textColor'] ?? null;
 		$vars['--sensei-background-color']       = $element_colors['background'] ?? $styles['backgroundColor'] ?? null;
-		$vars['--sensei-primary-contrast-color'] = $vars['background-color'];
+		$vars['--sensei-primary-contrast-color'] = $vars['--sensei-background-color'];
 
 		$link = $styles['elements']['link']['color'] ?? null;
 
@@ -147,11 +146,15 @@ class Sensei_Course_Theme_Styles {
 	 * Generate CSS variables.
 	 *
 	 * @param array $variables Key-value pair of variable names and values.
+	 * @param array $postfix   Optional variable name postfix.
 	 */
-	private static function format_css_variables( $variables ) {
+	private static function format_css_variables( $variables, $postfix = '' ) {
 		$css = [];
 
 		foreach ( $variables as $variable => $value ) {
+			if ( $postfix ) {
+				$variable = $variable . $postfix;
+			}
 			if ( $value ) {
 				$css[] = sprintf( '%s: %s;', $variable, self::get_property_value( $value ) );
 			}


### PR DESCRIPTION
Follow-up for #5563

The CSS variables we use for learning mode styles are now a bit more exposed and without namespacing could cause conflicts with themes or other plugins. 

### Changes proposed in this Pull Request

* Add `sensei-` prefix to CSS variables

### Testing instructions

* Check that primary, text and background colors for the blocks in learning mode templates still work as expected
