### PR TITLE
Fix/message sent notice

### DIFF
--- a/assets/css/sensei-course-theme/blocks/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/blocks/contact-teacher.scss
@@ -35,7 +35,6 @@
 
 	.sensei-contact-teacher-success {
 		font-family: inherit;
-		display: block;
 		position: absolute;
 		top: -5px;
 		right: -5px;

--- a/assets/css/sensei-course-theme/blocks/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/blocks/contact-teacher.scss
@@ -75,6 +75,7 @@
 			.sensei-contact-teacher-success {
 				z-index: 1;
 				opacity: 1;
+				display: flex;
 
 		}
 	}


### PR DESCRIPTION
Fixes #5840

### Changes proposed in this Pull Request

* Adds a `display: flex` property to the message sent notice.

### Testing instructions

* Go to LM Mode,
* Click Contact Teacher
* Send Message
* Make sure you see this:

<img width="586" alt="Screen Shot 2022-10-03 at 10 04 33 AM" src="https://user-images.githubusercontent.com/3220162/193636458-f4919c46-a4c4-4298-b947-74185e7510a1.png">