### PR TITLE
Remove some Sensei specific artifacts and dependencies from shared classes

### DIFF
--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -48,7 +48,7 @@ final class Sensei_Home {
 	 * Home constructor. Prevents other instances from being created outside `Sensei_Home::instance()`.
 	 */
 	private function __construct() {
-		$this->remote_data_api = new Sensei_Home_Remote_Data_API( 'sensei-lms', Sensei()->version );
+		$this->remote_data_api = new Sensei_Home_Remote_Data_API( 'sensei-lms', SENSEI_LMS_VERSION );
 		$this->notices         = new Sensei_Home_Notices( $this->remote_data_api );
 	}
 

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -49,7 +49,7 @@ final class Sensei_Home {
 	 */
 	private function __construct() {
 		$this->remote_data_api = new Sensei_Home_Remote_Data_API( 'sensei-lms', SENSEI_LMS_VERSION );
-		$this->notices         = new Sensei_Home_Notices( $this->remote_data_api );
+		$this->notices         = new Sensei_Home_Notices( $this->remote_data_api, self::SCREEN_ID );
 	}
 
 	/**

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -48,7 +48,7 @@ final class Sensei_Home {
 	 * Home constructor. Prevents other instances from being created outside `Sensei_Home::instance()`.
 	 */
 	private function __construct() {
-		$this->remote_data_api = new Sensei_Home_Remote_Data_API( 'sensei-lms' );
+		$this->remote_data_api = new Sensei_Home_Remote_Data_API( 'sensei-lms', Sensei()->version );
 		$this->notices         = new Sensei_Home_Notices( $this->remote_data_api );
 	}
 

--- a/includes/admin/home/class-sensei-home-remote-data-api.php
+++ b/includes/admin/home/class-sensei-home-remote-data-api.php
@@ -27,6 +27,13 @@ class Sensei_Home_Remote_Data_API {
 	private $primary_plugin_slug;
 
 	/**
+	 * The plugin version.
+	 *
+	 * @var string
+	 */
+	private $plugin_version;
+
+	/**
 	 * The local cache for multiple calls to `fetch` within the same request.
 	 *
 	 * @var array
@@ -37,9 +44,11 @@ class Sensei_Home_Remote_Data_API {
 	 * Sensei_Home_Remote_Data_API constructor.
 	 *
 	 * @param string $primary_plugin_slug The primary plugin slug.
+	 * @param string $plugin_version      The plugin version.
 	 */
-	public function __construct( string $primary_plugin_slug ) {
+	public function __construct( string $primary_plugin_slug, string $plugin_version ) {
 		$this->primary_plugin_slug = $primary_plugin_slug;
+		$this->plugin_version      = $plugin_version;
 	}
 
 	/**
@@ -201,7 +210,7 @@ class Sensei_Home_Remote_Data_API {
 		$url = sprintf( self::API_BASE_URL . '%s.json', $this->get_primary_plugin_slug() );
 
 		$query_args = [
-			'version' => Sensei()->version,
+			'version' => $this->plugin_version,
 			'lang'    => determine_locale(),
 		];
 

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -20,14 +20,22 @@ class Sensei_Home_Notices_Provider {
 	 * @var Sensei_Admin_Notices
 	 */
 	private $admin_notices;
+	/**
+	 * Screen ID to show notices on.
+	 *
+	 * @var array
+	 */
+	private $screen_id;
 
 	/**
 	 * Sensei_Home_News_Provider constructor.
 	 *
 	 * @param Sensei_Admin_Notices $admin_notices   The remote admin notices helper.
+	 * @param string               $screen_id       The screen ID to show notices on.
 	 */
-	public function __construct( $admin_notices = null ) {
+	public function __construct( $admin_notices = null, $screen_id = null ) {
 		$this->admin_notices = $admin_notices;
+		$this->screen_id     = $screen_id;
 	}
 
 	/**
@@ -57,7 +65,7 @@ class Sensei_Home_Notices_Provider {
 	 * @return array
 	 */
 	public function get(): array {
-		$notices = isset( $this->admin_notices ) ? $this->admin_notices->get_notices_to_display( Sensei_Home::SCREEN_ID ) : $this->local_only();
+		$notices = isset( $this->admin_notices ) ? $this->admin_notices->get_notices_to_display( $this->screen_id ) : $this->local_only();
 
 		return array_map( [ $this, 'format_item' ], $notices );
 	}

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -23,7 +23,7 @@ class Sensei_Home_Notices_Provider {
 	/**
 	 * Screen ID to show notices on.
 	 *
-	 * @var array
+	 * @var string
 	 */
 	private $screen_id;
 

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -24,6 +24,13 @@ class Sensei_Home_Notices {
 	private $remote_data_api;
 
 	/**
+	 * Screen ID to show notices on.
+	 *
+	 * @var array
+	 */
+	private $screen_id;
+
+	/**
 	 * Cache of local plugin updates.
 	 *
 	 * @var array
@@ -34,16 +41,18 @@ class Sensei_Home_Notices {
 	 * Sensei_Home_Notices constructor.
 	 *
 	 * @param Sensei_Home_Remote_Data_API $remote_data_api The remote data helper.
+	 * @param string                      $screen_id       The screen ID to show notices on.
 	 */
-	public function __construct( Sensei_Home_Remote_Data_API $remote_data_api ) {
+	public function __construct( Sensei_Home_Remote_Data_API $remote_data_api, string $screen_id ) {
 		$this->remote_data_api = $remote_data_api;
+		$this->screen_id       = $screen_id;
 	}
 
 	/**
 	 * Add the hooks related to this class.
 	 */
 	public function init() {
-		add_filter( 'sensei_show_admin_notices_' . Sensei_Home::SCREEN_ID, '__return_false' );
+		add_filter( 'sensei_show_admin_notices_' . $this->screen_id, '__return_false' );
 		add_filter( 'sensei_admin_notices', [ $this, 'add_update_notices' ] );
 	}
 

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -182,7 +182,7 @@ class Sensei_Home_Notices {
 			'conditions'  => [
 				[
 					'type'    => 'screens',
-					'screens' => [ Sensei_Home::SCREEN_ID ],
+					'screens' => [ $this->screen_id ],
 				],
 			],
 			'dismissible' => $is_dismissible,

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -26,7 +26,7 @@ class Sensei_Home_Notices {
 	/**
 	 * Screen ID to show notices on.
 	 *
-	 * @var array
+	 * @var string
 	 */
 	private $screen_id;
 

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -92,7 +92,7 @@ class Sensei_REST_API_Internal {
 		$this->tasks_provider       = new Sensei_Home_Tasks_Provider();
 		$this->news_provider        = new Sensei_Home_News_Provider( $remote_data_api );
 		$this->guides_provider      = new Sensei_Home_Guides_Provider( $remote_data_api );
-		$this->notices_provider     = new Sensei_Home_Notices_Provider( Sensei_Admin_Notices::instance() );
+		$this->notices_provider     = new Sensei_Home_Notices_Provider( Sensei_Admin_Notices::instance(), Sensei_Home::SCREEN_ID );
 
 		add_action( 'rest_api_init', [ $this, 'register' ] );
 	}

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices-provider.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices-provider.php
@@ -13,7 +13,7 @@
 class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 	public function testGet_GivenSimpleFilterResponse_ReturnsFilterValue() {
 		// Arrange.
-		$notices_provider = new Sensei_Home_Notices_Provider();
+		$notices_provider = new Sensei_Home_Notices_Provider( null, 'screen-id' );
 
 		$test_data = $this->getSimpleResponse();
 
@@ -33,7 +33,7 @@ class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 
 	public function testGet_GivenMixedNotices_ReturnsHomeNoticesOnly() {
 		// Arrange.
-		$notices_provider = new Sensei_Home_Notices_Provider();
+		$notices_provider = new Sensei_Home_Notices_Provider( null, 'screen-id' );
 		add_filter(
 			'sensei_admin_notices',
 			function() {
@@ -61,7 +61,7 @@ class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 			->method( 'get_notices_to_display' )
 			->willReturn( $test_response );
 
-		$notices_provider = new Sensei_Home_Notices_Provider( $admin_notices_mock );
+		$notices_provider = new Sensei_Home_Notices_Provider( $admin_notices_mock, null );
 
 		// Act.
 		$notices = $notices_provider->get();

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
@@ -214,7 +214,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 	private function getRemoteDataMock( $response ) {
 		$remote_data_api = $this->getMockBuilder( Sensei_Home_Remote_Data_API::class )
 			->setMethods( [ 'fetch' ] )
-			->setConstructorArgs( [ 'example-plugin' ] )
+			->setConstructorArgs( [ 'example-plugin', '1.0.0' ] )
 			->getMock();
 
 		$remote_data_api->expects( $this->any() )

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
@@ -196,7 +196,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 	 */
 	private function getNoticesMock( $remote_data_mock, $local_update_available = true ) {
 		$notices_mock = $this->getMockBuilder( Sensei_Home_Notices::class )
-			->setConstructorArgs( [ $remote_data_mock ] )
+			->setConstructorArgs( [ $remote_data_mock, Sensei_Home::SCREEN_ID ] )
 			->setMethods( [ 'is_plugin_update_available' ] )
 			->getMock();
 

--- a/tests/unit-tests/admin/home/test-class-sensei-home-guides-provider.php
+++ b/tests/unit-tests/admin/home/test-class-sensei-home-guides-provider.php
@@ -107,7 +107,7 @@ class Sensei_Home_Guides_Provider_Test extends WP_UnitTestCase {
 	private function getRemoteDataMock( $response ) {
 		$remote_data_api = $this->getMockBuilder( Sensei_Home_Remote_Data_API::class )
 			->setMethods( [ 'fetch' ] )
-			->setConstructorArgs( [ 'example-plugin' ] )
+			->setConstructorArgs( [ 'example-plugin', '1.0.0' ] )
 			->getMock();
 
 		$remote_data_api->expects( $this->any() )

--- a/tests/unit-tests/admin/home/test-class-sensei-home-news-provider.php
+++ b/tests/unit-tests/admin/home/test-class-sensei-home-news-provider.php
@@ -113,7 +113,7 @@ class Sensei_Home_News_Provider_Test extends WP_UnitTestCase {
 	private function getRemoteDataMock( $response ) {
 		$remote_data_api = $this->getMockBuilder( Sensei_Home_Remote_Data_API::class )
 			->setMethods( [ 'fetch' ] )
-			->setConstructorArgs( [ 'example-plugin' ] )
+			->setConstructorArgs( [ 'example-plugin', '1.0.0' ] )
 			->getMock();
 
 		$remote_data_api->expects( $this->any() )

--- a/tests/unit-tests/admin/home/test-class-sensei-home-remote-data-api.php
+++ b/tests/unit-tests/admin/home/test-class-sensei-home-remote-data-api.php
@@ -17,7 +17,7 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 	 */
 	public function testFetchCorrectPluginData() {
 		$http_requests = $this->trackHttpRequests( [] );
-		$provider      = new Sensei_Home_Remote_Data_API( 'dinosaurs' );
+		$provider      = new Sensei_Home_Remote_Data_API( 'dinosaurs', '1.0.0' );
 		$remote_data   = $provider->fetch();
 
 		$this->stopTrackingHttpRequests();
@@ -40,7 +40,7 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 		);
 
 		$http_requests = $this->trackHttpRequests( [] );
-		$provider      = new Sensei_Home_Remote_Data_API( 'dinosaurs' );
+		$provider      = new Sensei_Home_Remote_Data_API( 'dinosaurs', '1.0.0' );
 		$remote_data   = $provider->fetch();
 
 		$this->stopTrackingHttpRequests();
@@ -64,7 +64,7 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 			}
 		);
 
-		$provider     = new Sensei_Home_Remote_Data_API( 'dinosaurs' );
+		$provider     = new Sensei_Home_Remote_Data_API( 'dinosaurs', '1.0.0' );
 		$first_fetch  = $provider->fetch();
 		$second_fetch = $provider->fetch();
 		$this->stopTrackingHttpRequests();

--- a/tests/unit-tests/admin/home/test-class-sensei-home-remote-data-api.php
+++ b/tests/unit-tests/admin/home/test-class-sensei-home-remote-data-api.php
@@ -92,7 +92,7 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 		$url     = Sensei_Home_Remote_Data_API::API_BASE_URL . '/test.json';
 
 		$provider = $this->getMockBuilder( Sensei_Home_Remote_Data_API::class )
-			->setConstructorArgs( [ 'dinosaurs' ] )
+			->setConstructorArgs( [ 'dinosaurs', '1.0.0' ] )
 			->setMethods( [ 'get_api_url' ] )
 			->getMock();
 		$provider->expects( $this->any() )->method( 'get_api_url' )->willReturn( $url );
@@ -131,7 +131,7 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 		$url     = Sensei_Home_Remote_Data_API::API_BASE_URL . '/test.json';
 
 		$provider = $this->getMockBuilder( Sensei_Home_Remote_Data_API::class )
-			->setConstructorArgs( [ 'dinosaurs' ] )
+			->setConstructorArgs( [ 'dinosaurs', '1.0.0' ] )
 			->setMethods( [ 'get_api_url' ] )
 			->getMock();
 		$provider->expects( $this->any() )->method( 'get_api_url' )->willReturn( $url );
@@ -166,7 +166,7 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 		$url     = Sensei_Home_Remote_Data_API::API_BASE_URL . '/test.json';
 
 		$provider = $this->getMockBuilder( Sensei_Home_Remote_Data_API::class )
-			->setConstructorArgs( [ 'dinosaurs' ] )
+			->setConstructorArgs( [ 'dinosaurs', '1.0.0' ] )
 			->setMethods( [ 'get_api_url' ] )
 			->getMock();
 		$provider->expects( $this->any() )->method( 'get_api_url' )->willReturn( $url );


### PR DESCRIPTION
While working on the Sensei Blocks REST API for Home, I realized I left a sneaky Sensei dependencies in some shared classes.

### Changes proposed in this Pull Request

* This removes the `Sensei()` dependency for easy usage in Sensei Blocks.
* Removes the Sensei_Home::SCREEN_ID reference in the Notices and Notices Provider.

### Testing instructions

- Ensure tests pass.
- Clear transients and enable Query Monitor to track external requests.
- Visit Sensei Home and verify the right endpoint was requested in SenseiLMS.com (with the correct `version=` argument) from within Query Monitor.