### PR TITLE
Retrieve data from native WordPress

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -138,10 +138,11 @@ class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
 	 * @param WP_REST_Request $request  Full details about the request.
 	 * @return array Modified data object with additional fields.
 	 */
-	protected function add_additional_fields_to_object( $prepared, $request ) {
-		global $pagenow;
+protected function add_additional_fields_to_object( $prepared, $request ) {
 
-		if ( ! Sensei()->quiz->is_block_based_editor_enabled() || 'post-new.php' === $pagenow ) {
+                $prepared = parent::add_additional_fields_to_object( $prepared, $request );
+
+		if ( ! Sensei()->quiz->is_block_based_editor_enabled() ) {
 			return $prepared;
 		}
 


### PR DESCRIPTION
Hello,

I'm Sebastien from Polylang Pro helpdesk.
We have several common customer/user and they fall in an error with Sensei LMS lessons and Polylang Pro.

We're adding in the WordPress block editor a custom metabox to allow our customer managing the CPT languages. Actually, your code is overriding default WordPress data we're using.

This PR retrieve the WordPress method to merge them with your data.

Thank you

