### PR TITLE
Add "Install Demo Course" Quick (Magical) Link

### DIFF
--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -507,6 +507,7 @@ $break-medium: 783px; // adminbar goes big
 			.components-spinner {
 				width: 13px;
 				height: 13px;
+				margin-left: 0;
 			}
 		}
 

--- a/assets/home/home.scss
+++ b/assets/home/home.scss
@@ -503,6 +503,11 @@ $break-medium: 783px; // adminbar goes big
 				font-size: 13px;
 				margin: 0;
 			}
+
+			.components-spinner {
+				width: 13px;
+				height: 13px;
+			}
 		}
 
 		&__link {

--- a/assets/home/install-demo-course.js
+++ b/assets/home/install-demo-course.js
@@ -13,13 +13,13 @@ import { buildJobEndpointUrl } from '../data-port/import/helpers/url';
 import Link from './link';
 
 const useDemoCourseInstaller = () => {
-	const [ error, setError ] = useState( null );
+	const [ hasError, setHasError ] = useState( false );
 	const [ jobId, setJobId ] = useState( null );
 	const [ pollingCount, setPollingCount ] = useState( 0 );
 
-	const catchError = ( e ) => {
+	const catchError = () => {
 		setPollingCount( 0 );
-		setError( e.message );
+		setHasError( true );
 		setJobId( null );
 	};
 
@@ -56,7 +56,7 @@ const useDemoCourseInstaller = () => {
 			.catch( catchError );
 	}, [] );
 
-	return [ jobId, pollingCount, error ];
+	return [ jobId, pollingCount, hasError ];
 };
 
 /**
@@ -81,7 +81,7 @@ function InstallDemoCourse( { remove, restoreLink } ) {
 		}
 	}, [ error, pollingCount, remove, restoreLink ] );
 	if ( error ) {
-		return __( 'Error while installing demo course', 'sensei-lms' );
+		return __( 'Error while installing. Try again.', 'sensei-lms' );
 	}
 	if ( showInstalledLink ) {
 		const { setupSampleCourseNonce } = window.sensei_home;

--- a/assets/home/install-demo-course.js
+++ b/assets/home/install-demo-course.js
@@ -1,0 +1,106 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { buildJobEndpointUrl } from '../data-port/import/helpers/url';
+import Link from './link';
+
+const useDemoCourseInstaller = () => {
+	const [ error, setError ] = useState( null );
+	const [ jobId, setJobId ] = useState( null );
+	const [ pollingCount, setPollingCount ] = useState( 0 );
+
+	const catchError = ( e ) => {
+		setPollingCount( 0 );
+		setError( e.message );
+		setJobId( null );
+	};
+
+	// Logs polling.
+	useEffect( () => {
+		if ( ! jobId ) {
+			return;
+		}
+
+		apiFetch( {
+			path: buildJobEndpointUrl( jobId, [ 'process' ] ),
+			method: 'POST',
+		} )
+			.then( ( res ) => {
+				if ( 'completed' === res.status.status ) {
+					setPollingCount( -1 );
+					return;
+				}
+
+				setPollingCount( ( n ) => ( n + 1 ) % 3 );
+			} )
+			.catch( catchError );
+	}, [ jobId, pollingCount ] );
+
+	// Start installation job.
+	useEffect( () => {
+		apiFetch( {
+			path: buildJobEndpointUrl( null, [ 'start-sample' ] ),
+			method: 'POST',
+		} )
+			.then( ( res ) => {
+				setJobId( res.id );
+			} )
+			.catch( catchError );
+	}, [] );
+
+	return [ jobId, pollingCount, error ];
+};
+
+/**
+ * Component to Install Demo Course. Invoked when clicking on a link pointing to "sensei://install-demo-course".
+ *
+ * @param {Object}   props             Component props.
+ * @param {Function} props.remove      Function to call to remove the item from the Quick Links Column.
+ * @param {Function} props.restoreLink Function to call to restore the link on the Quick Links Column.
+ */
+function InstallDemoCourse( { remove, restoreLink } ) {
+	const [ jobId, pollingCount, error ] = useDemoCourseInstaller();
+	const [ showInstalledLink, setShowInstalledLink ] = useState( false );
+	useEffect( () => {
+		let run = null;
+		if ( error ) {
+			run = restoreLink;
+		} else if ( ! error && pollingCount < 0 ) {
+			run = () => setShowInstalledLink( true );
+		}
+		if ( run ) {
+			setTimeout( run, 2000 );
+		}
+	}, [ error, pollingCount, remove, restoreLink ] );
+	if ( error ) {
+		return __( 'Error while installing demo course', 'sensei-lms' );
+	}
+	if ( showInstalledLink ) {
+		const { setupSampleCourseNonce } = window.sensei_home;
+		return (
+			<Link
+				url={ `?redirect_imported_sample=1&job_id=${ jobId }&nonce=${ setupSampleCourseNonce }` }
+				label={ __( 'Edit Demo Course', 'sensei-lms' ) }
+			/>
+		);
+	}
+	if ( pollingCount < 0 ) {
+		return __( 'Installed', 'sensei-lms' );
+	}
+	return (
+		<>
+			<Spinner />
+			{ __( 'Installing', 'sensei-lms' ) }
+		</>
+	);
+}
+
+export default InstallDemoCourse;

--- a/assets/home/sections/quick-links.js
+++ b/assets/home/sections/quick-links.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -11,49 +11,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import Section from '../section';
 import { Grid, Col } from '../grid';
 import Link from '../link';
-
-/**
- * Component to Install Demo Course. Invoked when clicking on a link pointing to "sensei://install-demo-course".
- *
- * @param {Object}   props        Component props.
- * @param {Function} props.remove Function to call to remove the item from the Quick Links Column.
- * @return {string} A message to the user with the status of the installation.
- */
-function InstallDemoCourse( { remove } ) {
-	const [ title, setTitle ] = useState( 'Installing' );
-	const timer = useRef( 0 );
-	const installedMessage = 'Installed!';
-	const clear = () => {
-		if ( timer.current ) {
-			clearTimeout( timer.current );
-		}
-		timer.current = 0;
-	};
-	useEffect( () => {
-		if ( null === title ) {
-			remove();
-		}
-	}, [ title, remove ] );
-	useEffect( () => {
-		const run = () => {
-			setTitle( ( oldTitle ) => {
-				if ( installedMessage === oldTitle ) {
-					clear();
-					return null;
-				}
-				if ( ! oldTitle.includes( '...' ) ) {
-					timer.current = setTimeout( run, 500 );
-					return oldTitle + '.';
-				}
-				timer.current = setTimeout( run, 2000 );
-				return installedMessage;
-			} );
-		};
-		clear();
-		timer.current = setTimeout( run, 500 );
-	}, [] );
-	return title;
-}
+import InstallDemoCourse from '../install-demo-course';
 
 const quickLinksSpecialMapping = {
 	'sensei://install-demo-course': InstallDemoCourse,

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -129,6 +129,8 @@ final class Sensei_Home {
 
 		$data['tasks_dismissed'] = get_option( self::DISMISS_TASKS_OPTION );
 
+		$data['setupSampleCourseNonce'] = wp_create_nonce( 'sensei-home' );
+
 		wp_localize_script(
 			'sensei-home',
 			'sensei_home',

--- a/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
+++ b/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
@@ -24,7 +24,7 @@ class Sensei_Home_Quick_Links_Provider {
 				__( 'Courses', 'sensei-lms' ),
 				[
 					$this->create_item( __( 'Create a Course', 'sensei-lms' ), admin_url( '/post-new.php?post_type=course' ) ),
-					$this->create_item( __( 'Install a Demo Course', 'sensei-lms' ), self::ACTION_INSTALL_DEMO_COURSE ),
+					$this->create_demo_link(),
 					$this->create_item( __( 'Import a Course', 'sensei-lms' ), admin_url( '/edit.php?post_type=course&page=sensei-tools&tool=import-content' ) ),
 					$this->create_item( __( 'Reports', 'sensei-lms' ), admin_url( '/edit.php?post_type=course&page=sensei_reports' ) ),
 				]
@@ -48,6 +48,33 @@ class Sensei_Home_Quick_Links_Provider {
 				]
 			),
 		];
+	}
+
+	/**
+	 * Return the magical link to create a demo course, or the link to edit the demo course.
+	 *
+	 * @return array The magical link to create a demo course or the link to edit the demo course.
+	 */
+	private function create_demo_link() {
+		global $wpdb;
+		$cache_key   = 'home/metadata/demo-course';
+		$cache_group = 'sensei/temporary';
+		$result      = wp_cache_get( $cache_key, $cache_group );
+		if ( false === $result ) {
+			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
+			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name LIKE %s ORDER BY post_status='published' DESC, ID ASC LIMIT 1", "{$prefix}%" ) );
+			if ( null === $post_id ) {
+				$result = null;
+			} else {
+				$result = $post_id;
+				wp_cache_set( $cache_key, $result, $cache_group, 60 );
+			}
+		}
+		if ( null !== $result ) {
+			return $this->create_item( __( 'Edit Demo Course', 'sensei-lms' ), get_edit_post_link( $result, 'api' ) );
+		}
+		return $this->create_item( __( 'Install a Demo Course', 'sensei-lms' ), self::ACTION_INSTALL_DEMO_COURSE );
 	}
 
 	/**

--- a/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
+++ b/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
@@ -72,7 +72,7 @@ class Sensei_Home_Quick_Links_Provider {
 			}
 		}
 		if ( null !== $result ) {
-			return $this->create_item( __( 'Edit Demo Course', 'sensei-lms' ), get_edit_post_link( $result, 'api' ) );
+			return $this->create_item( __( 'Edit Demo Course', 'sensei-lms' ), get_edit_post_link( $result, '&' ) );
 		}
 		return $this->create_item( __( 'Install a Demo Course', 'sensei-lms' ), self::ACTION_INSTALL_DEMO_COURSE );
 	}

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -115,7 +115,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'sensei-setup-wizard' ) ) {
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'sensei-home' ) ) {
 			wp_die( esc_html__( 'Invalid request', 'sensei-lms' ) );
 		}
 

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
@@ -295,7 +295,7 @@ class Sensei_Data_Port_Manager_Test extends WP_UnitTestCase {
 	public function redirectImportSampleDataSources() {
 		return [
 			'valid'         => [
-				wp_create_nonce( 'sensei-setup-wizard' ),
+				wp_create_nonce( 'sensei-home' ),
 				$this->once(),
 				false,
 			],


### PR DESCRIPTION
Fixes #5749

### Changes proposed in this Pull Request

* Add component to install demo course;
* Instead of removing the quick link, change it to an "Edit Demo Course" link;
* On the backend, returns a "Edit Demo Course" link if the demo course is found;
* Change code to generate nonce for redirecting to edit course based on Sensei Home, instead of on Sensei Setup Wizard;

### Testing instructions
 
On a WP installation containing this branch of the Sensei LMS plugin:

1. Visit Sensei Home;
2. Click on "Install a Demo Course" link, in the Quick Links section;
3. Verify if the system shows a "Installing" message with spinner after clicking the link;
4. Verify if it shows the "Installed" message;
5. Verify if, after ~2 seconds, it shows the "Edit Demo Course" link;
6. Refresh the page;
7. Verify if the "Edit Demo Course" instantaneously appear on the Quick Links section;
8. Finally, move the demo course to Trash, and verify if the "Install a Demo Course" appears again on the Quick Links section;

### Notes

I didn't include tests, but I accept suggestions on what automated tests to add. I'm also open to suggestions regarding where to put the "install-demo-course.js" component/file.