### PR TITLE
Change: open internal links on same tab in sensei home

### DIFF
--- a/assets/home/link.js
+++ b/assets/home/link.js
@@ -6,19 +6,7 @@ import { external, Icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { addUtms } from './utils';
-
-/**
- * Return hostname for a given URL.
- *
- * @param {string} url URL to parse.
- * @return {string} The hostname for the given URL.
- */
-const getHostname = ( url ) => {
-	const element = document.createElement( 'a' );
-	element.href = url;
-	return element.hostname;
-};
+import { addUtms, isUrlExternal } from './utils';
 
 /**
  * Link component. Will add an external link icon if the url is for an external domain.
@@ -29,8 +17,7 @@ const getHostname = ( url ) => {
  * @param {Function} props.onClick The event listener for the click event.
  */
 const Link = ( { label, url, onClick } ) => {
-	const isExternal = getHostname( window.location ) !== getHostname( url );
-
+	const isExternal = isUrlExternal( url );
 	return (
 		<div className="sensei-home__link">
 			<a

--- a/assets/home/link.js
+++ b/assets/home/link.js
@@ -35,7 +35,7 @@ const Link = ( { label, url, onClick } ) => {
 		<div className="sensei-home__link">
 			<a
 				href={ addUtms( url ) }
-				target={ onClick ? undefined : '_blank' }
+				target={ onClick || ! isExternal ? undefined : '_blank' }
 				rel="noreferrer"
 				onClick={ onClick }
 			>

--- a/assets/home/link.js
+++ b/assets/home/link.js
@@ -18,14 +18,15 @@ import { addUtms, isUrlExternal } from './utils';
  */
 const Link = ( { label, url, onClick } ) => {
 	const isExternal = isUrlExternal( url );
+	const linkProps = {
+		href: addUtms( url ),
+		target: onClick || ! isExternal ? undefined : '_blank',
+		rel: isExternal ? 'noreferrer' : undefined,
+		onClick,
+	};
 	return (
 		<div className="sensei-home__link">
-			<a
-				href={ addUtms( url ) }
-				target={ onClick || ! isExternal ? undefined : '_blank' }
-				rel="noreferrer"
-				onClick={ onClick }
-			>
+			<a { ...linkProps }>
 				{ label }
 				{ isExternal && (
 					<Icon

--- a/assets/home/sections/quick-links.test.js
+++ b/assets/home/sections/quick-links.test.js
@@ -72,7 +72,7 @@ describe( '<QuickLinks />', () => {
 		const link = container.querySelector( 'a' );
 
 		expect( queryByText( 'internal link' ) ).toBeTruthy();
-		expect( link.target ).toEqual( '_blank' );
+		expect( link.target ).not.toEqual( '_blank' );
 		expect( link.href ).toEqual(
 			'http://localhost/wp-admin/post-new.php?post_type=course'
 		);

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -20,10 +20,12 @@ import { isUrlExternal } from '../utils';
  */
 const TaskItem = ( { title, url, done } ) => {
 	const Tag = done ? 'span' : 'a';
+	const isExternal = isUrlExternal( url );
 
 	const linkProps = ! done && {
 		href: url,
-		target: isUrlExternal( url ) ? '_blank' : undefined,
+		target: isExternal ? '_blank' : undefined,
+		rel: isExternal ? 'noreferrer' : undefined,
 	};
 
 	return (

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -22,8 +22,6 @@ const TaskItem = ( { title, url, done } ) => {
 
 	const linkProps = ! done && {
 		href: url,
-		target: '_blank',
-		rel: 'noreferrer',
 	};
 
 	return (

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import CheckIcon from '../../icons/checked.svg';
 import ChevronRightIcon from '../../icons/chevron-right.svg';
+import { isUrlExternal } from '../utils';
 
 /**
  * Tasks item component.
@@ -22,6 +23,7 @@ const TaskItem = ( { title, url, done } ) => {
 
 	const linkProps = ! done && {
 		href: url,
+		target: isUrlExternal( url ) ? '_blank' : undefined,
 	};
 
 	return (

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -12,10 +12,10 @@ import ChevronRightIcon from '../../icons/chevron-right.svg';
 /**
  * Tasks item component.
  *
- * @param {Object} props       Component props.
- * @param {Object} props.title Item title.
- * @param {Object} props.url   Item URL.
- * @param {Object} props.done  Whether item is completed.
+ * @param {Object}  props       Component props.
+ * @param {string}  props.title Item title.
+ * @param {string}  props.url   Item URL.
+ * @param {boolean} props.done  Whether item is completed.
  */
 const TaskItem = ( { title, url, done } ) => {
 	const Tag = done ? 'span' : 'a';

--- a/assets/home/utils.js
+++ b/assets/home/utils.js
@@ -17,3 +17,25 @@ export const addUtms = ( url ) => {
 		return url;
 	}
 };
+
+/**
+ * Return hostname for a given URL.
+ *
+ * @param {string} url URL to parse.
+ * @return {string} The hostname for the given URL.
+ */
+const getHostname = ( url ) => {
+	const element = document.createElement( 'a' );
+	element.href = url;
+	return element.hostname;
+};
+
+/**
+ * Verifies if a given URL is external or not.
+ *
+ * @param {string} url The URL to analyze.
+ * @return {boolean} If it's external or not.
+ */
+export const isUrlExternal = ( url ) => {
+	return getHostname( window.location ) !== getHostname( url );
+};


### PR DESCRIPTION
Fixes #6018

### Changes proposed in this Pull Request

* If link on Sensei Home is internal, open on the same tab, instead of always opening a new tab/window with the link.

### Testing instructions

Verify if the non-external links in Sensei Home (more specifically, the ones in the Quick Links and Task List sections, but it'd be nice to test other links too) open in the same tab/window, instead of always opening everything on a new tab. :)
