### PR TITLE
Fix Course List buttons extending outside container

### DIFF
--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -5,6 +5,12 @@
 
 	.wp-block-button__link {
 		box-sizing: border-box;
+
+		&:disabled {
+			pointer-events: none;
+			opacity: 0.5;
+			filter: grayscale(100%);
+		}
 	}
 
 	&.has-text-align-full {
@@ -15,12 +21,6 @@
 			width: 100%;
 			flex: 1;
 		}
-	}
-
-	.wp-block-button__link:disabled {
-		pointer-events: none;
-		opacity: 0.5;
-		filter: grayscale(100%);
 	}
 
 	&__notice {

--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -3,6 +3,10 @@
 		display: block;
 	}
 
+	.wp-block-button__link {
+		box-sizing: border-box;
+	}
+
 	&.has-text-align-full {
 		text-align: center;
 
@@ -29,8 +33,8 @@
 }
 
 /**
-  * Buttons in container.
-  */
+	* Buttons in container.
+	*/
 .sensei-buttons-container {
 	margin: -9px;
 	overflow: hidden; /* Clearfix solution */


### PR DESCRIPTION
Related https://github.com/Automattic/sensei-theme/issues/42.

### Changes proposed in this Pull Request
Fixes Course List buttons extending outside container. This should be a fairly benign change, but it wouldn't hurt to check that other buttons (e.g. Take Course, Contact Teacher) aren't affected.

### Testing instructions
- Activate the Sensei theme.
- Add a Course List block to a page.
- View that page in the editor and on the frontend and ensure the buttons don't extend outside of their parent container.
- Test on other themes. I saw this issue on Twenty Twenty Two and Twenty Twenty Three as well.

### Screenshot

#### Before
![Screen Shot 2022-10-24 at 4 02 30 PM](https://user-images.githubusercontent.com/1190420/197618044-196e5394-96be-4fd7-8c2f-59a341903bee.jpg)

#### After
![Screen Shot 2022-10-24 at 4 01 02 PM](https://user-images.githubusercontent.com/1190420/197617773-a70cc4b7-e15e-4c0c-bac9-4fe4a56e79c0.jpg)