### PR TITLE
Fix setup wizard redirect when it's completed

### DIFF
--- a/assets/setup-wizard/constants.js
+++ b/assets/setup-wizard/constants.js
@@ -1,1 +1,1 @@
-export const HOME_PATH = 'admin.php?page=sensei-home';
+export const HOME_PATH = 'admin.php?page=sensei';


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the redirect after the Setup Wizard is completed.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Complete the Setup Wizard.
* Make sure you're redirected to Sensei Home.