### PR TITLE
Fix: Validate colors when saving email template options.

### DIFF
--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -933,7 +933,7 @@ class Sensei_Settings_API {
 		foreach ( $this->fields as $k => $v ) {
 			if ( 'color' === $v['type'] ) {
 				$input[ $k ] = str_replace( '#', '', $input[ $k ] );
-				if ( ! ctype_xdigit( $input ) && strlen( $input[ $k ] ) !== 6 ) {
+				if ( ! ctype_xdigit( $input[ $k ] ) || strlen( $input[ $k ] ) !== 6 ) {
 					$input[ $k ] = false;
 				}
 			}

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -931,6 +931,12 @@ class Sensei_Settings_API {
 		$options = $this->get_settings();
 
 		foreach ( $this->fields as $k => $v ) {
+			if ( $v['type'] === 'color' ) {
+				$input[$k] = str_replace( '#', '', $input[$k] );
+				if( ! ctype_xdigit( $input ) && strlen( $input[$k] ) !== 6) {
+					$input[ $k ] = false;
+				}
+			}
 			// Make sure checkboxes are present even when false.
 			if ( $v['type'] == 'checkbox' && ! isset( $input[ $k ] ) ) {
 				$input[ $k ] = false; }

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -931,9 +931,9 @@ class Sensei_Settings_API {
 		$options = $this->get_settings();
 
 		foreach ( $this->fields as $k => $v ) {
-			if ( $v['type'] === 'color' ) {
-				$input[$k] = str_replace( '#', '', $input[$k] );
-				if( ! ctype_xdigit( $input ) && strlen( $input[$k] ) !== 6) {
+			if ( 'color' === $v['type'] ) {
+				$input[ $k ] = str_replace( '#', '', $input[ $k ] );
+				if ( ! ctype_xdigit( $input ) && strlen( $input[ $k ] ) !== 6 ) {
 					$input[ $k ] = false;
 				}
 			}

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -210,9 +210,6 @@ if ( ! function_exists( 'sensei_rgb_from_hex' ) ) {
 	 */
 	function sensei_rgb_from_hex( $color ) {
 		$color = str_replace( '#', '', $color );
-		if ( strlen( $color ) > 3 && strlen( $color ) < 6 ) {
-			$color = substr( $color, 0, 3 );
-		}
 		// Convert shorthand colors to full format, e.g. "FFF" -> "FFFFFF"
 		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -210,6 +210,9 @@ if ( ! function_exists( 'sensei_rgb_from_hex' ) ) {
 	 */
 	function sensei_rgb_from_hex( $color ) {
 		$color = str_replace( '#', '', $color );
+		if ( strlen( $color ) > 3 && strlen( $color ) < 6 ) {
+			$color = substr( $color, 0, 3 );
+		}
 		// Convert shorthand colors to full format, e.g. "FFF" -> "FFFFFF"
 		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1947

### Changes proposed in this Pull Request

* This change will not allow you to save a Hex color that is not 6-digits in length.  When you try to do that, you'll see this error:
<img width="555" alt="Screen Shot 2022-10-17 at 3 18 46 PM" src="https://user-images.githubusercontent.com/3220162/196294535-97c83b5e-2ba5-4a09-8e1c-c863c01f9842.png">

### Testing instructions

* Go to Sensei -> Settings
* Click "Email Notifications"
* Change any Color setting to anything other than 6 characters
* Notice that A) You don't have any PHP Errors, and B) You get a Admin notice.

### Screenshot / Video
![hex-validation](https://user-images.githubusercontent.com/3220162/196294785-1c34bb68-bae7-40f4-a081-cced8d54daee.gif)

