### PR TITLE
Fix status after installation

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -218,13 +218,12 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function install_extension( WP_REST_Request $request ) {
-		$json_params       = $request->get_json_params();
-		$plugin_slug       = $json_params['plugin'];
-		$available_plugins = Sensei_Extensions::instance()->get_extensions_and_woocommerce( 'plugin' );
+		$json_params = $request->get_json_params();
+		$plugin_slug = $json_params['plugin'];
 
 		$plugin_to_install = array_values(
 			array_filter(
-				$available_plugins,
+				Sensei_Extensions::instance()->get_extensions_and_woocommerce( 'plugin' ),
 				function( $plugin ) use ( $plugin_slug ) {
 					return $plugin->product_slug === $plugin_slug;
 				}
@@ -245,7 +244,7 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 		}
 
 		$installed_plugins = array_filter(
-			$available_plugins,
+			Sensei_Extensions::instance()->get_extensions_and_woocommerce( 'plugin' ),
 			function( $plugin ) use ( $plugin_slug ) {
 				return $plugin->product_slug === $plugin_slug;
 			}


### PR DESCRIPTION
Fixes #6014

### Changes proposed in this Pull Request

* It fixes the extensions `install` endpoint, returning the correct plugins status after the installation.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Make sure you don't have at least one of the Sensei extensions installed.
* Go to the Sensei Home.
* In the extensions section, click on "Install" in one of the extensions.
* Make sure that after it's completed it updates the button to "Installed".

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/197873436-86be98b6-e71b-4236-bd64-5e5c4b6755bc.mov
