### PR TITLE
Add back some packages from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33972,6 +33972,628 @@
         "node": ">= 4.0"
       }
     },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/abbrev": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/aproba": {
+      "version": "1.2.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/are-we-there-yet": {
+      "version": "1.1.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/balanced-match": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/chownr": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/concat-map": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/debug": {
+      "version": "3.2.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/delegates": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs-minipass": {
+      "version": "1.2.7",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/gauge": {
+      "version": "2.7.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/glob": {
+      "version": "7.1.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ignore-walk": {
+      "version": "3.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inflight": {
+      "version": "1.0.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inherits": {
+      "version": "2.0.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ini": {
+      "version": "1.3.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/isarray": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimatch": {
+      "version": "3.0.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimist": {
+      "version": "1.2.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minipass": {
+      "version": "2.9.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minizlib": {
+      "version": "1.3.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/mkdirp": {
+      "version": "0.5.3",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ms": {
+      "version": "2.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/needle": {
+      "version": "2.3.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/node-pre-gyp": {
+      "version": "0.14.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/nopt": {
+      "version": "4.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-bundled": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-packlist": {
+      "version": "1.4.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npmlog": {
+      "version": "4.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/object-assign": {
+      "version": "4.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/once": {
+      "version": "1.4.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/osenv": {
+      "version": "0.1.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rc": {
+      "version": "1.2.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rimraf": {
+      "version": "2.7.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/sax": {
+      "version": "1.2.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/semver": {
+      "version": "5.7.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/signal-exit": {
+      "version": "3.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string-width": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/tar": {
+      "version": "4.4.13",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wide-align": {
+      "version": "1.1.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wrappy": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents/node_modules/yallist": {
+      "version": "3.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/jest-jasmine2": {
       "version": "24.9.0",
       "dev": true,
@@ -73928,6 +74550,479 @@
           "requires": {
             "bindings": "^1.5.0",
             "nan": "^2.12.1"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.4",
+              "bundled": true,
+              "extraneous": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "extraneous": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.6",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.3",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "extraneous": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "extraneous": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "extraneous": true
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.3.3",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "minipass": "^2.9.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.3",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "needle": {
+              "version": "2.3.3",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.14.0",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4.4.2"
+              }
+            },
+            "nopt": {
+              "version": "4.0.3",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.1.1",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "npm-packlist": {
+              "version": "1.4.8",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "extraneous": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "extraneous": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "extraneous": true
+            },
+            "tar": {
+              "version": "4.4.13",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "extraneous": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "extraneous": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "bundled": true,
+              "extraneous": true
+            }
           }
         }
       }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* After debugging for a while, we still can't figure out why @fjorgemota's `npm` is throwing out some packages. My guess is it is a platform difference since our `npm` versions and config are similar enough. 