### PR TITLE
Learning Mode - Keep Featured Video block always on top

### DIFF
--- a/assets/blocks/featured-video/index.js
+++ b/assets/blocks/featured-video/index.js
@@ -1,14 +1,11 @@
 /**
  * WordPress dependencies
  */
+import { useRef, useEffect } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-/**
- * External dependencies
- */
-import { useRef, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -29,7 +26,9 @@ export default {
 	),
 	...metadata,
 	edit: function EditBlock( { className, clientId } ) {
-		const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+		const { replaceInnerBlocks, moveBlockToPosition } = useDispatch(
+			'core/block-editor'
+		);
 		const innerBlockCount = useSelect(
 			( select ) =>
 				select( 'core/block-editor' ).getBlocks( clientId ).length
@@ -45,6 +44,36 @@ export default {
 			}
 			previousBlockCount.current = innerBlockCount;
 		}, [ innerBlockCount, clientId, replaceInnerBlocks ] );
+
+		const { parentBlocks, rootClientId, blockIndex } = useSelect(
+			( select ) => {
+				const {
+					getBlockParents,
+					getBlockRootClientId,
+					getBlockIndex,
+				} = select( 'core/block-editor' );
+				return {
+					parentBlocks: getBlockParents( clientId ),
+					rootClientId: getBlockRootClientId( clientId ),
+					blockIndex: getBlockIndex( clientId ),
+				};
+			},
+			[ clientId ]
+		);
+
+		// Move Featured Video block to top at top level.
+		useEffect( () => {
+			if ( parentBlocks?.length || blockIndex ) {
+				moveBlockToPosition( clientId, rootClientId, '', 0 );
+			}
+		}, [
+			parentBlocks,
+			rootClientId,
+			blockIndex,
+			moveBlockToPosition,
+			clientId,
+		] );
+
 		return (
 			<div className={ className }>
 				{


### PR DESCRIPTION
Fixes #5775 

### Changes proposed in this Pull Request

* Moves the Featured Video block to top and to top level if it detects a parent or if it detects it's position index is not `0`.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Open Lesson editor.
* Try adding Featured Video in the middle of the lesson content.
* Try adding Featured Video as inner block to some other block.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/2578542/193071312-73a53ad9-94df-43ef-98b1-07fb33e4e668.mp4

