### PR TITLE
Fix PHP notice on Sensei Home Notices Provider

### DIFF
--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -94,8 +94,14 @@ class Sensei_Home_Notices_Provider {
 	 * @return array
 	 */
 	private function format_item( $notice ) {
+		$level = 'info';
+		if ( array_key_exists( 'level', $notice ) ) {
+			$level = $notice['level'];
+		} elseif ( array_key_exists( 'style', $notice ) ) {
+			$level = $notice['style'];
+		}
 		return [
-			'level'       => ( $notice['level'] ?? $notice['style'] ) ?? 'info',
+			'level'       => $level,
 			'heading'     => $notice['heading'] ?? null,
 			'message'     => $notice['message'],
 			'info_link'   => $notice['info_link'] ?? null,


### PR DESCRIPTION
So, when neither level nor style is available, it doesn't emit this PHP notice:

![image](https://user-images.githubusercontent.com/529864/197827495-11a493c3-c80f-474d-85a2-3755fa1be4d2.png)


### Changes proposed in this Pull Request

* Change logic to detect `level` of a given notice;

### Testing instructions

Install WC Paid Courses (based on this branch of the code) and WooCommerce and make sure the PHP notice shown above doesn't appear.