### PR TITLE
Add delete method to quiz submission repositories and fix quiz reset

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -719,8 +719,7 @@ class Sensei_Quiz {
 
 			$quiz_submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
 			if ( $quiz_submission ) {
-				$quiz_submission->set_final_grade( null );
-				Sensei()->quiz_submission_repository->save( $quiz_submission );
+				Sensei()->quiz_submission_repository->delete( $quiz_submission );
 				Sensei()->quiz_grade_repository->delete_all( $quiz_submission->get_id() );
 				Sensei()->quiz_answer_repository->delete_all( $quiz_submission->get_id() );
 			}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -716,13 +716,6 @@ class Sensei_Quiz {
 		if ( $quiz_id ) {
 			// Delete quiz answers, this auto deletes the corresponding meta data, such as the question/answer grade.
 			Sensei_Utils::sensei_delete_quiz_answers( $quiz_id, $user_id );
-
-			$quiz_submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
-			if ( $quiz_submission ) {
-				Sensei()->quiz_submission_repository->delete( $quiz_submission );
-				Sensei()->quiz_grade_repository->delete_all( $quiz_submission->get_id() );
-				Sensei()->quiz_answer_repository->delete_all( $quiz_submission->get_id() );
-			}
 		}
 
 		// Update course completion.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -659,26 +659,46 @@ class Sensei_Utils {
 		return $question_grade;
 	}
 
-	public static function sensei_delete_quiz_answers( $quiz_id = 0, $user_id = 0 ) {
-		if ( intval( $user_id ) == 0 ) {
+	/**
+	 * Delete the quiz answers and all related data including the grades.
+	 *
+	 * @param int $quiz_id The quiz ID.
+	 * @param int $user_id The user ID.
+	 *
+	 * @return bool
+	 */
+	public static function sensei_delete_quiz_answers( $quiz_id = 0, $user_id = 0 ): bool {
+		if ( intval( $user_id ) === 0 ) {
 			$user_id = get_current_user_id();
 		}
 
-		$delete_answers = false;
-		if ( intval( $quiz_id ) > 0 ) {
-			$questions = self::sensei_get_quiz_questions( $quiz_id );
-			foreach ( $questions as $question ) {
-				$delete_answers = self::sensei_delete_activities(
-					array(
-						'post_id' => $question->ID,
-						'user_id' => $user_id,
-						'type'    => 'sensei_user_answer',
-					)
-				);
-			}
+		if ( ! $quiz_id || ! $user_id ) {
+			return false;
 		}
 
-		return $delete_answers;
+		$deleted   = false;
+		$questions = self::sensei_get_quiz_questions( $quiz_id );
+		foreach ( $questions as $question ) {
+			// Fallback for pre 1.7.4 data.
+			$deleted = self::sensei_delete_activities(
+				array(
+					'post_id' => $question->ID,
+					'user_id' => $user_id,
+					'type'    => 'sensei_user_answer',
+				)
+			);
+		}
+
+		$quiz_submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
+		if ( $quiz_submission ) {
+			Sensei()->quiz_submission_repository->delete( $quiz_submission );
+			Sensei()->quiz_answer_repository->delete_all( $quiz_submission->get_id() );
+			Sensei()->quiz_grade_repository->delete_all( $quiz_submission->get_id() );
+
+			$deleted = true;
+		}
+
+		return $deleted;
 	}
 
 	/**

--- a/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
@@ -163,6 +163,17 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	}
 
 	/**
+	 * Delete the quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param Submission $submission The quiz submission.
+	 */
+	public function delete( Submission $submission ): void {
+		delete_comment_meta( $submission->get_id(), 'grade' );
+	}
+
+	/**
 	 * Get the lesson status comment.
 	 *
 	 * @param int $quiz_id The quiz ID.

--- a/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
@@ -79,4 +79,13 @@ interface Submission_Repository_Interface {
 	 * @param Submission $submission The quiz submission.
 	 */
 	public function save( Submission $submission ): void;
+
+	/**
+	 * Delete the quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param Submission $submission The quiz submission.
+	 */
+	public function delete( Submission $submission ): void;
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -141,12 +141,8 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	 * @param Quiz_Progress $quiz_progress Quiz progress.
 	 */
 	public function delete( Quiz_Progress $quiz_progress ): void {
-		delete_comment_meta( $quiz_progress->get_quiz_id(), 'quiz_answers' );
-		delete_comment_meta( $quiz_progress->get_id(), 'grade' );
-
-		// Backward compatibility with Sensei prior to 1.7.
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_progress->get_quiz_id() );
-		Sensei_Utils::sensei_delete_quiz_grade( $lesson_id, $quiz_progress->get_user_id() );
+
 		Sensei_Utils::sensei_delete_quiz_answers( $lesson_id, $quiz_progress->get_user_id() );
 	}
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -141,8 +141,6 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	 * @param Quiz_Progress $quiz_progress Quiz progress.
 	 */
 	public function delete( Quiz_Progress $quiz_progress ): void {
-		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_progress->get_quiz_id() );
-
-		Sensei_Utils::sensei_delete_quiz_answers( $lesson_id, $quiz_progress->get_user_id() );
+		Sensei_Utils::sensei_delete_quiz_answers( $quiz_progress->get_quiz_id(), $quiz_progress->get_user_id() );
 	}
 }

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
@@ -257,6 +257,24 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		);
 	}
 
