### PR TITLE
Add configure learning mode task

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,6 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
 jQuery( document ).ready( function ( $ ) {
 	/***** Settings Tabs *****/
-	$senseiSettings = $( '#woothemes-sensei.sensei-settings' );
+	const $senseiSettings = $( '#woothemes-sensei.sensei-settings' );
 
 	function hideAllSections() {
 		$senseiSettings.find( 'section' ).hide();
@@ -13,6 +18,7 @@ jQuery( document ).ready( function ( $ ) {
 			.find( `[href="#${ sectionId }"]` )
 			.addClass( 'current' );
 		sensei_log_event( 'settings_view', { view: sectionId } );
+		markSectionAsVisited( sectionId );
 	}
 
 	// Hide header and submit on page load if needed
@@ -70,6 +76,14 @@ jQuery( document ).ready( function ( $ ) {
 		show( sectionId );
 		return false;
 	} );
+
+	function markSectionAsVisited( sectionId ) {
+		const data = new FormData();
+		data.append( 'action', 'sensei_settings_section_visited' );
+		data.append( 'sectionId', sectionId );
+		data.append( 'nonce', window.sensei_settings_section_visit_nonce );
+		fetch( ajaxurl, { method: 'POST', body: data } );
+	}
 
 	/***** Colour pickers *****/
 

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -75,8 +75,8 @@ jQuery( document ).ready( function ( $ ) {
 	function markSectionAsVisited( sectionId ) {
 		const data = new FormData();
 		data.append( 'action', 'sensei_settings_section_visited' );
-		data.append( 'sectionId', sectionId );
-		data.append( 'nonce', window.sensei_settings_section_visit_nonce );
+		data.append( 'section_id', sectionId );
+		data.append( 'nonce', window.senseiSettingsSectionVisitNonce );
 		fetch( ajaxurl, { method: 'POST', body: data } );
 	}
 

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,8 +1,3 @@
-/**
- * WordPress dependencies
- */
-import apiFetch from '@wordpress/api-fetch';
-
 jQuery( document ).ready( function ( $ ) {
 	/***** Settings Tabs *****/
 	const $senseiSettings = $( '#woothemes-sensei.sensei-settings' );

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -29,6 +29,7 @@ class Sensei_Home_Tasks_Provider {
 		// TODO Implement the logic for this.
 		return [
 			new Sensei_Home_Task_Setup_Site(),
+			new Sensei_Home_Task_Configure_Learning_Mode(),
 		];
 	}
 

--- a/includes/admin/home/tasks/task/class-sensei-home-task-configure-learning-mode.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-configure-learning-mode.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * File containing the Sensei_Home_Task_Configure_Learning_Mode class.
+ *
+ * @package sensei-lms
+ * @since $$next-version$$
+ */
+
+/**
+ * Sensei_Home_Task_Configure_Learning_Mode class.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Home_Task_Configure_Learning_Mode implements Sensei_Home_Task {
+
+	const VISITED_SETTING_SECTIONS_OPTION_KEY = 'sensei-settings-sections-visited';
+
+	/**
+	 * The ID for the task.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'configure-learning-mode';
+	}
+
+	/**
+	 * Number used to sort in frontend.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return 200;
+	}
+
+	/**
+	 * Task title.
+	 *
+	 * @return string
+	 */
+	public function get_title(): string {
+		return __( 'Configure Learning Mode', 'sensei-lms' );
+	}
+
+	/**
+	 * Task url.
+	 *
+	 * @return string
+	 */
+	public function get_url(): ?string {
+		return admin_url( 'edit.php?post_type=course&page=sensei-settings#appearance-settings' );
+	}
+
+	/**
+	 * Task image.
+	 *
+	 * @return string|null
+	 */
+	public function get_image(): ?string {
+		// TODO Add image path.
+		return null;
+	}
+
+	/**
+	 * Whether the task is completed or not.
+	 *
+	 * @return bool
+	 */
+	public function is_completed(): bool {
+		return in_array( 'appearance-settings', get_site_option( self::VISITED_SETTING_SECTIONS_OPTION_KEY, [] ), true );
+	}
+}

--- a/includes/admin/home/tasks/task/class-sensei-home-task-configure-learning-mode.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-configure-learning-mode.php
@@ -13,8 +13,6 @@
  */
 class Sensei_Home_Task_Configure_Learning_Mode implements Sensei_Home_Task {
 
-	const VISITED_SETTING_SECTIONS_OPTION_KEY = 'sensei-settings-sections-visited';
-
 	/**
 	 * The ID for the task.
 	 *
@@ -67,6 +65,7 @@ class Sensei_Home_Task_Configure_Learning_Mode implements Sensei_Home_Task {
 	 * @return bool
 	 */
 	public function is_completed(): bool {
-		return in_array( 'appearance-settings', get_site_option( self::VISITED_SETTING_SECTIONS_OPTION_KEY, [] ), true );
+		$visited_settings_sections = get_site_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY, [] );
+		return in_array( 'appearance-settings', $visited_settings_sections, true );
 	}
 }

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -87,6 +87,7 @@ class Sensei_Data_Cleaner {
 		'sensei_dismiss_wcpc_prompt',
 		'sensei-cancelled-wccom-connect-dismissed',
 		'sensei_course_theme_query_var_flushed',
+		'sensei_settings_sections_visited',
 	);
 
 	/**

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -15,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Settings extends Sensei_Settings_API {
 
+	const VISITED_SECTIONS_OPTION_KEY = 'sensei_settings_sections_visited';
+
 	/**
 	 * Constructor.
 	 *
@@ -45,6 +47,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Make sure we don't trigger queries if legacy options aren't loaded in pre-loaded options.
 		add_filter( 'alloptions', [ $this, 'no_special_query_for_legacy_options' ] );
 
+		// Mark settings section as visited on ajax action received.
+		add_action( 'wp_ajax_sensei_settings_section_visited', [ $this, 'mark_section_as_visited' ] );
 	}
 
 	/**
@@ -936,6 +940,36 @@ class Sensei_Settings extends Sensei_Settings_API {
 			</p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Enqueue javascript.
+	 */
+	public function enqueue_scripts() {
+		parent::enqueue_scripts();
+
+		// Generate nonce for marking section visited action.
+		wp_add_inline_script(
+			'sensei-settings',
+			'window.sensei_settings_section_visit_nonce  = "' . wp_create_nonce( 'sensei-mark-settings-section-visited' ) . '";',
+			'before'
+		);
+	}
+
+	/**
+	 * Marks the given section as visited.
+	 */
+	public function mark_section_as_visited() {
+		if ( isset( $_POST['nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'sensei-mark-settings-section-visited' ) ) {
+			if ( isset( $_POST['sectionId'] ) ) {
+				$section_id = sanitize_key( $_POST['sectionId'] );
+				$visited    = get_option( self::VISITED_SECTIONS_OPTION_KEY, [] );
+				if ( ! in_array( $section_id, $visited, true ) ) {
+					$visited[] = $section_id;
+					update_option( self::VISITED_SECTIONS_OPTION_KEY, $visited );
+				}
+			}
+		}
 	}
 }
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -951,7 +951,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Generate nonce for marking section visited action.
 		wp_add_inline_script(
 			'sensei-settings',
-			'window.sensei_settings_section_visit_nonce  = "' . wp_create_nonce( 'sensei-mark-settings-section-visited' ) . '";',
+			'window.senseiSettingsSectionVisitNonce  = "' . wp_create_nonce( 'sensei-mark-settings-section-visited' ) . '";',
 			'before'
 		);
 	}
@@ -961,8 +961,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 */
 	public function mark_section_as_visited() {
 		if ( isset( $_POST['nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'sensei-mark-settings-section-visited' ) ) {
-			if ( isset( $_POST['sectionId'] ) ) {
-				$section_id = sanitize_key( $_POST['sectionId'] );
+			if ( isset( $_POST['section_id'] ) ) {
+				$section_id = sanitize_key( $_POST['section_id'] );
 				$visited    = get_option( self::VISITED_SECTIONS_OPTION_KEY, [] );
 				if ( ! in_array( $section_id, $visited, true ) ) {
 					$visited[] = $section_id;

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
@@ -26,7 +26,7 @@ class Sensei_Home_Task_Configure_Learning_Mode_Test extends WP_UnitTestCase {
 	}
 
 	public function tearDown() {
-		delete_site_option( Sensei_Home_Task_Configure_Learning_Mode::VISITED_SETTING_SECTIONS_OPTION_KEY );
+		delete_site_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY );
 		parent::tearDown();
 	}
 
@@ -42,7 +42,7 @@ class Sensei_Home_Task_Configure_Learning_Mode_Test extends WP_UnitTestCase {
 	 * Test adding the proper option marks task as complete.
 	 */
 	public function testTaskIsCompletedWhenAddingTheSettingsVisitedOption() {
-		add_site_option( Sensei_Home_Task_Configure_Learning_Mode::VISITED_SETTING_SECTIONS_OPTION_KEY, [ 'appearance-settings' ] );
+		add_site_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY, [ 'appearance-settings' ] );
 
 		$this->assertTrue( $this->task->is_completed() );
 	}

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file contains the Sensei_Home_Task_Configure_Learning_Mode_Test class.
+ *
+ * @package sensei
+ */
+
+
+/**
+ * Tests for Sensei_Home_Task_Configure_Learning_Mode class.
+ *
+ * @covers Sensei_Home_Task_Configure_Learning_Mode
+ */
+class Sensei_Home_Task_Configure_Learning_Mode_Test extends WP_UnitTestCase {
+
+	/**
+	 * The task under test.
+	 *
+	 * @var Sensei_Home_Task_Configure_Learning_Mode
+	 */
+	private $task;
+
+	public function setUp() {
+		parent::setUp();
+		$this->task = new Sensei_Home_Task_Configure_Learning_Mode();
+	}
+
+	public function tearDown() {
+		delete_site_option( Sensei_Home_Task_Configure_Learning_Mode::VISITED_SETTING_SECTIONS_OPTION_KEY );
+		parent::tearDown();
+	}
+
+
+	/**
+	 * Test task is not completed by default.
+	 */
+	public function testTaskIsNotCompletedByDefault() {
+		$this->assertFalse( $this->task->is_completed() );
+	}
+
+	/**
+	 * Test adding the proper option marks task as complete.
+	 */
+	public function testTaskIsCompletedWhenAddingTheSettingsVisitedOption() {
+		add_site_option( Sensei_Home_Task_Configure_Learning_Mode::VISITED_SETTING_SECTIONS_OPTION_KEY, [ 'appearance-settings' ] );
+
+		$this->assertTrue( $this->task->is_completed() );
+	}
+}

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -37,7 +37,16 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( Sensei_Home_Tasks::class, $tasks );
 		$items = $tasks->get_items();
 		$this->assertIsArray( $items );
-		$this->assertCount( 1, $items, 'At the moment only one task is expected.' );
-		$this->assertInstanceOf( Sensei_Home_Task_Setup_Site::class, $items[0] );
+		$this->assertTrue( $this->containsInstanceOf( $items, Sensei_Home_Task_Setup_Site::class ), 'Setup Site task must be returned.' );
+		$this->assertTrue( $this->containsInstanceOf( $items, Sensei_Home_Task_Configure_Learning_Mode::class ), 'Configure Learning Mode task must be returned' );
+	}
+
+	private function containsInstanceOf( $items, $class ) {
+		foreach ( $items as $item ) {
+			if ( $item instanceof $class ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
Fixes #5637 

### Changes proposed in this Pull Request
* [x] Added new `Sensei_Home_Task_Configure_Learning_Mode` task.
* [x] Check completion by checking a site option.
* [x] Add option when visiting the appearance setting page.
* [x] Support multisite.
* [x] Cleanup new options on uninstall.

### Testing instructions
- Check that "Configure Learning Mode" task is returned in: `curl -s -X GET --user aaron:development --insecure 'https://test2.local/wp-json/sensei-internal/v1/home' | jq .tasks`.
- Confirm that task has "done" as `false` by default.
- Confirm that after visiting the Appearance setting section "done" attribute is returned as true.

### Screenshot / Video

https://user-images.githubusercontent.com/799065/193595460-cdda8d12-0b0e-4a5b-bbfd-8d6592609304.mov

