### PR TITLE
Fix warning with LM content rendering

### DIFF
--- a/includes/blocks/course-theme/class-course-content.php
+++ b/includes/blocks/course-theme/class-course-content.php
@@ -48,8 +48,15 @@ class Course_Content {
 
 		ob_start();
 		the_content();
-		return ob_get_clean();
+		$content = ob_get_clean();
 
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
+
+		return (
+			'<div ' . $wrapper_attributes . '>' .
+			$content .
+			'</div>'
+		);
 	}
 
 	/**
@@ -82,15 +89,9 @@ class Course_Content {
 				break;
 		}
 
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
-
 		add_filter( 'the_content', [ $this, 'render_content' ] );
 
-		return (
-			'<div ' . $wrapper_attributes . '>' .
-			$content .
-			'</div>'
-		);
+		return $content;
 
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix calling `get_block_wrapper_attributes` in a function that's not actually a block render callback
* Move that wrapper to the block rendering function instead

### Testing instructions

* Lesson and quiz content in learning mode templates should still work, including content width and alignments
* 
