### PR TITLE
Add support for dismissible flag to admin notices

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -2,12 +2,6 @@ $sensei-notice-icon-height: 30px;
 $sensei-notice-icon-width: 30px;
 
 /* Sensei Notice */
-.wp-core-ui .notice {
-	&.is-dismissible {
-		padding: 10px 16px;
-	}
-}
-
 .sensei-notice {
 	@import '../shared/styles/wp-admin';
 
@@ -16,6 +10,7 @@ $sensei-notice-icon-width: 30px;
 	display: flex;
 	gap: 10px;
 	min-height: 40px;
+	padding: 10px 16px;
 
 	&__icon {
 		color: #26212E;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* In our Home implementation we started allowing `dismissible => false`. This adds the same support for all other admin notices.
* Changes it so our padding is applied to all Sensei notices. I'm not sure why were were touching notices outside of Sensei.

### Testing instructions
- Try to dismiss a notice without the `dismissible` flag in Sensei Home or outside and ensure it works.
- Make sure notices that have `dismissible` set to `false` are not dismissible.

This snippet might help:
```php
add_filter(
	'sensei_admin_notices',
	function( $notices ) {
		$shared_conditions = [
			[
				'type'    => 'screens',
				'screens' => [ 'sensei*', 'plugins', 'plugins-network', 'dashboard' ],
			],
		];
		
		$notices['test-is-dismissible-assumed'] = [
			'type'       => 'site-wide',
			'icon'       => 'sensei',
			'style'      => 'error',
			'heading'    => 'Sensei Test',
			'message'    => 'This message should be assumed to be dismissible.',
			'conditions' => $shared_conditions,
		];
		
		$notices['test-is-dismissible'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei Test',
			'message'     => 'This message should for sure be dismissible.',
			'dismissible' => true,
			'conditions'  => $shared_conditions,
		];
		
		$notices['test-not-dismissible'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei Test',
			'message'     => 'This message should NOT be dismissible.',
			'dismissible' => false,
			'conditions'  => $shared_conditions,
		];
		return $notices;		
	}
);
```