### PR TITLE
Prevent modules to be linked in learning mode

### DIFF
--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -84,6 +84,7 @@ class Sensei_Course_Theme {
 		add_action( 'template_redirect', [ $this, 'load_theme' ] );
 		add_filter( 'the_content', [ $this, 'add_lesson_video_to_content' ], 80, 1 );
 		add_filter( 'sensei_do_link_to_module', [ $this, 'prevent_link_to_module' ] );
+		add_filter( 'template_redirect', [ $this, 'redirect_modules_to_first_lesson' ] );
 	}
 
 	/**
@@ -495,5 +496,28 @@ class Sensei_Course_Theme {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Redirect all module pages to the first module lesson.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function redirect_modules_to_first_lesson(): void {
+		if ( ! Sensei_Course_Theme_Option::should_use_learning_mode() || ! is_tax( 'module' ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action based on input.
+		$course_id = ! empty( $_GET['course_id'] ) ? (int) $_GET['course_id'] : Sensei_Utils::get_current_course();
+		if ( ! $course_id ) {
+			return;
+		}
+
+		$module_lessons = Sensei()->modules->get_lessons( $course_id, get_queried_object_id() );
+		if ( $module_lessons ) {
+			wp_safe_redirect( get_permalink( $module_lessons[0] ) );
+			die();
+		}
 	}
 }

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -79,12 +79,12 @@ class Sensei_Course_Theme {
 		add_action( 'registered_post_type', [ $this, 'add_post_type_rewrite_rules' ], 10, 2 );
 		add_action( 'shutdown', [ $this, 'maybe_flush_rewrite_rules' ] );
 		add_action( 'setup_theme', [ $this, 'maybe_override_theme' ], 2 );
+		add_action( 'template_redirect', [ $this, 'redirect_modules_to_first_lesson' ], 9 );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Quiz::instance(), 'init' ] );
 		add_action( 'template_redirect', [ $this, 'load_theme' ] );
 		add_filter( 'the_content', [ $this, 'add_lesson_video_to_content' ], 80, 1 );
 		add_filter( 'sensei_do_link_to_module', [ $this, 'prevent_link_to_module' ] );
-		add_filter( 'template_redirect', [ $this, 'redirect_modules_to_first_lesson' ] );
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -77,7 +77,6 @@ class Sensei_Course_Theme {
 
 		add_action( 'setup_theme', [ $this, 'add_query_var' ], 1 );
 		add_action( 'registered_post_type', [ $this, 'add_post_type_rewrite_rules' ], 10, 2 );
-		add_action( 'registered_taxonomy', [ $this, 'add_taxonomy_rewrite_rules' ], 10, 3 );
 		add_action( 'shutdown', [ $this, 'maybe_flush_rewrite_rules' ] );
 		add_action( 'setup_theme', [ $this, 'maybe_override_theme' ], 2 );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
@@ -234,23 +233,6 @@ class Sensei_Course_Theme {
 		add_rewrite_rule( '^' . self::QUERY_VAR . '/' . $slug . '/([^/]+)(?:/([0-9]+))?\??(.*)', 'index.php?' . self::QUERY_VAR . '=1&' . $post_type . '=$matches[1]&page=$matches[2]&$matches[3]', 'top' );
 		add_rewrite_tag( '%' . self::QUERY_VAR . '%', '([^?]+)' );
 
-	}
-
-	/**
-	 * Add a route with a /learn prefix for using course theme for a taxonomy.
-	 *
-	 * @param string $taxonomy    Taxonomy slug.
-	 * @param array  $object_type Array of object types supported by the taxonomy.
-	 * @param array  $args        Arguments used to register the taxonomy.
-	 */
-	public function add_taxonomy_rewrite_rules( $taxonomy, $object_type, $args ) {
-		if ( ! in_array( $taxonomy, [ 'module' ], true ) ) {
-			return;
-		}
-
-		$slug = preg_quote( $args['rewrite']['slug'] ?? $taxonomy, '/' );
-
-		add_rewrite_rule( '^' . self::QUERY_VAR . '/' . $slug . '/([^/]+)(?:/([0-9]+))?\??(.*)', 'index.php?' . self::QUERY_VAR . '=1&' . $taxonomy . '=$matches[1]', 'top' );
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -84,8 +84,8 @@ class Sensei_Course_Theme {
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Quiz::instance(), 'init' ] );
 		add_action( 'template_redirect', [ $this, 'load_theme' ] );
 		add_filter( 'the_content', [ $this, 'add_lesson_video_to_content' ], 80, 1 );
