### PR TITLE
Handle logged out users for video lessons

### DIFF
--- a/assets/css/sensei-course-theme/video-container.scss
+++ b/assets/css/sensei-course-theme/video-container.scss
@@ -73,7 +73,7 @@
 		/**
 		 * Fixed right sidebar mode when there is no video.
 		 */
-		&__video-container.no-video {
+		body:not(.sensei-video-lesson) &__video-container {
 			width: var(--sidebar-width);
 			justify-content: flex-end;
 			position: fixed;

--- a/includes/blocks/course-theme/class-lesson-video.php
+++ b/includes/blocks/course-theme/class-lesson-video.php
@@ -13,7 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use \Sensei_Blocks;
-use \Sensei_Course;
 use \Sensei_Utils;
 use \Sensei_Frontend;
 
@@ -48,15 +47,18 @@ class Lesson_Video {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render() : string {
+	public function render(): string {
 
-		if ( ! sensei_can_user_view_lesson() ) {
-			return '';
-		}
+		$video = sensei_can_user_view_lesson() ? Sensei_Utils::get_featured_video_html() : null;
 
-		$content = Sensei_Utils::get_featured_video_html() ?? '';
-
-		if ( empty( $content ) ) {
+		if ( ! empty( $video ) ) {
+			add_filter(
+				'body_class',
+				function( $classes ) {
+					return array_merge( $classes, [ 'sensei-video-lesson' ] );
+				}
+			);
+		} else {
 			return '';
 		}
 
@@ -74,7 +76,7 @@ class Lesson_Video {
 		return sprintf(
 			'<div %1s>%2s</div>',
 			$wrapper_attr,
-			trim( $content )
+			trim( $video )
 		);
 	}
 }

--- a/includes/blocks/course-theme/class-ui.php
+++ b/includes/blocks/course-theme/class-ui.php
@@ -48,27 +48,10 @@ class Ui {
 	public function render( array $attributes, string $content ): string {
 		$element_class = $attributes['elementClass'] ?? '';
 
+		// Add variation-specific rendering here.
 		switch ( $element_class ) {
-			case 'sensei-course-theme__video-container':
-				return $this->render_video_container( $attributes, $content );
 			default:
 				return $content;
 		}
-	}
-
-	/**
-	 * Renders the video container variation of the UI block.
-	 *
-	 * @param array  $attributes The block attributes.
-	 * @param string $content The block content.
-	 */
-	public function render_video_container( array $attributes, string $content ) {
-		$post = get_post();
-
-		if ( ! has_block( 'sensei-lms/featured-video', $post ) ) {
-			$content = str_replace( 'sensei-course-theme__video-container', 'sensei-course-theme__video-container no-video', $content );
-		}
-
-		return $content;
 	}
 }


### PR DESCRIPTION

We need to change the video container block to a 'no-video' mode even when there is a video in the lesson, but the user cannot see it, for example because they are logged out. 

This updates the video detection to be the same logic as the video rendering, and moves to a more generic global class `sensei-video-lesson`.

### Changes proposed in this Pull Request

* In the Lesson Video block, add a 'sensei-video-lesson' class if the video is being rendered
* Use this class in the Video Container block to change the sidebar mode

### Testing instructions

* Use the 'Video' template
* View lessons with and without a featured video, as an enrolled student and as a guest
* The video or sidebar should show up correctly

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Video visible

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/176949/193905400-f1e1555e-70c7-421d-a52c-89142a5e14d5.png">

#### Video not visible

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/176949/193905419-bbd8f3b0-908f-4462-886f-e673da1f9056.png">

