### PR TITLE
Fix/remove warning

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -238,7 +238,7 @@ class Sensei_Course_Theme_Templates {
 	 */
 	public function add_course_theme_block_templates( $templates, $query, $template_type ) {
 
-		if ( 'wp_template' !== $template_type || $query['wp_id'] ) {
+		if ( 'wp_template' !== $template_type || ! empty( $query['wp_id'] ) ) {
 			return $templates;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fixes a warning in case 'wp_id' is not defined.

### Testing instructions

* Open the lesson editor page and make sure that no warnings are printed.
* Go to a post, click 'New' in template selector, create a temlpate, and make sure that it works as it should.
