### PR TITLE
Update newsletter signup to work without a new window to avoid breaking the onboarding flow

### DIFF
--- a/assets/setup-wizard/newsletter/signup-form.js
+++ b/assets/setup-wizard/newsletter/signup-form.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { TextControl, Notice } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -9,6 +11,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { logLink } from '../../shared/helpers/log-event';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
+
+const SIGNUP_CALLBACK = 'senseiSignupCallback';
 
 /**
  * Sign up to Sensei Mailing list.
@@ -22,43 +26,82 @@ import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 const SignupForm = ( { onSubmit } ) => {
 	const { stepData } = useSetupWizardStep( 'newsletter' );
 
-	const submitHandler = () => {
-		// Make sure it will run after the submit is done.
-		setTimeout( () => {
-			onSubmit();
-		} );
+	const [ email, setEmail ] = useState( stepData.admin_email );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ error, setError ] = useState( false );
+
+	const submitHandler = ( e ) => {
+		e.preventDefault();
+
+		const formData = new window.FormData( e.target );
+
+		const url = addQueryArgs(
+			e.target.action,
+			Object.fromEntries( formData )
+		);
+
+		// JSONP callback.
+		window[ SIGNUP_CALLBACK ] = ( json ) => {
+			setIsSubmitting( false );
+
+			if ( 'error' === json.result ) {
+				setError( json.msg );
+			} else {
+				onSubmit();
+			}
+		};
+
+		// Create and append JSONP script.
+		const script = document.createElement( 'script' );
+		script.src = `${ url }&c=${ SIGNUP_CALLBACK }`;
+
+		setIsSubmitting( true );
+		setError( false );
+		document.body.append( script );
 	};
 
 	return (
-		<form
-			action={ stepData.mc_url }
-			method="post"
-			target="_blank"
-			className="sensei-signup-form"
-			onSubmit={ submitHandler }
-		>
-			<input
-				type="hidden"
-				name={ `gdpr[${ stepData.gdpr_field }]` }
-				value="Y"
-			/>
-
-			<TextControl
-				className="sensei-setup-wizard__text-control sensei-signup-form__text-control"
-				label={ __( 'Your email address', 'sensei-lms' ) }
-				type="email"
-				name="EMAIL"
-				defaultValue={ stepData.admin_email }
-			/>
-
-			<button
-				className="sensei-setup-wizard__button sensei-setup-wizard__button--primary sensei-signup-form__button"
-				type="submit"
-				{ ...logLink( 'setup_wizard_newsletter_signup' ) }
+		<>
+			{ error && (
+				<Notice
+					status="error"
+					className="sensei-setup-wizard__submit-error"
+					isDismissible={ false }
+				>
+					{ error }
+				</Notice>
+			) }
+			<form
+				action={ stepData.mc_url }
+				method="GET"
+				className="sensei-signup-form"
+				onSubmit={ submitHandler }
 			>
-				{ __( 'Nice! Sign me up', 'sensei-lms' ) }
-			</button>
-		</form>
+				<input
+					type="hidden"
+					name={ `gdpr[${ stepData.gdpr_field }]` }
+					value="Y"
+				/>
+
+				<TextControl
+					className="sensei-setup-wizard__text-control sensei-signup-form__text-control"
+					label={ __( 'Your email address', 'sensei-lms' ) }
+					type="email"
+					name="EMAIL"
+					value={ email }
+					onChange={ setEmail }
+				/>
+
+				<button
+					disabled={ isSubmitting }
+					className="sensei-setup-wizard__button sensei-setup-wizard__button--primary sensei-signup-form__button"
+					type="submit"
+					{ ...logLink( 'setup_wizard_newsletter_signup' ) }
+				>
+					{ __( 'Nice! Sign me up', 'sensei-lms' ) }
+				</button>
+			</form>
+		</>
 	);
 };
 

--- a/assets/setup-wizard/style.scss
+++ b/assets/setup-wizard/style.scss
@@ -182,7 +182,7 @@ $big-horizontal-padding: 80px;
 	}
 
 	&__submit-error {
-		margin-bottom: 32px;
+		margin: 0 0 32px;
 	}
 
 	// Columns.

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -25,7 +25,7 @@ class Sensei_Setup_Wizard {
 	const MC_LIST_ID                  = '4fa225a515';
 	const MC_USER_ID                  = '7a061a9141b0911d6d9bafe3a';
 	const MC_GDPR_FIELD               = '23563';
-	const MC_URL                      = 'https://senseilms.us19.list-manage.com/subscribe/post?u=' . self::MC_USER_ID . '&id=' . self::MC_LIST_ID;
+	const MC_URL                      = 'https://senseilms.us19.list-manage.com/subscribe/post-json?u=' . self::MC_USER_ID . '&id=' . self::MC_LIST_ID;
 
 	/**
 	 * Default value for setup wizard user data.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* After this review from @aaronfc and a conversation with @Luchadores, I implemented this change to submit the newsletter signup without opening a new window.
* I'd also like to point here that this approach is not officially documented by Mailchimp, but many unofficial links (like [this one](https://stackoverflow.com/a/15120409)) on the internet mention how to do it. - Basically, changing the URL to `/post-json`, and adding a `c` query string for a JSONP callback.
* Some more details: p1663940942193819-slack-C07418EJ0

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->

* Go to the onboarding newsletter (`/wp-admin/admin.php?page=sensei_setup_wizard&step=newsletter`).
* Add your email, and click on "Nice! Sign me up".
* Make sure it works properly, and you go to the next step.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

For this test, it's using a test Mailchimp account:

https://user-images.githubusercontent.com/876340/192028768-c9895c5d-ae99-4211-bd4c-50a3625acf6a.mov