### PR TITLE
Fix: Remove 10 posts limit for courses list in students page.

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -437,7 +437,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 * @return string The HTML for the column.
 	 */
 	private function get_learner_courses_html( $user_id ) {
-		$query   = $this->learner->get_enrolled_courses_query( $user_id );
+		$query   = $this->learner->get_enrolled_courses_query( $user_id, [ 'posts_per_page' => -1 ] );
 		$courses = $query->get_posts();
 
 		if ( empty( $courses ) ) {


### PR DESCRIPTION
Fixes #6013

### Changes proposed in this Pull Request
* Remove 10 `posts_per_page` limitation for list of Enrolled Courses in Students page.

### Testing instructions
* Enrol a user in more than 10 courses.
* Check the Students page and confirm that all the courses (more than 10) are displayed in the Enrolled Courses column.
<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="1554" alt="image" src="https://user-images.githubusercontent.com/799065/198024132-5bd7a76a-aec1-4e9f-9acf-b1c94bf7e36d.png">
