### PR TITLE
Set spacer to 50px

### DIFF
--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -50,8 +50,8 @@
 
 		<!-- wp:post-content /-->
 
-		<!-- wp:spacer {"height":"100px"} -->
-		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- wp:spacer {"height":"50px"} -->
+		<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
         <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->


### PR DESCRIPTION
Fixing a spacing issue as proposed here p6rkRX-4Bm-p2#comment-4915.

### Changes proposed in this Pull Request

* Reduces the spacer to 50px

<img width="1590" alt="image-30" src="https://user-images.githubusercontent.com/53191348/195387743-3a8dac4d-2db3-443d-b8e6-0e1a3b03faa6.png">


### Testing instructions

* Open a lesson with the default LM template and observe that the space between the content and the button is reduced.