### PR TITLE
LM - Video Template - Fix 0 height for video container in FSE.

### DIFF
--- a/assets/css/sensei-course-theme/video-container.scss
+++ b/assets/css/sensei-course-theme/video-container.scss
@@ -75,14 +75,14 @@
 		/**
 		 * Fixed right sidebar mode when there is no video.
 		 */
-		body:not(.sensei-video-lesson) &__video-container {
+		body:not(.sensei-video-lesson):not(.editor-styles-wrapper) &__video-container {
 			justify-content: flex-end;
 			border: none;
 			height: 0;
 			overflow: visible;
 			padding: 0!important;
 			margin-top: 0!important;
-			margin-bottom: 0!important;
+			margin-bottom: -32px!important;
 			transition: none;
 
 			&:after {


### PR DESCRIPTION
Fixes #5925 
Fixes #5861 

### Changes proposed in this Pull Request

* Fixes the height issue for Video Container block in FSE for LM Video template.
* Fixes the alignment issue for LM template when there is no video.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Activate LM Video template.
* Open FSE and edit LM Video template.
* Confirm that you see Notices, Post Content and Lesson Actions blocks below the Video Container block.
* Visit a lesson page without Featured Video in it and confirm the top of the post content is aligned with the top of the sidebar on the right.


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

### Before (Frontent)

<img width="1888" alt="before-frontend" src="https://user-images.githubusercontent.com/2578542/195587166-0d7d9c36-9277-4648-80e4-b453a17e6569.png">

### Before (Editor)

<img width="1889" alt="before-editor" src="https://user-images.githubusercontent.com/2578542/195586726-f489b545-6ee9-4848-bb31-e28abd415179.png">

### After (Frontend)

<img width="1889" alt="after-frontend" src="https://user-images.githubusercontent.com/2578542/195586750-9e6c83f7-0f9e-4eb1-baed-f2e15afbd81c.png">

### After (Editor)

<img width="1887" alt="after-editor" src="https://user-images.githubusercontent.com/2578542/195586886-0fc2b82a-b6e4-48f0-94ea-1f2abc3171c1.png">
