### PR TITLE
Add some usage tracking data for learning mode

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -27,39 +27,39 @@ class Sensei_Usage_Tracking_Data {
 		$question_type_count = self::get_question_type_count();
 		$quiz_stats          = self::get_quiz_stats();
 		$usage_data          = array(
-			'courses'                       => wp_count_posts( 'course' )->publish,
-			'course_active'                 => self::get_course_active_count(),
-			'course_completed'              => self::get_course_completed_count(),
-			'course_completion_rate'        => self::get_course_completion_rate(),
-			'course_videos'                 => self::get_course_videos_count(),
-			'course_no_notifications'       => self::get_course_no_notifications_count(),
-			'course_prereqs'                => self::get_course_prereqs_count(),
-			'course_featured'               => self::get_course_featured_count(),
-			'enrolments'                    => self::get_course_enrolments(),
-			'enrolment_first'               => self::get_first_course_enrolment(),
-			'enrolment_last'                => self::get_last_course_enrolment(),
-			'enrolment_calculated'          => self::get_is_enrolment_calculated() ? 1 : 0,
-			'learners'                      => self::get_learner_count(),
-			'lessons'                       => wp_count_posts( 'lesson' )->publish,
-			'lesson_modules'                => self::get_lesson_module_count(),
-			'lesson_prereqs'                => self::get_lesson_prerequisite_count(),
-			'lesson_previews'               => self::get_lesson_preview_count(),
-			'lesson_length'                 => self::get_lesson_has_length_count(),
-			'lesson_complexity'             => self::get_lesson_with_complexity_count(),
-			'lesson_videos'                 => self::get_lesson_with_video_count(),
-			'messages'                      => wp_count_posts( 'sensei_message' )->publish,
-			'modules'                       => wp_count_terms( 'module' ),
-			'modules_max'                   => self::get_max_module_count(),
-			'modules_min'                   => self::get_min_module_count(),
-			'questions'                     => wp_count_posts( 'question' )->publish,
-			'question_media'                => self::get_question_media_count(),
-			'question_random_order'         => self::get_question_random_order_count(),
-			'teachers'                      => self::get_teacher_count(),
-			'courses_using_course_theme'    => self::get_courses_using_course_theme_count(),
-			'course_theme_enabled_globally' => self::get_is_course_theme_enabled_globally() ? 1 : 0,
-			'course_theme_template'         => self::get_selected_course_theme_template(),
-			'course_theme_is_customized'    => self::get_course_theme_is_customized(),
-			'course_theme_template_version' => self::get_template_version(),
+			'courses'                        => wp_count_posts( 'course' )->publish,
+			'course_active'                  => self::get_course_active_count(),
+			'course_completed'               => self::get_course_completed_count(),
+			'course_completion_rate'         => self::get_course_completion_rate(),
+			'course_videos'                  => self::get_course_videos_count(),
+			'course_no_notifications'        => self::get_course_no_notifications_count(),
+			'course_prereqs'                 => self::get_course_prereqs_count(),
+			'course_featured'                => self::get_course_featured_count(),
+			'enrolments'                     => self::get_course_enrolments(),
+			'enrolment_first'                => self::get_first_course_enrolment(),
+			'enrolment_last'                 => self::get_last_course_enrolment(),
+			'enrolment_calculated'           => self::get_is_enrolment_calculated() ? 1 : 0,
+			'learners'                       => self::get_learner_count(),
+			'lessons'                        => wp_count_posts( 'lesson' )->publish,
+			'lesson_modules'                 => self::get_lesson_module_count(),
+			'lesson_prereqs'                 => self::get_lesson_prerequisite_count(),
+			'lesson_previews'                => self::get_lesson_preview_count(),
+			'lesson_length'                  => self::get_lesson_has_length_count(),
+			'lesson_complexity'              => self::get_lesson_with_complexity_count(),
+			'lesson_videos'                  => self::get_lesson_with_video_count(),
+			'messages'                       => wp_count_posts( 'sensei_message' )->publish,
+			'modules'                        => wp_count_terms( 'module' ),
+			'modules_max'                    => self::get_max_module_count(),
+			'modules_min'                    => self::get_min_module_count(),
+			'questions'                      => wp_count_posts( 'question' )->publish,
+			'question_media'                 => self::get_question_media_count(),
+			'question_random_order'          => self::get_question_random_order_count(),
+			'teachers'                       => self::get_teacher_count(),
+			'courses_using_learning_mode'    => self::get_courses_using_learning_mode_count(),
+			'learning_mode_enabled_globally' => self::get_is_learning_mode_enabled_globally() ? 1 : 0,
+			'learning_mode_template'         => self::get_selected_learning_mode_template(),
+			'learning_mode_is_customized'    => self::get_learning_mode_is_customized(),
+			'learning_mode_template_version' => self::get_template_version(),
 		);
 
 		return array_merge( $question_type_count, $usage_data, $quiz_stats );
@@ -926,7 +926,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of active courses.
 	 **/
-	private static function get_courses_using_course_theme_count() {
+	private static function get_courses_using_learning_mode_count() {
 		$query = new WP_Query(
 			array(
 				'post_type'  => 'course',
@@ -951,7 +951,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return bool
 	 */
-	private static function get_is_course_theme_enabled_globally() {
+	private static function get_is_learning_mode_enabled_globally() {
 		return (bool) \Sensei()->settings->get( 'sensei_learning_mode_all' );
 	}
 
@@ -974,7 +974,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return string Selected template name.
 	 */
-	private static function get_selected_course_theme_template() {
+	private static function get_selected_learning_mode_template() {
 		return \Sensei_Course_Theme_Template_Selection::get_active_template_name();
 	}
 
@@ -983,7 +983,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return bool Is customised?
 	 */
-	private static function get_course_theme_is_customized() {
+	private static function get_learning_mode_is_customized() {
 		return count( \Sensei_Course_Theme_Templates::get_db_templates() ) > 0;
 	}
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -57,7 +57,9 @@ class Sensei_Usage_Tracking_Data {
 			'teachers'                      => self::get_teacher_count(),
 			'courses_using_course_theme'    => self::get_courses_using_course_theme_count(),
 			'course_theme_enabled_globally' => self::get_is_course_theme_enabled_globally() ? 1 : 0,
-			'course_theme_theme_styles'     => self::get_course_theme_has_theme_styles_enabled() ? 1 : 0,
+			'course_theme_template'         => self::get_selected_course_theme_template(),
+			'course_theme_is_customized'    => self::get_course_theme_is_customized(),
+			'course_theme_template_version' => self::get_template_version(),
 		);
 
 		return array_merge( $question_type_count, $usage_data, $quiz_stats );
@@ -954,17 +956,6 @@ class Sensei_Usage_Tracking_Data {
 	}
 
 	/**
-	 * Checks if theme styles are enabled for learning mode
-	 *
-	 * @since 4.0.2
-	 *
-	 * @return bool
-	 */
-	private static function get_course_theme_has_theme_styles_enabled() {
-		return (bool) \Sensei()->settings->get( 'sensei_learning_mode_theme' );
-	}
-
-	/**
 	 * Get the question type key. Replaces dashes with underscores in order to conform to
 	 * Tracks naming conventions.
 	 *
@@ -976,5 +967,35 @@ class Sensei_Usage_Tracking_Data {
 	 **/
 	private static function get_question_type_key( $key ) {
 		return str_replace( '-', '_', 'question_' . $key );
+	}
+
+	/**
+	 * Get the selected course theme template.
+	 *
+	 * @return string Selected template name.
+	 */
+	private static function get_selected_course_theme_template() {
+		return \Sensei_Course_Theme_Template_Selection::get_active_template_name();
+	}
+
+	/**
+	 * Check if the course theme is customised.
+	 *
+	 * @return bool Is customised?
+	 */
+	private static function get_course_theme_is_customized() {
+		return count( \Sensei_Course_Theme_Templates::get_db_templates() ) > 0;
+	}
+
+	/**
+	 * Get the version of the active Learning Mode template.
+	 *
+	 * @return string Version string in the format of 4-0-2
+	 */
+	private static function get_template_version() {
+		global $_wp_current_template_content;
+
+		preg_match( '/sensei-version--(\d+-\d+-\d+)/', $_wp_current_template_content ?? '', $version_matches );
+		return $version_matches[1] ?? 'latest';
 	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1643,22 +1643,49 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests getting if course theme is enabled globally.
+	 * Tests getting selected course theme template.
 	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
-	 * @covers Sensei_Usage_Tracking_Data::get_course_theme_has_theme_styles_enabled
+	 * @covers Sensei_Usage_Tracking_Data::get_selected_course_theme_template
 	 */
-	public function testGetDoesCourseThemeHasThemeStyles() {
-		Sensei()->settings->set( 'sensei_learning_mode_theme', false );
+	public function testGetCourseThemeTemplate() {
+		Sensei()->settings->set( 'sensei_learning_mode_template', 'default' );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_theme_styles', $usage_data, 'Key' );
-		$this->assertEquals( 0, $usage_data['course_theme_theme_styles'], 'Boolean int' );
+		$this->assertArrayHasKey( 'course_theme_template', $usage_data, 'Key' );
+		$this->assertEquals( 'default', $usage_data['course_theme_template'], 'String' );
 
-		Sensei()->settings->set( 'sensei_learning_mode_theme', true );
+		Sensei()->settings->set( 'sensei_learning_mode_template', 'modern' );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_theme_styles', $usage_data, 'Key' );
-		$this->assertEquals( 1, $usage_data['course_theme_theme_styles'], 'Boolean int' );
+		$this->assertArrayHasKey( 'course_theme_template', $usage_data, 'Key' );
+		$this->assertEquals( 'modern', $usage_data['course_theme_template'], 'Boolean int' );
+	}
+
+	/**
+	 * Tests getting if the course theme is customised.
+	 *
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_course_theme_is_customized
+	 */
+	public function testIsCourseThemeCustomised() {
+		Sensei()->settings->set( 'sensei_learning_mode_all', true );
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'course_theme_is_customized', $usage_data, 'Key' );
+		$this->assertEquals( false, $usage_data['course_theme_is_customized'], 'Boolean int' );
+	}
+
+	/**
+	 * Tests getting the course theme template version.
+	 *
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_template_version
+	 */
+	public function testCourseThemeTemplateVersion() {
+		Sensei()->settings->set( 'sensei_learning_mode_all', true );
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'course_theme_template_version', $usage_data, 'Key' );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1595,7 +1595,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * Tests getting courses using course theme count.
 	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
-	 * @covers Sensei_Usage_Tracking_Data::get_courses_using_course_theme_count
+	 * @covers Sensei_Usage_Tracking_Data::get_courses_using_learning_mode_count
 	 */
 	public function testGetCoursesUsingCourseThemeCount() {
 		$this->factory->course->create_many(
@@ -1618,62 +1618,62 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'courses_using_course_theme', $usage_data, 'Key' );
-		$this->assertEquals( 2, $usage_data['courses_using_course_theme'], 'Count' );
+		$this->assertArrayHasKey( 'courses_using_learning_mode', $usage_data, 'Key' );
+		$this->assertEquals( 2, $usage_data['courses_using_learning_mode'], 'Count' );
 	}
 
 	/**
 	 * Tests getting if course theme is enabled globally.
 	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
-	 * @covers Sensei_Usage_Tracking_Data::get_is_course_theme_enabled_globally
+	 * @covers Sensei_Usage_Tracking_Data::get_is_learning_mode_enabled_globally
 	 */
 	public function testGetIsCourseThemeEnabledGlobally() {
 		Sensei()->settings->set( 'sensei_learning_mode_all', false );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_enabled_globally', $usage_data, 'Key' );
-		$this->assertEquals( 0, $usage_data['course_theme_enabled_globally'], 'Boolean int' );
+		$this->assertArrayHasKey( 'learning_mode_enabled_globally', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['learning_mode_enabled_globally'], 'Boolean int' );
 
 		Sensei()->settings->set( 'sensei_learning_mode_all', true );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_enabled_globally', $usage_data, 'Key' );
-		$this->assertEquals( 1, $usage_data['course_theme_enabled_globally'], 'Boolean int' );
+		$this->assertArrayHasKey( 'learning_mode_enabled_globally', $usage_data, 'Key' );
+		$this->assertEquals( 1, $usage_data['learning_mode_enabled_globally'], 'Boolean int' );
 	}
 
 	/**
 	 * Tests getting selected course theme template.
 	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
-	 * @covers Sensei_Usage_Tracking_Data::get_selected_course_theme_template
+	 * @covers Sensei_Usage_Tracking_Data::get_selected_learning_mode_template
 	 */
 	public function testGetCourseThemeTemplate() {
 		Sensei()->settings->set( 'sensei_learning_mode_template', 'default' );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_template', $usage_data, 'Key' );
-		$this->assertEquals( 'default', $usage_data['course_theme_template'], 'String' );
+		$this->assertArrayHasKey( 'learning_mode_template', $usage_data, 'Key' );
+		$this->assertEquals( 'default', $usage_data['learning_mode_template'], 'String' );
 
 		Sensei()->settings->set( 'sensei_learning_mode_template', 'modern' );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_template', $usage_data, 'Key' );
-		$this->assertEquals( 'modern', $usage_data['course_theme_template'], 'Boolean int' );
+		$this->assertArrayHasKey( 'learning_mode_template', $usage_data, 'Key' );
+		$this->assertEquals( 'modern', $usage_data['learning_mode_template'], 'Boolean int' );
 	}
 
 	/**
 	 * Tests getting if the course theme is customised.
 	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
-	 * @covers Sensei_Usage_Tracking_Data::get_course_theme_is_customized
+	 * @covers Sensei_Usage_Tracking_Data::get_learning_mode_is_customized
 	 */
 	public function testIsCourseThemeCustomised() {
 		Sensei()->settings->set( 'sensei_learning_mode_all', true );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_is_customized', $usage_data, 'Key' );
-		$this->assertEquals( false, $usage_data['course_theme_is_customized'], 'Boolean int' );
+		$this->assertArrayHasKey( 'learning_mode_is_customized', $usage_data, 'Key' );
+		$this->assertEquals( false, $usage_data['learning_mode_is_customized'], 'Boolean int' );
 	}
 
 	/**
@@ -1686,6 +1686,6 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		Sensei()->settings->set( 'sensei_learning_mode_all', true );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_theme_template_version', $usage_data, 'Key' );
+		$this->assertArrayHasKey( 'learning_mode_template_version', $usage_data, 'Key' );
 	}
 }


### PR DESCRIPTION
Fixes #5688 

### Changes proposed in this Pull Request

* Adds a few keys to the usage tracking data: `course_theme_template`, `course_theme_is_customized`, `course_theme_template_version`.
* Adds some basic unit tests as a starter.
* Also removes `course_theme_theme_styles` since that's always enabled now.

### Testing instructions

- Run the test file: `npm run test-php tests/unit-tests/test-class-sensei-usage-tracking-data.php`