### PR TITLE
Add course plugin sidebar

### DIFF
--- a/assets/js/admin/course-access-period-promo-sidebar.js
+++ b/assets/js/admin/course-access-period-promo-sidebar.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { ExternalLink, SelectControl } from '@wordpress/components';
+import { ExternalLink, SelectControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,10 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 const CourseAccessPeriodPromoSidebar = () => {
 	return (
-		<PluginDocumentSettingPanel
-			name="sensei-course-access-period-promo"
-			title={ __( 'Access Period', 'sensei-lms' ) }
-		>
+		<PanelBody title={ __( 'Access Period', 'sensei-lms' ) }>
 			<div className="sensei-course-access-period-promo">
 				<p>
 					<ExternalLink href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=course_access_period">
@@ -38,7 +34,7 @@ const CourseAccessPeriodPromoSidebar = () => {
 					/>
 				</div>
 			</div>
-		</PluginDocumentSettingPanel>
+		</PanelBody>
 	);
 };
 

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,35 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { select, subscribe, dispatch, useSelect } from '@wordpress/data';
-import { applyFilters } from '@wordpress/hooks';
+import { select, subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { registerPlugin } from '@wordpress/plugins';
-import { __ } from '@wordpress/i18n';
-import {
-	PluginDocumentSettingPanel,
-	PluginSidebar,
-	PluginSidebarMoreMenuItem,
-} from '@wordpress/edit-post';
-import { Slot } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { startBlocksTogglingControl } from './blocks-toggling-control';
-import CourseTheme from './course-theme';
-import CourseVideoSidebar from './course-video-sidebar';
-import CoursePricingPromoSidebar from './course-pricing-promo-sidebar';
-import CourseAccessPeriodPromoSidebar from './course-access-period-promo-sidebar';
 import {
 	extractStructure,
 	getFirstBlockByName,
 } from '../../blocks/course-outline/data';
-
-import SenseiIcon from '../../icons/logo-tree.svg';
-
-const pluginSidebarHandle = 'sensei-lms-course-settings-sidebar';
-const pluginDocumentHandle = 'sensei-lms-document-settings-sidebar';
+import {
+	CourseSidebar,
+	SenseiSettingsDocumentSidebar,
+	pluginSidebarHandle,
+	pluginDocumentHandle,
+} from './course-settings-plugin-sidebar';
 
 ( () => {
 	const editPostSelector = select( 'core/edit-post' );
@@ -119,63 +108,9 @@ domReady( () => {
  * Plugins
  */
 
-const CourseSidebar = () => {
-	const hideCoursePricing = applyFilters( 'senseiCoursePricingHide', false );
-	const hideAccessPeriod = applyFilters(
-		'senseiCourseAccessPeriodHide',
-		false
-	);
-	return (
-		<>
-			<PluginSidebarMoreMenuItem
-				target={ pluginSidebarHandle }
-				icon={ <SenseiIcon height="20" width="20" color="#43AF99" /> }
-			>
-				{ __( 'Sensei Settings', 'sensei-lms' ) }
-			</PluginSidebarMoreMenuItem>
-			<PluginSidebar
-				name={ pluginSidebarHandle }
-				title={ __( 'Sensei Settings', 'sensei-lms' ) }
-				icon={ <SenseiIcon color="#43AF99" /> }
-				position={ 1 }
-			>
-				{ ! hideCoursePricing && <CoursePricingPromoSidebar /> }
-				{ ! hideAccessPeriod && <CourseAccessPeriodPromoSidebar /> }
-				<Slot name="SenseiCourseSidebar" />
-				<CourseTheme />
-				<CourseVideoSidebar />
-			</PluginSidebar>
-		</>
-	);
-};
-
 registerPlugin( pluginSidebarHandle, {
 	render: CourseSidebar,
 } );
-
-const SenseiSettingsDocumentSidebar = () => {
-	const isSenseiEditorPanelOpen = useSelect( ( select ) => {
-		return select( 'core/edit-post' ).isEditorPanelOpened(
-			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
-		);
-	} );
-	if ( isSenseiEditorPanelOpen ) {
-		// when 'Sensei Settings' is clicked, isSenseiEditorPanelOpen returns true, so we open the 'Sensei Settings'
-		// plugin sidebar and then close the 'Sensei Settings' panel which sets isSenseiEditorPanelOpen back to false.
-		dispatch( 'core/edit-post' ).openGeneralSidebar(
-			`${ pluginSidebarHandle }/${ pluginSidebarHandle }`
-		);
-		dispatch( 'core/edit-post' ).toggleEditorPanelOpened(
-			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
-		);
-	}
-	return (
-		<PluginDocumentSettingPanel
-			name={ pluginDocumentHandle }
-			title={ __( 'Sensei Settings ', 'sensei-lms' ) }
-		></PluginDocumentSettingPanel>
-	);
-};
 
 registerPlugin( pluginDocumentHandle, {
 	render: SenseiSettingsDocumentSidebar,

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { select, subscribe } from '@wordpress/data';
+import { select, subscribe, dispatch, useSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import domReady from '@wordpress/dom-ready';
 import { registerPlugin, getPlugin } from '@wordpress/plugins';
@@ -21,9 +21,14 @@ import {
 } from '../../blocks/course-outline/data';
 
 import SenseiIcon from '../../icons/logo-tree.svg';
-import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
+import {
+	PluginDocumentSettingPanel,
+	PluginSidebar,
+	PluginSidebarMoreMenuItem,
+} from '@wordpress/edit-post';
 
-const pluginHandle = 'sensei-lms-course-sidebar';
+const pluginSidebarHandle = 'sensei-lms-course-settings-sidebar';
+const pluginDocumentHandle = 'sensei-lms-document-settings-sidebar';
 
 ( () => {
 	const editPostSelector = select( 'core/edit-post' );
@@ -117,13 +122,13 @@ const CourseSidebar = () => {
 	return (
 		<>
 			<PluginSidebarMoreMenuItem
-				target={ pluginHandle }
+				target={ pluginSidebarHandle }
 				icon={ <SenseiIcon height="20" width="20" color="#43AF99" /> }
 			>
 				{ __( 'Sensei Settings', 'sensei-lms' ) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
-				name={ pluginHandle }
+				name={ pluginSidebarHandle }
 				title={ __( 'Sensei Settings', 'sensei-lms' ) }
 				icon={ <SenseiIcon color="#43AF99" /> }
 			></PluginSidebar>
@@ -131,8 +136,37 @@ const CourseSidebar = () => {
 	);
 };
 
-registerPlugin( pluginHandle, {
+registerPlugin( pluginSidebarHandle, {
 	render: CourseSidebar,
+} );
+
+const SenseiSettingsDocumentSidebar = () => {
+	const isSenseiEditorPanelOpen = useSelect( ( select ) => {
+		return select( 'core/edit-post' ).isEditorPanelOpened(
+			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
+		);
+	} );
+	if ( isSenseiEditorPanelOpen ) {
+		// when 'Sensei Settings' is clicked, isSenseiEditorPanelOpen returns true, so we open the 'Sensei Settings'
+		// plugin sidebar and then close the 'Sensei Settings' panel which sets isSenseiEditorPanelOpen back to false.
+		dispatch( 'core/edit-post' ).openGeneralSidebar(
+			`${ pluginSidebarHandle }/${ pluginSidebarHandle }`
+		);
+		dispatch( 'core/edit-post' ).toggleEditorPanelOpened(
+			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
+		);
+	}
+	return (
+		<PluginDocumentSettingPanel
+			name={ pluginDocumentHandle }
+			title={ __( 'Sensei Settings ', 'sensei-lms' ) }
+		></PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( pluginDocumentHandle, {
+	render: SenseiSettingsDocumentSidebar,
+	icon: null,
 } );
 
 /**

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -4,7 +4,8 @@
 import { select, subscribe } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import domReady from '@wordpress/dom-ready';
-import { registerPlugin } from '@wordpress/plugins';
+import { registerPlugin, getPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -18,6 +19,11 @@ import {
 	extractStructure,
 	getFirstBlockByName,
 } from '../../blocks/course-outline/data';
+
+import SenseiIcon from '../../icons/logo-tree.svg';
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
+
+const pluginHandle = 'sensei-lms-course-sidebar';
 
 ( () => {
 	const editPostSelector = select( 'core/edit-post' );
@@ -106,6 +112,28 @@ domReady( () => {
 /**
  * Plugins
  */
+
+const CourseSidebar = () => {
+	return (
+		<>
+			<PluginSidebarMoreMenuItem
+				target={ pluginHandle }
+				icon={ <SenseiIcon height="20" width="20" color="#43AF99" /> }
+			>
+				{ __( 'Sensei Settings', 'sensei-lms' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar
+				name={ pluginHandle }
+				title={ __( 'Sensei Settings', 'sensei-lms' ) }
+				icon={ <SenseiIcon color="#43AF99" /> }
+			></PluginSidebar>
+		</>
+	);
+};
+
+registerPlugin( pluginHandle, {
+	render: CourseSidebar,
+} );
 
 /**
  * Filters the course pricing sidebar toggle.

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -4,8 +4,14 @@
 import { select, subscribe, dispatch, useSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import domReady from '@wordpress/dom-ready';
-import { registerPlugin, getPlugin } from '@wordpress/plugins';
+import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
+import {
+	PluginDocumentSettingPanel,
+	PluginSidebar,
+	PluginSidebarMoreMenuItem,
+} from '@wordpress/edit-post';
+import { Slot } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -21,11 +27,6 @@ import {
 } from '../../blocks/course-outline/data';
 
 import SenseiIcon from '../../icons/logo-tree.svg';
-import {
-	PluginDocumentSettingPanel,
-	PluginSidebar,
-	PluginSidebarMoreMenuItem,
-} from '@wordpress/edit-post';
 
 const pluginSidebarHandle = 'sensei-lms-course-settings-sidebar';
 const pluginDocumentHandle = 'sensei-lms-document-settings-sidebar';
@@ -119,6 +120,11 @@ domReady( () => {
  */
 
 const CourseSidebar = () => {
+	const hideCoursePricing = applyFilters( 'senseiCoursePricingHide', false );
+	const hideAccessPeriod = applyFilters(
+		'senseiCourseAccessPeriodHide',
+		false
+	);
 	return (
 		<>
 			<PluginSidebarMoreMenuItem
@@ -131,7 +137,14 @@ const CourseSidebar = () => {
 				name={ pluginSidebarHandle }
 				title={ __( 'Sensei Settings', 'sensei-lms' ) }
 				icon={ <SenseiIcon color="#43AF99" /> }
-			></PluginSidebar>
+				position={ 1 }
+			>
+				{ ! hideCoursePricing && <CoursePricingPromoSidebar /> }
+				{ ! hideAccessPeriod && <CourseAccessPeriodPromoSidebar /> }
+				<Slot name="SenseiCourseSidebar" />
+				<CourseTheme />
+				<CourseVideoSidebar />
+			</PluginSidebar>
 		</>
 	);
 };
@@ -166,47 +179,5 @@ const SenseiSettingsDocumentSidebar = () => {
 
 registerPlugin( pluginDocumentHandle, {
 	render: SenseiSettingsDocumentSidebar,
-	icon: null,
-} );
-
-/**
- * Filters the course pricing sidebar toggle.
- *
- * @since 4.1.0
- *
- * @hook  senseiCoursePricingHide     Hook used to hide course pricing promo sidebar.
- *
- * @param {boolean} hideCoursePricing Boolean value that defines if the course pricing promo sidebar should be hidden.
- * @return {boolean}                  Returns a boolean value that defines if the course pricing promo sidebar should be hidden.
- */
-if ( ! applyFilters( 'senseiCoursePricingHide', false ) ) {
-	registerPlugin( 'sensei-course-pricing-promo-sidebar', {
-		render: CoursePricingPromoSidebar,
-		icon: null,
-	} );
-}
-
-/**
- * Filters the course access period display.
- *
- * @since 4.1.0
- *
- * @param {boolean} hideCourseAccessPeriod Whether to hide the access period.
- * @return {boolean} Whether to hide the access period.
- */
-if ( ! applyFilters( 'senseiCourseAccessPeriodHide', false ) ) {
-	registerPlugin( 'sensei-course-access-period-promo-plugin', {
-		render: CourseAccessPeriodPromoSidebar,
-		icon: null,
-	} );
-}
-
-registerPlugin( 'sensei-course-theme-plugin', {
-	render: CourseTheme,
-	icon: null,
-} );
-
-registerPlugin( 'sensei-course-video-progression-plugin', {
-	render: CourseVideoSidebar,
 	icon: null,
 } );

--- a/assets/js/admin/course-pricing-promo-sidebar.js
+++ b/assets/js/admin/course-pricing-promo-sidebar.js
@@ -3,9 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { escapeHTML } from '@wordpress/escape-html';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, PanelBody } from '@wordpress/components';
 
 /**
  * Course Pricing Promo Sidebar component.
@@ -29,10 +28,7 @@ const CoursePricingPromoSidebar = () => {
 	);
 
 	return (
-		<PluginDocumentSettingPanel
-			name="sensei-course-pricing-promo"
-			title={ __( 'Pricing ', 'sensei-lms' ) }
-		>
+		<PanelBody title={ __( 'Pricing', 'sensei-lms' ) }>
 			<p> { escapeHTML( description ) } </p>
 			<p>
 				<ExternalLink
@@ -63,7 +59,7 @@ const CoursePricingPromoSidebar = () => {
 					{ __( 'Create a product', 'sensei-lms' ) }
 				</Button>
 			</div>
-		</PluginDocumentSettingPanel>
+		</PanelBody>
 	);
 };
 

--- a/assets/js/admin/course-settings-plugin-sidebar.js
+++ b/assets/js/admin/course-settings-plugin-sidebar.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+import {
+	PluginDocumentSettingPanel,
+	PluginSidebar,
+	PluginSidebarMoreMenuItem,
+} from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+import { dispatch, useSelect } from '@wordpress/data';
+import { Slot } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import CoursePricingPromoSidebar from './course-pricing-promo-sidebar';
+import CourseAccessPeriodPromoSidebar from './course-access-period-promo-sidebar';
+import CourseTheme from './course-theme';
+import CourseVideoSidebar from './course-video-sidebar';
+import SenseiIcon from '../../icons/logo-tree.svg';
+
+export const pluginSidebarHandle = 'sensei-lms-course-settings-sidebar';
+export const pluginDocumentHandle = 'sensei-lms-document-settings-sidebar';
+
+export const CourseSidebar = () => {
+	const hideCoursePricing = applyFilters( 'senseiCoursePricingHide', false );
+	const hideAccessPeriod = applyFilters(
+		'senseiCourseAccessPeriodHide',
+		false
+	);
+	return (
+		<>
+			<PluginSidebarMoreMenuItem
+				target={ pluginSidebarHandle }
+				icon={ <SenseiIcon height="20" width="20" color="#43AF99" /> }
+			>
+				{ __( 'Sensei Settings', 'sensei-lms' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar
+				name={ pluginSidebarHandle }
+				title={ __( 'Sensei Settings', 'sensei-lms' ) }
+				icon={ <SenseiIcon height="20" width="20" color="#43AF99" /> }
+			>
+				{ ! hideCoursePricing && <CoursePricingPromoSidebar /> }
+				{ ! hideAccessPeriod && <CourseAccessPeriodPromoSidebar /> }
+				<Slot name="SenseiCourseSidebar" />
+				<CourseTheme />
+				<CourseVideoSidebar />
+			</PluginSidebar>
+		</>
+	);
+};
+
+export const SenseiSettingsDocumentSidebar = () => {
+	const isSenseiEditorPanelOpen = useSelect( ( select ) => {
+		return select( 'core/edit-post' ).isEditorPanelOpened(
+			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
+		);
+	} );
+	if ( isSenseiEditorPanelOpen ) {
+		// when 'Sensei Settings' is clicked, isSenseiEditorPanelOpen returns true, so we open the 'Sensei Settings'
+		// plugin sidebar and then close the 'Sensei Settings' panel which sets isSenseiEditorPanelOpen back to false.
+		dispatch( 'core/edit-post' ).openGeneralSidebar(
+			`${ pluginSidebarHandle }/${ pluginSidebarHandle }`
+		);
+		dispatch( 'core/edit-post' ).toggleEditorPanelOpened(
+			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
+		);
+	}
+	return (
+		<PluginDocumentSettingPanel
+			name={ pluginDocumentHandle }
+			title={ __( 'Sensei Settings ', 'sensei-lms' ) }
+		></PluginDocumentSettingPanel>
+	);
+};

--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -1,24 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { ToggleControl, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import useCourseMeta from '../../../react-hooks/use-course-meta';
-import {
-	SENSEI_THEME,
-	WORDPRESS_THEME,
-	SENSEI_PREVIEW_QUERY,
-} from './constants';
+import { SENSEI_THEME, WORDPRESS_THEME } from './constants';
 import courseOutlineBlock from '../../../blocks/course-outline/outline-block/block.json';
 import courseModuleBlock from '../../../blocks/course-outline/module-block/block.json';
 import courseLessonBlock from '../../../blocks/course-outline/lesson-block/block.json';
-import { getFirstBlockByName } from '../../../blocks/course-outline/data';
 
 const courseOutlineBlockName = courseOutlineBlock.name;
 const courseModuleBlockName = courseModuleBlock.name;
@@ -36,10 +29,7 @@ const CourseThemeSidebar = () => {
 	const [ theme, setTheme ] = useCourseMeta( '_course_theme' );
 
 	return (
-		<PluginDocumentSettingPanel
-			name="sensei-course-theme"
-			title={ __( 'Learning Mode', 'sensei-lms' ) }
-		>
+		<PanelBody title={ __( 'Learning Mode', 'sensei-lms' ) }>
 			{ globalLearningModeEnabled ? (
 				<p>
 					<a href="/wp-admin/admin.php?page=sensei-settings#appearance-settings">
@@ -69,7 +59,7 @@ const CourseThemeSidebar = () => {
 					</p>
 				</>
 			) }
-		</PluginDocumentSettingPanel>
+		</PanelBody>
 	);
 };
 

--- a/assets/js/admin/course-video-sidebar.js
+++ b/assets/js/admin/course-video-sidebar.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,10 +24,7 @@ const CourseVideoSidebar = () => {
 	);
 
 	return (
-		<PluginDocumentSettingPanel
-			name="sensei-course-video"
-			title={ __( 'Video', 'sensei-lms' ) }
-		>
+		<PanelBody title={ __( 'Video', 'sensei-lms' ) }>
 			<ToggleControl
 				label={ __( 'Autocomplete Lesson', 'sensei-lms' ) }
 				checked={ autocomplete }
@@ -53,7 +49,7 @@ const CourseVideoSidebar = () => {
 					'sensei-lms'
 				) }
 			/>
-		</PluginDocumentSettingPanel>
+		</PanelBody>
 	);
 };
 


### PR DESCRIPTION
Fixes #6024 
Fixes #6025
Fixes #6026 

### Changes proposed in this Pull Request

* Creates a plugin sidebar component for Sensei settings.
* Create a Plugin Document Setting Panel named 'Sensei Settings'.
* Moves the current sensei course settings to the plugin sidebar

### Testing instructions

- Click on the new 'Sensei Settings' on the side bar.
- It should open the Sensei settings plugin sidebar.
- Check that all the settings you expect to see are in order.
- Click on the 3 dot menu item on the far right of the settings sidebar, there should be an item: Sensei Settings
- Clicking on it should open the same plugin sidebar.

### Screenshot / Video
<img width="283" alt="Screenshot 2022-11-02 at 17 22 17" src="https://user-images.githubusercontent.com/26160845/199542895-a6d9e746-c67d-48cf-b0ec-63917d0e86fe.png">

<img width="319" alt="Screenshot 2022-11-02 at 17 22 39" src="https://user-images.githubusercontent.com/26160845/199543201-37b5bc23-d4df-4aac-be3e-71a07b8e7ef3.png">

<img width="306" alt="Screenshot 2022-11-02 at 17 24 40" src="https://user-images.githubusercontent.com/26160845/199543309-01eefce9-5a8f-455e-8b57-f2e99be28633.png">