### PR TITLE
Change progress bar animation

### DIFF
--- a/assets/setup-wizard/features/style.scss
+++ b/assets/setup-wizard/features/style.scss
@@ -1,3 +1,14 @@
+$bar-color: #217D7C;
+
+@keyframes bar-animation {
+	0% {
+		background-position: 0 0;
+	}
+	100% {
+		background-position: 50px 50px;
+	}
+}
+
 .sensei-setup-wizard {
 	&__features-status {
 		margin-bottom: 24px;
@@ -16,8 +27,16 @@
 	}
 
 	&__features-progress-bar-filled {
-		background-color: #217D7C;
+		background-color: $bar-color;
+		background-image: linear-gradient(
+			135deg,
+			lighten($bar-color, 5%) 25%, $bar-color 25%,
+			$bar-color 50%, lighten($bar-color, 5%) 50%,
+			lighten($bar-color, 5%) 75%, $bar-color 75%
+		);
+		background-size: 50px 50px;
 		height: 100%;
 		transition: 1.5s width linear;
+		animation: bar-animation 3s linear infinite;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It tries to improve the progress bar animation.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go through the Setup Wizard until the last step, and check if the progress bar animation looks nicer with a sensation that it's in progress even when it's stuck (we have a minimum time of 1.5s for every step, but if they delay more than that, the bar can be stuck for a while).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/198100328-2079fac4-ec32-4a77-b42c-d4c4f0160f37.mov

Notice that this step in the image will always take 1.5s. I just forced it to delay a little more to reproduce the scenario. The steps that can delay more are the plugins installation.