### PR TITLE
Change show_admin_bar flag only in lesson pages

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -209,6 +209,11 @@ class Sensei_Course_Theme_Option {
 	 */
 	public function show_admin_bar_only_for_editors( $show_admin_bar ) {
 		$lesson_id = Sensei_Utils::get_current_lesson();
+
+		if ( null === $lesson_id || null === get_post_type( 'lesson' ) ) {
+			return $show_admin_bar;
+		}
+
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
 		if ( self::has_learning_mode_enabled( $course_id ) ) {


### PR DESCRIPTION
This came up  in 5608836-zd-woothemes. 

I couldn't really find a way to reproduce it but I think that it's possible to happen if there is a plugin that calls `is_admin_bar_showing` before `init` hook as at that point we haven't registered our post types yet. For example here is a snippet that will cause this error:
```add_action( 'init', 'is_admin_bar_showing' );```

### Changes proposed in this Pull Request

* Adds a check to hide the admin bar only in lessons pages and only if the post type has been registered.

### Testing instructions
* Add the above snippet
* Observe that there are no warnings when any page is visited in the frontend.
* Observe that the admin bar is displayed normally when you use an admin user.
