### PR TITLE
Fix block issues introduced by the `block.json` updates

### DIFF
--- a/assets/blocks/conditional-content-block/index.js
+++ b/assets/blocks/conditional-content-block/index.js
@@ -12,6 +12,7 @@ import metadata from './block.json';
 import icon from '../../icons/conditional-content.svg';
 
 export default {
+	...metadata,
 	metadata,
 	icon,
 	edit,

--- a/assets/blocks/core-pattern-polyfill/index.js
+++ b/assets/blocks/core-pattern-polyfill/index.js
@@ -4,4 +4,8 @@
 import metadata from './block.json';
 import edit from './edit';
 
-export default { metadata, edit };
+export default {
+	...metadata,
+	metadata,
+	edit,
+};

--- a/assets/blocks/course-actions-block/course-actions/index.js
+++ b/assets/blocks/course-actions-block/course-actions/index.js
@@ -12,6 +12,7 @@ import save from './course-actions-save';
 import icon from '../../../icons/buttons.svg';
 
 export default {
+	...metadata,
 	metadata,
 	example: {
 		innerBlocks: [

--- a/assets/blocks/course-categories-block/index.js
+++ b/assets/blocks/course-categories-block/index.js
@@ -13,6 +13,7 @@ import edit from './course-categories-edit';
 import save from './course-categories-save';
 
 export default {
+	...metadata,
 	metadata,
 	example: {
 		attributes: {

--- a/assets/blocks/course-list-filter-block/index.js
+++ b/assets/blocks/course-list-filter-block/index.js
@@ -6,6 +6,7 @@ import metadata from './block.json';
 import edit from './course-list-filter-edit';
 
 export default {
+	...metadata,
 	metadata,
 	icon,
 	edit,

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -11,6 +11,7 @@ import edit from './lesson-edit';
 import metadata from './block.json';
 
 export default {
+	...metadata,
 	metadata,
 	icon,
 	example: {

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -13,6 +13,7 @@ import transforms from './transforms';
 import metadata from './block.json';
 
 export default {
+	...metadata,
 	metadata,
 	icon,
 	example: {

--- a/assets/blocks/course-outline/outline-block/index.js
+++ b/assets/blocks/course-outline/outline-block/index.js
@@ -12,6 +12,7 @@ import edit from './outline-edit';
 import save from './outline-save';
 
 export default {
+	...metadata,
 	metadata,
 	styles: [
 		{

--- a/assets/blocks/course-progress-block/index.js
+++ b/assets/blocks/course-progress-block/index.js
@@ -6,6 +6,7 @@ import edit from './course-progress-edit';
 import metadata from './block.json';
 
 export default {
+	...metadata,
 	metadata,
 	icon,
 	edit,

--- a/assets/blocks/course-results-block/index.js
+++ b/assets/blocks/course-results-block/index.js
@@ -11,6 +11,7 @@ import metadata from './block.json';
 import edit from './course-results-edit';
 
 export default {
+	...metadata,
 	metadata,
 	styles: [
 		{

--- a/assets/blocks/featured-video/block.json
+++ b/assets/blocks/featured-video/block.json
@@ -1,5 +1,7 @@
 {
 	"name": "sensei-lms/featured-video",
+	"title": "Featured Video",
+	"description": "Add a featured video to your lesson to highlight the video and make use of our video templates.",
     "icon": "format-video",
 	"category": "sensei-lms",
 	"textdomain": "sensei-lms",

--- a/assets/blocks/featured-video/index.js
+++ b/assets/blocks/featured-video/index.js
@@ -3,7 +3,6 @@
  */
 import { useRef, useEffect } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -21,11 +20,8 @@ const ALLOWED_BLOCKS = [
 ];
 
 export default {
-	title: __( 'Featured Video', 'sensei-lms' ),
-	description: __(
-		'Add a featured video to your lesson to highlight the video and make use of our video templates.',
-		'sensei-lms'
-	),
+	...metadata,
+	metadata,
 	example: {
 		innerBlocks: [
 			{
@@ -36,8 +32,6 @@ export default {
 			},
 		],
 	},
-	...metadata,
-	metadata,
 	edit: function EditBlock( { className, clientId } ) {
 		const { replaceInnerBlocks, moveBlockToPosition } = useDispatch(
 			'core/block-editor'

--- a/assets/blocks/featured-video/index.js
+++ b/assets/blocks/featured-video/index.js
@@ -37,6 +37,7 @@ export default {
 		],
 	},
 	...metadata,
+	metadata,
 	edit: function EditBlock( { className, clientId } ) {
 		const { replaceInnerBlocks, moveBlockToPosition } = useDispatch(
 			'core/block-editor'

--- a/assets/blocks/learner-courses-block/index.js
+++ b/assets/blocks/learner-courses-block/index.js
@@ -6,6 +6,7 @@ import metadata from './block.json';
 import icon from '../../icons/learner-courses.svg';
 
 export default {
+	...metadata,
 	metadata,
 	example: {},
 	icon,

--- a/assets/blocks/lesson-actions/lesson-actions-block/index.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/index.js
@@ -7,6 +7,7 @@ import save from './lesson-actions-save';
 import icon from '../../../icons/buttons.svg';
 
 export default {
+	...metadata,
 	metadata,
 	example: {
 		innerBlocks: [

--- a/assets/blocks/lesson-properties/index.js
+++ b/assets/blocks/lesson-properties/index.js
@@ -6,6 +6,7 @@ import metadata from './block.json';
 import edit from './lesson-properties-edit';
 
 export default {
+	...metadata,
 	metadata,
 	icon,
 	example: {

--- a/assets/blocks/quiz/category-question-block/index.js
+++ b/assets/blocks/quiz/category-question-block/index.js
@@ -15,6 +15,7 @@ import icon from '../../../icons/question.svg';
  * Quiz category question block definition.
  */
 export default {
+	...metadata,
 	metadata,
 	icon,
 	usesContext: [ 'sensei-lms/quizId' ],

--- a/assets/blocks/quiz/question-answers-block/index.js
+++ b/assets/blocks/quiz/question-answers-block/index.js
@@ -14,6 +14,7 @@ import icon from '../../../icons/question.svg';
  * Question answers block.
  */
 export default {
+	...metadata,
 	metadata,
 	icon,
 	edit,

--- a/assets/blocks/quiz/question-block/index.js
+++ b/assets/blocks/quiz/question-block/index.js
@@ -16,6 +16,7 @@ import icon from '../../../icons/question.svg';
  * Quiz question block definition.
  */
 export default {
+	...metadata,
 	metadata,
 	icon,
 	usesContext: [ 'sensei-lms/quizId' ],

--- a/assets/blocks/quiz/question-description-block/index.js
+++ b/assets/blocks/quiz/question-description-block/index.js
@@ -14,6 +14,7 @@ import icon from '../../../icons/question.svg';
  * Question description block.
  */
 export default {
+	...metadata,
 	metadata,
 	icon,
 	usesContext: [ 'sensei-lms/quizId' ],

--- a/assets/blocks/quiz/quiz-block/index.js
+++ b/assets/blocks/quiz/quiz-block/index.js
@@ -14,6 +14,7 @@ import metadata from './block.json';
  * Quiz block definition.
  */
 const quizBlock = {
+	...metadata,
 	metadata,
 	icon,
 	providesContext: {

--- a/assets/blocks/register-sensei-blocks.js
+++ b/assets/blocks/register-sensei-blocks.js
@@ -20,6 +20,9 @@ const registerSenseiBlocks = ( blocks ) => {
 
 	blocks.forEach( ( block ) => {
 		const { metadata, name, ...settings } = block;
+
+		// For the block to be fully translatable, the `block.json` metadata object should be passed.
+		// @see https://github.com/Automattic/sensei/pull/5782
 		registerBlockType( metadata || name, settings );
 	} );
 };

--- a/assets/blocks/register-sensei-blocks.js
+++ b/assets/blocks/register-sensei-blocks.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { registerBlockType, updateCategory } from '@wordpress/blocks';
@@ -11,6 +16,7 @@ import SenseiIcon from '../icons/sensei.svg';
 /**
  * Register Sensei blocks.
  *
+ * @todo  Refactor how the metadata and settings are passed to `registerBlockType`.
  * @param {Array} blocks Blocks to be registered.
  */
 const registerSenseiBlocks = ( blocks ) => {
@@ -19,10 +25,16 @@ const registerSenseiBlocks = ( blocks ) => {
 	} );
 
 	blocks.forEach( ( block ) => {
-		const { metadata, name, ...settings } = block;
+		let { metadata, name, ...settings } = block;
 
-		// For the block to be fully translatable, the `block.json` metadata object should be passed.
-		// @see https://github.com/Automattic/sensei/pull/5782
+		if ( metadata ) {
+			// Remove the overlapping metadata keys from the settings object to make localization work.
+			// This is needed because only the metadata object is localized, but the overlapping keys will be overwritten by the settings object and the localization is lost.
+			settings = omit( settings, Object.keys( metadata ) );
+		}
+
+		// The metadata object should be used for the `block.json` strings to be localized.
+		// See https://github.com/Automattic/sensei/pull/5782 for more details.
 		registerBlockType( metadata || name, settings );
 	} );
 };


### PR DESCRIPTION
Relates to https://github.com/Automattic/sensei/pull/5782#issuecomment-1271705659

This PR fixes multiple issues that were introduced by the updates to the `block.json` file and the blocks object changes. The most noticeable issue is that the Quiz Block was causing errors when you try to add it, but there are other logic related bugs as well.

The fix reverts to the previous block object structure which has the `block.json` metadata directly in it. It's hard to track down where the code logic uses this metadata, so I've decided to revert it to minimize risk.

### Changes proposed in this Pull Request

* Revert the previous block object structure (before the updates in #5782).

### Testing instructions

* Adding the Quiz Block should work.
* All other blocks should be working as before.
