### PR TITLE
Fix learning mode settings link

### DIFF
--- a/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
+++ b/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
@@ -33,7 +33,7 @@ class Sensei_Home_Quick_Links_Provider {
 				__( 'Settings', 'sensei-lms' ),
 				[
 					$this->create_item( __( 'Email notifications', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#email-notification-settings' ) ),
-					$this->create_item( __( 'Learning Mode', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#course-settings' ) ),
+					$this->create_item( __( 'Learning Mode', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#appearance-settings' ) ),
 					$this->create_item( __( 'WooCommerce', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#woocommerce-settings' ) ),
 					$this->create_item( __( 'Content Drip', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#sensei-content-drip-settings' ) ),
 				]


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the link to the Learning mode settings. I think we added this link before the last Learning mode project, and we need to change it now, right?

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go to the Sensei Home. On the "Quick links" section, click on "Learning mode", and make sure you see the Learning mode settings.