+		add_filter( 'sensei_do_link_to_module', [ $this, 'prevent_link_to_module' ] );
 	}
-
 
 	/**
 	 * Is the theme active for the current request.
@@ -496,5 +496,22 @@ class Sensei_Course_Theme {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Prevent modules to be linked in learning mode.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $do_link_to_module True if module should be linked to.
+	 *
+	 * @return bool
+	 */
+	public function prevent_link_to_module( bool $do_link_to_module ): bool {
+		if ( ! Sensei_Course_Theme_Option::should_use_learning_mode() ) {
+			return $do_link_to_module;
+		}
+
+		return false;
 	}
 }

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
@@ -112,4 +112,21 @@ class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 		// Expect only one video embed class.
 		$this->assertEquals( 1, substr_count( $output, Sensei_Frontend::VIDEO_EMBED_CLASS ) );
 	}
+
+	public function testPreventLinkToModule_WhenLearningModeEnabled_ReturnsFalse() {
+		/* Arrange. */
+		$course = $this->factory->course->create_and_get();
+		$lesson = $this->factory->lesson->create_and_get();
+
+		add_post_meta( $lesson->ID, '_lesson_course', $course->ID );
+		add_post_meta( $course->ID, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		$this->go_to( get_permalink( $lesson ) );
+
+		/* Act. */
+		$result = $this->instance->prevent_link_to_module( true );
+
+		/* Assert. */
+		$this->assertFalse( $result );
+	}
 }

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
@@ -129,4 +129,40 @@ class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertFalse( $result );
 	}
+
+	public function testRedirectModulesToFirstLesson_WhenLearningModeEnabled_RedirectsToLesson() {
+		/* Arrange. */
+		$course_info = $this->factory->get_course_with_lessons( [ 'module_count' => 1 ] );
+		$course_id   = $course_info['course_id'];
+		$lesson_id   = array_pop( $course_info['lesson_ids'] );
+		$module_id   = array_pop( $course_info['modules'] );
+		$module      = get_term( $module_id );
+
+		add_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		$this->go_to( sensei_get_navigation_url( $course_id, $module ) );
+
+		/* Act. */
+		$halt_redirect = function( $location, $status ) {
+			throw new \Exception(
+				wp_json_encode(
+					[
+						'location' => $location,
+						'status'   => $status,
+					]
+				)
+			);
+		};
+		add_filter( 'wp_redirect', $halt_redirect, 1, 2 );
+		try {
+			$this->instance->redirect_modules_to_first_lesson();
+		} catch ( \Exception $e ) {
+			$redirect = json_decode( $e->getMessage(), true );
+		}
+		remove_filter( 'wp_redirect', $halt_redirect, 1, 2 );
+
+		/* Assert. */
+		$this->assertEquals( 302, $redirect['status'] );
+		$this->assertEquals( get_permalink( $lesson_id ), $redirect['location'] );
+	}
 }


### PR DESCRIPTION
Related to #5008 and #4551

At the moment, we don't have a dedicated template for modules in learning mode so this PR prevents the modules to be linked when the course is using learning mode. This should also solve some 404 issues that the users are having related to modules.

If for some reason, a module link is accessed, it will redirect to the first lesson in that module.

### Testing instructions

* Make a course with 2 modules with lessons.
* Enable learning mode for that course.
* Add a description to each module. This makes a module have a dedicated page.
* Complete the last lesson of the first module.
* Make sure you are redirected to the first lesson of the second module.
* Go to Sensei LMS -> Modules and access the frontend link of one of the modules directly (`/modules/[slug]`).
* Make sure you are redirected to the module's first lesson.
* Disable learning mode.
* Again access the frontend link of one of the modules.
* Make sure you see the module's page. 

### Context

p1664353742643519-slack-C07418EJ0
164-gh-a8cteam51/jeffgothelf