### PR TITLE
Add/enable lm for new users

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -467,7 +467,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'description' => __( 'Show an immersive and distraction-free view for lessons and quizzes.', 'sensei-lms' ),
 			'form'        => 'render_learning_mode_setting',
 			'type'        => 'checkbox',
-			'default'     => false,
+			'default'     => version_compare( \Sensei()->version, '$$next-version$$', '>=' ),
 			'section'     => 'appearance-settings',
 		);
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -467,7 +467,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'description' => __( 'Show an immersive and distraction-free view for lessons and quizzes.', 'sensei-lms' ),
 			'form'        => 'render_learning_mode_setting',
 			'type'        => 'checkbox',
-			'default'     => version_compare( \Sensei()->version, '$$next-version$$', '>=' ),
+			'default'     => \Sensei()->install_version && version_compare( \Sensei()->install_version, '$$next-version$$', '>=' ),
 			'section'     => 'appearance-settings',
 		);
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -33,6 +33,15 @@ class Sensei_Main {
 	public $version;
 
 	/**
+	 * Main reference to the plugin's version when it was installed.
+	 * Or false if the install version is not available.
+	 *
+	 * @since $$next-version$$
+	 * @var string|false
+	 */
+	public $install_version;
+
+	/**
 	 * Public token, referencing for the text domain.
 	 */
 	public $token = 'sensei';
@@ -235,6 +244,7 @@ class Sensei_Main {
 		$this->plugin_path           = trailingslashit( dirname( $this->main_plugin_file_name ) );
 		$this->template_url          = apply_filters( 'sensei_template_url', 'sensei/' );
 		$this->version               = isset( $args['version'] ) ? $args['version'] : null;
+		$this->install_version       = get_option( 'sensei-install-version' );
 
 		// Initialize the core Sensei functionality
 		$this->init();
@@ -657,7 +667,7 @@ class Sensei_Main {
 
 		// Make sure the current version is up-to-date.
 		if ( ! $current_version || $is_upgrade ) {
-			$this->register_plugin_version();
+			$this->register_plugin_version( $is_new_install );
 		}
 
 		$this->updates = new Sensei_Updates( $current_version, $is_new_install, $is_upgrade );
@@ -744,13 +754,17 @@ class Sensei_Main {
 	 *
 	 * @access public
 	 * @since  1.0.0
+	 * @param boolean $is_new_install Is this a new install.
 	 * @return void
 	 */
-	private function register_plugin_version() {
+	private function register_plugin_version( $is_new_install ) {
 		if ( isset( $this->version ) ) {
 
 			update_option( 'sensei-version', $this->version );
 
+			if ( $is_new_install ) {
+				update_option( 'sensei-install-version', $this->version );
+			}
 		}
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -65,7 +65,6 @@ class Sensei_Course_Theme_Option {
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 		add_action( 'template_redirect', [ $this, 'ensure_learning_mode_url_prefix' ] );
 		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar_only_for_editors' ] );
-		add_filter( 'sensei_admin_notices', [ $this, 'add_course_theme_notice' ] );
 	}
 
 	/**
@@ -224,39 +223,6 @@ class Sensei_Course_Theme_Option {
 		}
 
 		return $show_admin_bar;
-	}
-
-	/**
-	 * Adds a course theme notice.
-	 *
-	 * @access private
-	 *
-	 * @param array $notices Notices list.
-	 *
-	 * @return array Notices including the course theme notice.
-	 */
-	public function add_course_theme_notice( array $notices ) {
-		$notices['sensei-course-theme'] = [
-			'type'       => 'user',
-			'icon'       => 'sensei',
-			'heading'    => __( 'Sensei’s new Learning Mode is here!', 'sensei-lms' ),
-			'message'    => __( 'Give your students an intuitive and distraction-free learning experience.', 'sensei-lms' ),
-			'actions'    => [
-				[
-					'label'  => __( 'Learn more', 'sensei-lms' ),
-					'url'    => 'https://senseilms.com/wordpress-course-theme',
-					'target' => '_blank',
-				],
-			],
-			'conditions' => [
-				[
-					'type'    => 'screens',
-					'screens' => [ 'sensei*' ],
-				],
-			],
-		];
-
-		return $notices;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4550 

### Changes proposed in this Pull Request

* Sets the default value for `'sensei_learning_mode_all'` setting to `true` for Sensei versions equal to or higher than then next release.
* Removes the wp-admin notice about the Learning Mode. See below.

<img width="1654" alt="Screen Shot 2022-09-27 at 13 01 59" src="https://user-images.githubusercontent.com/2578542/192486272-4b06c202-848f-4e53-862b-034e73363697.png">


### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
#### Testing the default Learning Mode setting

We determine if the sensei is newly installed by checking if there are any courses in the db. So to test this change you need to install the plugin on fresh installation without any courses.

* Update `includes/class-sensei-settings.php:470` and replace `$$next-version$$` with `4.7.0`.
* Go to Sensei > Settings > Appearance and confirm that the "Learning Mode" **is not** enabled.
* Now update the file `sensei-lms.php` and set `SENSEI_LMS_VERSION` to 4.7.0 or higher.
* * Go to Sensei > Settings > Appearance and confirm that the "Learning Mode" **is** enabled.

#### Testing the Learning Mode admin notice
* Switch to `feature/learning-mode` branch.
* Run `DELETE FROM wp_usermeta WHERE meta_key="sensei-dismissed-notices";` command on your wp installation db.
* Go to Sensei > Courses page in wp-admin and confirm there is a notice regarding the Learning Mode. Do not dismiss it!
* Switch back to this branch and confirm that notice does not show up anymore.
