### PR TITLE
Fix some issues with author names getting appended to module names

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2207,7 +2207,10 @@ class Sensei_Core_Modules {
 		// look for the author in the slug
 		$slug_parts = explode( '-', $slug );
 
-		if ( count( $slug_parts ) > 1 ) {
+		if (
+			count( $slug_parts ) > 1
+			&& is_numeric( $slug_parts[0] )
+		) {
 
 			// get the user data
 			$possible_user_id = $slug_parts[0];

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2541,6 +2541,11 @@ class Sensei_Core_Modules {
 				continue;
 			}
 
+			if ( 'module' !== $term->taxonomy ) {
+				$users_terms[] = $term;
+				continue;
+			}
+
 			$author = self::get_term_author( $term->slug );
 
 			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) ) {


### PR DESCRIPTION
In researching #6033 I found a number of improvements we can make to how we handle modules.

### Changes proposed in this Pull Request

* `Sensei_Modules::append_teacher_name_to_module` can be called with an array of taxonomies. Before, if _one_ of those taxonomies were modules we were treating them _all_ like modules. I changed the method so it only tried to manipulate with modules.
* Relatedly, `Sensei_Modules::get_term_author` could be called with anything and we weren't doing a basic check to see if what we passed it could have a numeric user ID where we expect it to be.

### Testing instructions
- Create a course as a **teacher** with modules.
- Go to Sensei LMS > Modules and ensure the teacher name was still appended to the module name.