### PR TITLE
Tweak default template

### DIFF
--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -84,49 +84,4 @@
 			}
 		}
 	}
-
-	//		// Floating lesson actions footer.
-	//
-	//		&-lesson-actions {
-	//			position: fixed;
-	//			bottom: 0;
-	//			left: 0;
-	//			right: 0;
-	//			background: var(--bg-color);
-	//			box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
-	//			transition: bottom 800ms ease-in;
-	//
-	//			padding: 12px !important;
-	//			display: flex;
-	//			gap: 12px;
-	//			align-items: center;
-	//
-	//			> * {
-	//				flex: 1;
-	//			}
-	//
-	//			button {
-	//				width: 100%;
-	//			}
-	//		}
-	//
-	//		&--sidebar-open &-lesson-actions {
-	//			transition: bottom 300ms 0ms;
-	//			bottom: -30vh;
-	//		}
-	//
-	//		&.scroll-down &-lesson-actions {
-	//			transition-delay: 200ms;
-	//			bottom: -100px;
-	//		}
-	//
-	//		&.scroll-bottom &-lesson-actions {
-	//			bottom: 0;
-	//		}
-	//	}
-	//}
-	//
-	//body {
-	//	padding-bottom: 140px;
-	//}
 }

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -27,6 +27,7 @@
 				transition: none !important;
 				display: flex;
 				flex-direction: column;
+
 				> *:first-child {
 					flex: 1;
 				}
@@ -55,7 +56,6 @@
 			}
 
 
-
 			&__header {
 				.sensei-course-theme-course-progress {
 					display: none;
@@ -82,50 +82,51 @@
 					right: 24px;
 				}
 			}
-
-
-			// Floating lesson actions footer.
-
-			&-lesson-actions {
-				position: fixed;
-				bottom: 0;
-				left: 0;
-				right: 0;
-				background: var(--bg-color);
-				box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
-				transition: bottom 800ms ease-in;
-
-				padding: 12px !important;
-				display: flex;
-				gap: 12px;
-				align-items: center;
-
-				> * {
-					flex: 1;
-				}
-
-				button {
-					width: 100%;
-				}
-			}
-
-			&--sidebar-open &-lesson-actions {
-				transition: bottom 300ms 0ms;
-				bottom: -30vh;
-			}
-
-			&.scroll-down &-lesson-actions {
-				transition-delay: 200ms;
-				bottom: -100px;
-			}
-
-			&.scroll-bottom &-lesson-actions {
-				bottom: 0;
-			}
 		}
 	}
 
-	body {
-		padding-bottom: 140px;
-	}
+	//		// Floating lesson actions footer.
+	//
+	//		&-lesson-actions {
+	//			position: fixed;
+	//			bottom: 0;
+	//			left: 0;
+	//			right: 0;
+	//			background: var(--bg-color);
+	//			box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
+	//			transition: bottom 800ms ease-in;
+	//
+	//			padding: 12px !important;
+	//			display: flex;
+	//			gap: 12px;
+	//			align-items: center;
+	//
+	//			> * {
+	//				flex: 1;
+	//			}
+	//
+	//			button {
+	//				width: 100%;
+	//			}
+	//		}
+	//
+	//		&--sidebar-open &-lesson-actions {
+	//			transition: bottom 300ms 0ms;
+	//			bottom: -30vh;
+	//		}
+	//
+	//		&.scroll-down &-lesson-actions {
+	//			transition-delay: 200ms;
+	//			bottom: -100px;
+	//		}
+	//
+	//		&.scroll-bottom &-lesson-actions {
+	//			bottom: 0;
+	//		}
+	//	}
+	//}
+	//
+	//body {
+	//	padding-bottom: 140px;
+	//}
 }

--- a/assets/css/sensei-course-theme/ui-blocks.scss
+++ b/assets/css/sensei-course-theme/ui-blocks.scss
@@ -82,5 +82,9 @@ body.sensei-course-theme {
 			margin-left: var(--sidebar-width) !important;
 		}
 	}
