### PR TITLE
Fix content padding on mobile

### DIFF
--- a/assets/css/sensei-course-theme/4-0-2/layout.scss
+++ b/assets/css/sensei-course-theme/4-0-2/layout.scss
@@ -114,7 +114,7 @@ body.sensei-course-theme {
 	}
 
 	&__main-content {
-		padding: 32px 0;
+		padding: 32px var(--content-padding);
 		margin-right: var(--sidebar-width) !important;
 
 		// A Divi fix since it doesn't load Gutenberg block library styles.

--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -12,8 +12,9 @@ body {
 	--wp--custom--layout--wide-size: 1100px;
 	--wp--style--root--padding-top: 0px !important;
 	--wp--style--root--padding-bottom: 0px;
+	--wp--custom--gap--horizontal: var(--content-padding, 24px);
 
-	--max-content-size: calc(100vw - var(--content-padding));
+	--max-content-size: 100vw;
 	--content-size: min(var(--wp--custom--layout--content-size), var(--max-content-size));
 	--wide-size: min(var(--wp--custom--layout--wide-size), var(--max-content-size));
 
@@ -27,6 +28,10 @@ body {
 .wp-block-post-title {
 	margin-top: 20px!important;
 	margin-bottom: 20px!important;
+}
+
+.wp-site-blocks {
+	padding: 0 var(--content-padding);
 }
 
 /**

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -20,7 +20,7 @@
 		}
 
 		.sensei-course-theme {
-			--content-padding: 18px;
+			--content-padding: 24px;
 
 			&__header {
 				transition: none !important;
@@ -34,7 +34,7 @@
 					gap: 12px !important;
 				}
 
-				.sensei-course-theme-prev-next-lesson-text {
+				.sensei-course-theme-prev-next-lesson-text, .wp-block-sensei-lms-exit-course {
 					display: none;
 				}
 


### PR DESCRIPTION
Fixes #5862 

### Changes proposed in this Pull Request

* Move content padding to the root block
* Ensure the legacy template's padding on main content still works

### Testing instructions

* Use the Astra theme
* View a lesson in mobile view on the Modern, Video, Large Video and Legacy templates
* Check that there is spacing around the content

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Before

<img width="530" src="https://user-images.githubusercontent.com/176949/194080020-59dbfa4c-e8e7-49ba-ba5c-53e2e1aa0444.png" />

#### After

<img width="530" alt="image" src="https://user-images.githubusercontent.com/176949/194090013-d5f40157-47a1-4bab-9c44-b4a448027e36.png">
