### PR TITLE
Add a Course Overview block and add it to the Course List block

### DIFF
--- a/assets/blocks/course-list-block/course-list-block-editor.scss
+++ b/assets/blocks/course-list-block/course-list-block-editor.scss
@@ -22,10 +22,6 @@
 			.wp-block-post {
 				.wp-block-group {
 					height: 100%;
-
-					.wp-block-post-excerpt {
-						flex: 1;
-					}
 				}
 			}
 		}

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -107,8 +107,8 @@ $block: '.wp-block-sensei-lms-course-list';
 					gap: 18px;
 
 					& > * {
-						margin-block-start: 0px;
-						margin-block-end: 0px;
+						margin-block-start: 0;
+						margin-block-end: 0;
 					}
 
 					.wp-block-post-title {
@@ -116,7 +116,7 @@ $block: '.wp-block-sensei-lms-course-list';
 						text-align: left;
 					}
 
-					.wp-block-post-excerpt {
+					.wp-block-sensei-lms-course-overview {
 						flex: 1;
 					}
 
@@ -125,7 +125,7 @@ $block: '.wp-block-sensei-lms-course-list';
 					.course-list-featured-label__course-categories,
 					.wp-block-post-featured-image,
 					.wp-block-sensei-lms-course-progress{
-						margin: 0px;
+						margin: 0;
 					}
 
 					.course-list-featured-label__course-categories {
@@ -133,7 +133,7 @@ $block: '.wp-block-sensei-lms-course-list';
 					}
 
 					.sensei-cta > * {
-						margin: 0px;
+						margin: 0;
 					}
 				}
 				.wp-block-group__inner-container {

--- a/assets/blocks/course-overview-block/block.json
+++ b/assets/blocks/course-overview-block/block.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "sensei-lms/course-overview",
+	"title": "Course Overview",
+	"category": "sensei-lms",
+	"description": "Displays a link to the course.",
+	"textdomain": "sensei-lms",
+	"usesContext": [ "postType" ],
+	"example": {}
+}

