### PR TITLE
Use admin_enqueue_scripts to enqueue JS/CSS scripts on the Onboard Wizard

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -142,13 +142,6 @@ class Sensei_Setup_Wizard {
 	 * @access private
 	 */
 	public function enqueue_scripts() {
-		/**
-		 * Triggered on the Setup Wizard page to add additional scripts and behaviors to the page.
-		 *
-		 * @since $$next-version$$
-		 * @hook sensei_setup_wizard_enqueue_scripts
-		 */
-		do_action( 'sensei_setup_wizard_enqueue_scripts' );
 		$handle = 'sensei-setup-wizard';
 		Sensei()->assets->enqueue( $handle, 'setup-wizard/index.js', [ 'sensei-event-logging' ], true );
 		Sensei()->assets->preload_data( [ '/sensei-internal/v1/setup-wizard' ] );

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -181,8 +181,8 @@ class Sensei_Setup_Wizard {
 	 * Set up hooks for loading Setup Wizard page assets.
 	 */
 	public function prepare_wizard_page() {
-		add_action( 'admin_print_scripts', [ $this, 'enqueue_scripts' ] );
-		add_action( 'admin_print_styles', [ $this, 'enqueue_styles' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_styles' ] );
 		add_action( 'admin_body_class', [ $this, 'filter_body_class' ] );
 
 		add_filter( 'show_admin_bar', '__return_false' );

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -142,6 +142,13 @@ class Sensei_Setup_Wizard {
 	 * @access private
 	 */
 	public function enqueue_scripts() {
+		/**
+		 * Triggered on the Setup Wizard page to add additional scripts and behaviors to the page.
+		 *
+		 * @since $$next-version$$
+		 * @hook sensei_setup_wizard_enqueue_scripts
+		 */
+		do_action( 'sensei_setup_wizard_enqueue_scripts' );
 		$handle = 'sensei-setup-wizard';
 		Sensei()->assets->enqueue( $handle, 'setup-wizard/index.js', [ 'sensei-event-logging' ], true );
 		Sensei()->assets->preload_data( [ '/sensei-internal/v1/setup-wizard' ] );


### PR DESCRIPTION
Related to 1788-gh-Automattic/sensei-pro 

### Changes proposed in this Pull Request

* Use admin_enqueue_scripts to enqueue JS/CSS scripts on the Onboard Wizard;

### Testing instructions

Check the test instructions in 1803-gh-Automattic/sensei-pro

Verify that the onboarding wizard still works.