### PR TITLE
Fix unit tests on WP nightly

### DIFF
--- a/tests/unit-tests/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
+++ b/tests/unit-tests/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
@@ -11,7 +11,7 @@ use Sensei\Student_Progress\Course_Progress\Repositories\Comments_Based_Course_P
  * @covers \Sensei\Student_Progress\Course_Progress\Repositories\Comments_Based_Course_Progress_Repository
  */
 class Comments_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
-	private $factory;
+	protected $factory;
 
 	public function setup() {
 		parent::setup();

--- a/tests/unit-tests/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
+++ b/tests/unit-tests/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
@@ -11,7 +11,7 @@ use Sensei\Student_Progress\Lesson_Progress\Repositories\Comments_Based_Lesson_P
  * @covers \Sensei\Student_Progress\Lesson_Progress\Repositories\Comments_Based_Lesson_Progress_Repository
  */
 class Comments_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
-	private $factory;
+	protected $factory;
 
 	public function setup() {
 		parent::setup();

--- a/tests/unit-tests/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -16,7 +16,7 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 	 *
 	 * @var \Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	public function setup() {
 		parent::setup();


### PR DESCRIPTION
Related to #5634

PR to fix unit tests on WP nightly PHP 7.2.

### Changes proposed in this Pull Request

Make private `$factory` attributes protected `$factory` to match parent class.

### Testing instructions

* Ensure tests pass.