+
+	&__content-footer {
+		border-top: 1px solid var(--border-color, #1E1E1E);
+	}
 }
 

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -1,64 +1,63 @@
-<!-- wp:sensei-lms/ui {"className":"sensei-version--4-8-0", "elementClass": "sensei-course-theme__header"} -->
-<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__header sensei-version--4-8-0"><!-- wp:group {"style":{"spacing":{"padding":{"right":"24px","left":"24px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-    <div class="wp-block-group" style="padding-right:24px;padding-left:24px"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-        <div class="wp-block-group"><!-- wp:site-logo {"width":50} /-->
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version--4-8-0"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-8-0 sensei-course-theme__header">
+	<!-- wp:group {"style":{"spacing":{"padding":{"right":"24px","left":"24px","top":"6px","bottom":"6px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group" style="padding-top:6px;padding-right:24px;padding-bottom:6px;padding-left:24px">
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group"><!-- wp:site-logo {"width":50,"style":{"color":{"duotone":["#1a4548","#ffe2c7"]}}} /-->
 
-            <!-- wp:sensei-lms/course-title /-->
+			<!-- wp:sensei-lms/course-title /--></div>
+		<!-- /wp:group -->
 
-            <!-- wp:sensei-lms/course-theme-course-progress-counter /--></div>
-        <!-- /wp:group -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"12px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+			<!-- wp:sensei-lms/course-theme-course-progress-counter {"style":{"color":{"text":"#7f7e7e"}}} /-->
 
-        <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-        <div class="wp-block-group"><!-- wp:sensei-lms/course-theme-prev-next-lesson /-->
+			<!-- wp:sensei-lms/exit-course /-->
 
-            <!-- wp:sensei-lms/sidebar-toggle-button /-->
+			<!-- wp:sensei-lms/sidebar-toggle-button /--></div>
+		<!-- /wp:group --></div>
+	<!-- /wp:group -->
 
-            <!-- wp:sensei-lms/course-theme-lesson-actions /--></div>
-        <!-- /wp:group --></div>
-    <!-- /wp:group -->
-
-    <!-- wp:sensei-lms/course-theme-course-progress-bar /--></div>
+	<!-- wp:sensei-lms/course-theme-course-progress-bar /--></div>
 <!-- /wp:sensei-lms/ui -->
 
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns"} -->
-<div class="wp-block-sensei-lms-ui sensei-course-theme__columns"><!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":""} -->
-    <div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar" >
-        <!-- wp:sensei-lms/focus-mode-toggle /-->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__columns">
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":""} -->
+	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar">
+		<!-- wp:sensei-lms/course-navigation /-->
 
-        <!-- wp:sensei-lms/course-navigation /-->
+		<!-- wp:sensei-lms/spacer-flex -->
+		<div class="wp-block-sensei-lms-spacer-flex sensei-course-theme__spacer-flex"></div>
+		<!-- /wp:sensei-lms/spacer-flex -->
 
-        <!-- wp:sensei-lms/spacer-flex -->
-        <div class="wp-block-sensei-lms-spacer-flex sensei-course-theme__spacer-flex"></div>
-        <!-- /wp:sensei-lms/spacer-flex -->
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"12px","bottom":"12px"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+		<div class="wp-block-group" style="margin-top:12px;margin-bottom:12px"><!-- wp:sensei-lms/button-contact-teacher -->
+			<div
+				class="wp-block-sensei-lms-button-contact-teacher is-style-outline wp-block-sensei-button wp-block-button has-text-align-left">
+				<a class="wp-block-button__link">Contact Teacher</a></div>
+			<!-- /wp:sensei-lms/button-contact-teacher --></div>
+		<!-- /wp:group --></div>
+	<!-- /wp:sensei-lms/ui -->
 
-        <!-- wp:group {"style":{"spacing":{"margin":{"top":"12px","bottom":"12px"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-        <div class="wp-block-group" style="margin-top:12px;margin-bottom:12px"><!-- wp:sensei-lms/button-contact-teacher -->
-            <div class="wp-block-sensei-lms-button-contact-teacher is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link">Contact Teacher</a></div>
-            <!-- /wp:sensei-lms/button-contact-teacher -->
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false}} -->
+	<div class="wp-block-sensei-lms-ui sensei-course-theme__main-content">
+		<!-- wp:sensei-lms/course-theme-lesson-module /-->
 
-            <!-- wp:sensei-lms/exit-course /--></div>
-        <!-- /wp:group --></div>
-    <!-- /wp:sensei-lms/ui -->
+		<!-- wp:post-title {"level":1} /-->
 
-    <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false}} -->
-    <div class="wp-block-sensei-lms-ui sensei-course-theme__main-content"><!-- wp:sensei-lms/course-theme-lesson-module /-->
+		<!-- wp:sensei-lms/course-theme-notices /-->
 
-        <!-- wp:post-title {"level":1} /-->
+		<!-- wp:post-content /-->
 
-        <!-- wp:sensei-lms/course-theme-notices /-->
+		<!-- wp:spacer {"height":"150px"} -->
+		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 
-        <!-- wp:post-content /-->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+		<div class="wp-block-group"><!-- wp:sensei-lms/page-actions /-->
 
-        <!-- wp:spacer {"height":"150px"} -->
-        <div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
-        <!-- /wp:spacer -->
-
-        <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-        <div class="wp-block-group"><!-- wp:sensei-lms/page-actions /-->
-
-            <!-- wp:sensei-lms/course-theme-prev-next-lesson /-->
-
-            <!-- wp:sensei-lms/course-theme-lesson-actions /--></div>
-        <!-- /wp:group --></div>
-    <!-- /wp:sensei-lms/ui --></div>
+			<!-- wp:sensei-lms/course-theme-lesson-actions {"options":{"nextLesson":true}} /--></div>
+		<!-- /wp:group --></div>
+	<!-- /wp:sensei-lms/ui --></div>
 <!-- /wp:sensei-lms/ui -->

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -3,7 +3,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"24px","left":"24px","top":"6px","bottom":"6px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group" style="padding-top:6px;padding-right:24px;padding-bottom:6px;padding-left:24px">
 		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group"><!-- wp:site-logo {"width":50,"style":{"color":{"duotone":["#1a4548","#ffe2c7"]}}} /-->
+		<div class="wp-block-group"><!-- wp:site-logo {"width":50} /-->
 
 			<!-- wp:sensei-lms/course-title /--></div>
 		<!-- /wp:group -->


### PR DESCRIPTION
Fixes #5735

### Changes proposed in this Pull Request

* Update default template to new design:
* Remove action buttons from header
* Move exit course and course progress text to header right side
* Move lesson actions to bottom of the post
* Remove focus mode toggle

### Testing instructions

* Use default template for Learning mode, make sure customizations are cleared
* View a lesson in the frontend. Check that everything looks right

Note: the mobile menu is not working correctly, looking to fix that in https://github.com/Automattic/sensei/pull/5759

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/176949/192525189-130e705f-1486-4994-9ad8-3959182e52d4.png">
