### PR TITLE
Add Sensei Home notice badge count

### DIFF
--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -29,14 +29,6 @@ final class Sensei_Home {
 	 */
 	private static $instance;
 
-
-	/**
-	 * The remote data helper instance.
-	 *
-	 * @var Sensei_Home_Remote_Data_API
-	 */
-	private $remote_data_api;
-
 	/**
 	 * The Sensei Home Notices instance.
 	 *
@@ -45,7 +37,49 @@ final class Sensei_Home {
 	private $notices;
 
 	/**
-	 * The Sensei Home Notices Provider instance.
+	 * Sensei Home Quick Links provider.
+	 *
+	 * @var Sensei_Home_Quick_Links_Provider
+	 */
+	private $quick_links_provider;
+
+	/**
+	 * Sensei Home Help provider.
+	 *
+	 * @var Sensei_Home_Help_Provider
+	 */
+	private $help_provider;
+
+	/**
+	 * Sensei Home Promo Banner provider.
+	 *
+	 * @var Sensei_Home_Promo_Banner_Provider
+	 */
+	private $promo_provider;
+
+	/**
+	 * Sensei Home Tasks provider.
+	 *
+	 * @var Sensei_Home_Tasks_Provider
+	 */
+	private $tasks_provider;
+
+	/**
+	 * Sensei Home News provider.
+	 *
+	 * @var Sensei_Home_News_Provider
+	 */
+	private $news_provider;
+
+	/**
+	 * Sensei Home Guides provider.
+	 *
+	 * @var Sensei_Home_Guides_Provider
+	 */
+	private $guides_provider;
+
+	/**
+	 * Sensei Notices provider.
 	 *
 	 * @var Sensei_Home_Notices_Provider
 	 */
@@ -55,27 +89,35 @@ final class Sensei_Home {
 	 * Home constructor. Prevents other instances from being created outside `Sensei_Home::instance()`.
 	 */
 	private function __construct() {
-		$this->remote_data_api  = new Sensei_Home_Remote_Data_API( 'sensei-lms', SENSEI_LMS_VERSION );
-		$this->notices          = new Sensei_Home_Notices( $this->remote_data_api, self::SCREEN_ID );
-		$this->notices_provider = new Sensei_Home_Notices_Provider( Sensei_Admin_Notices::instance(), self::SCREEN_ID );
+		$remote_data_api            = new Sensei_Home_Remote_Data_API( 'sensei-lms', SENSEI_LMS_VERSION );
+		$this->notices              = new Sensei_Home_Notices( $remote_data_api, self::SCREEN_ID );
+		$this->notices_provider     = new Sensei_Home_Notices_Provider( Sensei_Admin_Notices::instance(), self::SCREEN_ID );
+		$this->quick_links_provider = new Sensei_Home_Quick_Links_Provider();
+		$this->help_provider        = new Sensei_Home_Help_Provider();
+		$this->promo_provider       = new Sensei_Home_Promo_Banner_Provider();
+		$this->tasks_provider       = new Sensei_Home_Tasks_Provider();
+		$this->news_provider        = new Sensei_Home_News_Provider( $remote_data_api );
+		$this->guides_provider      = new Sensei_Home_Guides_Provider( $remote_data_api );
 	}
 
 	/**
-	 * Gets the remote data API.
+	 * Gets a REST API controller for Sensei Home.
 	 *
-	 * @return Sensei_Home_Remote_Data_API
-	 */
-	public function get_remote_data_api() {
-		return $this->remote_data_api;
-	}
-
-	/**
-	 * Gets the Sensei Home Notices provider instance.
+	 * @param string $namespace The REST API namespace.
 	 *
-	 * @return Sensei_Home_Remote_Data_API
+	 * @return Sensei_REST_API_Home_Controller
 	 */
-	public function get_notices_provider() {
-		return $this->notices_provider;
+	public function get_rest_api_controller( $namespace ) {
+		return new Sensei_REST_API_Home_Controller(
+			$namespace,
+			$this->quick_links_provider,
+			$this->help_provider,
+			$this->promo_provider,
+			$this->tasks_provider,
+			$this->news_provider,
+			$this->guides_provider,
+			$this->notices_provider
+		);
 	}
 
 	/**

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -45,11 +45,19 @@ final class Sensei_Home {
 	private $notices;
 
 	/**
+	 * The Sensei Home Notices Provider instance.
+	 *
+	 * @var Sensei_Home_Notices_Provider
+	 */
+	private $notices_provider;
+
+	/**
 	 * Home constructor. Prevents other instances from being created outside `Sensei_Home::instance()`.
 	 */
 	private function __construct() {
-		$this->remote_data_api = new Sensei_Home_Remote_Data_API( 'sensei-lms', SENSEI_LMS_VERSION );
-		$this->notices         = new Sensei_Home_Notices( $this->remote_data_api, self::SCREEN_ID );
+		$this->remote_data_api  = new Sensei_Home_Remote_Data_API( 'sensei-lms', SENSEI_LMS_VERSION );
+		$this->notices          = new Sensei_Home_Notices( $this->remote_data_api, self::SCREEN_ID );
+		$this->notices_provider = new Sensei_Home_Notices_Provider( Sensei_Admin_Notices::instance(), self::SCREEN_ID );
 	}
 
 	/**
@@ -59,6 +67,15 @@ final class Sensei_Home {
 	 */
 	public function get_remote_data_api() {
 		return $this->remote_data_api;
+	}
+
+	/**
+	 * Gets the Sensei Home Notices provider instance.
+	 *
+	 * @return Sensei_Home_Remote_Data_API
+	 */
+	public function get_notices_provider() {
+		return $this->notices_provider;
 	}
 
 	/**
@@ -139,18 +156,12 @@ final class Sensei_Home {
 	}
 
 	/**
-	 * Get updates count.
+	 * Get notices count.
 	 *
-	 * @return int Updates count.
+	 * @return int Notices count.
 	 */
-	private function get_has_update_count() {
-		$extensions = Sensei_Extensions::instance()->get_extensions( 'plugin' );
-
-		return count(
-			array_filter(
-				array_column( $extensions, 'has_update' )
-			)
-		);
+	private function get_notices_count() {
+		return $this->notices_provider->get_badge_count();
 	}
 
 	/**
@@ -161,17 +172,17 @@ final class Sensei_Home {
 	 * @access private
 	 */
 	public function add_admin_menu_item() {
-		$updates_html = '';
-		$updates      = $this->get_has_update_count();
+		$notices_html  = '';
+		$notices_count = $this->get_notices_count();
 
-		if ( $updates > 0 ) {
-			$updates_html = ' <span class="awaiting-mod">' . esc_html( $updates ) . '</span>';
+		if ( $notices_count > 0 ) {
+			$notices_html = ' <span class="awaiting-mod">' . (int) $notices_count . '</span>';
 		}
 
 		add_submenu_page(
 			'sensei',
 			__( 'Sensei LMS Home', 'sensei-lms' ),
-			__( 'Home', 'sensei-lms' ) . $updates_html,
+			__( 'Home', 'sensei-lms' ) . $notices_html,
 			'manage_sensei',
 			'sensei',
 			[ $this, 'render' ],

--- a/includes/admin/home/class-sensei-home-guides-provider.php
+++ b/includes/admin/home/class-sensei-home-guides-provider.php
@@ -36,7 +36,7 @@ class Sensei_Home_Guides_Provider {
 	 * @return array
 	 */
 	public function get(): array {
-		$remote_data = $this->remote_data_api->fetch( HOUR_IN_SECONDS, true );
+		$remote_data = $this->remote_data_api->fetch( HOUR_IN_SECONDS );
 		$guides      = $remote_data['guides'] ?? [];
 
 		if ( isset( $guides['items'] ) ) {

--- a/includes/admin/home/class-sensei-home-news-provider.php
+++ b/includes/admin/home/class-sensei-home-news-provider.php
@@ -36,7 +36,7 @@ class Sensei_Home_News_Provider {
 	 * @return array
 	 */
 	public function get(): array {
-		$remote_data = $this->remote_data_api->fetch( HOUR_IN_SECONDS, true );
+		$remote_data = $this->remote_data_api->fetch( HOUR_IN_SECONDS );
 		$news        = $remote_data['news'] ?? [];
 
 		if ( isset( $news['items'] ) ) {

--- a/includes/admin/home/class-sensei-home-remote-data-api.php
+++ b/includes/admin/home/class-sensei-home-remote-data-api.php
@@ -54,15 +54,26 @@ class Sensei_Home_Remote_Data_API {
 	/**
 	 * Fetch data from SenseiLMS.com.
 	 *
-	 * @param int  $max_age      Maximum age of the cached data in seconds. Max is 1 day (in seconds).
-	 * @param bool $retry_error  Retry failed requests.
+	 * @param int $max_age Maximum age of the cached data in seconds. Max is 1 day (in seconds).
 	 *
 	 * @return array|\WP_Error
 	 */
-	public function fetch( int $max_age = null, $retry_error = false ) {
+	public function fetch( int $max_age = null ) {
 		$url       = $this->get_api_url();
 		$cache_key = self::CACHE_KEY_PREFIX . md5( $url );
 		$data      = $this->remote_data[ $cache_key ] ?? get_transient( $cache_key );
+
+		/**
+		 * Filter if we should retry errors when fetching remote data.
+		 *
+		 * @since $$next-version$$
+		 * @hook sensei_home_remote_data_retry_error
+		 *
+		 * @param {bool} $retry_error If we should retry errors. Default true.
+		 *
+		 * @return {bool} If we should retry errors.
+		 */
+		$retry_error = apply_filters( 'sensei_home_remote_data_retry_error', true );
 
 		// If the cached data is an error, return it unless we've forced a refresh.
 		if ( isset( $data['error'] ) ) {

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -75,6 +75,19 @@ class Sensei_Home_Notices_Provider {
 	}
 
 	/**
+	 * Get the number of notices for the Sensei Home badge.
+	 *
+	 * @return int
+	 */
+	public function get_badge_count(): int {
+		add_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
+		$notices = $this->get( DAY_IN_SECONDS );
+		remove_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
+
+		return count( $notices );
+	}
+
+	/**
 	 * Format a notice item.
 	 *
 	 * @param array $notice The unformatted notice.

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -49,7 +49,7 @@ class Sensei_Home_Notices_Provider {
 		/**
 		 * This filter is documented in `class-sensei-admin-notices.php`.
 		 */
-		$notices = apply_filters( 'sensei_admin_notices', [] );
+		$notices = apply_filters( 'sensei_admin_notices', [], $max_age );
 
 		return array_filter(
 			$notices,

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -41,9 +41,11 @@ class Sensei_Home_Notices_Provider {
 	/**
 	 * Fallback for when we're in an environment that doesn't have `Sensei_Admin_Notices`.
 	 *
+	 * @param int|null $max_age The max age (seconds) of the source data.
+	 *
 	 * @return array
 	 */
-	private function local_only() : array {
+	private function local_only( $max_age = null ) : array {
 		/**
 		 * This filter is documented in `class-sensei-admin-notices.php`.
 		 */
@@ -62,10 +64,12 @@ class Sensei_Home_Notices_Provider {
 	/**
 	 * Returns all the information for the notices section.
 	 *
+	 * @param int|null $max_age The max age (seconds) of the source data.
+	 *
 	 * @return array
 	 */
-	public function get(): array {
-		$notices = isset( $this->admin_notices ) ? $this->admin_notices->get_notices_to_display( $this->screen_id ) : $this->local_only();
+	public function get( $max_age = HOUR_IN_SECONDS ): array {
+		$notices = isset( $this->admin_notices ) ? $this->admin_notices->get_notices_to_display( $this->screen_id, $max_age ) : $this->local_only( $max_age );
 
 		return array_map( [ $this, 'format_item' ], $notices );
 	}

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -53,7 +53,7 @@ class Sensei_Home_Notices {
 	 */
 	public function init() {
 		add_filter( 'sensei_show_admin_notices_' . $this->screen_id, '__return_false' );
-		add_filter( 'sensei_admin_notices', [ $this, 'add_update_notices' ] );
+		add_filter( 'sensei_admin_notices', [ $this, 'add_update_notices' ], 10, 2 );
 	}
 
 	/**
@@ -61,16 +61,17 @@ class Sensei_Home_Notices {
 	 *
 	 * @access private
 	 *
-	 * @param array $notices The notices to add the update notices to.
+	 * @param array    $notices The notices to add the update notices to.
+	 * @param int|null $max_age The max age (seconds) of the source data.
 	 *
 	 * @return array
 	 */
-	public function add_update_notices( $notices ) {
+	public function add_update_notices( $notices, $max_age = null ) {
 		if ( ! current_user_can( 'install_plugins' ) ) {
 			return $notices;
 		}
 
-		$data = $this->remote_data_api->fetch();
+		$data = $this->remote_data_api->fetch( $max_age );
 		if ( $data instanceof \WP_Error || empty( $data['versions'] ) ) {
 			return $notices;
 		}

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -84,15 +84,16 @@ class Sensei_REST_API_Internal {
 	 * Sensei_REST_API_Internal constructor.
 	 */
 	public function __construct() {
-		$remote_data_api = Sensei_Home::instance()->get_remote_data_api();
+		$sensei_home     = Sensei_Home::instance();
+		$remote_data_api = $sensei_home->get_remote_data_api();
 
+		$this->notices_provider     = $sensei_home->get_notices_provider();
 		$this->quick_links_provider = new Sensei_Home_Quick_Links_Provider();
 		$this->help_provider        = new Sensei_Home_Help_Provider();
 		$this->promo_provider       = new Sensei_Home_Promo_Banner_Provider();
 		$this->tasks_provider       = new Sensei_Home_Tasks_Provider();
 		$this->news_provider        = new Sensei_Home_News_Provider( $remote_data_api );
 		$this->guides_provider      = new Sensei_Home_Guides_Provider( $remote_data_api );
-		$this->notices_provider     = new Sensei_Home_Notices_Provider( Sensei_Admin_Notices::instance(), Sensei_Home::SCREEN_ID );
 
 		add_action( 'rest_api_init', [ $this, 'register' ] );
 	}

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -32,69 +32,9 @@ class Sensei_REST_API_Internal {
 	private $controllers = [];
 
 	/**
-	 * Sensei Home Quick Links provider.
-	 *
-	 * @var Sensei_Home_Quick_Links_Provider
-	 */
-	private $quick_links_provider;
-
-	/**
-	 * Sensei Home Help provider.
-	 *
-	 * @var Sensei_Home_Help_Provider
-	 */
-	private $help_provider;
-
-	/**
-	 * Sensei Home Promo Banner provider.
-	 *
-	 * @var Sensei_Home_Promo_Banner_Provider
-	 */
-	private $promo_provider;
-
-	/**
-	 * Sensei Home Tasks provider.
-	 *
-	 * @var Sensei_Home_Tasks_Provider
-	 */
-	private $tasks_provider;
-
-	/**
-	 * Sensei Home News provider.
-	 *
-	 * @var Sensei_Home_News_Provider
-	 */
-	private $news_provider;
-
-	/**
-	 * Sensei Home Guides provider.
-	 *
-	 * @var Sensei_Home_Guides_Provider
-	 */
-	private $guides_provider;
-
-	/**
-	 * Sensei Notices provider.
-	 *
-	 * @var Sensei_Home_Notices_Provider
-	 */
-	private $notices_provider;
-
-	/**
 	 * Sensei_REST_API_Internal constructor.
 	 */
 	public function __construct() {
-		$sensei_home     = Sensei_Home::instance();
-		$remote_data_api = $sensei_home->get_remote_data_api();
-
-		$this->notices_provider     = $sensei_home->get_notices_provider();
-		$this->quick_links_provider = new Sensei_Home_Quick_Links_Provider();
-		$this->help_provider        = new Sensei_Home_Help_Provider();
-		$this->promo_provider       = new Sensei_Home_Promo_Banner_Provider();
-		$this->tasks_provider       = new Sensei_Home_Tasks_Provider();
-		$this->news_provider        = new Sensei_Home_News_Provider( $remote_data_api );
-		$this->guides_provider      = new Sensei_Home_Guides_Provider( $remote_data_api );
-
 		add_action( 'rest_api_init', [ $this, 'register' ] );
 	}
 
@@ -114,16 +54,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Send_Message_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Students_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Progress_Controller( $this->namespace ),
-			new Sensei_REST_API_Home_Controller(
-				$this->namespace,
-				$this->quick_links_provider,
-				$this->help_provider,
-				$this->promo_provider,
-				$this->tasks_provider,
-				$this->news_provider,
-				$this->guides_provider,
-				$this->notices_provider
-			),
+			Sensei_Home::instance()->get_rest_api_controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices-provider.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices-provider.php
@@ -70,10 +70,30 @@ class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 		$this->assertEquals( wp_json_encode( $test_response ), wp_json_encode( $notices ) );
 	}
 
+
+	public function testGetBadgeCount_GivenSenseiAdminNoticeResponse_ReturnsAdminNoticeCount() {
+		// Arrange.
+		$test_response      = $this->getSimpleResponse();
+		$admin_notices_mock = $this->createMock( Sensei_Admin_Notices::class );
+
+		$admin_notices_mock
+			->expects( $this->once() )
+			->method( 'get_notices_to_display' )
+			->willReturn( $test_response );
+
+		$notices_provider = new Sensei_Home_Notices_Provider( $admin_notices_mock, null );
+
+		// Act.
+		$notices = $notices_provider->get_badge_count();
+
+		// Assert.
+		$this->assertEquals( count( $test_response ), wp_json_encode( $notices ) );
+	}
+
 	/**
 	 * Provides a very simple response.
 	 *
-	 * @return arraay
+	 * @return array
 	 */
 	private function getSimpleResponse() {
 		return [

--- a/tests/unit-tests/admin/home/test-class-sensei-home-remote-data-api.php
+++ b/tests/unit-tests/admin/home/test-class-sensei-home-remote-data-api.php
@@ -174,7 +174,9 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 		// Clone the provider to avoid local cache issues.
 		$provider_b = clone $provider;
 
+		add_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
 		$first_fetch = $provider->fetch( $max_age );
+		remove_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
 		$this->stopTrackingHttpRequests();
 		$this->assertWPError( $first_fetch );
 
@@ -184,8 +186,9 @@ class Sensei_Home_Remote_Data_API_Test extends WP_UnitTestCase {
 				return [ 'hit' => uniqid() ];
 			}
 		);
-
+		add_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
 		$second_fetch = $provider_b->fetch( $max_age );
+		remove_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
 		$this->assertWPError( $second_fetch );
 		$this->assertEquals( $first_fetch->get_error_code(), $second_fetch->get_error_code(), 'The error codes should be the same' );
 


### PR DESCRIPTION
Fixes #5958 

### Changes proposed in this Pull Request

* Passes `max_age` down to all Notice data sources.
* Introduces `get_badge_count` into notices provider.
* Wires new method up to provide the count on the Home menu.

### Testing instructions
* Force notices by manipulating various versions of checked Sensei plugins.
* Check to make sure the notice count updates accordingly.