### PR TITLE
Prevent course enrollment if user did not complete prerequisites or if course requires a password.

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3217,7 +3217,11 @@ class Sensei_Course {
 	 * @return bool
 	 */
 	public static function can_current_user_manually_enrol( $course_id ) {
-		if ( ! is_user_logged_in() ) {
+		if (
+			! is_user_logged_in() ||
+			! self::is_prerequisite_complete( $course_id ) ||
+			post_password_required()
+		) {
 			return false;
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3217,11 +3217,7 @@ class Sensei_Course {
 	 * @return bool
 	 */
 	public static function can_current_user_manually_enrol( $course_id ) {
-		if (
-			! is_user_logged_in() ||
-			! self::is_prerequisite_complete( $course_id ) ||
-			post_password_required()
-		) {
+		if ( ! is_user_logged_in() ) {
 			return false;
 		}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1174,6 +1174,8 @@ class Sensei_Frontend {
 			&& isset( $_POST['course_start'] )
 			&& wp_verify_nonce( $_POST['woothemes_sensei_start_course_noonce'], 'woothemes_sensei_start_course_noonce' )
 			&& Sensei_Course::can_current_user_manually_enrol( $post->ID )
+			&& Sensei_Course::is_prerequisite_complete( $post->ID )
+			&& ! post_password_required( $post->ID )
 		) {
 
 			/**


### PR DESCRIPTION
Fixes #5955 

### Changes proposed in this Pull Request

* Checks if student has completed the prerequisites for a course before enrolling.
* If the course is password protected, checks if the student has provided the password before enrolling.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->

### How to reproduce the bug

* Checkout the `trunk` branch.
* We'll need two courses: Course A, Course B
* Set Course A as a prerequisite to Course B
* Go to Course A page. Do not enroll to Course A. In Course A page inspect the **Take Course** button in dev console. Find the `woothemes_sensei_start_course_noonce` value. See below screenshot to see what I am talking about. This will be our `COURSE_A_NOONCE` value.
* Open the **Network** tab of the browser dev tools and get the WordPress login cookie. This will be our `WP_COOKIE` value.
* Go to Course B page and copy the url. This will be our `COURSE_B_URL` value.
* Run the below `curl` command with values from above steps.
```bash
curl --request POST \
  --url [COURSE_B_URL] \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --header 'Cookie: [WP_COOKIE]' \
  --data course_start=1 \
  --data woothemes_sensei_start_course_noonce=[COURSE_A_NOONCE]
```
This will enroll the user to **Course B** even though the student had not completed prerequisite course **Course A**.

The above steps also allows the user to enroll to a password protected course.

⚠️ **The above steps does not allow the student to enroll to a paid course that they did not buy.** ⚠️ 

### How to confirm the fix

* Repeat the steps above for this branch
* Confirm the student does not get enrolled to a course with prerequisites.
* Confirm the student does not get enrolled to a password protected course.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Get the noonce value

<img width="567" alt="Screen Shot 2022-10-17 at 18 33 06" src="https://user-images.githubusercontent.com/2578542/196209974-86ff918c-96d8-48fa-a755-0b97600d1d1c.png">

#### Get the WordPress cookie

<img width="557" alt="Screen Shot 2022-10-17 at 18 50 57" src="https://user-images.githubusercontent.com/2578542/196209991-951cf4a8-d85e-4205-be14-21fc480aead7.png">
