### PR TITLE
Learning Mode - Add support for Featured Video block transformations.

### DIFF
--- a/assets/blocks/featured-video/index.js
+++ b/assets/blocks/featured-video/index.js
@@ -11,6 +11,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import metadata from './block.json';
+import { transforms } from './transforms';
+
 const FEATURED_VIDEO_TEMPLATE = [ [ 'core/video' ] ];
 const ALLOWED_BLOCKS = [
 	'core/embed',
@@ -89,4 +91,5 @@ export default {
 	save: () => {
 		return <InnerBlocks.Content />;
 	},
+	transforms,
 };

--- a/assets/blocks/featured-video/transforms.js
+++ b/assets/blocks/featured-video/transforms.js
@@ -8,11 +8,6 @@ import { createBlock } from '@wordpress/blocks';
  */
 import blockMeta from './block.json';
 
-const transformFrom = ( blockName, attributes, innerBlocks ) =>
-	createBlock( blockMeta.name, {}, [
-		createBlock( blockName, attributes, innerBlocks ),
-	] );
-
 export const transforms = {
 	from: [ 'core/video', 'core/embed', 'sensei-pro/interactive-video' ].map(
 		( blockName ) => ( {
@@ -23,7 +18,9 @@ export const transforms = {
 				if ( 'core/embed' === name && ! attributes.providerNameSlug ) {
 					name = 'core/video';
 				}
-				return transformFrom( name, attributes, innerBlocks );
+				return createBlock( blockMeta.name, {}, [
+					createBlock( name, attributes, innerBlocks ),
+				] );
 			},
 		} )
 	),

--- a/assets/blocks/featured-video/transforms.js
+++ b/assets/blocks/featured-video/transforms.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import blockMeta from './block.json';
+
+const transformFrom = ( blockName, attributes, innerBlocks ) =>
+	createBlock( blockMeta.name, {}, [
+		createBlock( blockName, attributes, innerBlocks ),
+	] );
+
+export const transforms = {
+	from: [ 'core/video', 'core/embed', 'sensei-pro/interactive-video' ].map(
+		( blockName ) => ( {
+			type: 'block',
+			blocks: [ blockName ],
+			transform: ( attributes = {}, innerBlocks = [] ) => {
+				let name = blockName;
+				if ( 'core/embed' === name && ! attributes.providerNameSlug ) {
+					name = 'core/video';
+				}
+				return transformFrom( name, attributes, innerBlocks );
+			},
+		} )
+	),
+
+	to: [ 'core/video', 'core/embed', 'sensei-pro/interactive-video' ].map(
+		( blockName ) => ( {
+			type: 'block',
+
+			blocks: [ blockName ],
+
+			isMatch: ( _, block = {} ) =>
+				blockName === block.innerBlocks?.[ 0 ]?.name,
+
+			transform: ( _, inner = [] ) => {
+				const { attributes = {}, innerBlocks = [] } = inner[ 0 ] || {};
+				return createBlock( blockName, attributes, innerBlocks );
+			},
+		} )
+	),
+};


### PR DESCRIPTION
Fixes #5826 

### Changes proposed in this Pull Request

* Adds block transformation support to and from Featured Video block.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Open a lesson editor.
* Insert one of Video, Vimeo, YouTube, VideoPress or Interactive Video blocks and try transforming them into Featured Video and back from Featured Video block to their respective block types.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/2578542/193269568-74660c06-9dda-4da3-86ad-d9603b695359.mp4

