### PR TITLE
Add script to resize lesson video

### DIFF
--- a/assets/course-theme/featured-video-size.js
+++ b/assets/course-theme/featured-video-size.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+function setupLessonVideoIframes() {
+	document
+		.querySelectorAll( '.sensei-course-theme-lesson-video iframe' )
+		.forEach( updateElementHeightOnResize );
+}
+
+/**
+ * Get aspect ratio from element width and height attribute.
+ *
+ * @param {HTMLElement} element
+ * @param {string}      element.width
+ * @param {string}      element.height
+ * @return {null|number} Width / Height aspect ratio.
+ */
+function getAspectRatio( { width, height } ) {
+	if ( ! height || ! width ) {
+		return null;
+	}
+	return +width / +height;
+}
+
+/**
+ * Update video height when its width changes to keep original aspect ratio.
+ *
+ * @param {HTMLElement} element Element to track. Must have width and height attributes.
+ */
+function updateElementHeightOnResize( element ) {
+	const ratio = getAspectRatio( element );
+
+	const observer = new window.ResizeObserver( resizeElement );
+	observer.observe( element );
+
+	function resizeElement() {
+		const { offsetHeight, offsetWidth } = element;
+		const height = offsetWidth / ratio;
+
+		if ( ! height || height === offsetHeight ) {
+			return;
+		}
+
+		element.setAttribute( 'height', offsetWidth / ratio );
+	}
+}
+
+domReady( setupLessonVideoIframes );

--- a/assets/course-theme/learning-mode.js
+++ b/assets/course-theme/learning-mode.js
@@ -3,6 +3,7 @@
  */
 import './scroll-direction';
 import './adminbar-layout';
+import './featured-video-size';
 import { toggleFocusMode } from './focus-mode';
 import { submitContactTeacher } from './contact-teacher';
 import { initCompleteLessonTransition } from './complete-lesson-button';


### PR DESCRIPTION
Based on #5779 
Fixes #5769 

This solves some issues with Vimeo and VideoPress blocks having fixed height despite the video width being responsive and filling the container. That meant that the video top/bottom can get cut off or have extra whitespace above/beyond

### Changes proposed in this Pull Request

* Add a script that updates the video iframe's height when the width changes

### Testing instructions

* Add a lesson with a featured video from video
* View it in a LM template that has video (see #5779 for instructions)

