### PR TITLE
Fix lesson complete overlay width

### DIFF
--- a/assets/css/sensei-course-theme/lesson-complete-transition.scss
+++ b/assets/css/sensei-course-theme/lesson-complete-transition.scss
@@ -14,6 +14,7 @@
 	justify-content: center;
 	align-items: center;
 	background-color: var(--sensei-background-color);
+	max-width: var(--content-size) fit-content !important;
 
 	&__text {
 		margin: 25px 0;


### PR DESCRIPTION
Fixes #5834

### Changes proposed in this Pull Request

* Adds a max-width property to the Lesson Overlay so that the width matches the size of the lesson container.

### Testing instructions

* To make this a bit easier, you can disable this: https://github.com/Automattic/sensei/blob/ebcbc6112654e85db00edb71685cf0fdf7a8aacd/assets/course-theme/complete-lesson-button.js#L46 so that the form won't submit
* Go to a Lesson in Learning Mode
* Make sure the lesson has some Numbered Lists
* Click "Complete Lesson" 
* Make sure the numbered list doesn't show

Before:
<img width="808" alt="Screen Shot 2022-10-03 at 10 25 42 AM" src="https://user-images.githubusercontent.com/3220162/193640386-d5a4c0e1-3313-450c-b0f4-a5b4bee6f8d3.png">

After:
<img width="866" alt="Screen Shot 2022-10-03 at 10 26 02 AM" src="https://user-images.githubusercontent.com/3220162/193640456-6cd44456-ed00-463b-bf8c-1dc31e1a0ca3.png">
