### PR TITLE
Add filter to add content on the top of the Sensei Home

### DIFF
--- a/assets/home/main.js
+++ b/assets/home/main.js
@@ -28,7 +28,7 @@ const Main = () => {
 	 * @param {JSX.Element} element The element to be injected
 	 * @return {JSX.Element} Filtered element.
 	 */
-	const topRow = applyFilters( 'sensei.home.top', <></> );
+	const topRow = applyFilters( 'sensei.home.top', null );
 
 	return (
 		<>

--- a/assets/home/main.js
+++ b/assets/home/main.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { EditorNotices } from '@wordpress/editor';
+import { applyFilters, addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -20,16 +21,23 @@ import Extensions from './sections/extensions';
 const Main = () => {
 	useSenseiColorTheme();
 
+	/**
+	 * Filters the component that will be injected on the top of the Sensei Home
+	 *
+	 * @since $$next-version$$
+	 * @param {JSX.Element} element The element to be injected
+	 * @return {JSX.Element} Filtered element.
+	 */
+	const topRow = applyFilters( 'sensei.home.top', <></> );
+
 	return (
 		<>
 			<Grid as="main" className="sensei-home">
 				<Col as="section" className="sensei-home__section" cols={ 12 }>
-					<EditorNotices />
-				</Col>
-
-				<Col as="section" className="sensei-home__section" cols={ 12 }>
 					<Header />
 				</Col>
+
+				{ topRow }
 
 				<Col as="section" className="sensei-home__section" cols={ 12 }>
 					<TaskList />
@@ -60,5 +68,24 @@ const Main = () => {
 		</>
 	);
 };
+
+/**
+ * Filter to add the notices section based on the EditorNotices component.
+ *
+ * @param {JSX.Element} previous The previous element to be added
+ * @return {JSX.Element} The new top of the Sensei Home page, with the editor notices as a column.
+ */
+function addNotices( previous ) {
+	return (
+		<>
+			{ previous }
+			<Col as="section" className="sensei-home__section" cols={ 12 }>
+				<EditorNotices />
+			</Col>
+		</>
+	);
+}
+
+addFilter( 'sensei.home.top', 'sensei/home/top/add-notices', addNotices );
 
 export default Main;


### PR DESCRIPTION
Something I forgot to do on #5727

### Changes proposed in this Pull Request

* Add filter to add content on the top of the Sensei Home page;
* Move EditorNotices to be a filter instead, allowing us to customize the position of the notices when considering the licensing block on Sensei Pro, for instance;

### Testing instructions

Verify if the Sensei Home page still works OK with this code. :) 

You can run the following code on your browser dev tools to check if the notices still appear correctly on Sensei Home:

```js
wp.data.dispatch( 'core/notices' ).createNotice(
        'info', // Can be one of: success, info, warning, error.
        'Hey there, visit the Sensei website, now!', // Text string to display.
        {
            isDismissible: true, // Whether the user can dismiss the notice.
            // Any actions the user can perform.
            actions: [
                {
                    url: 'https://senseilms.com',
                    label: 'View site', variant: 'primary'
                },
            ],
        }
    );
```

### New/Updated Hooks

* `sensei.home.top` - A filter that returns a component to be rendered on the top of the page;
