### PR TITLE
Use plugin file folder as slug for update notices

### DIFF
--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -140,15 +140,17 @@ class Sensei_Home_Notices {
 
 			$available_updates = get_plugin_updates();
 			foreach ( $available_updates as $plugin_data ) {
-				$plugin_slug    = $plugin_data->update->slug;
-				$update_version = $plugin_data->update->new_version;
-				$update_package = $plugin_data->update->package;
+				$plugin_slug_given = $plugin_data->update->slug;
+				$plugin_slug_file  = dirname( $plugin_data->update->plugin );
+				$update_version    = $plugin_data->update->new_version;
+				$update_package    = $plugin_data->update->package;
 
-				if ( ! $plugin_slug || ! $update_version || ! $update_package ) {
+				if ( ! $plugin_slug_given || ! $plugin_slug_file || ! $update_version || ! $update_package ) {
 					continue;
 				}
 
-				$this->local_plugin_updates[ $plugin_slug ] = $update_version;
+				$this->local_plugin_updates[ $plugin_slug_given ] = $update_version;
+				$this->local_plugin_updates[ $plugin_slug_file ]  = $update_version;
 			}
 		}
 

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -140,17 +140,15 @@ class Sensei_Home_Notices {
 
 			$available_updates = get_plugin_updates();
 			foreach ( $available_updates as $plugin_data ) {
-				$plugin_slug_given = $plugin_data->update->slug;
-				$plugin_slug_file  = dirname( $plugin_data->update->plugin );
-				$update_version    = $plugin_data->update->new_version;
-				$update_package    = $plugin_data->update->package;
+				$plugin_slug    = dirname( $plugin_data->update->plugin );
+				$update_version = $plugin_data->update->new_version;
+				$update_package = $plugin_data->update->package;
 
-				if ( ! $plugin_slug_given || ! $plugin_slug_file || ! $update_version || ! $update_package ) {
+				if ( ! $plugin_slug || ! $update_version || ! $update_package ) {
 					continue;
 				}
 
-				$this->local_plugin_updates[ $plugin_slug_given ] = $update_version;
-				$this->local_plugin_updates[ $plugin_slug_file ]  = $update_version;
+				$this->local_plugin_updates[ $plugin_slug ] = $update_version;
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* WooCommerce changes the `slug` field in the plugin update response to be something arbitrary for its plugins (i.e. `woothemes-sensei`). The plugin file's folder should work as the slug.

### Testing instructions

* Downgrade Sensei Certificates and ensure the notice appears on Home.
* Note: It may take a few refreshes for the update to enter cache. You might need to refresh the plugins page first and then go back to Sensei Home.