### PR TITLE
Make course progress constructor consistent with other progress models

### DIFF
--- a/includes/student-progress/course-progress/models/class-course-progress.php
+++ b/includes/student-progress/course-progress/models/class-course-progress.php
@@ -91,13 +91,13 @@ class Course_Progress {
 	 * @param int                    $id          Progress identifier.
 	 * @param int                    $course_id Course identifier.
 	 * @param int                    $user_id  User identifier.
-	 * @param DateTimeInterface      $created_at Course progress created date.
 	 * @param string|null            $status   Progress status.
 	 * @param DateTimeInterface|null $started_at Course start date.
 	 * @param DateTimeInterface|null $completed_at Course completion date.
-	 * @param DateTimeInterface|null $updated_at Course progress updated date.
+	 * @param DateTimeInterface      $created_at Course progress created date.
+	 * @param DateTimeInterface      $updated_at Course progress updated date.
 	 */
-	public function __construct( int $id, int $course_id, int $user_id, DateTimeInterface $created_at, string $status = null, DateTimeInterface $started_at = null, DateTimeInterface $completed_at = null, DateTimeInterface $updated_at = null ) {
+	public function __construct( int $id, int $course_id, int $user_id, ?string $status, ?DateTimeInterface $started_at, ?DateTimeInterface $completed_at, DateTimeInterface $created_at, DateTimeInterface $updated_at ) {
 		$this->id           = $id;
 		$this->course_id    = $course_id;
 		$this->user_id      = $user_id;
@@ -105,7 +105,7 @@ class Course_Progress {
 		$this->started_at   = $started_at;
 		$this->completed_at = $completed_at;
 		$this->created_at   = $created_at;
-		$this->updated_at   = $updated_at ?? $created_at;
+		$this->updated_at   = $updated_at;
 	}
 
 	/**

--- a/includes/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
+++ b/includes/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
@@ -72,7 +72,7 @@ class Comments_Based_Course_Progress_Repository implements Course_Progress_Repos
 			$completed_at = null;
 		}
 
-		return new Course_Progress( (int) $comment->comment_ID, $course_id, $user_id, $comment_date, $comment->comment_approved, $started_at, $completed_at, $comment_date );
+		return new Course_Progress( (int) $comment->comment_ID, $course_id, $user_id, $comment->comment_approved, $started_at, $completed_at, $comment_date, $comment_date );
 	}
 
 	/**

--- a/tests/unit-tests/student-progress/course-progress/models/test-class-comments-based-course-progress.php
+++ b/tests/unit-tests/student-progress/course-progress/models/test-class-comments-based-course-progress.php
@@ -70,7 +70,7 @@ class Comments_Based_Course_Progress_Test extends \WP_UnitTestCase {
 			new \DateTime( '2020-01-01 00:00:01' ),
 			new \DateTime( '2020-01-01 00:00:02' ),
 			new \DateTime( '2020-01-01 00:00:00' ),
-			new \DateTime( '2020-01-01 00:00:03' ),
+			new \DateTime( '2020-01-01 00:00:03' )
 		);
 	}
 }

--- a/tests/unit-tests/student-progress/course-progress/models/test-class-comments-based-course-progress.php
+++ b/tests/unit-tests/student-progress/course-progress/models/test-class-comments-based-course-progress.php
@@ -66,12 +66,11 @@ class Comments_Based_Course_Progress_Test extends \WP_UnitTestCase {
 			1,
 			2,
 			3,
-			new \DateTime( '2020-01-01 00:00:00' ),
 			'complete',
 			new \DateTime( '2020-01-01 00:00:01' ),
 			new \DateTime( '2020-01-01 00:00:02' ),
+			new \DateTime( '2020-01-01 00:00:00' ),
 			new \DateTime( '2020-01-01 00:00:03' ),
-			[ 'a' => 'b' ]
 		);
 	}
 }


### PR DESCRIPTION
The signature of the course progress model is a bit different from other progress models.
This PR aims to make them consistent.

### Changes proposed in this Pull Request

* Update `Course_Progress`'s constructor signature.

### Testing instructions

* (optional) Run tests locally.
* On the frontend, start a course, complete that course.
* No errors expected.