### PR TITLE
Enable customization of the lesson status icons

### DIFF
--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -280,7 +280,9 @@ class Course_Navigation {
 	 * @return string Icon HTML.
 	 */
 	private function lesson_status_icon( $status ) {
-		return Sensei()->assets->get_icon( self::ICONS[ $status ], 'sensei-lms-course-navigation-lesson__status' );
+		$icon = Sensei()->assets->get_icon( self::ICONS[ $status ], 'sensei-lms-course-navigation-lesson__status' );
+
+		return apply_filters( 'sensei_learning_mode_lesson_status_icon', $icon, $status );
 	}
 
 	/**


### PR DESCRIPTION
Part of # [Learning Mode - Style tweaks for all Learning Mode templates#46](https://github.com/Automattic/sensei-theme/issues/46)

### Changes proposed in this Pull Request

* Enable to customize the lesson status icons

### Testing instructions
Add it to the theme `functions.php` file.

```
function lesson_icons($icon, $status)
{
	$path = '/assets/images/learning-mode/lesson-status/' . $status . '.svg';
	if (file_exists(get_template_directory() .  $path)) {
		return '<img src="' . get_template_directory_uri() . $path . '" />';
	}
	return $icon;
}

add_filter( 'sensei_learning_mode_lesson_status_icon', 'lesson_icons', 10, 2);
```

* Add an icon on {THEME_FOLDER}/assets/images/learning-mode/lesson-status/completed.svg`
* Complete a lesson using the learning mode
* Check if the lesson is displaying the new icon.


