### PR TITLE
Learning Mode - Add "Customize Colors" link for non-block themes in Sensei settings

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -919,10 +919,15 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * @param array $args The field arguments.
 	 */
 	public function render_learning_mode_setting( $args ) {
-		$options       = $this->get_settings();
-		$key           = $args['key'];
-		$value         = $options[ $key ];
-		$customize_url = Sensei_Course_Theme::get_sensei_theme_customize_url( false, 'lesson' );
+		$options = $this->get_settings();
+		$key     = $args['key'];
+		$value   = $options[ $key ];
+
+		$color_customizer_url = '';
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
+			$color_customizer_url = Sensei_Course_Theme::get_learning_mode_customizer_url();
+		}
+
 		?>
 		<label for="<?php echo esc_attr( $key ); ?>">
 			<input id="<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>" type="checkbox" value="1" <?php checked( $value, '1' ); ?> />
@@ -931,14 +936,16 @@ class Sensei_Settings extends Sensei_Settings_API {
 		<p>
 			<span class="description"><?php echo esc_html( $args['data']['description'] ); ?></span>
 		</p>
-		<?php if ( $customize_url ) { ?>
+
+		<?php if ( $color_customizer_url ) : ?>
 			<p class="extra-content">
-				<a href="<?php echo esc_url( $customize_url ); ?>">
-					<?php esc_html_e( 'Customize', 'sensei-lms' ); ?>
+				<a href="<?php echo esc_url( $color_customizer_url ); ?>">
+					<?php esc_html_e( 'Customize Colors', 'sensei-lms' ); ?>
 				</a>
 			</p>
-			<?php
-		}
+		<?php endif; ?>
+
+		<?php
 	}
 
 	/**
@@ -990,7 +997,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'         => "{$this->token}[{$key}]",
 			'value'        => $value,
 			'options'      => $args['data']['options'],
-			'customizeUrl' => Sensei_Course_Theme::get_sensei_theme_customize_url( false, 'lesson' ),
+			'customizeUrl' => Sensei_Course_Theme::get_learning_mode_fse_url(),
 			'formId'       => "{$this->token}-form",
 			'section'      => $args['data']['section'],
 		];

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -424,43 +424,57 @@ class Sensei_Course_Theme {
 	/**
 	 * Returns the url for sensei theme customization.
 	 *
-	 * @param bool        $use_customizer True to use the customizer, false to use the site editor.
 	 * @param string|null $post_type The post type to customize.
 	 *
 	 * @return The customization url
 	 */
-	public static function get_sensei_theme_customize_url( bool $use_customizer = true, string $post_type = null ) : string {
-		if ( $use_customizer ) {
-			// Get the last modified lesson.
-			$result = get_posts(
-				[
-					'posts_per_page' => 1,
-					'post_type'      => 'lesson',
-					'orderby'        => 'modified',
-					'meta'           => [
-						'key'     => '_lesson_course',
-						'compare' => 'EXISTS',
-					],
-				]
-			);
-			if ( empty( $result ) ) {
-				return '';
-			}
-
-			$lesson      = $result[0];
-			$course_id   = get_post_meta( $lesson->ID, '_lesson_course', true );
-			$preview_url = '/?p=' . $lesson->ID;
-
-			if ( ! Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {
-				$preview_url .= '&' . self::PREVIEW_QUERY_VAR . '=' . $course_id;
-			}
-
-			return '/wp-admin/customize.php?autofocus[section]=sensei-course-theme&url=' . rawurlencode( $preview_url );
+	public static function get_learning_mode_fse_url( string $post_type = null ) : string {
+		// Get the post type manually if not provided.
+		if ( ! $post_type ) {
+			$post_type = get_post_type();
 		}
 
-		$post_type = $post_type ?? 'lesson';
+		// Fallback the post type to lesson if not determined.
+		if ( ! $post_type ) {
+			$post_type = 'lesson';
+		}
 
 		return admin_url( 'site-editor.php?postType=wp_template&postId=' . self::THEME_NAME . '//' . $post_type );
+	}
+
+	/**
+	 * Returnds the url for customizing Learning Mode template colors.
+	 */
+	public static function get_learning_mode_customizer_url(): string {
+			// Get the last modified lesson.
+		$result = get_posts(
+			[
+				'posts_per_page' => 1,
+				'post_type'      => 'lesson',
+				'orderby'        => 'modified',
+				'meta'           => [
+					'key'     => '_lesson_course',
+					'compare' => 'EXISTS',
+				],
+			]
+		);
+		if ( empty( $result ) ) {
+			return '';
+		}
+
+		$lesson      = $result[0];
+		$course_id   = get_post_meta( $lesson->ID, '_lesson_course', true );
+		$preview_url = '/?p=' . $lesson->ID;
+
+		if ( ! $course_id ) {
+			return '';
+		}
+
+		if ( ! Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {
+			$preview_url .= '&' . self::PREVIEW_QUERY_VAR . '=' . $course_id;
+		}
+
+		return '/wp-admin/customize.php?autofocus[section]=sensei-course-theme&url=' . rawurlencode( $preview_url );
 	}
 
 	/**
@@ -498,7 +512,7 @@ class Sensei_Course_Theme {
 			array(
 				'id'    => 'site-editor',
 				'title' => __( 'Edit Site', 'sensei-lms' ),
-				'href'  => self::get_sensei_theme_customize_url( false, get_post_type() ),
+				'href'  => self::get_learning_mode_fse_url( get_post_type() ),
 			)
 		);
 	}


### PR DESCRIPTION
Fixes #5915 

### Changes proposed in this Pull Request

* Adds a "Customize Colors" link for non-block based themes.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Activate a **non-block** based theme.
* Go to Sensei > Settings > Appearance.
* Confirm that there is a "Customize Colors" link and click on it.
* Confirm that it opens a WP Customizer with Sensei colors section.
* Go to Sensei > Settings > Apperance.
* Confirm the active template has a "Customize" button on it. Click on it.
* Confirm that it opens up a FSE for the active template.

***

* Activate a **block** based theme.
* Go to Sensei > Settings > Appearance.
* Confirm that there is **no** "Customize Color" present.
* Confirm that the active template has a "Customize" button.
* Confirm that the button opens a FSE for the active template.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/2578542/195844792-a3b283fa-3021-42ba-a50f-bff8ca9d6f3b.mp4

