### PR TITLE
Fix modules returning 404 in learning mode when using custom permalink structure

### DIFF
--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -248,9 +248,11 @@ class Sensei_Course_Theme {
 			return;
 		}
 
+		global $wp_rewrite;
+
 		$slug = preg_quote( $args['rewrite']['slug'] ?? $taxonomy, '/' );
 
-		add_rewrite_rule( '^' . self::QUERY_VAR . '/' . $slug . '/([^/]+)(?:/([0-9]+))?\??(.*)', 'index.php?' . self::QUERY_VAR . '=1&' . $taxonomy . '=$matches[1]', 'top' );
+		add_rewrite_rule( '^' . self::QUERY_VAR . $wp_rewrite->front . $slug . '/([^/]+)(?:/([0-9]+))?\??(.*)', 'index.php?' . self::QUERY_VAR . '=1&' . $taxonomy . '=$matches[1]', 'top' );
 	}
 
 	/**


### PR DESCRIPTION
Related to #5008

### Changes proposed in this Pull Request

* Fixes the modules permalink structure for learning mode. The module link wasn't working when a custom permalink structure is set.

### Testing instructions

* Go to Settings -> Permalinks.
* Set a custom structure. For example: `/blog/%postname%/`
* Create a course with 2 modules and multiple lessons in each module.
* Enable learning mode for that course.
* Take the course and complete the last lesson of the first module.
* You should be redirected to `/learn/blog/modules/[second-module-slug]/`.
* You should see the content of the first lesson in that module.
* Test that everything works as expected without having a custom permalink structure.
