### PR TITLE
Remove notices from setup wizard

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -88,6 +88,7 @@ class Sensei_Setup_Wizard {
 		if ( is_admin() ) {
 
 			add_action( 'admin_menu', [ $this, 'register_wizard_page' ], 20 );
+			add_action( 'current_screen', [ $this, 'remove_notices_from_setup_wizard' ] );
 			add_action( 'admin_notices', [ $this, 'setup_wizard_notice' ] );
 			add_action( 'admin_init', [ $this, 'skip_setup_wizard' ] );
 			add_action( 'admin_init', [ $this, 'activation_redirect' ] );
@@ -119,6 +120,19 @@ class Sensei_Setup_Wizard {
 				$this->page_slug,
 				[ $this, 'render_wizard_page' ]
 			);
+		}
+	}
+
+	/**
+	 * Remove notices from Sensei Setup Wizard.
+	 *
+	 * @access private
+	 *
+	 * @param WP_Screen $current_screen Current screen object.
+	 */
+	public function remove_notices_from_setup_wizard( $current_screen ) {
+		if ( strpos( $current_screen->id, $this->page_slug ) !== false ) {
+			remove_all_actions( 'admin_notices' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #5765

### Changes proposed in this Pull Request

* It removes all admin notices from the Setup Wizard pages.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Add a snippet to your site to force a notice:
  ```php
  add_action( 'admin_notices', function() { echo '<div>A notice</div>'; }, 15 );
  ```
* Navigate to the Setup Wizard (`/wp-admin/admin.php?page=sensei_setup_wizard`).
* Make sure no notices are displayed.