### PR TITLE
Fix learning mode task

### DIFF
--- a/includes/admin/home/tasks/task/class-sensei-home-task-configure-learning-mode.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-configure-learning-mode.php
@@ -65,7 +65,7 @@ class Sensei_Home_Task_Configure_Learning_Mode implements Sensei_Home_Task {
 	 * @return bool
 	 */
 	public function is_completed(): bool {
-		$visited_settings_sections = get_site_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY, [] );
+		$visited_settings_sections = get_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY, [] );
 		return in_array( 'appearance-settings', $visited_settings_sections, true );
 	}
 }

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
@@ -26,7 +26,7 @@ class Sensei_Home_Task_Configure_Learning_Mode_Test extends WP_UnitTestCase {
 	}
 
 	public function tearDown() {
-		delete_site_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY );
+		delete_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY );
 		parent::tearDown();
 	}
 
@@ -42,7 +42,7 @@ class Sensei_Home_Task_Configure_Learning_Mode_Test extends WP_UnitTestCase {
 	 * Test adding the proper option marks task as complete.
 	 */
 	public function testTaskIsCompletedWhenAddingTheSettingsVisitedOption() {
-		add_site_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY, [ 'appearance-settings' ] );
+		add_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY, [ 'appearance-settings' ] );
 
 		$this->assertTrue( $this->task->is_completed() );
 	}

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
@@ -5,6 +5,9 @@
  * @package sensei
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 /**
  * Tests for Sensei_Home_Task_Configure_Learning_Mode class.


### PR DESCRIPTION
Fixes #5870 

### Changes proposed in this Pull Request
* Add `ABSPATH` check.
* Stop using `_site_` method for option retrieval.

### Testing instructions
- Make sure the "Configure Learning Mode" task keeps working.
- `curl -s -X GET --user aaron:development 'http://test2.local/wp-json/sensei-internal/v1/home' | jq .tasks`

### Screenshot / Video
```
...
    "configure-learning-mode": {
      "id": "configure-learning-mode",
      "title": "Configure Learning Mode",
      "priority": 200,
      "url": "https://test2.local/wp-admin/edit.php?post_type=course&page=sensei-settings#appearance-settings",
      "image": null,
      "done": true
    },
...
```
