### PR TITLE
Remove the default last activity date from reports

### DIFF
--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -19,10 +19,8 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 * @return string The start date.
 	 */
 	protected function get_start_date_filter_value(): string {
-		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
-
 		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$start_date = $_GET['start_date'] ?? $default;
+		$start_date = $_GET['start_date'] ?? '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -71,6 +71,47 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_items( $table->items ) );
 	}
 
+	public function testPrepareItems_DefaultDateFilterSet_SetsMatchingItems() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+
+		$user1_id = $this->factory->user->create();
+		$user2_id = $this->factory->user->create();
+		$user3_id = $this->factory->user->create();
+		$user4_id = $this->factory->user->create();
+
+		$activity1_id = Sensei_Utils::start_user_on_course( $user1_id, $course_id );
+		$activity2_id = Sensei_Utils::start_user_on_course( $user2_id, $course_id );
+		$activity3_id = Sensei_Utils::start_user_on_course( $user3_id, $course_id );
+		$activity4_id = Sensei_Utils::start_user_on_course( $user4_id, $course_id );
+
+		$more_than_30days_ago = new DateTime( '-31 day' );
+		$exactly_30days_ago   = new DateTime( '-30 day' );
+		$week_ago             = new DateTime( '-7 day' );
+		$today                = new DateTime( 'now' );
+
+		update_comment_meta( $activity1_id, 'start', $more_than_30days_ago->format( 'Y-m-d' ) );
+		update_comment_meta( $activity2_id, 'start', $exactly_30days_ago->format( 'Y-m-d' ) );
+		update_comment_meta( $activity3_id, 'start', $week_ago->format( 'Y-m-d' ) );
+		update_comment_meta( $activity4_id, 'start', $today->format( 'Y-m-d' ) );
+
+		$_GET['view'] = 'user';
+
+		/* Act. */
+		$table = new Sensei_Analysis_Course_List_Table( $course_id );
+		$table->prepare_items();
+
+		/* Assert. */
+		$expected = [
+			$user1_id,
+			$user2_id,
+			$user3_id,
+			$user4_id,
+		];
+		sort( $expected );
+		self::assertSame( $expected, $this->export_items( $table->items ) );
+	}
+
 	public function testTableFooter_WhenCalledWithNoData_NotDisplayTheExportButton() {
 		/* Arrange. */
 		$list_table = new Sensei_Analysis_Course_List_Table();

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -71,46 +71,6 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_items( $table->items ) );
 	}
 
-	public function testPrepareItems_DefaultDateStartedFilterSet_SetsMatchingItems() {
-		/* Arrange. */
-		$course_id = $this->factory->course->create();
-
-		$user1_id = $this->factory->user->create();
-		$user2_id = $this->factory->user->create();
-		$user3_id = $this->factory->user->create();
-		$user4_id = $this->factory->user->create();
-
-		$activity1_id = Sensei_Utils::start_user_on_course( $user1_id, $course_id );
-		$activity2_id = Sensei_Utils::start_user_on_course( $user2_id, $course_id );
-		$activity3_id = Sensei_Utils::start_user_on_course( $user3_id, $course_id );
-		$activity4_id = Sensei_Utils::start_user_on_course( $user4_id, $course_id );
-
-		$more_than_30days_ago = new DateTime( '-31 day' );
-		$exactly_30days_ago   = new DateTime( '-30 day' );
-		$week_ago             = new DateTime( '-7 day' );
-		$today                = new DateTime( 'now' );
-
-		update_comment_meta( $activity1_id, 'start', $more_than_30days_ago->format( 'Y-m-d' ) );
-		update_comment_meta( $activity2_id, 'start', $exactly_30days_ago->format( 'Y-m-d' ) );
-		update_comment_meta( $activity3_id, 'start', $week_ago->format( 'Y-m-d' ) );
-		update_comment_meta( $activity4_id, 'start', $today->format( 'Y-m-d' ) );
-
-		$_GET['view'] = 'user';
-
-		/* Act. */
-		$table = new Sensei_Analysis_Course_List_Table( $course_id );
-		$table->prepare_items();
-
-		/* Assert. */
-		$expected = [
-			$user2_id,
-			$user3_id,
-			$user4_id,
-		];
-		sort( $expected );
-		self::assertSame( $expected, $this->export_items( $table->items ) );
-	}
-
 	public function testTableFooter_WhenCalledWithNoData_NotDisplayTheExportButton() {
 		/* Arrange. */
 		$list_table = new Sensei_Analysis_Course_List_Table();


### PR DESCRIPTION
This PR removes the default last activity start date. This was causing confusion for some users, so we decided to remove it.

The reason we had a default last activity date is to avoid possible performance issues. I did a quick test on [wpcourses.com](https://wpcourses.com/wp-admin/edit.php?s&page=sensei_reports&post_type=course&view=students&timezone&start_date&end_date&group_filter=Select+a+group&paged=1) and it works fine without a last activity date set, so I guess removing it should be ok.

### Changes proposed in this Pull Request

* Remove the default last activity start date from all report screens.

### Testing instructions

* Go to Sensei LMS -> Reports -> Students.
* Make sure the last activity start date input is empty.
* Go to Sensei LMS -> Reports -> Courses.
* Make sure the last activity start date input is empty.

### Screenshot / Video

![image](https://user-images.githubusercontent.com/1612178/192557502-336c7a11-ec65-40e2-8328-fa7633d8df9a.png)

### Context

p1664231630242489-slack-C02P7FHLVR9