### PR TITLE
Add course and site metadata for the tasks attribute on sensei home endpoint

### DIFF
--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -119,7 +119,7 @@ class Sensei_Home_Tasks_Provider {
 			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
 			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_name NOT LIKE %s LIMIT 1", "{$prefix}%" ) );
-			if ( false === $post_id ) {
+			if ( null === $post_id ) {
 				$result = null;
 			} else {
 				$result = [

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -25,6 +25,7 @@ class Sensei_Home_Tasks_Provider {
 	public function get(): array {
 		return [
 			'items'        => $this->get_tasks(),
+			'site'         => $this->get_site(),
 			'is_completed' => (bool) get_option( self::COMPLETED_TASKS_OPTION_KEY, false ),
 		];
 	}
@@ -85,6 +86,20 @@ class Sensei_Home_Tasks_Provider {
 			'url'      => $task->get_url(),
 			'image'    => $task->get_image(),
 			'done'     => $task->is_completed(),
+		];
+	}
+
+	/**
+	 * Return the site information needed for the task list component.
+	 *
+	 * @return array The site info, including title and image (which is the custom logo) URl.
+	 */
+	private function get_site() {
+		$custom_logo_id = get_theme_mod( 'custom_logo' );
+		$image          = wp_get_attachment_image_src( $custom_logo_id, 'full' );
+		return [
+			'title' => get_bloginfo( 'name' ),
+			'image' => $image[0],
 		];
 	}
 

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -127,7 +127,7 @@ class Sensei_Home_Tasks_Provider {
 					'title' => get_the_title( $post_id ),
 					'image' => $image ? $image : null,
 				];
-				wp_cache_set( $cache_key, $result, $cache_group );
+				wp_cache_set( $cache_key, $result, $cache_group, 60 );
 			}
 		}
 		return $result;

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -108,7 +108,7 @@ class Sensei_Home_Tasks_Provider {
 	 * Return the course information needed for the task list component, including title and image (which is the
 	 * featured image) for that course. Please note that the data for the demo course is never returned by this method.
 	 *
-	 * @return array|null The course information, including title and image URL.
+	 * @return array|null The course information, including title, the permalink and the URL for the featured image.
 	 */
 	private function get_course() {
 		global $wpdb;

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -93,7 +93,7 @@ class Sensei_Home_Tasks_Provider {
 	/**
 	 * Return the site information needed for the task list component.
 	 *
-	 * @return array The site info, including title and image (which is the custom logo) URl.
+	 * @return array The site info, including title and image (which is the custom logo) URL.
 	 */
 	private function get_site() {
 		$custom_logo_id = get_theme_mod( 'custom_logo' );

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -118,7 +118,7 @@ class Sensei_Home_Tasks_Provider {
 		if ( false === $result ) {
 			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
-			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_name NOT LIKE %s LIMIT 1", "{$prefix}%" ) );
+			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s LIMIT 1", "{$prefix}%" ) );
 			if ( null === $post_id ) {
 				$result = null;
 			} else {

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -122,9 +122,10 @@ class Sensei_Home_Tasks_Provider {
 			if ( null === $post_id ) {
 				$result = null;
 			} else {
+				$image  = get_the_post_thumbnail_url( $post_id, 'full' );
 				$result = [
 					'title' => get_the_title( $post_id ),
-					'image' => get_the_post_thumbnail_url( $post_id, 'full' ),
+					'image' => $image ? $image : null,
 				];
 				wp_cache_set( $cache_key, $result, $cache_group );
 			}

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -100,7 +100,7 @@ class Sensei_Home_Tasks_Provider {
 		$image          = wp_get_attachment_image_src( $custom_logo_id, 'full' );
 		return [
 			'title' => get_bloginfo( 'name' ),
-			'image' => $image[0],
+			'image' => $image ? $image[0] : null,
 		];
 	}
 

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -118,7 +118,7 @@ class Sensei_Home_Tasks_Provider {
 		if ( false === $result ) {
 			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
-			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s ORDER BY ID ASC LIMIT 1", "{$prefix}%" ) );
+			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s ORDER BY post_status='published' DESC, ID ASC LIMIT 1", "{$prefix}%" ) );
 			if ( null === $post_id ) {
 				$result = null;
 			} else {

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -118,7 +118,7 @@ class Sensei_Home_Tasks_Provider {
 		if ( false === $result ) {
 			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
-			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s LIMIT 1", "{$prefix}%" ) );
+			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s ORDER BY ID ASC LIMIT 1", "{$prefix}%" ) );
 			if ( null === $post_id ) {
 				$result = null;
 			} else {

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -124,8 +124,9 @@ class Sensei_Home_Tasks_Provider {
 			} else {
 				$image  = get_the_post_thumbnail_url( $post_id, 'full' );
 				$result = [
-					'title' => get_the_title( $post_id ),
-					'image' => $image ? $image : null,
+					'title'     => get_the_title( $post_id ),
+					'permalink' => get_permalink( $post_id ),
+					'image'     => $image ? $image : null,
 				];
 				wp_cache_set( $cache_key, $result, $cache_group, 60 );
 			}

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -138,7 +138,7 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 
 	public function testGet_WhenCalled_ReturnsCourseTitleWhenACourseIsFound() {
 		// Arrange
-		$this->factory->course->create(
+		$course_id = $this->factory->course->create(
 			[
 				'post_name'   => 'testing',
 				'post_title'  => 'Test Course',
@@ -155,6 +155,7 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'course', $result );
 		$this->assertIsArray( $result['course'] );
 		$this->assertEquals( 'Test Course', $result['course']['title'] );
+		$this->assertStringContainsString( 'p=' . $course_id, $result['course']['permalink'] );
 		$this->assertNull( $result['course']['image'] );
 	}
 
@@ -179,6 +180,7 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'course', $result );
 		$this->assertIsArray( $result['course'] );
 		$this->assertEquals( 'Test Course', $result['course']['title'] );
+		$this->assertStringContainsString( 'testing', $result['course']['permalink'] );
 		$this->assertEquals( 'test-image.png', $result['course']['image'] );
 	}
 

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -150,8 +150,9 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		// Arrange
 		$this->factory->course->create(
 			[
-				'post_name'  => 'testing',
-				'post_title' => 'Test Course',
+				'post_name'   => 'testing',
+				'post_title'  => 'Test Course',
+				'post_status' => 'draft',
 			]
 		);
 		self::flush_cache();
@@ -171,8 +172,9 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		// Arrange
 		$course_id = $this->factory->course->create(
 			[
-				'post_name'  => 'testing',
-				'post_title' => 'Test Course',
+				'post_name'   => 'testing',
+				'post_title'  => 'Test Course',
+				'post_status' => 'publish',
 			]
 		);
 		update_post_meta( $course_id, '_thumbnail_id', 42 );
@@ -188,6 +190,28 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $result['course'] );
 		$this->assertEquals( 'Test Course', $result['course']['title'] );
 		$this->assertEquals( 'test-featured-image.png', $result['course']['image'] );
+	}
+
+	public function testGet_WhenCalled_ReturnsCourseAsNullWhenTheCourseIsOnTrash() {
+		// Arrange
+		$course_id = $this->factory->course->create(
+			[
+				'post_name'   => 'testing',
+				'post_title'  => 'Test Course',
+				'post_status' => 'trash',
+			]
+		);
+		update_post_meta( $course_id, '_thumbnail_id', 42 );
+		add_filter( 'post_thumbnail_url', [ $this, 'overrideWithCustomImage' ] );
+		self::flush_cache();
+
+		// Act
+		$result = $this->provider->get();
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'course', $result );
+		$this->assertNull( $result['course'] );
 	}
 
 	public function testGet_WhenCalled_ReturnsIsCompletedFalseAsDefault() {

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -40,8 +40,7 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 
 	public function tearDown() {
 		remove_filter( 'sensei_home_tasks', [ $this, 'overrideWithFakeTask' ] );
-		remove_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomLogo' ] );
-		remove_filter( 'post_thumbnail_url', [ $this, 'overrideWithCustomImage' ] );
+		remove_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomImage' ] );
 		parent::tearDown();
 	}
 
@@ -89,23 +88,14 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 	 *
 	 * @return string[]
 	 */
-	public function overrideWithCustomLogo() : array {
+	public function overrideWithCustomImage() : array {
 		return [ 'test-image.png' ];
-	}
-
-	/**
-	 * Callback to be used in filter, to return a custom placeholder image for posts.
-	 *
-	 * @return string
-	 */
-	public function overrideWithCustomImage(): string {
-		return 'test-featured-image.png';
 	}
 
 	public function testGet_WhenCalled_ReturnsSiteContainingSiteInfo() {
 		// Arrange
 		update_option( 'blogname', 'Test site' );
-		add_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomLogo' ] );
+		add_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomImage' ] );
 
 		// Act
 		$result = $this->provider->get();
@@ -178,7 +168,7 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 			]
 		);
 		update_post_meta( $course_id, '_thumbnail_id', 42 );
-		add_filter( 'post_thumbnail_url', [ $this, 'overrideWithCustomImage' ] );
+		add_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomImage' ] );
 		self::flush_cache();
 
 		// Act
@@ -189,7 +179,7 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'course', $result );
 		$this->assertIsArray( $result['course'] );
 		$this->assertEquals( 'Test Course', $result['course']['title'] );
-		$this->assertEquals( 'test-featured-image.png', $result['course']['image'] );
+		$this->assertEquals( 'test-image.png', $result['course']['image'] );
 	}
 
 	public function testGet_WhenCalled_ReturnsCourseAsNullWhenTheCourseIsOnTrash() {

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -25,13 +25,23 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 	 */
 	private $provider;
 
+	/**
+	 * The factory to help with testing the course attribute.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
 	public function setUp() {
 		parent::setUp();
 		$this->provider = new Sensei_Home_Tasks_Provider();
+		$this->factory  = new Sensei_Factory();
 	}
 
 	public function tearDown() {
 		remove_filter( 'sensei_home_tasks', [ $this, 'overrideWithFakeTask' ] );
+		remove_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomLogo' ] );
+		remove_filter( 'post_thumbnail_url', [ $this, 'overrideWithCustomImage' ] );
 		parent::tearDown();
 	}
 
@@ -72,6 +82,112 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		return [
 			self::FAKE_TASK_ID => [ 'fake' ],
 		];
+	}
+
+	/**
+	 * Callback to be used in filter, to return a custom placeholder image for the site.
+	 *
+	 * @return string[]
+	 */
+	public function overrideWithCustomLogo() : array {
+		return [ 'test-image.png' ];
+	}
+
+	/**
+	 * Callback to be used in filter, to return a custom placeholder image for posts.
+	 *
+	 * @return string
+	 */
+	public function overrideWithCustomImage(): string {
+		return 'test-featured-image.png';
+	}
+
+	public function testGet_WhenCalled_ReturnsSiteContainingSiteInfo() {
+		// Arrange
+		update_option( 'blogname', 'Test site' );
+		add_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomLogo' ] );
+
+		// Act
+		$result = $this->provider->get();
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'site', $result );
+		$this->assertIsArray( $result['site'] );
+		$this->assertEquals( 'Test site', $result['site']['title'] );
+		$this->assertEquals( 'test-image.png', $result['site']['image'] );
+	}
+
+	public function testGet_WhenCalled_ReturnsSiteImageAsNullWhenNoCustomLogoIsDefined() {
+		// Arrange
+		update_option( 'blogname', 'Test site' );
+
+		// Act
+		$result = $this->provider->get();
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'site', $result );
+		$this->assertIsArray( $result['site'] );
+		$this->assertEquals( 'Test site', $result['site']['title'] );
+		$this->assertNull( $result['site']['image'] );
+	}
+
+	public function testGet_WhenCalled_ReturnsNullAsCourseWhenNoCourseIsFound() {
+		// Arrange
+		self::flush_cache();
+
+		// Act
+		$result = $this->provider->get();
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'course', $result );
+		$this->assertNull( $result['course'] );
+	}
+
+	public function testGet_WhenCalled_ReturnsCourseTitleWhenACourseIsFound() {
+		// Arrange
+		$this->factory->course->create(
+			[
+				'post_name'  => 'testing',
+				'post_title' => 'Test Course',
+			]
+		);
+		self::flush_cache();
+
+		// Act
+		$result = $this->provider->get();
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'course', $result );
+		$this->assertIsArray( $result['course'] );
+		$this->assertEquals( 'Test Course', $result['course']['title'] );
+		$this->assertNull( $result['course']['image'] );
+	}
+
+	public function testGet_WhenCalled_ReturnsCourseImageWhenACourseIsFound() {
+		// Arrange
+		$course_id = $this->factory->course->create(
+			[
+				'post_name'  => 'testing',
+				'post_title' => 'Test Course',
+			]
+		);
+		update_post_meta( $course_id, '_thumbnail_id', 42 );
+		add_filter( 'post_thumbnail_url', [ $this, 'overrideWithCustomImage' ] );
+		self::flush_cache();
+
+		// Act
+		$result = $this->provider->get();
+
+		// Assert
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'course', $result );
+		$this->assertIsArray( $result['course'] );
+		$this->assertEquals( 'Test Course', $result['course']['title'] );
+		$this->assertEquals( 'test-featured-image.png', $result['course']['image'] );
 	}
 
 	public function testGet_WhenCalled_ReturnsIsCompletedFalseAsDefault() {


### PR DESCRIPTION
Fixes #5930 

### Changes proposed in this Pull Request

* Add "course" and "site" metadata to the "tasks" object in the endpoint for Sensei Home;
* Add unit tests to check that;

### Testing instructions

On a WP installation containing Sensei LMS on this branch:

1.  Run `curl --user "user:application password" http://your-host/wp-json/sensei-internal/v1/home | jq .tasks` and make sure the "site" object includes the title of the site you're acessing, and the URL to a custom logo if one is defined (or null, if none is defined);
2. Add a custom logo to the site and verify if the image is linked there;
3. Now, import the sample course, and verify if that the "course" attribute is still `null`;
4. Now, create another course, and verify if the course title you just created appears on the `course` object, in the attribute `title`;
5. Add a featured image to the course you just created, and verify if the link to the image appears correctly in the `course` object, in the attribute `image`;
6. Finally, move the course to the trash, and verify if the `course` attribute returns `null` again;