### PR TITLE
Only disable lesson actions hook when it's added as a block

### DIFF
--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -19,7 +19,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	public function __construct() {
 		parent::__construct( [ 'lesson' ] );
 
-		add_action( 'init', [ $this, 'remove_block_related_content' ] );
+		add_action( 'template_redirect', [ $this, 'remove_block_related_content' ] );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -18,6 +18,8 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	 */
 	public function __construct() {
 		parent::__construct( [ 'lesson' ] );
+
+		add_action( 'init', [ $this, 'remove_block_related_content' ] );
 	}
 
 	/**
@@ -106,23 +108,27 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_View_Quiz_Block();
 		new Sensei_Featured_Video_Block();
 
-		if ( Sensei()->lesson->has_sensei_blocks() ) {
-			$this->remove_block_related_content();
-
-			// This constructor has some sideeffects so only initialize it when the lesson has Sensei blocks.
+		// This constructor has some sideeffects so only initialize it when the lesson has Sensei blocks.
+		if ( is_admin() || has_block( 'sensei-lms/contact-teacher' ) ) {
 			new Sensei_Block_Contact_Teacher();
 		}
 
 	}
 
 	/**
-	 * Helper method to remove functionality which is provided by blocks.
+	 * Remove functionality which is provided by blocks.
+	 *
+	 * @access private
 	 */
-	private function remove_block_related_content() {
-		// Remove contact teacher button.
-		remove_action( 'sensei_single_lesson_content_inside_before', [ Sensei()->post_types->messages, 'send_message_link' ], 30 );
+	public function remove_block_related_content() {
 
-		// Remove footer buttons.
-		remove_action( 'sensei_single_lesson_content_inside_after', [ 'Sensei_Lesson', 'footer_quiz_call_to_action' ] );
+		if ( has_block( 'sensei-lms/lesson-actions' ) ) {
+			remove_action( 'sensei_single_lesson_content_inside_after', [ 'Sensei_Lesson', 'footer_quiz_call_to_action' ] );
+		}
+
+		if ( Sensei()->lesson->has_sensei_blocks() ) {
+			remove_action( 'sensei_single_lesson_content_inside_before', [ Sensei()->post_types->messages, 'send_message_link' ], 30 );
+		}
+
 	}
 }

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5238,7 +5238,23 @@ class Sensei_Lesson {
 		$lesson = get_post( $lesson );
 		$post   = $lesson->post_content ?? null;
 
-		return ! empty( $post ) && has_blocks( $post ) && ( false !== strpos( $post, '<!-- wp:sensei-lms/' ) );
+		if ( empty( $post ) || ! has_blocks( $post ) ) {
+			return false;
+		}
+
+		$lesson_blocks = [
+			'sensei-lms/lesson-actions',
+			'sensei-lms/lesson-properties',
+			'sensei-lms/button-contact-teacher',
+		];
+
+		foreach ( $lesson_blocks as $block ) {
+			if ( has_block( $block, $lesson ) ) {
+				return true;
+			}
+		}
+
+		return false;
 
 	}
 


### PR DESCRIPTION
Fixes #5945 

This fixes 4.7.0 issue of the action buttons disappearing, but also changes the logic for the action buttons so they are always available on the lesson page: either as a block added, or from the hook — which addresses user confusion and reports about not understanding why its missing.

### Changes proposed in this Pull Request

* Only remove the hook adding lesson actions after the content when the lesson actions block is not added
* Keep the logic the same for the contact teacher button
* Restore the Sensei()->lesson->has_sensei_blocks() function to only check for the actions/info/contact-teacher blocks
  * Changing this to look for any Sensei blocks is the cause of issues for users where an auto-generated quiz block being picked up disables the hooks 


### Testing instructions

* Have a lesson with quiz or other Sensei blocks, but no 'Lesson Actions' block
* View it as an enrolled student on the frontend, without Learning mode
*
