### PR TITLE
Add quiz submission tables based repository

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -286,6 +286,7 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory::class => 'internal/quiz-submission/grade/repositories/class-grade-repository-factory.php',
 			\Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interface::class => 'internal/quiz-submission/grade/repositories/class-grade-repository-interface.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Models\Submission::class => 'internal/quiz-submission/submission/models/class-submission.php',
+			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Aggregate_Submission_Repository::class => 'internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository::class => 'internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository::class => 'internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory::class => 'internal/quiz-submission/submission/repositories/class-submission-repository-factory.php',

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -287,6 +287,7 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interface::class => 'internal/quiz-submission/grade/repositories/class-grade-repository-interface.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Models\Submission::class => 'internal/quiz-submission/submission/models/class-submission.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository::class => 'internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php',
+			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository::class => 'internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory::class => 'internal/quiz-submission/submission/repositories/class-submission-repository-factory.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface::class => 'internal/quiz-submission/submission/repositories/class-submission-repository-interface.php',
 		);

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3631,12 +3631,15 @@ class Sensei_Lesson {
 		if ( ! is_admin() || ( is_admin() && isset( $_GET['page'] ) && 'sensei_grading' === $_GET['page'] && isset( $_GET['user'] ) && isset( $_GET['quiz_id'] ) ) ) {
 
 			// Fetch the questions that the user was asked in their quiz if they have already completed it.
-			$quiz_submission_question_ids = Sensei()->quiz_submission_repository->get_question_ids( $quiz_id, $user_id );
+			$submission              = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
+			$submission_question_ids = $submission
+				? Sensei()->quiz_submission_repository->get_question_ids( $submission->get_id() )
+				: [];
 
-			if ( $quiz_submission_question_ids ) {
+			if ( $submission_question_ids ) {
 				// Fetch each question in the order in which they were asked.
 				$questions = [];
-				foreach ( $quiz_submission_question_ids as $question_id ) {
+				foreach ( $submission_question_ids as $question_id ) {
 					$question = get_post( $question_id );
 					if ( ! isset( $question ) || ! isset( $question->ID ) ) {
 						continue;

--- a/includes/internal/quiz-submission/submission/models/class-submission.php
+++ b/includes/internal/quiz-submission/submission/models/class-submission.php
@@ -167,4 +167,15 @@ class Submission {
 	public function get_updated_at(): DateTimeInterface {
 		return $this->updated_at;
 	}
+
+	/**
+	 * Set the updated at date.
+	 *
+	 * @internal
+	 *
+	 * @param DateTimeInterface $updated_at The updated date.
+	 */
+	public function set_updated_at( DateTimeInterface $updated_at ): void {
+		$this->updated_at = $updated_at;
+	}
 }

--- a/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * File containing the Aggregate_Submission_Repository class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
+
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Aggregate_Submission_Repository.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Aggregate_Submission_Repository implements Submission_Repository_Interface {
+	/**
+	 * Comments based quiz submission repository implementation.
+	 *
+	 * @var Comments_Based_Submission_Repository
+	 */
+	private $comments_based_repository;
+
+	/**
+	 * Tables based quiz submission repository implementation.
+	 *
+	 * @var Tables_Based_Submission_Repository
+	 */
+	private $tables_based_repository;
+
+	/**
+	 * The flag if the tables based implementation is available for use.
+	 *
+	 * @var bool
+	 */
+	private $use_tables;
+
+	/**
+	 * Constructor.
+	 *
+	 * @internal
+	 *
+	 * @param Comments_Based_Submission_Repository $comments_based_repository Comments based quiz submission repository implementation.
+	 * @param Tables_Based_Submission_Repository   $tables_based_repository  Tables based quiz submission repository implementation.
+	 * @param bool                                 $use_tables  The flag if the tables based implementation is available for use.
+	 */
+	public function __construct( Comments_Based_Submission_Repository $comments_based_repository, Tables_Based_Submission_Repository $tables_based_repository, bool $use_tables ) {
+		$this->comments_based_repository = $comments_based_repository;
+		$this->tables_based_repository   = $tables_based_repository;
+		$this->use_tables                = $use_tables;
+	}
+
+	/**
+	 * Creates a new quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int        $quiz_id     The quiz ID.
+	 * @param int        $user_id     The user ID.
+	 * @param float|null $final_grade The final grade.
+	 *
+	 * @return Submission The quiz submission.
+	 */
+	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+		$submission = $this->comments_based_repository->create( $quiz_id, $user_id, $final_grade );
+
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->create( $quiz_id, $user_id, $final_grade );
+		}
+
+		return $submission;
+	}
+
+	/**
+	 * Get or create a new quiz submission if it doesn't exist.
+	 *
+	 * @internal
+	 *
+	 * @param int        $quiz_id     The quiz ID.
+	 * @param int        $user_id     The user ID.
+	 * @param float|null $final_grade The final grade.
+	 *
+	 * @return Submission The quiz submission.
+	 */
+	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+		$submission = $this->get( $quiz_id, $user_id );
+
+		if ( $submission ) {
+			return $submission;
+		}
+
+		return $this->create( $quiz_id, $user_id, $final_grade );
+	}
+
+	/**
+	 * Gets a quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $quiz_id The quiz ID.
+	 * @param int $user_id The user ID.
+	 *
+	 * @return Submission|null The quiz submission.
+	 */
+	public function get( int $quiz_id, int $user_id ): ?Submission {
+		return $this->comments_based_repository->get( $quiz_id, $user_id );
+	}
+
+	/**
+	 * Get the questions related to the quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $submission_id The quiz submission ID.
+	 *
+	 * @return array An array of question post IDs.
+	 */
+	public function get_question_ids( int $submission_id ): array {
+		return $this->comments_based_repository->get_question_ids( $submission_id );
+	}
+
+	/**
+	 * Save quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param Submission $submission The quiz submission.
+	 */
+	public function save( Submission $submission ): void {
+		$this->comments_based_repository->save( $submission );
+
+		if ( $this->use_tables ) {
+			$tables_based_submission = $this->tables_based_repository->get( $submission->get_quiz_id(), $submission->get_user_id() );
+
+			if ( $tables_based_submission ) {
+				$submission_to_save = new Submission(
+					$tables_based_submission->get_id(),
+					$submission->get_quiz_id(),
+					$submission->get_user_id(),
+					$submission->get_final_grade(),
+					$submission->get_created_at(),
+					$submission->get_updated_at()
+				);
+
+				$this->tables_based_repository->save( $submission_to_save );
+			}
+		}
+	}
+
+	/**
+	 * Delete the quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param Submission $submission The quiz submission.
+	 */
+	public function delete( Submission $submission ): void {
+		$this->comments_based_repository->delete( $submission );
+
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete( $submission );
+		}
+	}
+}

--- a/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
@@ -95,7 +95,10 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	public function get( int $quiz_id, int $user_id ): ?Submission {
 		$status_comment = $this->get_status_comment( $quiz_id, $user_id );
 
-		if ( ! $status_comment ) {
+		if (
+			! $status_comment
+			|| ! $this->get_question_ids( $status_comment->comment_ID )
+		) {
 			return null;
 		}
 

--- a/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
@@ -113,22 +113,16 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	}
 
 	/**
-	 * Get the question IDs related to this quiz submission.
+	 * Get the questions related to the quiz submission.
 	 *
 	 * @internal
 	 *
-	 * @param int $quiz_id The quiz ID.
-	 * @param int $user_id The user ID.
+	 * @param int $submission_id The quiz submission ID.
 	 *
 	 * @return array An array of question post IDs.
 	 */
-	public function get_question_ids( int $quiz_id, int $user_id ): array {
-		$status_comment = $this->get_status_comment( $quiz_id, $user_id );
-		if ( ! $status_comment ) {
-			return [];
-		}
-
-		$questions_asked_csv = get_comment_meta( $status_comment->comment_ID, 'questions_asked', true );
+	public function get_question_ids( int $submission_id ): array {
+		$questions_asked_csv = get_comment_meta( $submission_id, 'questions_asked', true );
 		if ( ! $questions_asked_csv ) {
 			return [];
 		}

--- a/includes/internal/quiz-submission/submission/repositories/class-submission-repository-factory.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-submission-repository-factory.php
@@ -27,6 +27,12 @@ class Submission_Repository_Factory {
 	 * @return Submission_Repository_Interface
 	 */
 	public function create(): Submission_Repository_Interface {
-		return new Comments_Based_Submission_Repository();
+		global $wpdb;
+
+		return new Aggregate_Submission_Repository(
+			new Comments_Based_Submission_Repository(),
+			new Tables_Based_Submission_Repository( $wpdb ),
+			true
+		);
 	}
 }

--- a/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
@@ -60,16 +60,15 @@ interface Submission_Repository_Interface {
 	public function get( int $quiz_id, int $user_id ): ?Submission;
 
 	/**
-	 * Get the question IDs related to this quiz submission.
+	 * Get the questions related to the quiz submission.
 	 *
 	 * @internal
 	 *
-	 * @param int $quiz_id The quiz ID.
-	 * @param int $user_id The user ID.
+	 * @param int $submission_id The quiz submission ID.
 	 *
 	 * @return array An array of question post IDs.
 	 */
-	public function get_question_ids( int $quiz_id, int $user_id ): array;
+	public function get_question_ids( int $submission_id ): array;
 
 	/**
 	 * Save quiz submission.

--- a/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * File containing the Tables_Based_Submission_Repository class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use wpdb;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Tables_Based_Submission_Repository.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Tables_Based_Submission_Repository implements Submission_Repository_Interface {
+	/**
+	 * WordPress database object.
+	 *
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * Constructor.
+	 *
+	 * @internal
+	 *
+	 * @param wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Creates a new quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int        $quiz_id     The quiz ID.
+	 * @param int        $user_id     The user ID.
+	 * @param float|null $final_grade The final grade.
+	 *
+	 * @return Submission The quiz submission.
+	 */
+	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$date_format      = 'Y-m-d H:i:s';
+
+		$this->wpdb->insert(
+			$this->get_table_name(),
+			[
+				'quiz_id'     => $quiz_id,
+				'user_id'     => $user_id,
+				'final_grade' => $final_grade,
+				'created_at'  => $current_datetime->format( $date_format ),
+				'updated_at'  => $current_datetime->format( $date_format ),
+			],
+			[
+				'%d',
+				'%d',
+				is_null( $final_grade ) ? null : '%f',
+				'%s',
+				'%s',
+			]
+		);
+
+		return new Submission(
+			$this->wpdb->insert_id,
+			$quiz_id,
+			$user_id,
+			$final_grade,
+			$current_datetime,
+			$current_datetime
+		);
+	}
+
+	/**
+	 * Get or create a new quiz submission if it doesn't exist.
+	 *
+	 * @internal
+	 *
+	 * @param int        $quiz_id     The quiz ID.
+	 * @param int        $user_id     The user ID.
+	 * @param float|null $final_grade The final grade.
+	 *
+	 * @return Submission The quiz submission.
+	 */
+	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+		$submission = $this->get( $quiz_id, $user_id );
+
+		if ( $submission ) {
+			return $submission;
+		}
+
+		return $this->create( $quiz_id, $user_id, $final_grade );
+	}
+
+	/**
+	 * Gets a quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $quiz_id The quiz ID.
+	 * @param int $user_id The user ID.
+	 *
+	 * @return Submission|null The quiz submission.
+	 */
+	public function get( int $quiz_id, int $user_id ): ?Submission {
+		$query = $this->wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT * FROM {$this->get_table_name()} WHERE quiz_id = %d AND user_id = %d",
+			$quiz_id,
+			$user_id
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$row = $this->wpdb->get_row( $query );
+
+		if ( ! $row ) {
+			return null;
+		}
+
+		return new Submission(
+			(int) $row->id,
+			(int) $row->quiz_id,
+			(int) $row->user_id,
+			$row->final_grade,
+			new DateTimeImmutable( $row->created_at, new DateTimeZone( 'UTC' ) ),
+			new DateTimeImmutable( $row->updated_at, new DateTimeZone( 'UTC' ) )
+		);
+	}
+
+	/**
+	 * Get the questions related to the quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $submission_id The quiz submission ID.
+	 *
+	 * @return array An array of question post IDs.
+	 */
+	public function get_question_ids( int $submission_id ): array {
+		$quiz_answers_table = $this->wpdb->prefix . 'sensei_lms_quiz_answers';
+
+		$query = $this->wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT question_id FROM {$quiz_answers_table} WHERE submission_id = %d",
+			$submission_id
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$question_ids = $this->wpdb->get_col( $query );
+
+		return array_map( 'intval', $question_ids );
+	}
+
+	/**
+	 * Save quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param Submission $submission The quiz submission.
+	 */
+	public function save( Submission $submission ): void {
+		$updated_at = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$submission->set_updated_at( $updated_at );
+
+		$this->wpdb->update(
+			$this->get_table_name(),
+			[
+				'final_grade' => $submission->get_final_grade(),
+				'updated_at'  => $submission->get_updated_at()->format( 'Y-m-d H:i:s' ),
+			],
+			[
+				'id' => $submission->get_id(),
+			],
+			[
+				is_null( $submission->get_final_grade() ) ? null : '%f',
+				'%s',
+			],
+			[
+				'%d',
+			]
+		);
+	}
+
+	/**
+	 * Delete the quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param Submission $submission The quiz submission.
+	 */
+	public function delete( Submission $submission ): void {
+		$this->wpdb->delete(
+			$this->get_table_name(),
+			[
+				'quiz_id' => $submission->get_quiz_id(),
+				'user_id' => $submission->get_user_id(),
+			],
+			[
+				'%d',
+				'%d',
+			]
+		);
+	}
+
+	/**
+	 * Get the quiz submission table name.
+	 *
+	 * @return string
+	 */
+	private function get_table_name(): string {
+		return $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/submission/models/test-class-submission.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/models/test-class-submission.php
@@ -96,6 +96,17 @@ class Submission_Test extends \WP_UnitTestCase {
 		self::assertSame( '2020-01-01 00:00:02', $actual );
 	}
 
+	public function testSetUpdatedAt_WhenCalled_SetsUpdatedAt(): void {
+		/* Arrange. */
+		$submission = $this->createSubmission();
+
+		/* Act. */
+		$submission->set_updated_at( new \DateTime( '2020-01-01 00:00:01' ) );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:01', $submission->get_updated_at()->format( 'Y-m-d H:i:s' ) );
+	}
+
 	private function createSubmission(): Submission {
 		return new Submission(
 			1,

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-aggregate-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-aggregate-submission-repository.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
+
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Repositories\Aggregate_Submission_Repository;
+use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
+use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
+
+/**
+ * Class Aggregate_Submission_Repository_Test
+ *
+ * @covers \Sensei\Internal\Quiz_Submission\Submission\Repositories\Aggregate_Submission_Repository
+ */
+class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
+	public function testCreate_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'create' )
+			->with( 1, 2, 12.34 );
+
+		$repository->create( 1, 2, 12.34 );
+	}
+
+	public function testCreate_UseTablesOn_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'create' )
+			->with( 1, 2, 12.34 );
+
+		$repository->create( 1, 2, 12.34 );
+	}
+
+	public function testCreate_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'create' );
+
+		$repository->create( 1, 2, 12.34 );
+	}
+
+	public function testCreate_UseTablesOff_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'create' )
+			->with( 1, 2, 12.34 );
+
+		$repository->create( 1, 2, 12.34 );
+	}
+
+	public function testGetOrCreate_WhenHasSubmission_DoesntCallCreate(): void {
+		/* Arrange. */
+		$repository = $this->getMockBuilder( Aggregate_Submission_Repository::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get', 'create' ] )
+			->getMock();
+
+		/* Expect & Act. */
+		$repository
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( $this->createMock( Submission::class ) );
+
+		$repository
+			->expects( $this->never() )
+			->method( 'create' );
+
+		$repository->get_or_create( 1, 2, 12.34 );
+	}
+
+	public function testGetOrCreate_WhenHasNoSubmission_CallsCreate(): void {
+		/* Arrange. */
+		$repository = $this->getMockBuilder( Aggregate_Submission_Repository::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get', 'create' ] )
+			->getMock();
+
+		/* Expect & Act. */
+		$repository
+			->expects( $this->once() )
+			->method( 'create' );
+
+		$repository->get_or_create( 1, 2, 12.34 );
+	}
+
+	public function testGet_Always_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'get' )
+			->with( 1, 2 );
+
+		$repository->get( 1, 2 );
+	}
+
+	public function testGetQuestionIds_Always_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'get_question_ids' )
+			->with( 1 );
+
+		$repository->get_question_ids( 1 );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while saving.
+	 *
+	 * @param bool $use_tables
+	 * @dataProvider providerSave_Always_CallsCommentsBasedRepository
+	 */
+	public function testSave_Always_CallsCommentsBasedRepository( bool $use_tables ): void {
+		/* Arrange. */
+		$submission     = $this->create_submission();
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'save' )
+			->with( $submission );
+
+		$repository->save( $submission );
+	}
+
+	public function providerSave_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
+	public function testSave_UseTablesOnAndSubmissionFound_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$submission       = $this->create_submission();
+		$found_submission = $this->create_submission();
+		$comments_based   = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based     = $this->createMock( Tables_Based_Submission_Repository::class );
+		$tables_based
+			->method( 'get' )
+			->with( 2, 3 )
+			->willReturn( $found_submission );
+
+		$repository = new Aggregate_Submission_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->callback(
+					function ( Submission $submission_to_save ) use ( $submission, $found_submission ) {
+						self::assertNotSame( $submission, $submission_to_save, 'We should create a new submission based on a found one: not using passed for saving.' );
+						self::assertNotSame( $found_submission, $submission_to_save, 'We should create a new submission based on a found one: not the found one itself.' );
+						return true;
+					}
+				)
+			);
+
+		$repository->save( $submission );
+	}
+
+	public function testSave_UseTablesOnAndSubmissionNotFound_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$progress       = $this->create_submission();
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$tables_based
+			->method( 'get' )
+			->with( 2, 3 )
+			->willReturn( null );
+
+		$repository = new Aggregate_Submission_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'save' );
+
+		$repository->save( $progress );
+	}
+
+	public function testDelete_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$submission     = $this->create_submission();
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete' );
+
+		$repository->delete( $submission );
+	}
+
+	public function testDelete_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$submission     = $this->create_submission();
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete' )
+			->with( $submission );
+
+		$repository->delete( $submission );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDelete_Always_CallsCommentsBasedRepository
+	 */
+	public function testDelete_Always_CallsCommentsBasedRepository( $use_tables ): void {
+		/* Arrange. */
+		$submission     = $this->create_submission();
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$repository     = new Aggregate_Submission_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete' );
+
+		$repository->delete( $submission );
+	}
+
+	public function providerDelete_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
+	/**
+	 * Creates a submission object.
+	 *
+	 * @return Submission
+	 */
+	public function create_submission(): Submission {
+		return new Submission(
+			1,
+			2,
+			3,
+			12.34,
+			new \DateTimeImmutable(),
+			new \DateTimeImmutable()
+		);
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
@@ -153,20 +153,6 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0.0, $submission->get_final_grade() );
 	}
 
