### PR TITLE
Add "sell your course with woocommerce" placeholder

### DIFF
--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -45,6 +45,10 @@ class Sensei_Home_Tasks_Provider {
 			new Sensei_Home_Task_Publish_First_Course(),
 		];
 
+		if ( Sensei_Home_Task_Sell_Course_With_WooCommerce::is_active() ) {
+			$core_tasks[] = new Sensei_Home_Task_Sell_Course_With_WooCommerce();
+		}
+
 		$tasks = [];
 		/**
 		 * Each one of the core tasks.

--- a/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * File containing the Sensei_Home_Task_Sell_Course_With_WooCommerce class.
+ *
+ * @package sensei-lms
+ * @since $$next-version$$
+ */
+
+/**
+ * Sensei_Home_Task_Sell_Course_With_WooCommerce class.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Home_Task_Sell_Course_With_WooCommerce implements Sensei_Home_Task {
+	const VISITED_WOOCOMMERCE_ADMIN_OPTION_KEY = 'sensei_home_task_visited_woocommerce';
+
+	/**
+	 * The ID for the task.
+	 *
+	 * @return string
+	 */
+	public static function get_id(): string {
+		return 'sell-course-with-woocommerce';
+	}
+
+	/**
+	 * Number used to sort in frontend.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return 400;
+	}
+
+	/**
+	 * Task title.
+	 *
+	 * @return string
+	 */
+	public function get_title(): string {
+		return __( 'Sell your Course with WooCommerce', 'sensei-lms' );
+	}
+
+	/**
+	 * Task url.
+	 *
+	 * @return string
+	 */
+	public function get_url(): ?string {
+		return admin_url( 'admin.php?page=wc-admin' );
+	}
+
+	/**
+	 * Whether the task is completed or not.
+	 *
+	 * @return bool
+	 */
+	public function is_completed(): bool {
+		return (bool) get_option( self::VISITED_WOOCOMMERCE_ADMIN_OPTION_KEY, false );
+	}
+
+	/**
+	 * Mark the task as completed.
+	 *
+	 * @return void
+	 */
+	public static function mark_completed() {
+		update_option( self::VISITED_WOOCOMMERCE_ADMIN_OPTION_KEY, true, false );
+	}
+
+	/**
+	 * Test if this task should be active or not.
+	 *
+	 * @return bool Whether the task should be active or not.
+	 */
+	public static function is_active() {
+		$features = Sensei_Setup_Wizard::instance()->get_wizard_user_data( 'features' );
+		return in_array( 'woocommerce', $features['selected'], true );
+	}
+}

--- a/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
@@ -74,6 +74,9 @@ class Sensei_Home_Task_Sell_Course_With_WooCommerce implements Sensei_Home_Task 
 	 * @return bool Whether the task should be active or not.
 	 */
 	public static function is_active() {
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			return false;
+		}
 		$features = Sensei_Setup_Wizard::instance()->get_wizard_user_data( 'features' );
 		return in_array( 'woocommerce', $features['selected'], true );
 	}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -42,6 +42,7 @@ class Sensei_Admin {
 		add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
 		add_action( 'admin_head', array( $this, 'admin_menu_highlight' ) );
 		add_action( 'admin_init', array( $this, 'sensei_add_custom_menu_items' ) );
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'admin_print_scripts', array( $this, 'sensei_set_plugin_url' ) );
 
 		// Duplicate lesson & courses
@@ -1807,6 +1808,21 @@ class Sensei_Admin {
 		}
 
 		return $course_structure;
+	}
+
+	/**
+	 * Registers the hook to call mark_completed when the wc-admin page on WooCommerce is visited.
+	 *
+	 * @access private
+	 * @return void
+	 */
+	public function admin_init() {
+		if ( Sensei_Home_Task_Sell_Course_With_WooCommerce::is_active() ) {
+			add_action(
+				get_plugin_page_hook( 'wc-admin', 'woocommerce' ),
+				'Sensei_Home_Task_Sell_Course_With_WooCommerce::mark_completed'
+			);
+		}
 	}
 
 	function sensei_add_custom_menu_items() {

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1818,10 +1818,10 @@ class Sensei_Admin {
 	 */
 	public function admin_init() {
 		if ( Sensei_Home_Task_Sell_Course_With_WooCommerce::is_active() ) {
-			add_action(
-				get_plugin_page_hook( 'wc-admin', 'woocommerce' ),
-				'Sensei_Home_Task_Sell_Course_With_WooCommerce::mark_completed'
-			);
+			$hook = get_plugin_page_hook( 'wc-admin', 'woocommerce' );
+			if ( null !== $hook ) {
+				add_action( $hook, [ Sensei_Home_Task_Sell_Course_With_WooCommerce::class, 'mark_completed' ] );
+			}
 		}
 	}
 

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -89,7 +89,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_theme_query_var_flushed',
 		'sensei_settings_sections_visited',
 		'sensei_home_tasks_list_is_completed',
-		'sensei_home_task_visited_woocommerce'
+		'sensei_home_task_visited_woocommerce',
 	);
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -89,6 +89,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_theme_query_var_flushed',
 		'sensei_settings_sections_visited',
 		'sensei_home_tasks_list_is_completed',
+		'sensei_home_task_visited_woocommerce'
 	);
 
 	/**


### PR DESCRIPTION
Fixes #5907

### Changes proposed in this Pull Request

* Add class to implement "Sell your Course With WooCommerce" task;
* Register hooks to update an option to `true` when the `wc-admin` page from WooCommerce is visited;
* Added that option to the data cleaner;
* Also create a method to verify if the user selected WooCommerce as an intent on the onboarding wizard and just run the code above on that scenario;

### Testing instructions

On a WP installation containing JUST WordPress with the code from Sensei LMS on this branch installed (so, WITHOUT Sensei Pro):

1. On the onboarding wizard, select the intent to sell courses;
2. On Sensei Home, verify that the task "Sell your Course with WooCommerce" appears, and is set as not completed;
3. Click on the link of the task "Sell your Course with WooCommerce" to visit WooCommerce admin dashboard;
4. Now, verify that the task is completed;

It would be nice to verify, too, if the task doesn't appear if you select that you don't want to sell courses on the onboarding wizard.

### 	Notes

I didn't add tests initially because I feel like this is the sort of test that depends on too many factors, like the name of the WC-Admin page, if it's triggered or not, the name of the intent on the onboarding wizard, etc. etc. etc.

I can add tests later, but I think it's worth taking a look to check if this is on the right path given the hook to detect if a page is visited or not.