--- a/assets/blocks/course-overview-block/course-overview-edit.js
+++ b/assets/blocks/course-overview-block/course-overview-edit.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InvalidUsageError from '../../shared/components/invalid-usage';
+
+/**
+ * Course Overview block edit component.
+ *
+ * @param {Object} props
+ * @param {Object} props.context          Block context.
+ * @param {Object} props.context.postType Post type.
+ */
+const CourseOverviewEdit = ( { context: { postType } } ) => {
+	const blockProps = useBlockProps();
+
+	if ( ! [ 'course', 'lesson' ].includes( postType ) ) {
+		return (
+			<InvalidUsageError
+				message={ __(
+					'The Course Overview block can only be used inside the Course List block.',
+					'sensei-lms'
+				) }
+			/>
+		);
+	}
+
+	return (
+		<div { ...blockProps }>
+			{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+			<a href="#">{ __( 'Course Overview', 'sensei-lms' ) }</a>
+		</div>
+	);
+};
+
+export default CourseOverviewEdit;

--- a/assets/blocks/course-overview-block/index.js
+++ b/assets/blocks/course-overview-block/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { link as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './course-overview-edit';
+import metadata from './block.json';
+
+export default {
+	...metadata,
+	metadata,
+	icon,
+	edit,
+};

--- a/assets/blocks/global-blocks.js
+++ b/assets/blocks/global-blocks.js
@@ -2,22 +2,24 @@
  * Internal dependencies
  */
 import registerSenseiBlocks from './register-sensei-blocks';
-import CourseProgressBlock from './course-progress-block';
-import { ContinueCourse, CourseActions } from './course-actions-block';
-import TakeCourseBlock from './take-course-block';
-import ViewResultsBlock from './view-results-block';
 import { registerCourseListBlock } from './course-list-block';
+import { ContinueCourse, CourseActions } from './course-actions-block';
 import CourseCategoriesBlock from './course-categories-block';
 import CourseListFilterBlock from './course-list-filter-block';
+import CourseOverviewBlock from './course-overview-block';
+import CourseProgressBlock from './course-progress-block';
+import TakeCourseBlock from './take-course-block';
+import ViewResultsBlock from './view-results-block';
 
 registerCourseListBlock();
 
 registerSenseiBlocks( [
 	ContinueCourse,
 	CourseActions,
+	CourseCategoriesBlock,
+	CourseListFilterBlock,
+	CourseOverviewBlock,
 	CourseProgressBlock,
 	TakeCourseBlock,
 	ViewResultsBlock,
-	CourseCategoriesBlock,
-	CourseListFilterBlock,
 ] );

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -66,6 +66,8 @@ class Sensei_Course_List_Block_Patterns {
 
 													<!-- wp:post-excerpt {"textAlign":"left"} /-->
 
+													<!-- wp:sensei-lms/course-overview /-->
+
 													<!-- wp:sensei-lms/course-progress /-->
 												</div>
 											<!-- /wp:column -->
@@ -124,6 +126,8 @@ class Sensei_Course_List_Block_Patterns {
 										<!-- wp:post-author {"textAlign":"left","lock":{"move": true}} /-->
 
 										<!-- wp:post-excerpt {"textAlign":"left","lock":{"move": true}} /-->
+
+										<!-- wp:sensei-lms/course-overview /-->
 
 										<!-- wp:sensei-lms/course-progress {"lock":{"move": true}} /-->
 

--- a/includes/blocks/class-sensei-course-overview-block.php
+++ b/includes/blocks/class-sensei-course-overview-block.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * File containing the Sensei_Course_Overview_Block class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Overview_Block
+ */
+class Sensei_Course_Overview_Block {
+
+	/**
+	 * Sensei_Course_Overview_Block constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-overview',
+			[
+				'render_callback' => [ $this, 'render' ],
+			],
+			Sensei()->assets->src_path( 'blocks/course-overview-block' )
+		);
+	}
+
+	/**
+	 * Renders course overview block on the frontend.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Inner block content.
+	 *
+	 * @return string HTML of the block.
+	 */
+	public function render( array $attributes, string $content ): string {
+		$course_id = \Sensei_Utils::get_current_course();
+
+		if ( ! $course_id ) {
+			return '';
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes();
+
+		return sprintf(
+			'<div %1$s><a href="%2$s">%3$s</a></div>',
+			$wrapper_attributes,
+			esc_url( get_permalink( absint( $course_id ) ) ),
+			__( 'Course Overview', 'sensei-lms' )
+		);
+	}
+}

--- a/includes/blocks/class-sensei-global-blocks.php
+++ b/includes/blocks/class-sensei-global-blocks.php
@@ -27,9 +27,10 @@ class Sensei_Global_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_Block_Take_Course();
 		new Sensei_Block_View_Results();
 		new Sensei_Continue_Course_Block();
-		new Sensei_Course_Progress_Block();
 		new Sensei_Course_Categories_Block();
 		new Sensei_Course_List_Filter_Block();
+		new Sensei_Course_Progress_Block();
+		new Sensei_Course_Overview_Block();
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-course-overview-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-overview-block.php
@@ -4,7 +4,7 @@
  */
 class Sensei_Course_Overview_Block_Test extends WP_UnitTestCase {
 	/**
-	 * Continue Course block.
+	 * Course Overview block.
 	 *
 	 * @var Sensei_Course_Overview_Block
 	 */

--- a/tests/unit-tests/blocks/test-class-sensei-course-overview-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-overview-block.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for Sensei_Course_Overview_Block class.
+ */
+class Sensei_Course_Overview_Block_Test extends WP_UnitTestCase {
+	/**
+	 * Continue Course block.
+	 *
+	 * @var Sensei_Course_Overview_Block
+	 */
+	private $block;
+
+	/**
+	 * Block content.
+	 */
+	const CONTENT = '<!-- wp:sensei-lms/course-overview /-->';
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+		$this->block   = new Sensei_Course_Overview_Block();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/course-overview' );
+	}
+
+	/**
+	 * Doesn't render the block if course ID cannot be determined.
+	 *
+	 * @covers Sensei_Course_Overview_Block::render
+	 */
+	public function testRender_NoCourseId_ReturnsEmptyString() {
+		$result = do_blocks( self::CONTENT );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @covers Sensei_Course_Overview_Block::render
+	 */
+	public function testRender_ValidCourseId_ReturnsModifiedBlockContent() {
+		$GLOBALS['post'] = $this->factory->course->create_and_get( [ 'post_name' => 'course-overview-block' ] );
+
+		$result = do_blocks( self::CONTENT );
+
+		$this->assertEquals( '<div class="wp-block-sensei-lms-course-overview"><a href="http://example.org/?course=course-overview-block">Course Overview</a></div>', $result );
+	}
+}


### PR DESCRIPTION
This PR adds a Course Overview block, and adds it to the Course List block patterns. This block can also be added to a course (although I'm not sure why someone would want to do that) or a lesson.

## Testing Instructions

- Check out [this branch](https://github.com/Automattic/sensei-theme/pull/50).
- Add the Course List block to a page.
- Ensure the Course Overview link appears below the excerpt and that it looks similar to the [design](https://www.figma.com/file/nf4oV51c1JBxJKXshMe7cd/New-Sensei-Theme?node-id=20020078%3A3018) in both the editor and on the frontend.
- On the frontend, click on the Course Overview link. It should go to the appropriate course page.
- Add the Course Overview block to a page.
- You should see the "The Course Overview block can only be used inside the Course List block."
- Add the Course List block to a course.
- Check that the link works.
- Add the Course List block to a lesson.
- Check that the link works.

## Screenshots
Note that there is a separate issue for fixing the buttons.

![Screen Shot 2022-10-24 at 12 21 22 PM](https://user-images.githubusercontent.com/1190420/197576041-0072b4cb-b125-487e-ba5f-6065d4d24a08.jpg)

![Screen Shot 2022-10-24 at 12 13 58 PM](https://user-images.githubusercontent.com/1190420/197575045-774b5c18-1208-4e96-9573-ae10f16d35cb.jpg)