-	public function testGetQuestionIds_WhenLessonStatusNotFound_ReturnsEmptyArray(): void {
-		/* Arrange. */
-		$lesson_id  = $this->factory->lesson->create();
-		$user_id    = $this->factory->user->create();
-		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
-		$repository = new Comments_Based_Submission_Repository();
-
-		/* Act. */
-		$question_ids = $repository->get_question_ids( $quiz_id, $user_id );
-
-		/* Assert. */
-		$this->assertSame( [], $question_ids );
-	}
-
 	public function testGetQuestionIds_WhenLessonStatusFound_ReturnsQuestionIds(): void {
 		/* Arrange. */
 		$lesson_id  = $this->factory->lesson->create();
@@ -179,7 +165,7 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		update_comment_meta( $comment_id, 'questions_asked', implode( ',', [ 1, 2, 3 ] ) );
 
 		/* Act. */
-		$question_ids = $repository->get_question_ids( $quiz_id, $user_id );
+		$question_ids = $repository->get_question_ids( $comment_id );
 
 		/* Assert. */
 		$this->assertSame( [ 1, 2, 3 ], $question_ids );
@@ -192,10 +178,10 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
 		$repository = new Comments_Based_Submission_Repository();
 
-		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+		$comment_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
 
 		/* Act. */
-		$question_ids = $repository->get_question_ids( $quiz_id, $user_id );
+		$question_ids = $repository->get_question_ids( $comment_id );
 
 		/* Assert. */
 		$this->assertSame( [], $question_ids );

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
@@ -114,7 +114,7 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$this->assertNull( $submission );
 	}
 
