### PR TITLE
Fix some Home styles

### DIFF
--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -1,29 +1,30 @@
 
 .sensei-home {
-&__notices {
-	margin-bottom: 31px;
+	&__notices {
+		margin-bottom: 31px;
 
-	.sensei-notice {
-		margin-left: 0;
-		margin-right: 0;
-		padding: 10px 16px;
+		.sensei-notice {
+			margin-left: 0;
+			margin-right: 0;
+			padding: 10px 16px;
 
-		&__wrapper {
-			height: 100%;
-		}
+			&__wrapper {
+				height: 100%;
+			}
 
-		&__content {
-			display: flex;
-			align-items: center;
-		}
-
-		.sensei-home {
-			&__link {
+			&__content {
 				display: flex;
 				align-items: center;
-				height: 100%;
+			}
+
+			.sensei-home {
+				&__link {
+					display: flex;
+					align-items: center;
+					height: 100%;
+					white-space: nowrap;
+				}
 			}
 		}
 	}
-}
 }

--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -1,12 +1,15 @@
 
 .sensei-home {
 	&__notices {
-		margin-bottom: 31px;
+		margin-bottom: 20px;
 
 		.sensei-notice {
-			margin-left: 0;
-			margin-right: 0;
+			margin: 0 0 12px;
 			padding: 10px 16px;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
 
 			&__wrapper {
 				height: 100%;

--- a/assets/home/sections/sensei-pro-ad.scss
+++ b/assets/home/sections/sensei-pro-ad.scss
@@ -4,7 +4,7 @@
 	&__sensei-pro-ad {
 		display: flex;
 		flex-direction: column-reverse;
-		margin: 0 -10px 20px;
+		margin-bottom: 20px;
 		font-size: 18px;
 		line-height: 1.5;
 		background-color: #26212e;
@@ -12,7 +12,6 @@
 
 		@media (min-width: $break-medium) {
 			flex-direction: row;
-			margin: 20px 0;
 		}
 
 		p {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It avoids the "What's new" wrap, in order to not get weird when the notice has multiple lines.
* It fixes the notices spacing.
* It fixes the Sensei Pro banner spacing.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Play with the Sensei versions to force some notices to show up.
* Check in small resolutions that the "what's new" doesn't have a break line.
* Make sure the notices and Sensei Pro spacing look correct.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Before:

<img width="1268" alt="Screen Shot 2022-10-24 at 14 47 22" src="https://user-images.githubusercontent.com/876340/197593847-ec2e90a0-2cf1-4225-8113-ddf82bdaf173.png">

<img width="1275" alt="Screen Shot 2022-10-24 at 14 56 45" src="https://user-images.githubusercontent.com/876340/197593927-c0b8cf3f-5a9e-4774-aad1-cbbde61a883e.png">

After:

<img width="1283" alt="Screen Shot 2022-10-24 at 14 47 10" src="https://user-images.githubusercontent.com/876340/197593875-46466e78-bc87-477f-b93f-e7d758f7df53.png">

<img width="1272" alt="Screen Shot 2022-10-24 at 14 56 27" src="https://user-images.githubusercontent.com/876340/197593906-6b04e696-a222-4bd4-af3e-5bb82d35fe7c.png">
