### PR TITLE
Fix template selector in lesson editor

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -118,9 +118,9 @@ class Sensei_Course_Theme_Option {
 	 */
 	public static function should_use_learning_mode() {
 
-		$is_course_content = is_singular( 'lesson' ) || is_singular( 'quiz' ) || is_tax( 'module' );
+		$is_course_content = is_singular( [ 'lesson', 'quiz' ] ) || is_tax( 'module' );
 
-		if ( ! $is_course_content ) {
+		if ( ! $is_course_content && ! is_admin() ) {
 			return false;
 		}
 
@@ -132,14 +132,7 @@ class Sensei_Course_Theme_Option {
 
 		$course_id = absint( $course_id );
 
-		if (
-			self::has_learning_mode_enabled( $course_id ) ||
-			Sensei_Course_Theme::is_preview_mode( $course_id )
-		) {
-			return true;
-		}
-
-		return false;
+		return self::has_learning_mode_enabled( $course_id ) || Sensei_Course_Theme::is_preview_mode( $course_id );
 	}
 
 

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -238,7 +238,7 @@ class Sensei_Course_Theme_Templates {
 	 */
 	public function add_course_theme_block_templates( $templates, $query, $template_type ) {
 
-		if ( 'wp_template' !== $template_type ) {
+		if ( 'wp_template' !== $template_type || $query['wp_id'] ) {
 			return $templates;
 		}
 

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -68,8 +68,8 @@ class Sensei_Course_Theme_Templates {
 		add_action( 'admin_init', [ $this, 'maybe_add_theme_supports' ] );
 		add_filter( 'get_block_templates', [ $this, 'add_course_theme_block_templates' ], 10, 3 );
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_single_block_template' ], 10, 3 );
-		add_filter( 'theme_lesson_templates', [ $this, 'add_lesson_template' ], 10, 4 );
-		add_filter( 'theme_quiz_templates', [ $this, 'add_quiz_template' ], 10, 4 );
+		add_filter( 'theme_lesson_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
+		add_filter( 'theme_quiz_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
 
 	}
 
@@ -101,39 +101,22 @@ class Sensei_Course_Theme_Templates {
 	}
 
 	/**
-	 * Add learning mode templates to theme lesson templates.
+	 * Add learning mode templates to theme templates for quizzes and lessons.
+	 *
+	 * @access private
 	 *
 	 * @param string[]     $post_templates Array of template header names keyed by the template file name.
 	 * @param WP_Theme     $theme          The theme object.
 	 * @param WP_Post|null $post           The post being edited, provided for context, or null.
 	 * @param string       $post_type      Post type to get the templates for.
 	 */
-	public function add_lesson_template( $post_templates, $theme, $post, $post_type ) {
-		if ( 'lesson' !== $post_type ) {
+	public function add_learning_mode_template( $post_templates, $theme, $post, $post_type ) {
+		if ( ! Sensei_Course_Theme_Option::should_use_learning_mode() ) {
 			return $post_templates;
 		}
 
 		$this->load_file_templates();
-		$post_templates[ $this->file_templates['lesson']['slug'] ] = $this->file_templates['lesson']['title'];
-
-		return $post_templates;
-	}
-
-	/**
-	 * Add learning mode templates to theme quiz templates.
-	 *
-	 * @param string[]     $post_templates Array of template header names keyed by the template file name.
-	 * @param WP_Theme     $theme          The theme object.
-	 * @param WP_Post|null $post           The post being edited, provided for context, or null.
-	 * @param string       $post_type      Post type to get the templates for.
-	 */
-	public function add_quiz_template( $post_templates, $theme, $post, $post_type ) {
-		if ( 'quiz' !== $post_type ) {
-			return $post_templates;
-		}
-
-		$this->load_file_templates();
-		$post_templates[ $this->file_templates['quiz']['slug'] ] = $this->file_templates['quiz']['title'];
+		$post_templates[ $this->file_templates[ $post_type ]['slug'] ] = $this->file_templates[ $post_type ]['title'];
 
 		return $post_templates;
 	}

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -242,7 +242,7 @@ class Sensei_Course_Theme_Templates {
 			return $templates;
 		}
 
-		if ( $this->should_hide_lesson_template( $query['post_type'] ) ) {
+		if ( $this->should_hide_lesson_template( $query['post_type'] ?? null ) ) {
 			return $templates;
 		}
 

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -65,6 +65,7 @@ class Sensei_Course_Theme_Templates {
 
 		// The below hooks enable block theme support and inject the learning mode templates.
 		add_action( 'template_redirect', [ $this, 'maybe_use_course_theme_templates' ], 1 );
+		add_action( 'admin_init', [ $this, 'maybe_add_theme_supports' ] );
 		add_filter( 'get_block_templates', [ $this, 'add_course_theme_block_templates' ], 10, 3 );
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_single_block_template' ], 10, 3 );
 		add_filter( 'theme_lesson_templates', [ $this, 'add_lesson_template' ], 10, 4 );
@@ -75,6 +76,8 @@ class Sensei_Course_Theme_Templates {
 
 	/**
 	 * Use course theme if it's enabled for the current lesson or quiz.
+	 *
+	 * @access private
 	 */
 	public function maybe_use_course_theme_templates() {
 		if ( Sensei_Course_Theme_Option::should_use_learning_mode() ) {
@@ -82,6 +85,18 @@ class Sensei_Course_Theme_Templates {
 			add_filter( 'single_template_hierarchy', [ $this, 'set_single_template_hierarchy' ] );
 			add_theme_support( 'block-templates' );
 			add_theme_support( 'align-wide' );
+		}
+	}
+
+	/**
+	 * Add block template supports in admin.
+	 *
+	 * @access private
+	 */
+	public function maybe_add_theme_supports() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Argument cast to int and used for comparison.
+		if ( isset( $_GET['post'] ) && in_array( get_post_type( (int) $_GET['post'] ), [ 'lesson', 'quiz' ], true ) ) {
+			add_theme_support( 'block-templates' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #5817, #5821

### Changes proposed in this Pull Request

* Adds block template support for lesson pages.
* Hides the LM template for lessons that have LM disabled.
* As the template comes from a REST request which hasn't post id available, the only way to get the lesson id is by using HTTP referrer.

### Testing instructions
- Use a non block-based theme and open a lesson.
- Observe that the 'New' and 'Edit' links appear
- Disable LM in a course and open one of its lessons.
- Observe that the LM template does not exist in the selector.
- Open a post and try to create a new template using a block-based theme.
- Observe that the new template is created and opened in the template editor.