-	public function testGet_WhenLessonStatusFound_ReturnsSubmission(): void {
+	public function testGet_WhenNoQuestionsSubmitted_ReturnsNull(): void {
 		/* Arrange. */
 		$lesson_id  = $this->factory->lesson->create();
 		$user_id    = $this->factory->user->create();
@@ -127,12 +127,7 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$submission = $repository->get( $quiz_id, $user_id );
 
 		/* Assert. */
-		$expected = [
-			'quiz_id'     => $quiz_id,
-			'user_id'     => $user_id,
-			'final_grade' => null,
-		];
-		$this->assertSame( $expected, $this->export_submission( $submission ) );
+		$this->assertNull( $submission );
 	}
 
 	public function testGet_WhenFinalGradeIsZero_ReturnsSubmissionWithZeroFinalGrade(): void {
@@ -142,9 +137,11 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
 		$repository = new Comments_Based_Submission_Repository();
 
-		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+		$submission_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
 
 		$repository->create( $quiz_id, $user_id, 0 );
+
+		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
 
 		/* Act. */
 		$submission = $repository->get( $quiz_id, $user_id );
@@ -207,9 +204,11 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
 		$repository = new Comments_Based_Submission_Repository();
 
-		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+		$submission_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
 
 		$submission = $repository->create( $quiz_id, $user_id );
+
+		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
 
 		/* Act. */
 		$submission->set_final_grade( 12.34 );
@@ -229,7 +228,9 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
 		$repository = new Comments_Based_Submission_Repository();
 
-		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+		$submission_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+
+		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
 
 		$submission = $repository->create( $quiz_id, $user_id, 12.34 );
 
@@ -250,7 +251,9 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
 		$repository = new Comments_Based_Submission_Repository();
 
-		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+		$submission_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+
+		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
 
 		$submission = $repository->create( $quiz_id, $user_id, 12.34 );
 

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
+use wpdb;
+
+/**
+ * Class Tables_Based_Submission_Repository_Test
+ *
+ * @covers \Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository
+ */
+class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
+
+	protected $factory;
+
+	public function setup() {
+		parent::setup();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	public function testCreate_WhenCalled_InsertsToWpdb(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				'sensei_lms_quiz_submissions',
+				$this->callback(
+					function( $array ) {
+						return $array['quiz_id'] === 1
+							&& $array['user_id'] === 2
+							&& $array['final_grade'] === 12.34;
+					}
+				),
+				[
+					'%d',
+					'%d',
+					'%f',
+					'%s',
+					'%s',
+				]
+			);
+
+		$repository->create( 1, 2, 12.34 );
+	}
+
+	public function testCreate_WithNoFinalGradeProvided_ReturnsSubmissionWithNullGrade(): void {
+		/* Arrange. */
+		$wpdb            = $this->createMock( wpdb::class );
+		$wpdb->insert_id = 3;
+		$repository      = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Act. */
+		$submission = $repository->create( 1, 2 );
+
+		/* Assert. */
+		$expected = [
+			'id'          => 3,
+			'quiz_id'     => 1,
+			'user_id'     => 2,
+			'final_grade' => null,
+		];
+
+		$this->assertSame( $expected, $this->export_submission( $submission ) );
+	}
+
+	public function testCreate_WithFinalGradeProvided_ReturnsSubmissionWithGrade(): void {
+		/* Arrange. */
+		$wpdb            = $this->createMock( wpdb::class );
+		$wpdb->insert_id = 3;
+		$repository      = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Act. */
+		$submission = $repository->create( 1, 2, 12.34 );
+
+		/* Assert. */
+		$expected = [
+			'id'          => 3,
+			'quiz_id'     => 1,
+			'user_id'     => 2,
+			'final_grade' => 12.34,
+		];
+
+		$this->assertSame( $expected, $this->export_submission( $submission ) );
+	}
+
+	public function testGetOrCreate_WhenSubmissionExists_ReturnsExistingSubmission(): void {
+		/* Arrange. */
+		$repository_mock = $this->getMockBuilder( Tables_Based_Submission_Repository::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get', 'create' ] )
+			->getMock();
+
+		/* Act & Assert. */
+		$repository_mock
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( $this->createMock( Submission::class ) );
+
+		$repository_mock
+			->expects( $this->never() )
+			->method( 'create' );
+
+		$submission = $repository_mock->get_or_create( 1, 2 );
+
+		$this->assertInstanceOf( Submission::class, $submission );
+	}
+
+	public function testGetOrCreate_WhenSubmissionDoesNotExist_ReturnsNewSubmission(): void {
+		/* Arrange. */
+		$repository_mock = $this->getMockBuilder( Tables_Based_Submission_Repository::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get', 'create' ] )
+			->getMock();
+
+		/* Act & Assert. */
+		$repository_mock
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( null );
+
+		$repository_mock
+			->expects( $this->once() )
+			->method( 'create' )
+			->willReturn( $this->createMock( Submission::class ) );
+
+		$submission = $repository_mock->get_or_create( 1, 2 );
+
+		$this->assertInstanceOf( Submission::class, $submission );
+	}
+
+	public function testGet_WhenNotFound_ReturnsNull(): void {
+		/* Arrange. */
+		$wpdb = $this->createMock( wpdb::class );
+		$wpdb
+			->method( 'get_row' )
+			->willReturn( null );
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Act. */
+		$submission = $repository->get( 1, 2 );
+
+		/* Assert. */
+		$this->assertNull( $submission );
+	}
+
+	public function testGet_WhenFound_ReturnsSubmission() {
+		/* Arrange. */
+		$wpdb = $this->createMock( wpdb::class );
+		$wpdb
+			->method( 'get_row' )
+			->willReturn(
+				(object) [
+					'id'          => 3,
+					'quiz_id'     => 1,
+					'user_id'     => 2,
+					'final_grade' => 12.34,
+					'created_at'  => '2022-01-01 00:00:00',
+					'updated_at'  => '2022-01-02 00:00:00',
+				]
+			);
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Act. */
+		$submission = $repository->get( 1, 2 );
+
+		/* Assert. */
+		$expected = [
+			'id'          => 3,
+			'quiz_id'     => 1,
+			'user_id'     => 2,
+			'final_grade' => 12.34,
+			'created_at'  => '2022-01-01 00:00:00',
+			'updated_at'  => '2022-01-02 00:00:00',
+		];
+
+		$this->assertSame( $expected, $this->export_submission_with_dates( $submission ) );
+	}
+
+	public function testGetQuestionIds_WhenHasQuestions_ReturnsTheQuestionIds() {
+		/* Arrange. */
+		global $wpdb;
+
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		// Todo: Replace the wpdb inserts with calls to the quiz answers repository.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_quiz_answers',
+			[
+				'submission_id' => 1,
+				'question_id'   => 1,
+			]
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_quiz_answers',
+			[
+				'submission_id' => 1,
+				'question_id'   => 2,
+			]
+		);
+
+		/* Act. */
+		$question_ids = $repository->get_question_ids( 1 );
+
+		/* Assert. */
+		$this->assertSame( [ 1, 2 ], $question_ids );
+	}
+
+	public function testGetQuestionIds_WhenNoQuestions_ReturnsEmptyArray() {
+		/* Arrange. */
+		global $wpdb;
+
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Act. */
+		$question_ids = $repository->get_question_ids( 1 );
+
+		/* Assert. */
+		$this->assertSame( [], $question_ids );
+	}
+
+	public function testSave_WhenCalled_UpdatesTheDatabase() {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$timezone   = new DateTimeZone( 'UTC' );
+		$submission = new Submission(
+			1,
+			2,
+			3,
+			12.34,
+			new DateTimeImmutable( '2022-01-01 00:00:01', $timezone ),
+			new DateTimeImmutable( '2022-01-02 00:00:01', $timezone )
+		);
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'update' )
+			->with(
+				'sensei_lms_quiz_submissions',
+				$this->callback(
+					function ( $data ) use ( $timezone ) {
+						return 12.34 === $data['final_grade']
+							&& $data['updated_at'];
+					}
+				),
+				[
+					'id' => 1,
+				],
+				[
+					'%f',
+					'%s',
+				],
+				[
+					'%d',
+				]
+			);
+
+		$repository->save( $submission );
+	}
+
+	public function testDelete_WhenCalled_DeletesFromTheDatabase(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$submission = new Submission(
+			1,
+			2,
+			3,
+			12.34,
+			new DateTimeImmutable( '2022-01-01 00:00:01', wp_timezone() ),
+			new DateTimeImmutable( '2022-01-02 00:00:01', wp_timezone() )
+		);
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_quiz_submissions',
+				[
+					'quiz_id' => 2,
+					'user_id' => 3,
+				],
+				[
+					'%d',
+					'%d',
+				]
+			);
+
+		$repository->delete( $submission );
+	}
+
+	private function export_submission( Submission $submission ): array {
+		return [
+			'id'          => $submission->get_id(),
+			'quiz_id'     => $submission->get_quiz_id(),
+			'user_id'     => $submission->get_user_id(),
+			'final_grade' => $submission->get_final_grade(),
+		];
+	}
+
+	private function export_submission_with_dates( Submission $submission ): array {
+		return array_merge(
+			$this->export_submission( $submission ),
+			[
+				'created_at' => $submission->get_created_at()->format( 'Y-m-d H:i:s' ),
+				'updated_at' => $submission->get_updated_at()->format( 'Y-m-d H:i:s' ),
+			]
+		);
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
@@ -40,9 +40,9 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 				'sensei_lms_quiz_submissions',
 				$this->callback(
 					function( $array ) {
-						return $array['quiz_id'] === 1
-							&& $array['user_id'] === 2
-							&& $array['final_grade'] === 12.34;
+						return 1 === $array['quiz_id']
+							&& 2 === $array['user_id']
+							&& 12.34 === $array['final_grade'];
 					}
 				),
 				[

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -162,6 +162,7 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$progress->pass();
 		$repository->save( $progress );
 
+		update_comment_meta( $progress->get_id(), 'questions_asked', $question_id );
 		update_comment_meta( $progress->get_id(), 'quiz_answers', [ $question_id => 'answer' ] );
 
 		/* Act. */
@@ -185,6 +186,7 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$progress->pass();
 		$repository->save( $progress );
 
+		update_comment_meta( $progress->get_id(), 'questions_asked', '1,2' );
 		update_comment_meta( $progress->get_id(), 'grade', 1 );
 
 		/* Act. */

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1173,9 +1173,9 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	public function testGetUserAnswersFeedback() {
 
 		// Setup the data and objects needed for this test.
-		$test_user_id   = wp_create_user( 'studentFeedbackGet', 'studentFeedbackGet', 'studentFeedbackGet@test.com' );
-		$test_lesson_id = $this->factory->get_random_lesson_id();
-		$test_quiz_id   = Sensei()->lesson->lesson_quizzes( $test_lesson_id );
+		$user_id   = wp_create_user( 'studentFeedbackGet', 'studentFeedbackGet', 'studentFeedbackGet@test.com' );
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
 		// Does the save_user_answers function exist?
 		$this->assertTrue(
@@ -1189,13 +1189,17 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertFalse( Sensei()->quiz->get_user_answers_feedback( -1000, -121 ), 'The function should return false for incorrect parameters' );
 
 		// Save the answers to setup the next assertion.
-		Sensei_Utils::sensei_start_lesson( $test_lesson_id, $test_user_id );
-		$test_lesson_id             = $this->factory->get_random_lesson_id();
-		$test_user_answers_feedback = $this->factory->generate_user_answers_feedback( $test_quiz_id );
-		Sensei()->quiz->save_user_answers_feedback( $test_user_answers_feedback, $test_lesson_id, $test_user_id );
-		$retrieved_answer_feedback = Sensei()->quiz->get_user_answers_feedback( $test_lesson_id, $test_user_id );
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+		$lesson_id          = $this->factory->get_random_lesson_id();
+		$generated_answers  = $this->factory->generate_user_quiz_answers( $quiz_id );
+		$generated_feedback = $this->factory->generate_user_answers_feedback( $quiz_id );
 
-		$this->assertEquals( $test_user_answers_feedback, $retrieved_answer_feedback, 'Feedback retrieved does not match the saved data.' );
+		Sensei()->quiz->save_user_answers( $generated_answers, [], $lesson_id, $user_id );
+		Sensei()->quiz->save_user_answers_feedback( $generated_feedback, $lesson_id, $user_id );
+
+		$retrieved_feedback = Sensei()->quiz->get_user_answers_feedback( $lesson_id, $user_id );
+
+		$this->assertEquals( $generated_feedback, $retrieved_feedback, 'Feedback retrieved does not match the saved data.' );
 
 	}
 
@@ -1222,6 +1226,10 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$test_lesson_id             = $this->factory->get_random_lesson_id();
 		$test_quiz_id               = Sensei()->lesson->lesson_quizzes( $test_lesson_id );
 		$test_user_answers_feedback = $this->factory->generate_user_answers_feedback( $test_quiz_id );
+
+		$generated_answers = $this->factory->generate_user_quiz_answers( $test_quiz_id );
+		Sensei()->quiz->save_user_answers( $generated_answers, [], $test_lesson_id, $test_user_id );
+
 		Sensei_Utils::sensei_start_lesson( $test_lesson_id, $test_user_id );
 		Sensei()->quiz->save_user_answers_feedback( $test_user_answers_feedback, $test_lesson_id, $test_user_id );
 		$test_question_id = array_rand( $test_user_answers_feedback );
@@ -1267,6 +1275,10 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$test_quiz_id               = Sensei()->lesson->lesson_quizzes( $test_lesson_id );
 		$test_user_answers_feedback = $this->factory->generate_user_answers_feedback( $test_quiz_id );
 		Sensei_Utils::sensei_start_lesson( $test_lesson_id, $test_user_id );
+
+		$generated_answers = $this->factory->generate_user_quiz_answers( $test_quiz_id );
+		Sensei()->quiz->save_user_answers( $generated_answers, [], $test_lesson_id, $test_user_id );
+
 		Sensei()->quiz->save_user_answers_feedback( $test_user_answers_feedback, $test_lesson_id, $test_user_id );
 
 		// Was it saved correctly?
@@ -1623,7 +1635,9 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			]
 		);
 
-		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+		$submission_id = Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
+
 		Sensei_Utils::sensei_grade_quiz( $quiz_id, 12.34, $user_id );
 
 		/* Act. */
@@ -1633,7 +1647,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertSame( 12.34, $grade );
 	}
 
-	public function testResetUserLessonData_WhenCalled_ResetsTheQuizFinalGrade() {
+	public function testResetUserLessonData_WhenCalled_ResetsTheQuizSubmission() {
 		/* Arrange. */
 		$user_id   = $this->factory->user->create();
 		$lesson_id = $this->factory->lesson->create();
@@ -1646,7 +1660,10 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			]
 		);
 
-		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+		$submission_id = Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+
+		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
+
 		Sensei_Utils::sensei_grade_quiz( $quiz_id, 12.34, $user_id );
 
 		/* Act. */
@@ -1657,7 +1674,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$quiz_submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
 
 		/* Assert. */
-		$this->assertNull( $quiz_submission->get_final_grade() );
+		$this->assertNull( $quiz_submission );
 	}
 
 	public function testResetUserLessonData_WhenCalled_ResetsTheQuizAnswers() {
@@ -1676,15 +1693,15 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		$quiz_answers_map = $this->factory->generate_user_quiz_answers( $quiz_id );
 		Sensei()->quiz->save_user_answers( $quiz_answers_map, [], $lesson_id, $user_id );
-		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+
+		$submission_id = Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
 
 		/* Act. */
 		ob_start();
 		Sensei()->quiz->reset_user_lesson_data( $lesson_id, $user_id );
 		ob_end_clean();
 
-		$quiz_submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
-		$quiz_answers    = Sensei()->quiz_answer_repository->get_all( $quiz_submission->get_id() );
+		$quiz_answers = Sensei()->quiz_answer_repository->get_all( $submission_id );
 
 		/* Assert. */
 		$this->assertEmpty( $quiz_answers );
@@ -1710,15 +1727,14 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		Sensei()->quiz->save_user_answers( $quiz_answers_map, [], $lesson_id, $user_id );
 		Sensei()->quiz->set_user_grades( $quiz_grades_map, $lesson_id, $user_id );
 
-		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+		$submission_id = Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
 
 		/* Act. */
 		ob_start();
 		Sensei()->quiz->reset_user_lesson_data( $lesson_id, $user_id );
 		ob_end_clean();
 
-		$quiz_submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
-		$quiz_grades     = Sensei()->quiz_grade_repository->get_all( $quiz_submission->get_id() );
+		$quiz_grades = Sensei()->quiz_grade_repository->get_all( $submission_id );
 
 		/* Assert. */
 		$this->assertEmpty( $quiz_grades );

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1407,7 +1407,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		);
 
 		// Get questions after submitting.
-		$questions_asked_after_submitting = Sensei()->quiz_submission_repository->get_question_ids( $test_quiz_id, $test_user_id );
+		$questions_asked_after_submitting = Sensei()->quiz_submission_repository->get_question_ids( $user_lesson_status_comment_id );
 
 		// Check if questions asked have not been overwritten.
 		$this->assertCount(

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -286,7 +286,9 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 			]
 		);
 
-		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+		$submission_id = Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+
+		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
 
 		/* Act. */
 		Sensei_Utils::sensei_grade_quiz( $quiz_id, 12.34, $user_id );


### PR DESCRIPTION
Part of #5434

### Changes proposed in this Pull Request

* Add custom tables based repositories for quiz submission.
* Add aggregate repositories that use both types of repositories (comments based and tables based).

### Testing instructions

* Make a course a lesson and a quiz.
* Submit the quiz.
* Make sure there is an entry in the `wp_sensei_lms_quiz_submissions` table.
* Grade the quiz.
* Make sure the `final_grade` column is updated for the `wp_sensei_lms_quiz_submissions` entry.
* When resetting the quiz or resetting the course, the table entry should be deleted.