### PR TITLE
Fix draft lessons not getting duplicated with course

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -761,7 +761,7 @@ class Sensei_Admin {
 	 * @return int Number of lessons duplicated.
 	 */
 	private function duplicate_course_lessons( $old_course_id, $new_course_id ) {
-		$lessons              = Sensei()->course->course_lessons( $old_course_id );
+		$lessons              = Sensei()->course->course_lessons( $old_course_id, 'any' );
 		$new_lesson_id_lookup = array();
 		$lessons_to_update    = array();
 

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -52,6 +52,14 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		$course_id   = $duplication['course_id'];
 		$lessons_ids = $duplication['lessons_ids'];
 
+		// Make one of the lessons draft, it should also get duplicated.
+		wp_update_post(
+			[
+				'ID'          => $lessons_ids[0],
+				'post_status' => 'draft',
+			]
+		);
+
 		// Runs the duplication
 		Sensei()->admin->duplicate_course_with_lessons_action();
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/5755

### Changes proposed in this Pull Request

- When duplicating a Course with lessons, only the published lessons where getting duplicated. Fixed the issue so that all the lessons regardless of their statuses get duplicated.

### Testing instructions

- Create a course with multiple lessons, publish some of the lessons and keep some of them unpublished
- Now duplicate the course using the option shown in the screenshot
- Make sure all the lessons are duplicated

### Screenshot / Video
![image](https://user-images.githubusercontent.com/6820724/192054162-dd010ace-a20c-4368-b5ea-3ecf945bcd78.png)
