### PR TITLE
Fixes for lesson video rendering

### DIFF
--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -282,7 +282,7 @@ export default [
 						display: 'flex',
 						justifyContent: 'center',
 						alignItems: 'center',
-						height: '350px',
+						height: '500px',
 					} }
 				>
 					<p

--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -263,7 +263,7 @@ export default [
 	{
 		...courseThemeLessonVideoMeta,
 		...meta,
-		title: __( 'Lesson Video (Learning Mode)', 'sensei-lms' ),
+		title: __( 'Lesson Video', 'sensei-lms' ),
 		description: __(
 			'Displays the featured video if there is one for the lesson.',
 			'sensei-lms'

--- a/assets/css/sensei-course-theme/blocks/lesson-video.scss
+++ b/assets/css/sensei-course-theme/blocks/lesson-video.scss
@@ -1,10 +1,16 @@
 .sensei-course-theme-lesson-video {
 
-  .wp-block-embed, .wp-block-video {
-    margin: 0;
-  }
-  iframe, video {
-    width: 100% !important;
-  }
+	.wp-block-embed, .wp-block-video {
+		margin: 0;
+	}
+
+	iframe, video {
+		width: 100% !important;
+	}
+
+	@media screen and (max-width: (782px)) {
+
+		margin: 0 calc(-1 * var(--content-padding));
+	}
 
 }

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -99,21 +99,20 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		$post_type_object->template = apply_filters( 'sensei_lesson_block_template', $block_template, $post_type_object->template ?? [] );
 
 		new Sensei_Conditional_Content_Block();
-
-		if ( ! Sensei()->lesson->has_sensei_blocks() ) {
-			return;
-		}
-
 		new Sensei_Lesson_Actions_Block();
 		new Sensei_Lesson_Properties_Block();
 		new Sensei_Next_Lesson_Block();
 		new Sensei_Complete_Lesson_Block();
 		new Sensei_Reset_Lesson_Block();
 		new Sensei_View_Quiz_Block();
-		new Sensei_Block_Contact_Teacher();
 		new Sensei_Featured_Video_Block();
 
-		$this->remove_block_related_content();
+		if ( Sensei()->lesson->has_sensei_blocks() ) {
+			$this->remove_block_related_content();
+
+			// This constructor has some sideeffects so only initialize it when the lesson has Sensei blocks.
+			new Sensei_Block_Contact_Teacher();
+		}
 
 	}
 

--- a/includes/blocks/course-theme/class-lesson-video.php
+++ b/includes/blocks/course-theme/class-lesson-video.php
@@ -49,23 +49,12 @@ class Lesson_Video {
 	 * @return string The block HTML.
 	 */
 	public function render() : string {
-		$lesson_id = Sensei_Utils::get_current_lesson();
-		$user_id   = get_current_user_id();
 
-		if ( empty( $lesson_id ) || empty( $user_id ) ) {
+		if ( ! sensei_can_user_view_lesson() ) {
 			return '';
 		}
 
-		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
-
-		if (
-			! Sensei_Course::is_user_enrolled( $course_id )
-			|| Sensei_Utils::user_completed_lesson( $lesson_id )
-		) {
-			return '';
-		}
-
-		$content = Sensei_Utils::get_featured_video_html( $lesson_id ) ?? '';
+		$content = Sensei_Utils::get_featured_video_html() ?? '';
 
 		if ( empty( $content ) ) {
 			return '';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5105,20 +5105,10 @@ class Sensei_Lesson {
 	 */
 	public function has_sensei_blocks( $lesson = null ) {
 		$lesson = get_post( $lesson );
+		$post   = $lesson->post_content ?? null;
 
-		$lesson_blocks = [
-			'sensei-lms/lesson-actions',
-			'sensei-lms/lesson-properties',
-			'sensei-lms/button-contact-teacher',
-		];
+		return ! empty( $post ) && has_blocks( $post ) && ( false !== strpos( $post, '<!-- wp:sensei-lms/' ) );
 
-		foreach ( $lesson_blocks as $block ) {
-			if ( has_block( $block, $lesson ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2655,8 +2655,9 @@ class Sensei_Utils {
 		}
 		return Sensei_Wp_Kses::maybe_sanitize( $url, $allowed_html );
 	}
+
 	/**
-	 * Gets the HTML content from the Featured Video for a post
+	 * Gets the HTML content from the Featured Video for a lesson.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -2665,30 +2666,21 @@ class Sensei_Utils {
 	 * @return string|false The featured video HTML output if it exists, or false if it doesn't.
 	 */
 	public static function get_featured_video_html( $post_id = null ) {
-		$video_embed = '';
 		$post = get_post( $post_id );
 
-		if ( has_blocks( $post ) ) {
-
+		if ( has_block( 'sensei-lms/featured-video', $post ) ) {
 			$blocks = parse_blocks( $post->post_content );
 			foreach ( $blocks as $block ) {
 				if ( 'sensei-lms/featured-video' === $block['blockName'] ) {
-					// Handle Media Library Files.
-					if ( 'sensei-pro/interactive-video' === $block['innerBlocks'][0]['blockName'] ) {
-						$block = $block['innerBlocks'][0];
-					}
-					// Handle Media Library Videos.
-					if ( 'core/video' === $block['innerBlocks'][0]['blockName'] ) {
-						return trim( $block['innerBlocks'][0]['innerHTML'] );
-					}
-					// Handle oEmbeds.
-					$video_embed = $block['innerBlocks'][0]['attrs']['url'];
+					$content = render_block( $block );
+					global $wp_embed;
+					return $wp_embed->autoembed( $content );
 				}
 			}
-		} else {
-			$video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
 		}
-		return self::render_video_embed( $video_embed );
+		$video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
+		return $video_embed ? self::render_video_embed( $video_embed ) : '';
+
 	}
 }
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2664,10 +2664,12 @@ class Sensei_Utils {
 	 *
 	 * @return string|false The featured video HTML output if it exists, or false if it doesn't.
 	 */
-	public static function get_featured_video_html( $post_id ) {
+	public static function get_featured_video_html( $post_id = null ) {
 		$video_embed = '';
-		if ( has_blocks( $post_id ) ) {
-			$post   = get_post( $post_id );
+		$post = get_post( $post_id );
+
+		if ( has_blocks( $post ) ) {
+
 			$blocks = parse_blocks( $post->post_content );
 			foreach ( $blocks as $block ) {
 				if ( 'sensei-lms/featured-video' === $block['blockName'] ) {


### PR DESCRIPTION
Fixes #5773 

### Changes proposed in this Pull Request

* [Fix lesson blocks not initializing](https://github.com/Automattic/sensei/pull/5779/commits/0c45aba7ba1fb4518cd5976ed42dde6bf2f0563c) when there there are no other Sensei blocks in the lesson.
  * Simplified `Sensei_Lesson::has_sensei_blocks` to accept any Sensei block, since having a list of blocks in there was a source of errors like this one.
  * Also removed the early exit of not loading lesson blocks based on that check. Again a source of error with little performance benefit.
* [Render the whole featured video block](https://github.com/Automattic/sensei/pull/5779/commits/6c71c672e8ca20fb94b1e7e1286aec5b5c18fe45) in `get_featured_video_html` so the interactive video is preserved 
* Tweak styles

### Testing instructions

* Edit the Modern template and add the 'Lesson Video' block (or checkout this branch: 1802-gh-Automattic/sensei-pro )
* Create lessons in a course that each have a 'Featured Video' block, with various videos inside:
  * Video from media library
  * Video from Vimeo
  * Video from Youtube
  * Video from VideoPress (here is a test video I set to public: https://videopress.com/v/gRqriCDG)
  * Interactive Video with some breakpoints and a video
* Add some text before & after the video too
* Open the lessons in the frontend, and check that video is working correctly
