### PR TITLE
Fix meta-based featured lesson video

### DIFF
--- a/includes/blocks/course-theme/class-lesson-video.php
+++ b/includes/blocks/course-theme/class-lesson-video.php
@@ -69,6 +69,7 @@ class Lesson_Video {
 		);
 
 		remove_action( 'sensei_lesson_video', [ Sensei_Frontend::class, 'sensei_lesson_video' ] );
+		remove_action( 'the_content', [ \Sensei_Course_Theme::instance(), 'add_lesson_video_to_content' ], 80 );
 
 		global $sensei_template_has_lesson_video_block;
 		$sensei_template_has_lesson_video_block = true;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2680,8 +2680,7 @@ class Sensei_Utils {
 				}
 			}
 		}
-		$video_embed = get_post_meta( $post->ID
-			, '_lesson_video_embed', true );
+		$video_embed = get_post_meta( $post->ID, '_lesson_video_embed', true );
 		return $video_embed ? self::render_video_embed( $video_embed ) : null;
 
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2663,10 +2663,14 @@ class Sensei_Utils {
 	 *
 	 * @param string $post_id the post ID.
 	 *
-	 * @return string|false The featured video HTML output if it exists, or false if it doesn't.
+	 * @return string|null The featured video HTML output if it exists.
 	 */
 	public static function get_featured_video_html( $post_id = null ) {
 		$post = get_post( $post_id );
+
+		if ( empty( $post ) ) {
+			return null;
+		}
 
 		if ( has_block( 'sensei-lms/featured-video', $post ) ) {
 			$blocks = parse_blocks( $post->post_content );
@@ -2676,8 +2680,9 @@ class Sensei_Utils {
 				}
 			}
 		}
-		$video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
-		return $video_embed ? self::render_video_embed( $video_embed ) : '';
+		$video_embed = get_post_meta( $post->ID
+			, '_lesson_video_embed', true );
+		return $video_embed ? self::render_video_embed( $video_embed ) : null;
 
 	}
 


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Fix `get_featured_video_html` not using the current post to get `_lesson_video_embed` meta
* Fix lesson video still being appended to content in LM when the Lesson Video block is used

### Testing instructions

* Set the LM template to 'Video'
* Use the classic editor plugin, and edit a lesson in the classic editor
* Add a video in the Lesson Information metabox's Video Embed Code field (Just a video URL is enough)
* Save & view on frontend
* Check that the video is displayed as part of the video container
* Check that the video is not also rendered after the content

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="579" alt="image" src="https://user-images.githubusercontent.com/176949/196204809-1633faaf-ed21-4193-85c5-8aed45b1c150.png">

