### PR TITLE
Remove empty style block

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -331,7 +331,12 @@ class Sensei_Course_Theme_Templates {
 							}
 						}
 					}
-					$template_object->content = $html . Template_Style::serialize_block( $css );
+
+					$template_object->content = $html;
+
+					if ( ! empty( $css ) ) {
+						$template_object->content .= Template_Style::serialize_block( $css );
+					}
 				}
 				$template_object->wp_id  = null;
 				$template_object->author = null;


### PR DESCRIPTION
Fixes #5858

### Changes proposed in this Pull Request
- Adds the Template STyle block only if there is CSS to add to it
- This block was useful to exist when every template had its own CSS but now all CSS was moved to individual blocks and it's not needed anymore.

### Testing instructions
- Open a template and make sure that there is no Template Style block with no CSS in it.