### PR TITLE
Fix PHP course list block notice on category archive view

### DIFF
--- a/includes/blocks/course-list/class-sensei-course-list-filter-block.php
+++ b/includes/blocks/course-list/class-sensei-course-list-filter-block.php
@@ -96,7 +96,7 @@ class Sensei_Course_List_Filter_Block {
 	 * @return array
 	 */
 	public function filter_course_list( $parsed_block ) {
-		if ( 'core/query' !== $parsed_block['blockName'] || 'course' !== $parsed_block['attrs']['query']['postType'] ) {
+		if ( 'core/query' !== $parsed_block['blockName'] || ! array_key_exists( 'query', $parsed_block['attrs'] ) || 'course' !== $parsed_block['attrs']['query']['postType'] ) {
 			return $parsed_block;
 		}
 


### PR DESCRIPTION
Fixes #6057

### Changes proposed in this Pull Request
- Check if array key exists before check if it is equal to course

### Testing instructions

1. Activate the Sensei theme and Sensei LMS.
2. Add a category to 1 or more posts (e.g. "Test").
3. Browse to the category archive page (e.g. http://senseitheme.local/category/test/).
The following error IS NOT logged:
 PHP Notice:  Undefined index: query in /Users/donnapep/Local Sites/senseitheme/app/public/wp-content/plugins/se