+	public function testDelete_WhenCalled_DeletesTheGrade(): void {
+		/* Arrange. */
+		$lesson_id  = $this->factory->lesson->create();
+		$user_id    = $this->factory->user->create();
+		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+		$repository = new Comments_Based_Submission_Repository();
+
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+
+		$submission = $repository->create( $quiz_id, $user_id, 12.34 );
+
+		/* Act. */
+		$repository->delete( $submission );
+
+		/* Assert. */
+		$this->assertNull( $repository->get( $quiz_id, $user_id )->get_final_grade() );
+	}
+
 	private function export_submission( Submission $submission ): array {
 		return [
 			'quiz_id'     => $submission->get_quiz_id(),

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -162,13 +162,13 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$progress->pass();
 		$repository->save( $progress );
 
-		update_comment_meta( $quiz_id, 'quiz_answers', [ $question_id => 'answer' ] );
+		update_comment_meta( $progress->get_id(), 'quiz_answers', [ $question_id => 'answer' ] );
 
 		/* Act. */
 		$repository->delete( $progress );
 
 		/* Assert. */
-		$actual = get_comment_meta( $quiz_id, 'quiz_answers', true );
+		$actual = get_comment_meta( $progress->get_id(), 'quiz_answers', true );
 		self::assertEmpty( $actual );
 	}
 

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -1,5 +1,10 @@
 <?php
 
+use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface;
+use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interface;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface;
+
 class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 
 	/**
@@ -290,6 +295,89 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$quiz_submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
 
 		$this->assertSame( 12.34, $quiz_submission->get_final_grade() );
+	}
+
+	public function testSenseiDeleteQuizAnswers_WhenNoQuizProvided_ReturnsFalse() {
+		/* Act. */
+		$result = Sensei_Utils::sensei_delete_quiz_answers( 0, 1 );
+
+		/* Assert. */
+		$this->assertFalse( $result );
+	}
+
+	public function testSenseiDeleteQuizAnswers_WhenNoUserProvidedAndNoUserLoggedIn_ReturnsFalse() {
+		/* Act. */
+		$result = Sensei_Utils::sensei_delete_quiz_answers( 1, 0 );
+
+		/* Assert. */
+		$this->assertFalse( $result );
+	}
+
+	public function testSenseiDeleteQuizAnswers_WhenNoQuizSubmission_ReturnsFalse() {
+		/* Act. */
+		$result = Sensei_Utils::sensei_delete_quiz_answers( 1, 1 );
+
+		/* Assert. */
+		$this->assertFalse( $result );
+	}
+
+	public function testSenseiDeleteQuizAnswers_WhenHasQuizSubmission_ReturnsTrue() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [
+					'_quiz_lesson' => $lesson_id,
+				],
+			]
+		);
+
+		$this->factory->question->create( [ 'quiz_id' => $quiz_id ] );
+		$this->factory->question->create( [ 'quiz_id' => $quiz_id ] );
+
+		$answers = $this->factory->generate_user_quiz_answers( $quiz_id );
+
+		Sensei_Quiz::save_user_answers( $answers, [], $lesson_id, $user_id );
+
+		/* Act. */
+		$result = Sensei_Utils::sensei_delete_quiz_answers( $quiz_id, $user_id );
+
+		/* Assert. */
+		$this->assertTrue( $result );
+	}
+
+	public function testSenseiDeleteQuizAnswers_WhenHasQuizSubmission_DeletesTheQuizData() {
+		/* Arrange. */
+		$submission_id = 123;
+		$submission    = $this->createMock( Submission::class );
+		$submission->method( 'get_id' )->willReturn( $submission_id );
+
+		Sensei()->quiz_answer_repository     = $this->createMock( Answer_Repository_Interface::class );
+		Sensei()->quiz_grade_repository      = $this->createMock( Grade_Repository_Interface::class );
+		Sensei()->quiz_submission_repository = $this->createMock( Submission_Repository_Interface::class );
+		Sensei()->quiz_submission_repository
+			->method( 'get' )
+			->willReturn( $submission );
+
+		/* Act & Assert. */
+		Sensei()->quiz_submission_repository
+			->expects( $this->once() )
+			->method( 'delete' )
+			->with( $submission );
+
+		Sensei()->quiz_answer_repository
+			->expects( $this->once() )
+			->method( 'delete_all' )
+			->with( $submission_id );
+
+		Sensei()->quiz_answer_repository
+			->expects( $this->once() )
+			->method( 'delete_all' )
+			->with( $submission_id );
+
+		Sensei_Utils::sensei_delete_quiz_answers( 1, 1 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5967

### Changes proposed in this Pull Request

* Introduce a delete method to the quiz submission repository.
* Fix the quiz data not being deleted when the quiz progress is deleted.
* Move the quiz submission data deletion logic to `Sensei_Utils::sensei_delete_quiz_answers`.

### Testing instructions

* Submit a quiz.
* Grade it and provide feedback.
* Reset the quiz progress.
* Make sure the quiz metadata is removed: `grade`, `quiz_grades`, `quiz_answers_feedback`, `quiz_answers`, `questions_asked`
