### PR TITLE
Update skip onboarding link to go to the Sensei Home

### DIFF
--- a/assets/setup-wizard/constants.js
+++ b/assets/setup-wizard/constants.js
@@ -1,0 +1,1 @@
+export const HOME_PATH = '/wp-admin/admin.php?page=sensei-home';

--- a/assets/setup-wizard/constants.js
+++ b/assets/setup-wizard/constants.js
@@ -1,1 +1,1 @@
-export const HOME_PATH = '/wp-admin/admin.php?page=sensei-home';
+export const HOME_PATH = 'admin.php?page=sensei-home';

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -13,13 +13,12 @@ import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import useActionsNavigator, {
 	actionMinimumTimer,
 } from './use-actions-navigator';
+import { HOME_PATH } from '../constants';
 
 const featureLabels = {
 	woocommerce: __( 'Installing WooCommerce', 'sensei-lms' ),
 	'sensei-certificates': __( 'Installing Certificates', 'sensei-lms' ),
 };
-
-const senseiHomePath = '/wp-admin/admin.php?page=sensei-home';
 
 /**
  * Get actions for the features to be installed.
@@ -77,7 +76,7 @@ const Features = () => {
 								{},
 								{
 									onSuccess: () => {
-										window.location.href = senseiHomePath;
+										window.location.href = HOME_PATH;
 										resolve();
 									},
 								}
@@ -102,7 +101,7 @@ const Features = () => {
 						actions={ [
 							{
 								label: __( 'Go to Sensei Home', 'sensei-lms' ),
-								url: senseiHomePath,
+								url: HOME_PATH,
 							},
 						] }
 					>

--- a/assets/setup-wizard/welcome/index.js
+++ b/assets/setup-wizard/welcome/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { useQueryStringRouter } from '../../shared/query-string-router';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import { H } from '../../shared/components/section';
+import { HOME_PATH } from '../constants';
 
 /**
  * Welcome step for Setup Wizard.
@@ -75,7 +76,7 @@ const Welcome = () => {
 						{ __( 'Get started', 'sensei-lms' ) }
 					</button>
 					<div className="sensei-setup-wizard__action-skip">
-						<a href="edit.php?post_type=course">
+						<a href={ HOME_PATH }>
 							{ __( 'Skip onboarding', 'sensei-lms' ) }
 						</a>
 					</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It updates the "Skip onboarding" link from the welcome step in the setup wizard to go to the new Sensei Home.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Open the Setup Wizard, in the first step, click on "Skip onboarding".
* Make sure you go to the Sensei Home page.