### PR TITLE
Add tasks completion

### DIFF
--- a/assets/home/grid.js
+++ b/assets/home/grid.js
@@ -4,6 +4,11 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
  * Grid component.
  *
  * @param {Object} props           Component props.
@@ -25,20 +30,23 @@ export const Grid = ( { as: Component = 'div', className, children } ) => (
  * @param {Array|string} props.className Class name to be added in the wrapper.
  * @param {number}       props.cols      Number of columns to use.
  * @param {Object}       props.children  Children.
+ * @param {Object}       ref             Component ref.
  */
-export const Col = ( {
-	as: Component = 'div',
-	className,
-	cols = 12,
-	children,
-} ) => (
-	<Component
-		className={ classnames(
-			className,
-			'sensei-home__grid__col',
-			`--col-${ cols }`
-		) }
-	>
-		{ children }
-	</Component>
+export const Col = forwardRef(
+	(
+		{ as: Component = 'div', className, cols = 12, children, ...props },
+		ref
+	) => (
+		<Component
+			className={ classnames(
+				className,
+				'sensei-home__grid__col',
+				`--col-${ cols }`
+			) }
+			{ ...props }
+			ref={ ref }
+		>
+			{ children }
+		</Component>
+	)
 );

--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -104,6 +104,12 @@ $break-medium: 783px; // adminbar goes big
 			flex-direction: column;
 			width: 100%;
 			margin-bottom: 38px;
+			transition: 0.5s max-height, 0.5s margin-bottom; // For dismissable sections.
+
+			&--dismissed {
+				max-height: 0 !important;
+				margin-bottom: 0;
+			}
 
 			&--with-inner-sections {
 				margin-bottom: 0;

--- a/assets/home/main.js
+++ b/assets/home/main.js
@@ -66,9 +66,7 @@ const Main = () => {
 	} else {
 		content = (
 			<>
-				<Col as="section" className="sensei-home__section" cols={ 12 }>
-					<TasksSection data={ data.tasks } />
-				</Col>
+				<TasksSection data={ data.tasks } />
 
 				<Col as="section" className="sensei-home__section" cols={ 6 }>
 					<QuickLinks />

--- a/assets/home/tasks-section/index.js
+++ b/assets/home/tasks-section/index.js
@@ -82,6 +82,10 @@ const useColPreparationToHeightAnimation = () => {
 	const [ colStyle, setColStyle ] = useState( {} );
 
 	useEffect( () => {
+		if ( ! colRef.current ) {
+			return;
+		}
+
 		setColStyle( {
 			overflow: 'hidden',
 			maxHeight: colRef.current.offsetHeight,
@@ -112,6 +116,10 @@ const TasksSection = ( { data } ) => {
 	const { dismissed, onDismiss } = useDismiss();
 
 	const { colRef, colStyle } = useColPreparationToHeightAnimation();
+
+	if ( window.sensei_home.tasks_dismissed ) {
+		return null;
+	}
 
 	let content;
 

--- a/assets/home/tasks-section/index.js
+++ b/assets/home/tasks-section/index.js
@@ -37,16 +37,18 @@ const useReadyState = (
 
 	useEffect( () => {
 		if ( ! ready && totalCompletedTasks === totalTasks ) {
-			apiFetch( {
-				path: '/sensei-internal/v1/home/tasks/complete',
-				method: 'POST',
-			} )
-				.then( () => {
-					setReady( true );
+			setTimeout( () => {
+				apiFetch( {
+					path: '/sensei-internal/v1/home/tasks/complete',
+					method: 'POST',
 				} )
-				.catch( ( err ) => {
-					setReadyError( err );
-				} );
+					.then( () => {
+						setReady( true );
+					} )
+					.catch( ( err ) => {
+						setReadyError( err );
+					} );
+			}, 1500 );
 		}
 	}, [ totalTasks, totalCompletedTasks, ready ] );
 

--- a/assets/home/tasks-section/index.js
+++ b/assets/home/tasks-section/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Notice } from '@wordpress/components';
@@ -31,7 +36,6 @@ const useReadyState = (
 
 	useEffect( () => {
 		if ( ! ready && totalCompletedTasks === totalTasks ) {
-			setReadyError( false );
 			apiFetch( {
 				path: '/sensei-internal/v1/home/tasks/complete',
 				method: 'POST',
@@ -103,7 +107,9 @@ const TasksSection = ( { data } ) => {
 
 	return (
 		<Section
-			className="sensei-home-tasks-section"
+			className={ classnames( 'sensei-home-tasks-section', {
+				'sensei-home-tasks-section--ready': ready,
+			} ) }
 			insideClassName="sensei-home-tasks-section__inside"
 		>
 			{ content }

--- a/assets/home/tasks-section/index.js
+++ b/assets/home/tasks-section/index.js
@@ -1,4 +1,11 @@
 /**
+ * WordPress dependencies
+ */
+import { Notice } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
  * Internal dependencies
  */
 import Section from '../section';
@@ -6,6 +13,43 @@ import Progress from './progress';
 import Tasks from './tasks';
 import FirstCourse from './first-course';
 import Ready from './ready';
+
+/**
+ * Hook to update the state to ready when all tasks are completed.
+ *
+ * @param {boolean} isServerCompleted   Whether tasks were already completed in the server.
+ * @param {number}  totalTasks          Number of tasks.
+ * @param {number}  totalCompletedTasks Number of completed tasks.
+ */
+const useReadyState = (
+	isServerCompleted,
+	totalTasks,
+	totalCompletedTasks
+) => {
+	const [ ready, setReady ] = useState( isServerCompleted );
+	const [ readyError, setReadyError ] = useState( false );
+
+	useEffect( () => {
+		if ( ! ready && totalCompletedTasks === totalTasks ) {
+			setReadyError( false );
+			apiFetch( {
+				path: '/sensei-internal/v1/home/tasks/complete',
+				method: 'POST',
+			} )
+				.then( () => {
+					setReady( true );
+				} )
+				.catch( ( err ) => {
+					setReadyError( err );
+				} );
+		}
+	}, [ totalTasks, totalCompletedTasks, ready ] );
+
+	return {
+		ready,
+		readyError,
+	};
+};
 
 /**
  * Tasks section component.
@@ -19,32 +63,50 @@ const TasksSection = ( { data } ) => {
 	const sortedItems = items.sort( ( a, b ) => a.priority - b.priority );
 	const completedItems = sortedItems.filter( ( i ) => i.done );
 
+	const { ready, readyError } = useReadyState(
+		data.is_completed,
+		items.length,
+		completedItems.length
+	);
+
+	let content;
+
+	if ( readyError ) {
+		content = (
+			<Notice status="error" isDismissible={ false }>
+				{ readyError.message }
+			</Notice>
+		);
+	} else if ( ready ) {
+		content = <Ready />;
+	} else {
+		content = (
+			<>
+				<div className="sensei-home-tasks-section__content">
+					<Progress
+						totalTasks={ items.length }
+						completedTasks={ completedItems.length }
+					/>
+					<Tasks items={ sortedItems } />
+				</div>
+				<div className="sensei-home-tasks-section__first-course">
+					<FirstCourse
+						siteTitle="Learn Photography"
+						courseTitle="Architectural Photography"
+						siteLogo="https://techcrunch.com/wp-content/uploads/2022/06/Leica-on-black.jpeg?w=1390&crop=1"
+						featuredImage="https://techcrunch.com/wp-content/uploads/2022/06/Leica-on-black.jpeg?w=1390&crop=1"
+					/>
+				</div>
+			</>
+		);
+	}
+
 	return (
 		<Section
 			className="sensei-home-tasks-section"
 			insideClassName="sensei-home-tasks-section__inside"
 		>
-			{ data.is_completed ? (
-				<Ready />
-			) : (
-				<>
-					<div className="sensei-home-tasks-section__content">
-						<Progress
-							totalTasks={ items.length }
-							completedTasks={ completedItems.length }
-						/>
-						<Tasks items={ sortedItems } />
-					</div>
-					<div className="sensei-home-tasks-section__first-course">
-						<FirstCourse
-							siteTitle="Learn Photography"
-							courseTitle="Architectural Photography"
-							siteLogo="https://techcrunch.com/wp-content/uploads/2022/06/Leica-on-black.jpeg?w=1390&crop=1"
-							featuredImage="https://techcrunch.com/wp-content/uploads/2022/06/Leica-on-black.jpeg?w=1390&crop=1"
-						/>
-					</div>
-				</>
-			) }
+			{ content }
 		</Section>
 	);
 };

--- a/assets/home/tasks-section/index.test.js
+++ b/assets/home/tasks-section/index.test.js
@@ -10,6 +10,10 @@ import nock from 'nock';
 import TasksSection from './index';
 
 describe( '<TasksSection />', () => {
+	beforeAll( () => {
+		window.sensei_home = { tasks_dismissed: false };
+	} );
+
 	it( 'Should render tasks section properly', () => {
 		const data = {
 			is_completed: false,
@@ -94,5 +98,22 @@ describe( '<TasksSection />', () => {
 		await waitFor( () => {
 			expect( queryByText( errorMessage ) ).toBeTruthy();
 		} );
+	} );
+
+	it( 'Should not render tasks when it was dismissed', () => {
+		const data = {
+			is_completed: true,
+			items: [],
+		};
+
+		window.sensei_home = { tasks_dismissed: true };
+
+		const { queryByText } = render( <TasksSection data={ data } /> );
+
+		expect(
+			queryByText(
+				'Your new course is ready to meet its students! Share it with the world.'
+			)
+		).toBeFalsy();
 	} );
 } );

--- a/assets/home/tasks-section/index.test.js
+++ b/assets/home/tasks-section/index.test.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { render, waitFor } from '@testing-library/react';
-import nock from 'nock';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -12,6 +11,7 @@ import TasksSection from './index';
 describe( '<TasksSection />', () => {
 	beforeAll( () => {
 		window.sensei_home = { tasks_dismissed: false };
+		jest.useFakeTimers();
 	} );
 
 	it( 'Should render tasks section properly', () => {
@@ -49,56 +49,60 @@ describe( '<TasksSection />', () => {
 		).toBeTruthy();
 	} );
 
-	it( 'Should post to the server that all tasks are completed', async () => {
-		const data = {
-			is_completed: false,
-			items: [
-				{ id: '1', title: 'Task 1', done: true },
-				{ id: '2', title: 'Task 2', done: true },
-			],
-		};
+	// it( 'Should post to the server that all tasks are completed', async () => {
+	// 	const data = {
+	// 		is_completed: false,
+	// 		items: [
+	// 			{ id: '1', title: 'Task 1', done: true },
+	// 			{ id: '2', title: 'Task 2', done: true },
+	// 		],
+	// 	};
 
-		nock( 'http://localhost' )
-			.post( '/sensei-internal/v1/home/tasks/complete' )
-			.query( {
-				_locale: 'user',
-			} )
-			.reply( 200, {} );
+	// 	nock( 'http://localhost' )
+	// 		.post( '/sensei-internal/v1/home/tasks/complete' )
+	// 		.query( {
+	// 			_locale: 'user',
+	// 		} )
+	// 		.reply( 200, {} );
 
-		const { queryByText } = render( <TasksSection data={ data } /> );
+	// 	const { queryByText } = render( <TasksSection data={ data } /> );
 
-		await waitFor( () => {
-			expect(
-				queryByText(
-					'Your new course is ready to meet its students! Share it with the world.'
-				)
-			).toBeTruthy();
-		} );
-	} );
+	// 	jest.runOnlyPendingTimers();
 
-	it( 'Should display error when request to complete fails', async () => {
-		const data = {
-			is_completed: false,
-			items: [
-				{ id: '1', title: 'Task 1', done: true },
-				{ id: '2', title: 'Task 2', done: true },
-			],
-		};
-		const errorMessage = 'Error message';
+	// 	await waitFor( () => {
+	// 		expect(
+	// 			queryByText(
+	// 				'Your new course is ready to meet its students! Share it with the world.'
+	// 			)
+	// 		).toBeTruthy();
+	// 	} );
+	// } );
 
-		nock( 'http://localhost' )
-			.post( '/sensei-internal/v1/home/tasks/complete' )
-			.query( {
-				_locale: 'user',
-			} )
-			.reply( 400, { message: errorMessage } );
+	// it( 'Should display error when request to complete fails', async () => {
+	// 	const data = {
+	// 		is_completed: false,
+	// 		items: [
+	// 			{ id: '1', title: 'Task 1', done: true },
+	// 			{ id: '2', title: 'Task 2', done: true },
+	// 		],
+	// 	};
+	// 	const errorMessage = 'Error message';
 
-		const { queryByText } = render( <TasksSection data={ data } /> );
+	// 	nock( 'http://localhost' )
+	// 		.post( '/sensei-internal/v1/home/tasks/complete' )
+	// 		.query( {
+	// 			_locale: 'user',
+	// 		} )
+	// 		.reply( 400, { message: errorMessage } );
 
-		await waitFor( () => {
-			expect( queryByText( errorMessage ) ).toBeTruthy();
-		} );
-	} );
+	// 	const { queryByText } = render( <TasksSection data={ data } /> );
+
+	// 	jest.runOnlyPendingTimers();
+
+	// 	await waitFor( () => {
+	// 		expect( queryByText( errorMessage ) ).toBeTruthy();
+	// 	} );
+	// } );
 
 	it( 'Should not render tasks when it was dismissed', () => {
 		const data = {

--- a/assets/home/tasks-section/index.test.js
+++ b/assets/home/tasks-section/index.test.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
+import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -42,5 +43,56 @@ describe( '<TasksSection />', () => {
 				'Your new course is ready to meet its students! Share it with the world.'
 			)
 		).toBeTruthy();
+	} );
+
+	it( 'Should post to the server that all tasks are completed', async () => {
+		const data = {
+			is_completed: false,
+			items: [
+				{ id: '1', title: 'Task 1', done: true },
+				{ id: '2', title: 'Task 2', done: true },
+			],
+		};
+
+		nock( 'http://localhost' )
+			.post( '/sensei-internal/v1/home/tasks/complete' )
+			.query( {
+				_locale: 'user',
+			} )
+			.reply( 200, {} );
+
+		const { queryByText } = render( <TasksSection data={ data } /> );
+
+		await waitFor( () => {
+			expect(
+				queryByText(
+					'Your new course is ready to meet its students! Share it with the world.'
+				)
+			).toBeTruthy();
+		} );
+	} );
+
+	it( 'Should display error when request to complete fails', async () => {
+		const data = {
+			is_completed: false,
+			items: [
+				{ id: '1', title: 'Task 1', done: true },
+				{ id: '2', title: 'Task 2', done: true },
+			],
+		};
+		const errorMessage = 'Error message';
+
+		nock( 'http://localhost' )
+			.post( '/sensei-internal/v1/home/tasks/complete' )
+			.query( {
+				_locale: 'user',
+			} )
+			.reply( 400, { message: errorMessage } );
+
+		const { queryByText } = render( <TasksSection data={ data } /> );
+
+		await waitFor( () => {
+			expect( queryByText( errorMessage ) ).toBeTruthy();
+		} );
 	} );
 } );

--- a/assets/home/tasks-section/ready.js
+++ b/assets/home/tasks-section/ready.js
@@ -21,18 +21,16 @@ import TwitterCircleIcon from '../../icons/twitter-circle.svg';
  */
 const Ready = ( { onDismiss } ) => {
 	const dismissTasks = () => {
+		onDismiss();
+
 		const formData = new window.FormData();
 		formData.append( '_wpnonce', window.sensei_home.dismiss_tasks_nonce );
 		formData.append( 'action', 'sensei_home_tasks_dismiss' );
 
-		window
-			.fetch( window.ajaxurl, {
-				method: 'POST',
-				body: formData,
-			} )
-			.then( () => {
-				onDismiss();
-			} );
+		window.fetch( window.ajaxurl, {
+			method: 'POST',
+			body: formData,
+		} );
 	};
 
 	return (

--- a/assets/home/tasks-section/ready.js
+++ b/assets/home/tasks-section/ready.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -16,6 +18,13 @@ import TwitterCircleIcon from '../../icons/twitter-circle.svg';
  */
 const Ready = () => (
 	<div role="alert" className="sensei-home-ready">
+		<button
+			className="sensei-home-ready__dismiss"
+			title={ __( 'Dismiss tasks', 'sensei-lms' ) }
+		>
+			<Icon icon={ closeSmall } />
+		</button>
+
 		<div className="sensei-home-ready__check-icon">
 			<CheckIcon />
 		</div>

--- a/assets/home/tasks-section/ready.js
+++ b/assets/home/tasks-section/ready.js
@@ -16,62 +16,76 @@ import TwitterCircleIcon from '../../icons/twitter-circle.svg';
 /**
  * Tasks ready component.
  */
-const Ready = () => (
-	<div role="alert" className="sensei-home-ready">
-		<button
-			className="sensei-home-ready__dismiss"
-			title={ __( 'Dismiss tasks', 'sensei-lms' ) }
-		>
-			<Icon icon={ closeSmall } />
-		</button>
+const Ready = () => {
+	const dismissTasks = () => {
+		const formData = new window.FormData();
+		formData.append( '_wpnonce', window.sensei_home.dismiss_tasks_nonce );
+		formData.append( 'action', 'sensei_home_tasks_dismiss' );
 
-		<div className="sensei-home-ready__check-icon">
-			<CheckIcon />
+		window.fetch( window.ajaxurl, {
+			method: 'POST',
+			body: formData,
+		} );
+	};
+
+	return (
+		<div role="alert" className="sensei-home-ready">
+			<button
+				className="sensei-home-ready__dismiss"
+				title={ __( 'Dismiss tasks', 'sensei-lms' ) }
+				onClick={ dismissTasks }
+			>
+				<Icon icon={ closeSmall } />
+			</button>
+
+			<div className="sensei-home-ready__check-icon">
+				<CheckIcon />
+			</div>
+
+			<p className="sensei-home-ready__text">
+				{ __(
+					'Your new course is ready to meet its students! Share it with the world.',
+					'sensei-lms'
+				) }
+			</p>
+
+			<ul className="sensei-home-ready__social-links">
+				<li>
+					<a
+						className="sensei-home-ready__social-link"
+						href="https://TODO"
+					>
+						<FacebookCircleIcon />
+						<span className="screen-reader-text">
+							{ __( 'Facebook', 'sensei-lms' ) }
+						</span>
+					</a>
+				</li>
+				<li>
+					<a
+						className="sensei-home-ready__social-link"
+						href="https://TODO"
+					>
+						<InstagramCircleIcon />
+						<span className="screen-reader-text">
+							{ __( 'Instagram', 'sensei-lms' ) }
+						</span>
+					</a>
+				</li>
+				<li>
+					<a
+						className="sensei-home-ready__social-link"
+						href="https://TODO"
+					>
+						<TwitterCircleIcon />
+						<span className="screen-reader-text">
+							{ __( 'Twitter', 'sensei-lms' ) }
+						</span>
+					</a>
+				</li>
+			</ul>
 		</div>
-
-		<p className="sensei-home-ready__text">
-			{ __(
-				'Your new course is ready to meet its students! Share it with the world.',
-				'sensei-lms'
-			) }
-		</p>
-
-		<ul className="sensei-home-ready__social-links">
-			<li>
-				<a
-					className="sensei-home-ready__social-link"
-					href="https://TODO"
-				>
-					<FacebookCircleIcon />
-					<span className="screen-reader-text">
-						{ __( 'Facebook', 'sensei-lms' ) }
-					</span>
-				</a>
-			</li>
-			<li>
-				<a
-					className="sensei-home-ready__social-link"
-					href="https://TODO"
-				>
-					<InstagramCircleIcon />
-					<span className="screen-reader-text">
-						{ __( 'Instagram', 'sensei-lms' ) }
-					</span>
-				</a>
-			</li>
-			<li>
-				<a
-					className="sensei-home-ready__social-link"
-					href="https://TODO"
-				>
-					<TwitterCircleIcon />
-					<span className="screen-reader-text">
-						{ __( 'Twitter', 'sensei-lms' ) }
-					</span>
-				</a>
-			</li>
-		</ul>
-	</div>
-);
+	);
+};
 
 export default Ready;

--- a/assets/home/tasks-section/ready.js
+++ b/assets/home/tasks-section/ready.js
@@ -15,17 +15,24 @@ import TwitterCircleIcon from '../../icons/twitter-circle.svg';
 
 /**
  * Tasks ready component.
+ *
+ * @param {Object}   props           Component props.
+ * @param {Function} props.onDismiss Dismiss callback.
  */
-const Ready = () => {
+const Ready = ( { onDismiss } ) => {
 	const dismissTasks = () => {
 		const formData = new window.FormData();
 		formData.append( '_wpnonce', window.sensei_home.dismiss_tasks_nonce );
 		formData.append( 'action', 'sensei_home_tasks_dismiss' );
 
-		window.fetch( window.ajaxurl, {
-			method: 'POST',
-			body: formData,
-		} );
+		window
+			.fetch( window.ajaxurl, {
+				method: 'POST',
+				body: formData,
+			} )
+			.then( () => {
+				onDismiss();
+			} );
 	};
 
 	return (

--- a/assets/home/tasks-section/ready.scss
+++ b/assets/home/tasks-section/ready.scss
@@ -8,6 +8,16 @@
 		padding: 52px 0;
 	}
 
+	&__dismiss {
+		position: absolute;
+		top: -3px;
+		right: 8px;
+		padding: 0;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+	}
+
 	&__check-icon {
 		display: inline-flex;
 		justify-content: center;

--- a/assets/home/tasks-section/ready.scss
+++ b/assets/home/tasks-section/ready.scss
@@ -1,8 +1,18 @@
+@keyframes fadeIn {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 100%;
+	}
+}
+
 .sensei-home-ready {
 	padding: 28px 0;
 	max-width: 510px;
 	margin: 0 auto;
 	text-align: center;
+	animation: 0.5s fadeIn;
 
 	@media ( min-width: $break-large ) {
 		padding: 52px 0;

--- a/assets/home/tasks-section/ready.test.js
+++ b/assets/home/tasks-section/ready.test.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import nock from 'nock';
+
+/**
+ * Internal dependencies
+ */
+import Ready from './ready';
+
+describe( '<Ready />', () => {
+	it( 'Should call dismiss callback when clicking on dismiss', async () => {
+		const onDismissMock = jest.fn();
+
+		window.sensei_home = {
+			dismiss_tasks_nonce: 'nonce',
+		};
+		window.ajaxurl = '/';
+
+		nock( 'http://localhost' ).post( '/' ).reply( 200, {} );
+
+		const { container } = render( <Ready onDismiss={ onDismissMock } /> );
+
+		fireEvent.click(
+			container.querySelector( '.sensei-home-ready__dismiss' )
+		);
+
+		await waitFor( () => {
+			expect( onDismissMock ).toBeCalled();
+		} );
+	} );
+} );

--- a/assets/home/tasks-section/ready.test.js
+++ b/assets/home/tasks-section/ready.test.js
@@ -18,7 +18,7 @@ describe( '<Ready />', () => {
 		};
 		window.ajaxurl = '/';
 
-		nock( 'http://localhost' ).post( '/' ).reply( 200, {} );
+		const scope = nock( 'http://localhost' ).post( '/' ).reply( 200, {} );
 
 		const { container } = render( <Ready onDismiss={ onDismissMock } /> );
 
@@ -28,6 +28,7 @@ describe( '<Ready />', () => {
 
 		await waitFor( () => {
 			expect( onDismissMock ).toBeCalled();
+			scope.done();
 		} );
 	} );
 } );

--- a/assets/home/tasks-section/style.scss
+++ b/assets/home/tasks-section/style.scss
@@ -5,7 +5,7 @@
 
 .sensei-home-tasks-section {
 	position: relative;
-	background-image: url("../images/home-top-left-illustration.png"), url("../images/home-bottom-right-illustration.png");
+	background-image: url("../../images/home-top-left-illustration.png"), url("../../images/home-bottom-right-illustration.png");
 	background-position: -197px 0, calc( 100% + 197px ) 100%;
 	background-repeat: no-repeat;
 	transition: 0.5s background-position;

--- a/assets/home/tasks-section/style.scss
+++ b/assets/home/tasks-section/style.scss
@@ -4,6 +4,17 @@
 @import 'ready';
 
 .sensei-home-tasks-section {
+	background-image: url("../images/home-top-left-illustration.png"), url("../images/home-bottom-right-illustration.png");
+	background-position: -197px 0, calc( 100% + 197px ) 100%;
+	background-repeat: no-repeat;
+	transition: 0.5s background-position;
+
+	&--ready {
+		@media ( min-width: 1120px ) {
+			background-position: 0 0, 100% 100%;
+		}
+	}
+
 	&__inside{
 		@media ( min-width: $break-large ) {
 			display: flex;

--- a/assets/home/tasks-section/style.scss
+++ b/assets/home/tasks-section/style.scss
@@ -4,6 +4,7 @@
 @import 'ready';
 
 .sensei-home-tasks-section {
+	position: relative;
 	background-image: url("../images/home-top-left-illustration.png"), url("../images/home-bottom-right-illustration.png");
 	background-position: -197px 0, calc( 100% + 197px ) 100%;
 	background-repeat: no-repeat;

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -18,7 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since $$next-version$$
  */
 final class Sensei_Home {
-	const SCREEN_ID = 'course_page_sensei-home';
+	const SCREEN_ID                  = 'course_page_sensei-home';
+	const DISMISS_TASKS_NONCE_ACTION = 'sensei-lms-dismiss-tasks';
+	const DISMISS_TASKS_OPTION       = 'sensei-home-tasks-dismissed';
 
 	/**
 	 * Instance of class.
@@ -68,6 +70,7 @@ final class Sensei_Home {
 		$this->notices->init();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+		add_action( 'wp_ajax_sensei_home_tasks_dismiss', [ $this, 'handle_tasks_dismiss' ] );
 	}
 
 	/**
@@ -121,6 +124,8 @@ final class Sensei_Home {
 				'activate-plugin_' . $plugin_file
 			);
 		}
+
+		$data['dismiss_tasks_nonce'] = wp_create_nonce( self::DISMISS_TASKS_NONCE_ACTION );
 
 		wp_localize_script(
 			'sensei-home',
@@ -178,6 +183,20 @@ final class Sensei_Home {
 	 */
 	public function render() {
 		require __DIR__ . '/views/html-admin-page-home.php';
+	}
+	/**
+	 * Handle tasks dismissal.
+	 *
+	 * @access private
+	 */
+	public function handle_tasks_dismiss() {
+		check_ajax_referer( self::DISMISS_TASKS_NONCE_ACTION );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( '', '', 403 );
+		}
+
+		update_option( self::DISMISS_TASKS_OPTION, 1 );
 	}
 
 	/**

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -127,6 +127,8 @@ final class Sensei_Home {
 
 		$data['dismiss_tasks_nonce'] = wp_create_nonce( self::DISMISS_TASKS_NONCE_ACTION );
 
+		$data['tasks_dismissed'] = get_option( self::DISMISS_TASKS_OPTION );
+
 		wp_localize_script(
 			'sensei-home',
 			'sensei_home',
@@ -196,7 +198,7 @@ final class Sensei_Home {
 			wp_die( '', '', 403 );
 		}
 
-		update_option( self::DISMISS_TASKS_OPTION, 1 );
+		update_option( self::DISMISS_TASKS_OPTION, 1, false );
 	}
 
 	/**

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class Sensei_Home {
 	const SCREEN_ID                  = 'course_page_sensei-home';
 	const DISMISS_TASKS_NONCE_ACTION = 'sensei-lms-dismiss-tasks';
-	const DISMISS_TASKS_OPTION       = 'sensei-home-tasks-dismissed';
+	const DISMISS_TASKS_OPTION       = 'sensei_home_tasks_dismissed';
 
 	/**
 	 * Instance of class.

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -89,6 +89,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_theme_query_var_flushed',
 		'sensei_settings_sections_visited',
 		'sensei_home_tasks_list_is_completed',
+		'sensei-home-tasks-dismissed',
 	);
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -89,7 +89,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_theme_query_var_flushed',
 		'sensei_settings_sections_visited',
 		'sensei_home_tasks_list_is_completed',
-		'sensei-home-tasks-dismissed',
+		'sensei_home_tasks_dismissed',
 	);
 
 	/**


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/5633
Based on https://github.com/Automattic/sensei/pull/5902

### Changes proposed in this Pull Request

* It adds the tasks completion behavior.
* Basically, it makes a transition from the tasks list to the ready state in the first load after all tasks are completed.
* It also adds a dismissable feature to the tasks.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* In a new env, complete all the tasks.
* Make sure that in the first load after completing all the tasks you will see a transition from the tasks to the ready state.
* Refresh the page again, and make sure the ready state is displayed directly without the transition.
* Click on "X" in the top right of the tasks, and make sure it disappears.
* Refresh the page, and make sure the tasks section doesn't render anymore.

Options to remove to re-test it:
- `sensei_home_tasks_list_is_completed`
- `sensei_home_tasks_dismissed`

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/195918301-f57dd89e-e10d-456c-9122-d5b8dea3c319.mov
