### PR TITLE
Learning Mode - Fix non-video lessons for Video templates.

### DIFF
--- a/includes/blocks/course-theme/class-ui.php
+++ b/includes/blocks/course-theme/class-ui.php
@@ -31,10 +31,44 @@ class Ui {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/ui',
 			[
-				'style'       => 'sensei-learning-mode',
-				'editorStyle' => 'sensei-learning-mode-editor',
+				'style'           => 'sensei-learning-mode',
+				'editorStyle'     => 'sensei-learning-mode-editor',
+				'render_callback' => [ $this, 'render' ],
 			],
 			$block_json_path
 		);
+	}
+
+	/**
+	 * Renders the UI block.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content The block content.
+	 */
+	public function render( array $attributes, string $content ): string {
+		$element_class = $attributes['elementClass'] ?? '';
+
+		switch ( $element_class ) {
+			case 'sensei-course-theme__video-container':
+				return $this->render_video_container( $attributes, $content );
+			default:
+				return $content;
+		}
+	}
+
+	/**
+	 * Renders the video container variation of the UI block.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content The block content.
+	 */
+	public function render_video_container( array $attributes, string $content ) {
+		$post = get_post();
+
+		if ( ! has_block( 'sensei-lms/featured-video', $post ) ) {
+			$content = str_replace( 'sensei-course-theme__video-container', 'sensei-course-theme__video-container no-video', $content );
+		}
+
+		return $content;
 	}
 }


### PR DESCRIPTION
Fixes #5774 

### Changes proposed in this Pull Request

* Updates the render logic for `sensei-lms/ui` block. When it detects that it is a "video-container" variation and there is no featured video in the lesson it replaces `sensei-course-theme__video-container` with `sensei-course-theme__video-container no-video` in the block content.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Activate Learning Mode **Video** template.
* Open a lesson that does not have a featured video in it.
* Confirm that the sidebar is aligned to the right and everything works properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

### Before
<img width="1877" alt="before" src="https://user-images.githubusercontent.com/2578542/193215569-587b813a-7054-4cba-9924-aaa1e688bbfa.png">

### After
<img width="1878" alt="after" src="https://user-images.githubusercontent.com/2578542/193215581-61822b90-feb4-4bad-949d-7380d0701cfd.png">

