### PR TITLE
Add sensei guides section

### DIFF
--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -492,17 +492,15 @@ $break-medium: 783px; // adminbar goes big
 
 		&__link {
 			& a {
-				display: flex;
-				flex-direction: row;
-				align-items: center;
 				text-decoration: unset;
+			}
 
-				& svg {
-					fill: currentColor;
-					margin-left: 7px;
-					width: 16px;
-					height: 16px;
-				}
+			&__external-icon {
+				margin-left: 4px;
+				vertical-align: text-bottom;
+				fill: currentColor;
+				width: 16px;
+				height: 16px;
 			}
 		}
 	}

--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -8,6 +8,7 @@ $break-medium: 783px; // adminbar goes big
 @import 'tasks-section/style';
 @import 'sections/extensions';
 @import 'sections/get-help';
+@import 'sections/sensei-guides';
 
 @mixin white-box( $r: 2px ) {
 	border-radius: $r;
@@ -494,6 +495,7 @@ $break-medium: 783px; // adminbar goes big
 				display: flex;
 				flex-direction: row;
 				align-items: center;
+				text-decoration: unset;
 
 				& svg {
 					fill: currentColor;

--- a/assets/home/link.js
+++ b/assets/home/link.js
@@ -28,7 +28,13 @@ const Link = ( { label, url } ) => {
 	return (
 		<div className="sensei-home__link">
 			<a href={ url } target="_blank" rel="noreferrer">
-				{ label } { isExternal && <Icon icon={ external } /> }
+				{ label }
+				{ isExternal && (
+					<Icon
+						icon={ external }
+						className="sensei-home__link__external-icon"
+					/>
+				) }
 			</a>
 		</div>
 	);

--- a/assets/home/main.js
+++ b/assets/home/main.js
@@ -81,7 +81,7 @@ const Main = () => {
 				<SenseiProAd />
 
 				<Col as="section" className="sensei-home__section" cols={ 6 }>
-					<SenseiGuides />
+					<SenseiGuides data={ data?.guides } />
 				</Col>
 
 				<Col as="section" className="sensei-home__section" cols={ 6 }>

--- a/assets/home/sections/sensei-guides.js
+++ b/assets/home/sections/sensei-guides.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -29,10 +28,7 @@ const SenseiGuides = ( { data } ) => {
 			<ul>
 				{ data.items.map( ( item, key ) => (
 					<li key={ key }>
-						<Link
-							label={ decodeEntities( item.title ) }
-							url={ item.url }
-						/>
+						<Link label={ item.title } url={ item.url } />
 					</li>
 				) ) }
 			</ul>

--- a/assets/home/sections/sensei-guides.js
+++ b/assets/home/sections/sensei-guides.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -28,7 +29,10 @@ const SenseiGuides = ( { data } ) => {
 			<ul>
 				{ data.items.map( ( item, key ) => (
 					<li key={ key }>
-						<Link label={ item.title } url={ item.url } />
+						<Link
+							label={ decodeEntities( item.title ) }
+							url={ item.url }
+						/>
 					</li>
 				) ) }
 			</ul>

--- a/assets/home/sections/sensei-guides.js
+++ b/assets/home/sections/sensei-guides.js
@@ -7,16 +7,41 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Section from '../section';
+import Link from '../link';
 
 /**
  * Sensei Guides section component.
+ *
+ * @param {Object} props
+ * @param {Object} props.data
  */
-const SenseiGuides = () => (
-	<Section title={ __( 'Sensei Guides', 'sensei-lms' ) }>
-		<ul>
-			<li>Test 3</li>
-		</ul>
-	</Section>
-);
+const SenseiGuides = ( { data } ) => {
+	if ( ! data ) {
+		return null;
+	}
+
+	return (
+		<Section
+			title={ __( 'Sensei Guides', 'sensei-lms' ) }
+			className="sensei-home__guides"
+		>
+			<ul>
+				{ data.items.map( ( item, key ) => (
+					<li key={ key }>
+						<Link label={ item.title } url={ item.url } />
+					</li>
+				) ) }
+			</ul>
+			{ data.more_url && (
+				<div className="sensei-home__guides__more-link">
+					<Link
+						label={ __( 'See more', 'sensei-lms' ) }
+						url={ data.more_url }
+					/>
+				</div>
+			) }
+		</Section>
+	);
+};
 
 export default SenseiGuides;

--- a/assets/home/sections/sensei-guides.scss
+++ b/assets/home/sections/sensei-guides.scss
@@ -1,0 +1,18 @@
+.sensei-home-page {
+	.sensei-home {
+		&__guides {
+			ul {
+				display: flex;
+				flex-direction: column;
+				gap: 12px;
+				li {
+
+				}
+			}
+
+			&__more-link {
+				margin-top: 18px;
+			}
+		}
+	}
+}

--- a/assets/home/sections/sensei-guides.scss
+++ b/assets/home/sections/sensei-guides.scss
@@ -5,9 +5,6 @@
 				display: flex;
 				flex-direction: column;
 				gap: 12px;
-				li {
-
-				}
 			}
 
 			&__more-link {

--- a/assets/home/sections/sensei-guides.scss
+++ b/assets/home/sections/sensei-guides.scss
@@ -5,6 +5,10 @@
 				display: flex;
 				flex-direction: column;
 				gap: 12px;
+
+				li {
+					margin: 0;
+				}
 			}
 
 			&__more-link {


### PR DESCRIPTION
Fixes #5628 

### Changes proposed in this Pull Request
* Add Sensei Guides section.
* Connect to Main data retrieval.
* Reuses `<Link>` component.
* Improve `<Link>` component responsiveness for small screens.

### Testing instructions
* Checkout to the branch.
* Go to Sensei Home.
* Check that everything looks fine in both desktop and responsive.

### Screenshot / Video
<img width="805" alt="image" src="https://user-images.githubusercontent.com/799065/196187771-0f5117bc-ce9b-4f16-937a-c7e20bf0539c.png">
<img width="347" alt="image" src="https://user-images.githubusercontent.com/799065/196190503-ab4dcf8e-d3da-49ba-848c-071fa9ddb215.png">
