### PR TITLE
Remove the check so that meta data can be saved again

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -635,11 +635,6 @@ class Sensei_Lesson {
 	 */
 	public function meta_box_save( $post_id ) {
 
-		// This should only run on the Classic Editor.
-		if ( Sensei()->quiz->is_block_based_editor_enabled() ) {
-			return false;
-		}
-
 		// Verify the nonce before proceeding.
 		if ( ( get_post_type( $post_id ) !== $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_nonce' ], 'sensei-save-post-meta' ) ) {
 			return $post_id;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* I had added this check in https://github.com/Automattic/sensei/pull/5678 because of a bug with how post meta was being saved.  This was just an additional layer of caution but it prevented other postmeta from being saved, so I'm removing it.  

### Testing instructions

* Enable this PR
* Go to a Lesson
* Try to change the course that it's in
* Verify that the course was changed properly