### PR TITLE
Call parent method to get default values

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -141,6 +141,8 @@ class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
 	protected function add_additional_fields_to_object( $prepared, $request ) {
 		global $pagenow;
 
+		$prepared = parent::add_additional_fields_to_object( $prepared, $request );
+
 		if ( ! Sensei()->quiz->is_block_based_editor_enabled() || 'post-new.php' === $pagenow ) {
 			return $prepared;
 		}


### PR DESCRIPTION
Fixes #5890

### Changes proposed in this Pull Request

* Adds a call to the parent core method to populate the default values

### Testing instructions
* Follow the instructions in the linked issue and observe that the custom field is now included.