### PR TITLE
Fix contact teacher block check

### DIFF
--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -38,6 +38,7 @@ class Sensei_Block_Contact_Teacher {
 
 	/**
 	 * Check if a notice should be displayed.
+	 * Currently, it's also handling notices for legacy lessons (using templates).
 	 *
 	 * @access private
 	 */

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -109,7 +109,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_Featured_Video_Block();
 
 		// This constructor has some sideeffects so only initialize it when the lesson has Sensei blocks.
-		if ( is_admin() || has_block( 'sensei-lms/contact-teacher' ) ) {
+		if ( is_admin() || has_block( 'sensei-lms/button-contact-teacher' ) ) {
 			new Sensei_Block_Contact_Teacher();
 		}
 

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -108,8 +108,16 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_View_Quiz_Block();
 		new Sensei_Featured_Video_Block();
 
+		$course_id         = Sensei_Utils::get_current_course();
+		$has_learning_mode = ! empty( $course_id ) && Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
+
 		// This constructor has some sideeffects so only initialize it when the lesson has Sensei blocks.
-		if ( is_admin() || has_block( 'sensei-lms/button-contact-teacher' ) ) {
+		if (
+			is_admin()
+			|| has_block( 'sensei-lms/button-contact-teacher' )
+			// If contact teacher is in the Learning Mode template, but not in the post content.
+			|| $has_learning_mode
+		) {
 			new Sensei_Block_Contact_Teacher();
 		}
 

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -107,20 +107,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_Reset_Lesson_Block();
 		new Sensei_View_Quiz_Block();
 		new Sensei_Featured_Video_Block();
-
-		$course_id         = Sensei_Utils::get_current_course();
-		$has_learning_mode = ! empty( $course_id ) && Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
-
-		// This constructor has some sideeffects so only initialize it when the lesson has Sensei blocks.
-		if (
-			is_admin()
-			|| has_block( 'sensei-lms/button-contact-teacher' )
-			// If contact teacher is in the Learning Mode template, but not in the post content.
-			|| $has_learning_mode
-		) {
-			new Sensei_Block_Contact_Teacher();
-		}
-
+		new Sensei_Block_Contact_Teacher();
 	}
 
 	/**


### PR DESCRIPTION
Part of #6016

### Changes proposed in this Pull Request

* It fixes the Contact Teacher part of the mentioned issue.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with Learning Mode enabled (if it's not by default).
* Add a lesson with a Contact Teacher block.
* Go to the frontend as a student, and make sure the blocks is in the correct place, and it opens a modal when clicked.
* Remove the Contact Teacher block.
* Go to the frontend as a student, and make sure the Contact Teacher in the sidebar also works.