### PR TITLE
Add help section for Sensei Home.

### DIFF
--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -569,5 +569,38 @@ $break-medium: 783px; // adminbar goes big
 		.components-notice {
 			margin: 10px 0 0;
 		}
+
+		&__help {
+			&-category {
+				& h3 {
+					font-size: 13px;
+					line-height: 16px;
+					margin: 0;
+				}
+			}
+
+			&-item {
+				font-size: 13px;
+				display: flex;
+				flex-direction: row;
+				flex-wrap: wrap;
+
+				& a {
+					text-decoration: unset;
+				}
+
+				&__title {
+					margin-left: 16px;
+
+					&--disabled {
+						opacity: 0.6;
+					}
+				}
+
+				&__extra-link {
+					margin-left: 13px;
+				}
+			}
+		}
 	}
 }

--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -577,9 +577,10 @@ $break-medium: 783px; // adminbar goes big
 		&__help {
 			&-category {
 				& h3 {
+					color: #1E1E1E;
 					font-size: 13px;
 					line-height: 16px;
-					margin: 0;
+					margin: 14px 0 19px 0;
 				}
 			}
 
@@ -588,9 +589,17 @@ $break-medium: 783px; // adminbar goes big
 				display: flex;
 				flex-direction: row;
 				flex-wrap: wrap;
+				align-items: center;
+				margin-bottom: 18px;
 
 				& a {
 					text-decoration: unset;
+				}
+
+				&__icon {
+					display: flex;
+					flex-direction: column;
+					justify-content: center;
 				}
 
 				&__title {

--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -70,6 +70,10 @@ $break-medium: 783px; // adminbar goes big
 			cursor: unset;
 	}
 
+	.postbox .inside {
+		padding: 0 12px;
+	}
+
 	.sensei-home {
 		.components-button {
 			&.is-secondary {

--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -603,7 +603,7 @@ $break-medium: 783px; // adminbar goes big
 				}
 
 				&__title {
-					margin-left: 16px;
+					margin-left: 12px;
 
 					&--disabled {
 						opacity: 0.6;
@@ -612,6 +612,17 @@ $break-medium: 783px; // adminbar goes big
 
 				&__extra-link {
 					margin-left: 13px;
+
+					& a {
+						display: flex;
+						flex-direction: row;
+						align-items: center;
+
+						& svg {
+							fill: currentColor;
+							margin-left: 7px;
+						}
+					}
 				}
 			}
 		}

--- a/assets/home/main.js
+++ b/assets/home/main.js
@@ -17,9 +17,20 @@ import GetHelp from './sections/get-help';
 import SenseiGuides from './sections/sensei-guides';
 import LatestNews from './sections/latest-news';
 import Extensions from './sections/extensions';
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
 const Main = () => {
 	useSenseiColorTheme();
+	const [ data, setData ] = useState( {} );
+
+	useEffect( async () => {
+		const remoteData = await apiFetch( {
+			path: '/sensei-internal/v1/home',
+			method: 'GET',
+		} );
+		setData( remoteData );
+	}, [] );
 
 	/**
 	 * Filters the component that will be injected on the top of the Sensei Home
@@ -48,7 +59,7 @@ const Main = () => {
 				</Col>
 
 				<Col as="section" className="sensei-home__section" cols={ 6 }>
-					<GetHelp />
+					<GetHelp categories={ data?.help } />
 				</Col>
 
 				<SenseiProAd />

--- a/assets/home/main.js
+++ b/assets/home/main.js
@@ -25,12 +25,15 @@ const Main = () => {
 	useSenseiColorTheme();
 	const [ data, setData ] = useState( {} );
 
-	useEffect( async () => {
-		const remoteData = await apiFetch( {
-			path: '/sensei-internal/v1/home',
-			method: 'GET',
-		} );
-		setData( remoteData );
+	useEffect( () => {
+		async function fetchAndSetData() {
+			const remoteData = await apiFetch( {
+				path: '/sensei-internal/v1/home',
+				method: 'GET',
+			} );
+			setData( remoteData );
+		}
+		fetchAndSetData();
 	}, [] );
 
 	/**

--- a/assets/home/main.js
+++ b/assets/home/main.js
@@ -19,6 +19,7 @@ import LatestNews from './sections/latest-news';
 import Extensions from './sections/extensions';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import '../shared/data/api-fetch-preloaded-once';
 
 const Main = () => {
 	useSenseiColorTheme();

--- a/assets/home/sections/get-help.js
+++ b/assets/home/sections/get-help.js
@@ -14,10 +14,18 @@ import { Icon, help, lock, external } from '@wordpress/icons';
  */
 import Section from '../section';
 
+/**
+ * Component representing each of the items under a Help Category.
+ *
+ * @param {Object}      props           Component properties.
+ * @param {string}      props.title     The title.
+ * @param {string|null} props.url       Optional url. When missing the title will not be clickable.
+ * @param {Object|null} props.extraLink An extra link that will be displayed next to the main title.
+ */
 const Item = ( { title, url, extraLink } ) => {
-	const isLinkEnabled = url !== null;
+	const isTitleInteractive = url !== null;
 
-	const link = isLinkEnabled ? (
+	const link = isTitleInteractive ? (
 		<a href={ url } target="_blank" rel="noreferrer">
 			{ title }
 		</a>
@@ -28,11 +36,11 @@ const Item = ( { title, url, extraLink } ) => {
 	return (
 		<li className="sensei-home__help-item">
 			<div className="sensei-home__help-item__icon">
-				<Icon icon={ isLinkEnabled ? help : lock } size={ 16 } />
+				<Icon icon={ isTitleInteractive ? help : lock } size={ 22 } />
 			</div>
 			<div
 				className={ classNames( 'sensei-home__help-item__title', {
-					'sensei-home__help-item__title--disabled': ! isLinkEnabled,
+					'sensei-home__help-item__title--disabled': ! isTitleInteractive,
 				} ) }
 			>
 				{ link }
@@ -49,6 +57,13 @@ const Item = ( { title, url, extraLink } ) => {
 	);
 };
 
+/**
+ * Help Category component. It's composed by a title and a list of items.
+ *
+ * @param {Object}   props       Component properties.
+ * @param {string}   props.title The title.
+ * @param {Object[]} props.items List of items under the specific category.
+ */
 const Category = ( { title, items } ) => {
 	return (
 		<div className="sensei-home__help-category">
@@ -71,8 +86,8 @@ const Category = ( { title, items } ) => {
 /**
  * Get Help section component.
  *
- * @param {Object} props            Properties.
- * @param {Object} props.categories The actual data.
+ * @param {Object}   props            Properties.
+ * @param {Object[]} props.categories A list of categories and its items.
  */
 const GetHelp = ( { categories } ) => {
 	if ( categories === undefined ) {

--- a/assets/home/sections/get-help.js
+++ b/assets/home/sections/get-help.js
@@ -1,22 +1,95 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon, help, lock, external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import Section from '../section';
 
+const Item = ( { title, url, extraLink } ) => {
+	const isLinkEnabled = url !== null;
+
+	const link = isLinkEnabled ? (
+		<a href={ url } target="_blank" rel="noreferrer">
+			{ title }
+		</a>
+	) : (
+		title
+	);
+
+	return (
+		<li className="sensei-home__help-item">
+			<div className="sensei-home__help-item__icon">
+				<Icon icon={ isLinkEnabled ? help : lock } size={ 16 } />
+			</div>
+			<div
+				className={ classNames( 'sensei-home__help-item__title', {
+					'sensei-home__help-item__title--disabled': ! isLinkEnabled,
+				} ) }
+			>
+				{ link }
+			</div>
+			{ extraLink && (
+				<div className="sensei-home__help-item__extra-link">
+					<a href={ extraLink.url } target="_blank" rel="noreferrer">
+						{ extraLink.label }{ ' ' }
+						<Icon icon={ external } size={ 10 } />
+					</a>
+				</div>
+			) }
+		</li>
+	);
+};
+
+const Category = ( { title, items } ) => {
+	return (
+		<div className="sensei-home__help-category">
+			<h3>{ title }</h3>
+			<ul>
+				{ items.map( ( item, itemIndex ) => (
+					<Item
+						key={ itemIndex }
+						title={ item.title }
+						url={ item.url }
+						icon={ item.icon }
+						extraLink={ item.extra_link }
+					/>
+				) ) }
+			</ul>
+		</div>
+	);
+};
+
 /**
  * Get Help section component.
+ *
+ * @param {Object} props            Properties.
+ * @param {Object} props.categories The actual data.
  */
-const GetHelp = () => (
-	<Section title={ __( 'Get help', 'sensei-lms' ) }>
-		<ul>
-			<li>Test 2</li>
-		</ul>
-	</Section>
-);
+const GetHelp = ( { categories } ) => {
+	if ( categories === undefined ) {
+		return null;
+	}
+
+	return (
+		<Section title={ __( 'Get help', 'sensei-lms' ) }>
+			{ categories.map( ( category, categoryIndex ) => (
+				<Category
+					key={ categoryIndex }
+					title={ category.title }
+					items={ category.items }
+				/>
+			) ) }
+		</Section>
+	);
+};
 
 export default GetHelp;

--- a/assets/home/sections/get-help.js
+++ b/assets/home/sections/get-help.js
@@ -36,7 +36,7 @@ const Item = ( { title, url, extraLink } ) => {
 	return (
 		<li className="sensei-home__help-item">
 			<div className="sensei-home__help-item__icon">
-				<Icon icon={ isTitleInteractive ? help : lock } size={ 22 } />
+				<Icon icon={ isTitleInteractive ? help : lock } size={ 24 } />
 			</div>
 			<div
 				className={ classNames( 'sensei-home__help-item__title', {
@@ -49,7 +49,7 @@ const Item = ( { title, url, extraLink } ) => {
 				<div className="sensei-home__help-item__extra-link">
 					<a href={ extraLink.url } target="_blank" rel="noreferrer">
 						{ extraLink.label }{ ' ' }
-						<Icon icon={ external } size={ 10 } />
+						<Icon icon={ external } size={ 16 } />
 					</a>
 				</div>
 			) }

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -51,7 +51,7 @@ final class Sensei_Home {
 		if ( 'course_page_sensei-home' === $screen->id ) {
 			Sensei()->assets->enqueue( 'sensei-home', 'home/index.js', [], true );
 			Sensei()->assets->enqueue( 'sensei-home-style', 'home/home.css', [ 'sensei-wp-components' ] );
-			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin' ] );
+			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin', '/sensei-internal/v1/home' ] );
 
 			$this->localize_script();
 		}


### PR DESCRIPTION
Fixes #5627 

### Changes proposed in this Pull Request
- Added basic implementation for Help section in Sensei Home.
- Using icons from Guttenberg.
- Ignoring `icon` attribute from API.
- Basic consumption for Sensei Home API.

### Testing instructions
* Go to Sensei Home.
* Check "Get Help" section.
* Disable Sensei Pro and you should see the Upgrade CTA.

### Screenshot / Video
#### With Sensei Pro disabled
![image](https://user-images.githubusercontent.com/799065/195066747-656c5167-7bd0-485b-8b14-d863dcbd0d0b.png)

#### With Sensei Pro enabled
![image](https://user-images.githubusercontent.com/799065/195066820-f9db4207-f1ed-4962-aaa0-3894a6858353.png)

### Discussion
- I added some rudimentary implementation to consume the Sensei Home REST API. We might want to do this differently.
  - ~Currently the get help section is null while the API response is loaded.~ This is now useless since the API call is preloaded.
  - Also the API consumption is done in `<Main>` and I am passing the help section information as a property.
- Icons do not look perfect. opened a discussion about this [here](p1665413139207769-slack-C8QJAM52B) .
- I have ignored the `icon` attribute from the API. I might remove it since we can work it out from the fact that `url` is `null`.