### PR TITLE
Bump the version supported to 5.9

### DIFF
--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Requires at least: 5.8
+ * Requires at least: 5.9
  * Tested up to: 6.0
  * Requires PHP: 7.2
  * Text Domain: sensei-lms


### PR DESCRIPTION
6.1 Is out in a few weeks so we’ll drop support for 5.8.  This is also important becuase for Sensei 4.7.0 we have some Learning Mode features that work best with 5.9+