### PR TITLE
Improve error handling on News and Guides section

### DIFF
--- a/includes/admin/home/class-sensei-home-guides-provider.php
+++ b/includes/admin/home/class-sensei-home-guides-provider.php
@@ -33,15 +33,25 @@ class Sensei_Home_Guides_Provider {
 	/**
 	 * Returns all the information for the guides section.
 	 *
-	 * @return array
+	 * @return array|null
 	 */
-	public function get(): array {
+	public function get() {
 		$remote_data = $this->remote_data_api->fetch( HOUR_IN_SECONDS );
-		$guides      = $remote_data['guides'] ?? [];
-
-		if ( isset( $guides['items'] ) ) {
-			$guides['items'] = array_filter( array_map( [ $this, 'format_item' ], $guides['items'] ) );
+		if (
+			! $remote_data
+			|| $remote_data instanceof WP_Error
+			|| ! isset( $remote_data['guides'] )
+			|| ! isset( $remote_data['guides']['items'] )
+			|| ! is_array( $remote_data['guides']['items'] )
+		) {
+			return null;
 		}
+
+		$guides          = [
+			'items'    => $remote_data['guides']['items'],
+			'more_url' => $remote_data['guides']['more_url'] ?? null,
+		];
+		$guides['items'] = array_filter( array_map( [ $this, 'format_item' ], $guides['items'] ) );
 
 		return $guides;
 	}

--- a/includes/admin/home/class-sensei-home-news-provider.php
+++ b/includes/admin/home/class-sensei-home-news-provider.php
@@ -33,15 +33,25 @@ class Sensei_Home_News_Provider {
 	/**
 	 * Returns all the information for the news section.
 	 *
-	 * @return array
+	 * @return array|null
 	 */
-	public function get(): array {
+	public function get() {
 		$remote_data = $this->remote_data_api->fetch( HOUR_IN_SECONDS );
-		$news        = $remote_data['news'] ?? [];
-
-		if ( isset( $news['items'] ) ) {
-			$news['items'] = array_filter( array_map( [ $this, 'format_item' ], $news['items'] ) );
+		if (
+			! $remote_data
+			|| $remote_data instanceof WP_Error
+			|| ! isset( $remote_data['news'] )
+			|| ! isset( $remote_data['news']['items'] )
+			|| ! is_array( $remote_data['news']['items'] )
+		) {
+			return null;
 		}
+
+		$news          = [
+			'items'    => $remote_data['news']['items'],
+			'more_url' => $remote_data['news']['more_url'] ?? null,
+		];
+		$news['items'] = array_filter( array_map( [ $this, 'format_item' ], $news['items'] ) );
 
 		return $news;
 	}


### PR DESCRIPTION
Fixes #5973

### Changes proposed in this Pull Request

* Gracefully ignore errors on Sensei Homes' News and Guides sections. I also added some robust array structure checking/filtering.
* I opted for `ignore` because I think this is a non-critical feature and didn't want to present the user with an error that they don't really need to see and might be a distraction.

### Testing instructions
- Edit `Sensei_Home_Remote_Data_API::fetch` to prematurely return a `WP_Error`.
- Visit Sensei Home.
- Verify the News and Guides sections aren't there but no errors are displayed.