### PR TITLE
Ignore courses on trash and adjust cache expiration on task "Create your First Course"

### DIFF
--- a/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
@@ -70,7 +70,7 @@ class Sensei_Home_Task_Create_First_Course implements Sensei_Home_Task {
 				$result = 0;
 			} else {
 				$result = (int) $result;
-				wp_cache_set( $cache_key, $result, $cache_group );
+				wp_cache_set( $cache_key, $result, $cache_group, 60 );
 			}
 		}
 		return $result > 0;

--- a/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
@@ -65,7 +65,7 @@ class Sensei_Home_Task_Create_First_Course implements Sensei_Home_Task {
 		if ( false === $result ) {
 			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
-			$result = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type='course' AND post_name NOT LIKE %s", "{$prefix}%" ) );
+			$result = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s", "{$prefix}%" ) );
 			if ( null === $result ) {
 				$result = 0;
 			} else {

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-create-first-course.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-create-first-course.php
@@ -47,7 +47,8 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 		// Arrange
 		$this->factory->course->create(
 			[
-				'post_name' => 'testing',
+				'post_name'   => 'testing',
+				'post_status' => 'draft',
 			]
 		);
 		self::flush_cache();
@@ -58,7 +59,25 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 		// Assert
 		$this->assertTrue( $is_completed );
 	}
+	/**
+	 * Verify if is_completed returns false when a course that doesn't have the sample course slug is on trash.
+	 */
+	public function testIsCompleted_NonSampleCourseOnTrash_ReturnsFalse() {
+		// Arrange
+		$this->factory->course->create(
+			[
+				'post_name'   => 'testing',
+				'post_status' => 'trash',
+			]
+		);
+		self::flush_cache();
 
+		// Act
+		$is_completed = $this->task->is_completed();
+
+		// Assert
+		$this->assertFalse( $is_completed );
+	}
 
 	/**
 	 * Verify if is_completed still returns false when a course that has the sample course slug is registered.
@@ -67,7 +86,8 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 		// Arrange
 		$this->factory->course->create(
 			[
-				'post_name' => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG,
+				'post_name'   => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG,
+				'post_status' => 'draft',
 			]
 		);
 		self::flush_cache();
@@ -86,12 +106,14 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 		// Arrange
 		$this->factory->course->create(
 			[
-				'post_name' => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG,
+				'post_name'   => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG,
+				'post_status' => 'draft',
 			]
 		);
 		$this->factory->course->create(
 			[
-				'post_name' => 'test',
+				'post_name'   => 'test',
+				'post_status' => 'draft',
 			]
 		);
 		self::flush_cache();


### PR DESCRIPTION
Fixes #5934 
Fixes #5935

### Changes proposed in this Pull Request

* Add filter on the `post_status` to avoid considering posts that are not draft or published on the task "Create your First Course";
* Adjust expiration of the cache entry tor the task "Create your First Course";
* Adjust tests to verify the new condition;

### Testing instructions

On a WP installation containing Sensei LMS on this branch:

1.  Run `curl --user "user:application password" http://your-host/wp-json/sensei-internal/v1/home` and make sure that the task "Create your first Course" has `done` set to `false`, with the URL pointing to create a new course;
2. Import the sample course, and verify if that task still has `done` set to `false`, with the URL still pointing to create a new course.
3. Now, create another course, and verify if that task still has `done` set to `true`, with the URL still pointing to create a new course.;
4. Publish the course you just created, and verify if that task still has `done` set to `true`, with the URL still pointing to create a new course.;
5. Now, put the course you just created on the trash, and verify if that task now has `done` set to `false`;
