### PR TITLE
Fix featured video sizing

### DIFF
--- a/assets/course-theme/featured-video-size.js
+++ b/assets/course-theme/featured-video-size.js
@@ -3,9 +3,9 @@
  */
 import domReady from '@wordpress/dom-ready';
 
-function setupLessonVideoIframes() {
+function setupLessonVideoBlocks() {
 	document
-		.querySelectorAll( '.sensei-course-theme-lesson-video iframe' )
+		.querySelectorAll( '.sensei-course-theme-lesson-video' )
 		.forEach( updateElementHeightOnResize );
 }
 
@@ -27,15 +27,22 @@ function getAspectRatio( { width, height } ) {
 /**
  * Update video height when its width changes to keep original aspect ratio.
  *
- * @param {HTMLElement} element Element to track. Must have width and height attributes.
+ * @param {HTMLElement} block Container to track. Must have an <iframe> width and height attributes.
  */
-function updateElementHeightOnResize( element ) {
-	const ratio = getAspectRatio( element );
+function updateElementHeightOnResize( block ) {
+	const getVideoElement = () => block.querySelector( 'iframe' );
+	let element = getVideoElement();
+	const ratio = element && getAspectRatio( element );
 
-	const observer = new window.ResizeObserver( resizeElement );
-	observer.observe( element );
+	if ( ! ratio ) {
+		return;
+	}
+
+	new window.ResizeObserver( resizeElement ).observe( block );
+	resizeElement();
 
 	function resizeElement() {
+		element = getVideoElement();
 		const { offsetHeight, offsetWidth } = element;
 		const height = offsetWidth / ratio;
 
@@ -47,4 +54,4 @@ function updateElementHeightOnResize( element ) {
 	}
 }
 
-domReady( setupLessonVideoIframes );
+domReady( setupLessonVideoBlocks );

--- a/assets/course-theme/featured-video-size.js
+++ b/assets/course-theme/featured-video-size.js
@@ -43,6 +43,11 @@ function updateElementHeightOnResize( block ) {
 
 	function resizeElement() {
 		element = getVideoElement();
+
+		if ( ! element ) {
+			return;
+		}
+
 		const { offsetHeight, offsetWidth } = element;
 		const height = offsetWidth / ratio;
 

--- a/includes/blocks/class-sensei-featured-video-block.php
+++ b/includes/blocks/class-sensei-featured-video-block.php
@@ -50,6 +50,15 @@ class Sensei_Featured_Video_Block {
 		if ( $sensei_template_has_lesson_video_block ) {
 			return '';
 		}
+
+		global $wp_embed;
+		$original_content_width   = $GLOBALS['content_width'] ?? null;
+		$GLOBALS['content_width'] = 1200;
+
+		$content = $wp_embed->autoembed( $content );
+
+		$GLOBALS['content_width'] = $original_content_width;
+
 		return $content;
 	}
 }

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2672,9 +2672,7 @@ class Sensei_Utils {
 			$blocks = parse_blocks( $post->post_content );
 			foreach ( $blocks as $block ) {
 				if ( 'sensei-lms/featured-video' === $block['blockName'] ) {
-					$content = render_block( $block );
-					global $wp_embed;
-					return $wp_embed->autoembed( $content );
+					return render_block( $block );
 				}
 			}
 		}


### PR DESCRIPTION

Fixes the script introduced in #4925 — in some cases the `<iframe>` element is replaced when loading the video.

### Changes proposed in this Pull Request

* Move resize listener in `featured-video-size.js` to the containing block, and always query for the `<iframe>`
* Also set the content width for the embed query so the returned default dimensions are large enough.

### Testing instructions

* Add a featured video in a lesson, and add a Vimeo video inside
* 
* Open the page in the frontend using the 'Video' LM template
* Check that the video doesn't have extra whitespace above and below. Also check the same after resizing the page
