### PR TITLE
Remove filter from unit test that is no longer needed.

### DIFF
--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1568,9 +1568,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
 		$lesson              = new Sensei_Lesson();
 		$lesson->meta_fields = [ 'lesson_video_embed', 'lesson_preview', 'lesson_length' ];
-
-		// We need to enable this filter so that meta_box_save can properly run.
-		add_filter( 'sensei_quiz_enable_block_based_editor', '__return_false' );
+		
 		/* Act */
 		$lesson->meta_box_save( $post->ID );
 

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1568,7 +1568,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
 		$lesson              = new Sensei_Lesson();
 		$lesson->meta_fields = [ 'lesson_video_embed', 'lesson_preview', 'lesson_length' ];
-		
+
 		/* Act */
 		$lesson->meta_box_save( $post->ID );
 


### PR DESCRIPTION
Previously in https://github.com/Automattic/sensei/pull/5678 I added this filter because we had an added check for `is_block_based_editor_enabled` in the `meta_box_save` method.  That caused other problems so I've removed it.  This just cleans up the Unit Test.