### PR TITLE
Adjust texts on the Sensei Pro Ad in Sensei Home

### DIFF
--- a/assets/home/sections/sensei-pro-ad.js
+++ b/assets/home/sections/sensei-pro-ad.js
@@ -39,7 +39,7 @@ const SenseiProAd = ( { show } ) => {
 						<header className="sensei-home__sensei-pro-ad__header">
 							<h2 className="sensei-home__sensei-pro-ad__title">
 								{ __(
-									'Start selling with Sensei Pro',
+									'Better courses with Sensei Pro',
 									'sensei-lms'
 								) }
 							</h2>
@@ -48,7 +48,7 @@ const SenseiProAd = ( { show } ) => {
 						<div className="sensei-home__sensei-pro-ad__description">
 							<p>
 								{ __(
-									'All the features in one package made so that you can start selling your courses right away.',
+									'Get everything you need to sell courses and take your lessons to the next level.',
 									'sensei-lms'
 								) }
 							</p>
@@ -72,32 +72,37 @@ const SenseiProAd = ( { show } ) => {
 							<ul>
 								<li>
 									{ __(
-										'WooCommerce integration',
+										'Sell courses with WooCommerce',
 										'sensei-lms'
 									) }
 								</li>
 								<li>
 									{ __(
-										'Schedule ‘drip’ content',
+										'Schedule and drip courses and lessons',
 										'sensei-lms'
 									) }
 								</li>
 								<li>
 									{ __(
-										'Set expiration date of courses',
-										'sensei-lms'
-									) }
-								</li>
-								<li>{ __( 'Quiz timer', 'sensei-lms' ) }</li>
-								<li>
-									{ __(
-										'Flashcards, Image Hotspots, Checklists and Interactive Video',
+										'Manage groups and cohorts',
 										'sensei-lms'
 									) }
 								</li>
 								<li>
 									{ __(
-										'1 year of updates & support',
+										'Create interactive videos and lessons',
+										'sensei-lms'
+									) }
+								</li>
+								<li>
+									{ __(
+										'Add advanced quiz features',
+										'sensei-lms'
+									) }
+								</li>
+								<li>
+									{ __(
+										'Contact our experts for help',
 										'sensei-lms'
 									) }
 								</li>

--- a/assets/home/sections/sensei-pro-ad.scss
+++ b/assets/home/sections/sensei-pro-ad.scss
@@ -58,7 +58,7 @@
 			margin-bottom: 16px;
 
 			@media (min-width: $break-medium) {
-				margin: 0 0 24px -4px;
+				margin-bottom: 24px;
 			}
 		}
 


### PR DESCRIPTION
Fixes #6000

### Changes proposed in this Pull Request

* Adjust texts on Sensei Pro Ad as requested by Ronnie;
* Also remove negative margin on the title of the ad to align title and description more;

### Testing instructions

On a WP installation containing Sensei LMS based on this branch, verify:

1. If the texts match what are specified on the issue;
2. If the overall ad matches our design; (especially looking at the alignment between the title and the rest of the ad)

### Screenshot / Video

![Sensei Pro Ad screenshot](https://user-images.githubusercontent.com/529864/197562092-7c80dadf-58c9-46c3-a5d6-62c9b3e25be7.png)
