### PR TITLE
Cleanup student progress when course/lesson/quiz/user deleted

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -260,6 +260,10 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface::class => 'internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php',
 			\Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Comments_Based_Quiz_Progress_Repository::class => 'internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php',
 			\Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory::class => 'internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php',
+			\Sensei\Internal\Student_Progress\Services\Course_Deleted_Handler::class => 'internal/student-progress/services/class-course-deleted-handler.php',
+			\Sensei\Internal\Student_Progress\Services\Lesson_Deleted_Handler::class => 'internal/student-progress/services/class-lesson-deleted-handler.php',
+			\Sensei\Internal\Student_Progress\Services\Quiz_Deleted_Handler::class => 'internal/student-progress/services/class-quiz-deleted-handler.php',
+			\Sensei\Internal\Student_Progress\Services\User_Deleted_Handler::class => 'internal/student-progress/services/class-user-deleted-handler.php',
 
 			/**
 			 * Quiz Submission

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -12,6 +12,11 @@ use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progres
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Interface;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Services\Course_Deleted_Handler;
+use Sensei\Internal\Student_Progress\Services\Lesson_Deleted_Handler;
+use Sensei\Internal\Student_Progress\Services\Quiz_Deleted_Handler;
+use Sensei\Internal\Student_Progress\Services\User_Deleted_Handler;
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -550,6 +555,12 @@ class Sensei_Main {
 		$this->quiz_submission_repository = ( new Submission_Repository_Factory() )->create();
 		$this->quiz_answer_repository     = ( new Answer_Repository_Factory() )->create();
 		$this->quiz_grade_repository      = ( new Grade_Repository_Factory() )->create();
+
+		// Init student progress handlers.
+		( new Course_Deleted_Handler( $this->course_progress_repository ) )->init();
+		( new Lesson_Deleted_Handler( $this->lesson_progress_repository ) )->init();
+		( new Quiz_Deleted_Handler( $this->quiz_progress_repository ) )->init();
+		( new User_Deleted_Handler( $this->course_progress_repository, $this->lesson_progress_repository, $this->quiz_progress_repository ) )->init();
 	}
 
 	/**

--- a/includes/internal/student-progress/course-progress/repositories/class-aggregate-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-aggregate-course-progress-repository.php
@@ -151,4 +151,32 @@ class Aggregate_Course_Progress_Repository implements Course_Progress_Repository
 			$this->tables_based_repository->delete( $course_progress );
 		}
 	}
+
+	/**
+	 * Deletes all course progress for a course.
+	 *
+	 * @internal
+	 *
+	 * @param int $course_id The course ID.
+	 */
+	public function delete_for_course( int $course_id ): void {
+		$this->comments_based_repository->delete_for_course( $course_id );
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete_for_course( $course_id );
+		}
+	}
+
+	/**
+	 * Deletes all course progress for a user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void {
+		$this->comments_based_repository->delete_for_user( $user_id );
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete_for_user( $user_id );
+		}
+	}
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
@@ -164,6 +164,11 @@ class Comments_Based_Course_Progress_Repository implements Course_Progress_Repos
 		$this->delete_activities( $args );
 	}
 
+	/**
+	 * Delete activity comments for a given set of arguments.
+	 *
+	 * @param array $args The arguments.
+	 */
 	private function delete_activities( array $args ): void {
 		$comments = Sensei_Utils::sensei_check_for_activity( $args, true );
 		if ( ! $comments ) {

--- a/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
@@ -131,4 +131,59 @@ class Comments_Based_Course_Progress_Repository implements Course_Progress_Repos
 
 		Sensei_Utils::sensei_delete_activities( $args );
 	}
+
+	/**
+	 * Delete course progress for a given course.
+	 *
+	 * @internal
+	 *
+	 * @param int $course_id The course ID.
+	 */
+	public function delete_for_course( int $course_id ): void {
+		$args = array(
+			'post_id' => $course_id,
+			'type'    => 'sensei_course_status',
+		);
+
+		$this->delete_activities( $args );
+	}
+
+	/**
+	 * Delete course progress for a given user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void {
+		$args = array(
+			'user_id' => $user_id,
+			'type'    => 'sensei_course_status',
+		);
+
+		$this->delete_activities( $args );
+	}
+
+	private function delete_activities( array $args ): void {
+		$comments = Sensei_Utils::sensei_check_for_activity( $args, true );
+		if ( ! $comments ) {
+			return;
+		}
+
+		$comments = is_array( $comments ) ? $comments : [ $comments ];
+		$post_ids = [];
+		foreach ( $comments as $key => $value ) {
+			if ( isset( $value->comment_post_ID ) ) {
+				$post_ids[] = $value->comment_post_ID;
+			}
+
+			if ( isset( $value->comment_ID ) && 0 < $value->comment_ID ) {
+				$dataset_changes = wp_delete_comment( intval( $value->comment_ID ), true );
+			}
+		}
+
+		foreach ( $post_ids as $post_id ) {
+			Sensei()->flush_comment_counts_cache( $post_id );
+		}
+	}
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-interface.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-interface.php
@@ -71,4 +71,22 @@ interface Course_Progress_Repository_Interface {
 	 * @param Course_Progress $course_progress The course progress.
 	 */
 	public function delete( Course_Progress $course_progress ): void;
+
+	/**
+	 * Delete course progress for a given course.
+	 *
+	 * @internal
+	 *
+	 * @param int $course_id The course ID.
+	 */
+	public function delete_for_course( int $course_id ): void;
+
+	/**
+	 * Delete course progress for a given user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void;
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
@@ -215,4 +215,46 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 			]
 		);
 	}
+
+	/**
+	 * Delete course progress for a given course.
+	 *
+	 * @internal
+	 *
+	 * @param int $course_id The course ID.
+	 */
+	public function delete_for_course( int $course_id ): void {
+		$this->wpdb->delete(
+			$this->wpdb->prefix . 'sensei_lms_progress',
+			[
+				'post_id' => $course_id,
+				'type'    => 'course',
+			],
+			[
+				'%d',
+				'%s',
+			]
+		);
+	}
+
+	/**
+	 * Delete course progress for a given user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void {
+		$this->wpdb->delete(
+			$this->wpdb->prefix . 'sensei_lms_progress',
+			[
+				'user_id' => $user_id,
+				'type'    => 'course',
+			],
+			[
+				'%d',
+				'%s',
+			]
+		);
+	}
 }

--- a/includes/internal/student-progress/lesson-progress/repositories/class-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-aggregate-lesson-progress-repository.php
@@ -153,6 +153,34 @@ class Aggregate_Lesson_Progress_Repository implements Lesson_Progress_Repository
 	}
 
 	/**
+	 * Deletes all lesson progress for a lesson.
+	 *
+	 * @internal
+	 *
+	 * @param int $lesson_id The lesson ID.
+	 */
+	public function delete_for_lesson( int $lesson_id ): void {
+		$this->comments_based_repository->delete_for_lesson( $lesson_id );
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete_for_lesson( $lesson_id );
+		}
+	}
+
+	/**
+	 * Deletes all lesson progress for a user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void {
+		$this->comments_based_repository->delete_for_user( $user_id );
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete_for_user( $user_id );
+		}
+	}
+
+	/**
 	 * Returns the number of started lessons for a user in a course.
 	 * The number of started lessons is the same as the number of lessons that have a progress record.
 	 *

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
@@ -202,6 +202,11 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 		return Sensei_Utils::sensei_check_for_activity( $activity_args );
 	}
 
+	/**
+	 * Delete activity comments by given arguments.
+	 *
+	 * @param array $args Arguments to delete activity comments.
+	 */
 	private function delete_activities( array $args ): void {
 		$comments = Sensei_Utils::sensei_check_for_activity( $args, true );
 		if ( ! $comments ) {
@@ -225,3 +230,4 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 		}
 	}
 }
+

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
@@ -143,6 +143,40 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 	}
 
 	/**
+	 * Delete all lesson progress for a lesson.
+	 * This is used when a lesson is deleted.
+	 *
+	 * @internal
+	 *
+	 * @param int $lesson_id The lesson ID.
+	 */
+	public function delete_for_lesson( int $lesson_id ): void {
+		$args = array(
+			'post_id' => $lesson_id,
+			'type'    => 'sensei_lesson_status',
+		);
+
+		$this->delete_activities( $args );
+	}
+
+	/**
+	 * Delete all lesson progress for a user.
+	 * This is used when a user is deleted.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void {
+		$args = array(
+			'user_id' => $user_id,
+			'type'    => 'sensei_lesson_status',
+		);
+
+		$this->delete_activities( $args );
+	}
+
+	/**
 	 * Returns the number of started lessons for a user in a course.
 	 * The number of started lessons is the same as the number of lessons that have a progress record.
 	 *
@@ -166,5 +200,28 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 		);
 
 		return Sensei_Utils::sensei_check_for_activity( $activity_args );
+	}
+
+	private function delete_activities( array $args ): void {
+		$comments = Sensei_Utils::sensei_check_for_activity( $args, true );
+		if ( ! $comments ) {
+			return;
+		}
+
+		$comments = is_array( $comments ) ? $comments : [ $comments ];
+		$post_ids = [];
+		foreach ( $comments as $key => $value ) {
+			if ( isset( $value->comment_post_ID ) ) {
+				$post_ids[] = $value->comment_post_ID;
+			}
+
+			if ( isset( $value->comment_ID ) && 0 < $value->comment_ID ) {
+				$dataset_changes = wp_delete_comment( intval( $value->comment_ID ), true );
+			}
+		}
+
+		foreach ( $post_ids as $post_id ) {
+			Sensei()->flush_comment_counts_cache( $post_id );
+		}
 	}
 }

--- a/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
@@ -73,6 +73,26 @@ interface Lesson_Progress_Repository_Interface {
 	public function delete( Lesson_Progress $lesson_progress ): void;
 
 	/**
+	 * Delete all lesson progress for a lesson.
+	 * This is used when a lesson is deleted.
+	 *
+	 * @internal
+	 *
+	 * @param int $lesson_id The lesson ID.
+	 */
+	public function delete_for_lesson( int $lesson_id ): void;
+
+	/**
+	 * Delete all lesson progress for a user.
+	 * This is used when a user is deleted.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void;
+
+	/**
 	 * Returns the number of started lessons for a user in a course.
 	 * The number of started lessons is the same as the number of lessons that have a progress record.
 	 *

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -217,6 +217,34 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 		);
 	}
 
+	public function delete_for_lesson( int $lesson_id ): void {
+		$this->wpdb->delete(
+			$this->wpdb->prefix . 'sensei_lms_progress',
+			[
+				'post_id' => $lesson_id,
+				'type'    => 'lesson',
+			],
+			[
+				'%d',
+				'%s',
+			]
+		);
+	}
+
+	public function delete_for_user( int $user_id ): void {
+		$this->wpdb->delete(
+			$this->wpdb->prefix . 'sensei_lms_progress',
+			[
+				'user_id' => $user_id,
+				'type'    => 'lesson',
+			],
+			[
+				'%d',
+				'%s',
+			]
+		);
+	}
+
 	/**
 	 * Returns the number of started lessons for a user in a course.
 	 * The number of started lessons is the same as the number of lessons that have a progress record.

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -217,6 +217,13 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 		);
 	}
 
+	/**
+	 * Delete all lesson progress for a lesson.
+	 *
+	 * @internal
+	 *
+	 * @param int $lesson_id The lesson ID.
+	 */
 	public function delete_for_lesson( int $lesson_id ): void {
 		$this->wpdb->delete(
 			$this->wpdb->prefix . 'sensei_lms_progress',
@@ -231,6 +238,13 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 		);
 	}
 
+	/**
+	 * Delete all lesson progress for a user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
 	public function delete_for_user( int $user_id ): void {
 		$this->wpdb->delete(
 			$this->wpdb->prefix . 'sensei_lms_progress',

--- a/includes/internal/student-progress/quiz-progress/repositories/class-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-aggregate-quiz-progress-repository.php
@@ -151,4 +151,32 @@ class Aggregate_Quiz_Progress_Repository implements Quiz_Progress_Repository_Int
 			$this->tables_based_repository->delete( $quiz_progress );
 		}
 	}
+
+	/**
+	 * Deletes all quiz progresses for the given quiz.
+	 *
+	 * @internal
+	 *
+	 * @param int $quiz_id The quiz ID.
+	 */
+	public function delete_for_quiz( int $quiz_id ): void {
+		$this->comments_based_repository->delete_for_quiz( $quiz_id );
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete_for_quiz( $quiz_id );
+		}
+	}
+
+	/**
+	 * Deletes all quiz progresses for the given user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function delete_for_user( int $user_id ): void {
+		$this->comments_based_repository->delete_for_user( $user_id );
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete_for_user( $user_id );
+		}
+	}
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -141,12 +141,50 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	 * @param Quiz_Progress $quiz_progress Quiz progress.
 	 */
 	public function delete( Quiz_Progress $quiz_progress ): void {
-		delete_comment_meta( $quiz_progress->get_quiz_id(), 'quiz_answers' );
-		delete_comment_meta( $quiz_progress->get_id(), 'grade' );
+		$this->delete_grade_and_answers( $quiz_progress->get_id() );
 
 		// Backward compatibility with Sensei prior to 1.7.
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_progress->get_quiz_id() );
 		Sensei_Utils::sensei_delete_quiz_grade( $lesson_id, $quiz_progress->get_user_id() );
 		Sensei_Utils::sensei_delete_quiz_answers( $lesson_id, $quiz_progress->get_user_id() );
+	}
+
+	public function delete_for_quiz( int $quiz_id ): void {
+		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
+
+		$activity_args = [
+			'post_id' => $lesson_id,
+			'type'    => 'sensei_lesson_status',
+		];
+		$comments = Sensei_Utils::sensei_check_for_activity($activity_args, true);
+		foreach ( $comments as $comment ) {
+			$this->delete_grade_and_answers( $comment->comment_ID );
+		}
+	}
+
+	/**
+	 * Delete all quiz grades and answers for a user.
+	 *
+	 * @param int $user_id User identifier.
+	 */
+	public function delete_for_user( int $user_id ): void {
+		$activity_args = [
+			'user_id' => $user_id,
+			'type'    => 'sensei_lesson_status',
+		];
+		$comments = Sensei_Utils::sensei_check_for_activity($activity_args, true);
+		foreach ( $comments as $comment ) {
+			$this->delete_grade_and_answers( $comment->comment_ID );
+		}
+	}
+
+	/**
+	 * Delete the quiz grade and answers.
+	 *
+	 * @param int $comment_id Comment identifier.
+	 */
+	private function delete_grade_and_answers( $comment_id ): void {
+		delete_comment_meta( $comment_id, 'quiz_answers' );
+		delete_comment_meta( $comment_id, 'grade' );
 	}
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -144,6 +144,13 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 		Sensei_Utils::sensei_delete_quiz_answers( $quiz_progress->get_quiz_id(), $quiz_progress->get_user_id() );
 	}
 
+	/**
+	 * Delete all quiz progress for a given quiz.
+	 *
+	 * @internal
+	 *
+	 * @param int $quiz_id Quiz identifier.
+	 */
 	public function delete_for_quiz( int $quiz_id ): void {
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
 
@@ -151,14 +158,16 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 			'post_id' => $lesson_id,
 			'type'    => 'sensei_lesson_status',
 		];
-		$comments = Sensei_Utils::sensei_check_for_activity($activity_args, true);
+		$comments      = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 		foreach ( $comments as $comment ) {
-      Sensei_Utils::sensei_delete_quiz_answers( $quiz_id, $comment->user_id );
+			Sensei_Utils::sensei_delete_quiz_answers( $quiz_id, $comment->user_id );
 		}
 	}
 
 	/**
 	 * Delete all quiz grades and answers for a user.
+	 *
+	 * @internal
 	 *
 	 * @param int $user_id User identifier.
 	 */
@@ -167,7 +176,7 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 			'user_id' => $user_id,
 			'type'    => 'sensei_lesson_status',
 		];
-		$comments = Sensei_Utils::sensei_check_for_activity($activity_args, true);
+		$comments      = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 		foreach ( $comments as $comment ) {
 			$this->delete_grade_and_answers( $comment->comment_ID );
 		}

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
@@ -71,4 +71,22 @@ interface Quiz_Progress_Repository_Interface {
 	 * @param Quiz_Progress $quiz_progress The quiz progress.
 	 */
 	public function delete( Quiz_Progress $quiz_progress ): void;
+
+	/**
+	 * Delete all quiz progress for a quiz.
+	 *
+	 * @internal
+	 *
+	 * @param int $quiz_id Quiz identifier.
+	 */
+	public function delete_for_quiz( int $quiz_id ): void;
+
+	/**
+	 * Delete all quiz progress for a user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id User identifier.
+	 */
+	public function delete_for_user( int $user_id ): void;
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -215,6 +215,13 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 		);
 	}
 
+	/**
+	 * Delete all quiz progress for a quiz.
+	 *
+	 * @internal
+	 *
+	 * @param int $quiz_id Quiz identifier.
+	 */
 	public function delete_for_quiz( int $quiz_id ): void {
 		$this->wpdb->delete(
 			$this->wpdb->prefix . 'sensei_lms_progress',
@@ -229,6 +236,13 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 		);
 	}
 
+	/**
+	 * Delete all quiz progress for a user.
+	 *
+	 * @internal
+	 *
+	 * @param int $user_id User identifier.
+	 */
 	public function delete_for_user( int $user_id ): void {
 		$this->wpdb->delete(
 			$this->wpdb->prefix . 'sensei_lms_progress',

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -214,4 +214,32 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			]
 		);
 	}
+
+	public function delete_for_quiz( int $quiz_id ): void {
+		$this->wpdb->delete(
+			$this->wpdb->prefix . 'sensei_lms_progress',
+			[
+				'post_id' => $quiz_id,
+				'type'    => 'quiz',
+			],
+			[
+				'%d',
+				'%s',
+			]
+		);
+	}
+
+	public function delete_for_user( int $user_id ): void {
+		$this->wpdb->delete(
+			$this->wpdb->prefix . 'sensei_lms_progress',
+			[
+				'user_id' => $user_id,
+				'type'    => 'quiz',
+			],
+			[
+				'%d',
+				'%s',
+			]
+		);
+	}
 }

--- a/includes/internal/student-progress/services/class-course-deleted-handler.php
+++ b/includes/internal/student-progress/services/class-course-deleted-handler.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * File containing the class Course_Deleted_Handler.
+ * @package sensei-lms
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles the deletion of a course.
+ */
+class Course_Deleted_Handler {
+
+
+	public function __construct( Course_Progress_Repository_Interface $course_progress_repository ) {
+		$this->course_progress_repository = $course_progress_repository;
+	}
+
+	public function init() {
+		add_action( 'deleted_post', [ $this, 'handle' ], 10, 2 );
+	}
+
+	public function handle( $course_id, $course ) {
+		if ( ! $course || 'course' !== $course->post_type ) {
+			return;
+		}
+
+		$this->course_progress_repository->delete_for_course( $course_id );
+	}
+}
+

--- a/includes/internal/student-progress/services/class-course-deleted-handler.php
+++ b/includes/internal/student-progress/services/class-course-deleted-handler.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * File containing the class Course_Deleted_Handler.
+ *
  * @package sensei-lms
  */
 
@@ -14,18 +15,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Handles the deletion of a course.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
  */
 class Course_Deleted_Handler {
-
-
+	/**
+	 * The course deleted handler constructor.
+	 *
+	 * @param Course_Progress_Repository_Interface $course_progress_repository The course progress repository.
+	 */
 	public function __construct( Course_Progress_Repository_Interface $course_progress_repository ) {
 		$this->course_progress_repository = $course_progress_repository;
 	}
 
+	/**
+	 * Adds hooks to handle the deletion of a course.
+	 */
 	public function init() {
 		add_action( 'deleted_post', [ $this, 'handle' ], 10, 2 );
 	}
 
+	/**
+	 * Handles the deletion of a course.
+	 *
+	 * @param int     $course_id The post ID.
+	 * @param WP_Post $course The post object.
+	 */
 	public function handle( $course_id, $course ) {
 		if ( ! $course || 'course' !== $course->post_type ) {
 			return;

--- a/includes/internal/student-progress/services/class-lesson-deleted-handler.php
+++ b/includes/internal/student-progress/services/class-lesson-deleted-handler.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * File containing the Lesson_Deleted_Handler class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Interface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Lesson_Deleted_Handler.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Lesson_Deleted_Handler {
+	/**
+	 * Lesson_Progress_Repository_Interface instance.
+	 *
+	 * @var Lesson_Progress_Repository_Interface
+	 */
+	private $lesson_progress_repository;
+
+	/**
+	 * Lesson_Deleted_Handler constructor.
+	 *
+	 * @param Lesson_Progress_Repository_Interface $lesson_progress_repository Lesson progress repository.
+	 */
+	public function __construct( Lesson_Progress_Repository_Interface $lesson_progress_repository ) {
+		$this->lesson_progress_repository = $lesson_progress_repository;
+	}
+
+	public function init(): void {
+		add_action( 'deleted_post', [ $this, 'handle' ], 10, 2 );
+	}
+
+	/**
+	 * Handles the lesson deletion.
+	 *
+	 * @param int $lesson_id The lesson ID.
+	 */
+	public function handle( int $lesson_id, $post ): void {
+		if ( ! $post || 'lesson' !== $post->post_type ) {
+			return;
+		}
+		$this->lesson_progress_repository->delete_for_lesson( $lesson_id );
+	}
+}
+

--- a/includes/internal/student-progress/services/class-lesson-deleted-handler.php
+++ b/includes/internal/student-progress/services/class-lesson-deleted-handler.php
@@ -37,6 +37,9 @@ class Lesson_Deleted_Handler {
 		$this->lesson_progress_repository = $lesson_progress_repository;
 	}
 
+	/**
+	 * Adds hooks to handle lesson deletion.
+	 */
 	public function init(): void {
 		add_action( 'deleted_post', [ $this, 'handle' ], 10, 2 );
 	}
@@ -44,7 +47,8 @@ class Lesson_Deleted_Handler {
 	/**
 	 * Handles the lesson deletion.
 	 *
-	 * @param int $lesson_id The lesson ID.
+	 * @param int     $lesson_id The lesson ID.
+	 * @param WP_Post $post The post object.
 	 */
 	public function handle( int $lesson_id, $post ): void {
 		if ( ! $post || 'lesson' !== $post->post_type ) {

--- a/includes/internal/student-progress/services/class-quiz-deleted-handler.php
+++ b/includes/internal/student-progress/services/class-quiz-deleted-handler.php
@@ -37,6 +37,9 @@ class Quiz_Deleted_Handler {
 		$this->quiz_progress_repository = $quiz_progress_repository;
 	}
 
+	/**
+	 * Adds action hook for quiz deletion.
+	 */
 	public function init(): void {
 		add_action( 'deleted_post', [ $this, 'handle' ], 10, 2 );
 	}
@@ -44,7 +47,8 @@ class Quiz_Deleted_Handler {
 	/**
 	 * Handles the quiz deletion.
 	 *
-	 * @param int $quiz_id The quiz ID.
+	 * @param int     $quiz_id The quiz ID.
+	 * @param WP_Post $post The post object.
 	 */
 	public function handle( int $quiz_id, $post ): void {
 		if ( ! $post || 'quiz' !== $post->post_type ) {

--- a/includes/internal/student-progress/services/class-quiz-deleted-handler.php
+++ b/includes/internal/student-progress/services/class-quiz-deleted-handler.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * File containing the Quiz_Deleted_Handler class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Quiz_Deleted_Handler.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Quiz_Deleted_Handler {
+	/**
+	 * Quiz_Progress_Repository_Interface instance.
+	 *
+	 * @var Quiz_Progress_Repository_Interface
+	 */
+	private $quiz_progress_repository;
+
+	/**
+	 * Quiz_Deleted_Handler constructor.
+	 *
+	 * @param Quiz_Progress_Repository_Interface $quiz_progress_repository Quiz progress repository.
+	 */
+	public function __construct( Quiz_Progress_Repository_Interface $quiz_progress_repository ) {
+		$this->quiz_progress_repository = $quiz_progress_repository;
+	}
+
+	public function init(): void {
+		add_action( 'deleted_post', [ $this, 'handle' ], 10, 2 );
+	}
+
+	/**
+	 * Handles the quiz deletion.
+	 *
+	 * @param int $quiz_id The quiz ID.
+	 */
+	public function handle( int $quiz_id, $post ): void {
+		if ( ! $post || 'quiz' !== $post->post_type ) {
+			return;
+		}
+		$this->quiz_progress_repository->delete_for_quiz( $quiz_id );
+	}
+}
+

--- a/includes/internal/student-progress/services/class-user-deleted-handler.php
+++ b/includes/internal/student-progress/services/class-user-deleted-handler.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * File containing the User_Deleted_Handler class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles the user deletion.
+ *
+ * @since $$next-version$$
+ */
+class User_Deleted_Handler {
+
+	/**
+	 * Course progress repository.
+	 *
+	 * @var Course_Progress_Repository_Interface
+	 */
+	private $course_progress_repository;
+
+	/**
+	 * Lesson progress repository.
+	 *
+	 * @var Lesson_Progress_Repository_Interface
+	 */
+	private $lesson_progress_repository;
+
+	/**
+	 * Quiz progress repository.
+	 *
+	 * @var Quiz_Progress_Repository_Interface
+	 */
+	private $quiz_progress_repository;
+
+	/**
+	 * User_Deleted_Handler constructor.
+	 *
+	 * @param Course_Progress_Repository_Interface $course_progress_repository Course progress repository.
+	 * @param Lesson_Progress_Repository_Interface $lesson_progress_repository Lesson progress repository.
+	 * @param Quiz_Progress_Repository_Interface   $quiz_progress_repository   Quiz progress repository.
+	 */
+	public function __construct( Course_Progress_Repository_Interface $course_progress_repository, Lesson_Progress_Repository_Interface $lesson_progress_repository, Quiz_Progress_Repository_Interface $quiz_progress_repository ) {
+		$this->course_progress_repository = $course_progress_repository;
+		$this->lesson_progress_repository = $lesson_progress_repository;
+		$this->quiz_progress_repository   = $quiz_progress_repository;
+	}
+
+	/**
+	 * Adds hooks.
+	 */
+	public function init() {
+		add_action( 'deleted_user', [ $this, 'handle' ], 10, 1 );
+	}
+
+	/**
+	 * Handles the user deletion.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public function handle( $user_id ) {
+		$this->course_progress_repository->delete_for_user( $user_id );
+		$this->lesson_progress_repository->delete_for_user( $user_id );
+		$this->quiz_progress_repository->delete_for_user( $user_id );
+	}
+}
+

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-aggregate-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-aggregate-course-progress-repository.php
@@ -261,6 +261,132 @@ class Aggregate_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 		];
 	}
 
+	public function testDeleteForCourse_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$course_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Aggregate_Course_Progress_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete_for_course' );
+		$repository->delete_for_course( $course_id );
+	}
+
+	public function testDeleteForCourse_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$course_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Aggregate_Course_Progress_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete_for_course' )
+			->with( $course_id );
+		$repository->delete_for_course( $course_id );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDeleteForCourse_Always_CallsCommentsBasedRepository
+	 */
+	public function testDeleteForCourse_Always_CallsCommentsBasedRepository( $use_tables ): void {
+		/* Arrange. */
+		$course_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Aggregate_Course_Progress_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete_for_course' );
+		$repository->delete_for_course( $course_id );
+	}
+
+	public function providerDeleteForCourse_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
+	public function testDeleteForUser_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Aggregate_Course_Progress_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete_for_user' );
+		$repository->delete_for_user( $user_id );
+	}
+
+	public function testDeleteForUser_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Aggregate_Course_Progress_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete_for_user' )
+			->with( $user_id );
+		$repository->delete_for_user( $user_id );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDeleteForUser_Always_CallsCommentsBasedRepository
+	 */
+	public function testDeleteForUser_Always_CallsCommentsBasedRepository( $use_tables ): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Aggregate_Course_Progress_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete_for_user' );
+		$repository->delete_for_user( $user_id );
+	}
+
+	public function providerDeleteForUser_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
 	/**
 	 * Creates a course progress object.
 	 *

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
@@ -131,6 +131,40 @@ class Comments_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertFalse( $repository->has( $course_id, $user_id ) );
 	}
 
+	public function testDeleteForCourse_WhenCourseGiven_DeletesProgressForCourse(): void {
+		/* Arrange. */
+		$course_id              = $this->factory->course->create();
+		$second_course_id       = $this->factory->course->create();
+		$user_id                = $this->factory->user->create();
+		$repository             = new Comments_Based_Course_Progress_Repository();
+		$progress_to_be_deleted = $repository->create( $course_id, $user_id );
+		$progress_to_be_kept    = $repository->create( $second_course_id, $user_id );
+
+		/* Act. */
+		$repository->delete_for_course( $course_id );
+
+		/* Assert. */
+		self::assertFalse( $repository->has( $course_id, $user_id ) );
+		self::assertTrue( $repository->has( $second_course_id, $user_id ) );
+	}
+
+	public function testDeleteForUser_WhenUserGiven_DeletesProgressForUser(): void {
+		/* Arrange. */
+		$course_id              = $this->factory->course->create();
+		$user_id                = $this->factory->user->create();
+		$deleted_user_id        = $this->factory->user->create();
+		$repository             = new Comments_Based_Course_Progress_Repository();
+		$progress_to_be_deleted = $repository->create( $course_id, $user_id );
+		$progress_to_be_kept    = $repository->create( $course_id, $deleted_user_id );
+
+		/* Act. */
+		$repository->delete_for_user( $deleted_user_id );
+
+		/* Assert. */
+		self::assertFalse( $repository->has( $course_id, $deleted_user_id ) );
+		self::assertTrue( $repository->has( $course_id, $user_id ) );
+	}
+
 	private function export_progress( Course_Progress $progress ): array {
 		return [
 			'user_id'   => $progress->get_user_id(),

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-tables-based-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-tables-based-course-progress-repository.php
@@ -322,6 +322,52 @@ class Tables_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->delete( $progress );
 	}
 
+	public function testDeleteForCourse_CourseIdGiven_CallsWpdbDelete(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Course_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_progress',
+				[
+					'post_id' => 2,
+					'type'    => 'course',
+				],
+				[
+					'%d',
+					'%s',
+				]
+			);
+		$repository->delete_for_course( 2 );
+	}
+
+	public function testDeleteForUser_UserIdGiven_CallsWpdbDelete(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Course_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_progress',
+				[
+					'user_id' => 2,
+					'type'    => 'course',
+				],
+				[
+					'%d',
+					'%s',
+				]
+			);
+		$repository->delete_for_user( 2 );
+	}
+
 	private function export_progress( Course_Progress $progress ): array {
 		return [
 			'id'        => $progress->get_id(),

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-aggregate-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-aggregate-lesson-progress-repository.php
@@ -274,6 +274,132 @@ class Aggregate_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		];
 	}
 
+	public function testDeleteForLesson_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$lesson_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete_for_lesson' );
+		$repository->delete_for_lesson( $lesson_id );
+	}
+
+	public function testDeleteForLesson_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$lesson_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete_for_lesson' )
+			->with( $lesson_id );
+		$repository->delete_for_lesson( $lesson_id );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDeleteForLesson_Always_CallsCommentsBasedRepository
+	 */
+	public function testDeleteForLesson_Always_CallsCommentsBasedRepository( $use_tables ): void {
+		/* Arrange. */
+		$lesson_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete_for_lesson' );
+		$repository->delete_for_lesson( $lesson_id );
+	}
+
+	public function providerDeleteForLesson_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
+	public function testDeleteForUser_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete_for_user' );
+		$repository->delete_for_user( $user_id );
+	}
+
+	public function testDeleteForUser_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete_for_user' )
+			->with( $user_id );
+		$repository->delete_for_user( $user_id );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDeleteForUser_Always_CallsCommentsBasedRepository
+	 */
+	public function testDeleteForUser_Always_CallsCommentsBasedRepository( $use_tables ): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete_for_user' );
+		$repository->delete_for_user( $user_id );
+	}
+
+	public function providerDeleteForUser_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
 	public function testCount_Always_CallsCommentsBasedRepository(): void {
 		/* Arrange. */
 		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
@@ -154,6 +154,40 @@ class Comments_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertFalse( $repository->has( $lesson_id, $user_id ) );
 	}
 
+	public function testDeleteForLesson_WhenLessonGiven_DeletesProgressForLesson(): void {
+		/* Arrange. */
+		$lesson_id              = $this->factory->lesson->create();
+		$second_lesson_id       = $this->factory->lesson->create();
+		$user_id                = $this->factory->user->create();
+		$repository             = new Comments_Based_Lesson_Progress_Repository();
+		$progress_to_be_deleted = $repository->create( $lesson_id, $user_id );
+		$progress_to_be_kept    = $repository->create( $second_lesson_id, $user_id );
+
+		/* Act. */
+		$repository->delete_for_lesson( $lesson_id );
+
+		/* Assert. */
+		self::assertFalse( $repository->has( $lesson_id, $user_id ) );
+		self::assertTrue( $repository->has( $second_lesson_id, $user_id ) );
+	}
+
+	public function testDeleteForUser_WhenUserGiven_DeletesProgressForUser(): void {
+		/* Arrange. */
+		$lesson_id              = $this->factory->lesson->create();
+		$user_id                = $this->factory->user->create();
+		$deleted_user_id        = $this->factory->user->create();
+		$repository             = new Comments_Based_Lesson_Progress_Repository();
+		$progress_to_be_deleted = $repository->create( $lesson_id, $user_id );
+		$progress_to_be_kept    = $repository->create( $lesson_id, $deleted_user_id );
+
+		/* Act. */
+		$repository->delete_for_user( $deleted_user_id );
+
+		/* Assert. */
+		self::assertFalse( $repository->has( $lesson_id, $deleted_user_id ) );
+		self::assertTrue( $repository->has( $lesson_id, $user_id ) );
+	}
+
 	private function export_progress( Lesson_Progress $progress ): array {
 		return [
 			'user_id'   => $progress->get_user_id(),

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
@@ -321,6 +321,52 @@ class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->delete( $progress );
 	}
 
+	public function testDeleteForLesson_LessonIdGiven_CallsWpdbDelete(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Lesson_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_progress',
+				[
+					'post_id' => 2,
+					'type'    => 'lesson',
+				],
+				[
+					'%d',
+					'%s',
+				]
+			);
+		$repository->delete_for_lesson( 2 );
+	}
+
+	public function testDeleteForUser_UserIdGiven_CallsWpdbDelete(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Lesson_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_progress',
+				[
+					'user_id' => 2,
+					'type'    => 'lesson',
+				],
+				[
+					'%d',
+					'%s',
+				]
+			);
+		$repository->delete_for_user( 2 );
+	}
+
 	public function testCount_ParamsGiven_ReturnsMatchingValue(): void {
 		/* Arrange. */
 		$course = $this->createMock( Sensei_Course::class );

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-aggregate-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-aggregate-quiz-progress-repository.php
@@ -275,6 +275,132 @@ class Aggregate_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		];
 	}
 
+	public function testDeleteForQuiz_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$quiz_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete_for_quiz' );
+		$repository->delete_for_quiz( $quiz_id );
+	}
+
+	public function testDeleteForQuiz_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$quiz_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete_for_quiz' )
+			->with( $quiz_id );
+		$repository->delete_for_quiz( $quiz_id );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDeleteForQuiz_Always_CallsCommentsBasedRepository
+	 */
+	public function testDeleteForQuiz_Always_CallsCommentsBasedRepository( bool $use_tables ): void {
+		/* Arrange. */
+		$quiz_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete_for_quiz' );
+		$repository->delete_for_quiz( $quiz_id );
+	}
+
+	public function providerDeleteForQuiz_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
+	public function testDeleteForUser_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete_for_user' );
+		$repository->delete_for_user( $user_id );
+	}
+
+	public function testDeleteForUser_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete_for_user' )
+			->with( $user_id );
+		$repository->delete_for_user( $user_id );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDeleteForUser_Always_CallsCommentsBasedRepository
+	 */
+	public function testDeleteForUser_Always_CallsCommentsBasedRepository( bool $use_tables ): void {
+		/* Arrange. */
+		$user_id = 2;
+
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete_for_user' );
+		$repository->delete_for_user( $user_id );
+	}
+
+	public function providerDeleteForUser_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+
 	/**
 	 * Create a quiz progress.
 	 *

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -162,7 +162,7 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$progress->pass();
 		$repository->save( $progress );
 
-		update_comment_meta( $quiz_id, 'quiz_answers', [ $question_id => 'answer' ] );
+		update_comment_meta( $progress->get_id(), 'quiz_answers', [ $question_id => 'answer' ] );
 
 		/* Act. */
 		$repository->delete( $progress );
@@ -193,6 +193,52 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$actual = get_comment_meta( $progress->get_id(), 'grade', true );
 		self::assertEmpty( $actual );
+	}
+
+	public function testDeleteForQuiz_WhenQuizGiven_DeletesGradesForThisQuiz(): void {
+		/* Arrange. */
+		$lesson1_id = $this->factory->lesson->create();
+		$lesson2_id = $this->factory->lesson->create();
+		$user1_id   = $this->factory->user->create();
+		$user2_id   = $this->factory->user->create();
+		$quiz1_id  	= $this->factory->quiz->create( [ 'post_parent' => $lesson1_id ] );
+		$quiz2_id  	= $this->factory->quiz->create( [ 'post_parent' => $lesson2_id ] );
+		\Sensei_Utils::update_lesson_status( $user1_id, $lesson1_id, 'in-progress' );
+		\Sensei_Utils::update_lesson_status( $user1_id, $lesson2_id, 'in-progress' );
+		\Sensei_Utils::update_lesson_status( $user2_id, $lesson1_id, 'in-progress' );
+
+		$repository = new Comments_Based_Quiz_Progress_Repository();
+
+		$progress1 = $repository->get( $quiz1_id, $user1_id );
+		$progress1->pass();
+		$repository->save( $progress1 );
+		update_comment_meta( $progress1->get_id(), 'grade', 1 );
+
+		$progress2 = $repository->get( $quiz2_id, $user1_id );
+		$progress2->pass();
+		$repository->save( $progress2 );
+		update_comment_meta( $progress2->get_id(), 'grade', 1 );
+
+		$progress3 = $repository->get( $quiz1_id, $user2_id );
+		$progress3->pass();
+		$repository->save( $progress3 );
+		update_comment_meta( $progress3->get_id(), 'grade', 1 );
+
+		/* Act. */
+		$repository->delete_for_quiz( $quiz1_id );
+
+		/* Assert. */
+		$actual = [
+			'progress1 grade' => get_comment_meta( $progress1->get_id(), 'grade', true ),
+			'progress2 grade' => get_comment_meta( $progress2->get_id(), 'grade', true ),
+			'progress3 grade' => get_comment_meta( $progress3->get_id(), 'grade', true ),
+		];
+		$expected = [
+			'progress1 grade' => '',
+			'progress2 grade' => '1',
+			'progress3 grade' => '',
+		];
+		self::assertSame( $expected, $actual );
 	}
 
 	private function export_progress( Quiz_Progress $progress ): array {

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -241,6 +241,53 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertSame( $expected, $actual );
 	}
 
+	public function testDeleteForUser_WhenUserGiven_DeletesGradesForThisUser(): void {
+		/* Arrange. */
+		$lesson1_id = $this->factory->lesson->create();
+		$lesson2_id = $this->factory->lesson->create();
+		$user1_id   = $this->factory->user->create();
+		$user2_id   = $this->factory->user->create();
+		$quiz1_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson1_id ] );
+		$quiz2_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson2_id ] );
+		\Sensei_Utils::update_lesson_status( $user1_id, $lesson1_id, 'in-progress' );
+		\Sensei_Utils::update_lesson_status( $user1_id, $lesson2_id, 'in-progress' );
+		\Sensei_Utils::update_lesson_status( $user2_id, $lesson1_id, 'in-progress' );
+
+		$repository = new Comments_Based_Quiz_Progress_Repository();
+
+		$progress1 = $repository->get( $quiz1_id, $user1_id );
+		$progress1->pass();
+		$repository->save( $progress1 );
+		update_comment_meta( $progress1->get_id(), 'grade', 1 );
+
+		$progress2 = $repository->get( $quiz2_id, $user1_id );
+		$progress2->pass();
+		$repository->save( $progress2 );
+		update_comment_meta( $progress2->get_id(), 'grade', 1 );
+
+		$progress3 = $repository->get( $quiz1_id, $user2_id );
+		$progress3->pass();
+		$repository->save( $progress3 );
+		update_comment_meta( $progress3->get_id(), 'grade', 1 );
+
+		/* Act. */
+		$repository->delete_for_user( $user1_id );
+
+		/* Assert. */
+		$actual = [
+			'progress1 grade' => get_comment_meta( $progress1->get_id(), 'grade', true ),
+			'progress2 grade' => get_comment_meta( $progress2->get_id(), 'grade', true ),
+			'progress3 grade' => get_comment_meta( $progress3->get_id(), 'grade', true ),
+		];
+
+		$expected = [
+			'progress1 grade' => '',
+			'progress2 grade' => '',
+			'progress3 grade' => '1',
+		];
+		self::assertSame( $expected, $actual );
+	}
+
 	private function export_progress( Quiz_Progress $progress ): array {
 		return [
 			'user_id' => $progress->get_user_id(),

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -201,8 +201,8 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$lesson2_id = $this->factory->lesson->create();
 		$user1_id   = $this->factory->user->create();
 		$user2_id   = $this->factory->user->create();
-		$quiz1_id  	= $this->factory->quiz->create( [ 'post_parent' => $lesson1_id ] );
-		$quiz2_id  	= $this->factory->quiz->create( [ 'post_parent' => $lesson2_id ] );
+		$quiz1_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson1_id ] );
+		$quiz2_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson2_id ] );
 		\Sensei_Utils::update_lesson_status( $user1_id, $lesson1_id, 'in-progress' );
 		\Sensei_Utils::update_lesson_status( $user1_id, $lesson2_id, 'in-progress' );
 		\Sensei_Utils::update_lesson_status( $user2_id, $lesson1_id, 'in-progress' );
@@ -228,7 +228,7 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->delete_for_quiz( $quiz1_id );
 
 		/* Assert. */
-		$actual = [
+		$actual   = [
 			'progress1 grade' => get_comment_meta( $progress1->get_id(), 'grade', true ),
 			'progress2 grade' => get_comment_meta( $progress2->get_id(), 'grade', true ),
 			'progress3 grade' => get_comment_meta( $progress3->get_id(), 'grade', true ),

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
@@ -320,6 +320,52 @@ class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->delete( $progress );
 	}
 
+	public function testDeleteForQuiz_QuizIdGiven_CallsWpdbDelete(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Quiz_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_progress',
+				[
+					'post_id' => 2,
+					'type'    => 'quiz',
+				],
+				[
+					'%d',
+					'%s',
+				]
+			);
+		$repository->delete_for_quiz( 2 );
+	}
+
+	public function testDeleteForUser_UserIdGiven_CallsWpdbDelete(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Quiz_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_progress',
+				[
+					'user_id' => 2,
+					'type'    => 'quiz',
+				],
+				[
+					'%d',
+					'%s',
+				]
+			);
+		$repository->delete_for_user( 2 );
+	}
+
 	private function export_progress( Quiz_Progress $progress ): array {
 		return [
 			'id'      => $progress->get_id(),

--- a/tests/unit-tests/internal/student-progress/services/test-class-course-deleted-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-course-deleted-handler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SenseiTest\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Services\Course_Deleted_Handler;
+use WP_Post;
+
+class Course_Deleted_Handler_Test extends \WP_UnitTestCase {
+	public function testHandle_NonCoursePostGiven_DoesntCallDeleteMethod() {
+		/* Arrange. */
+		$course_progress_repository = $this->createMock( Course_Progress_Repository_Interface::class );
+
+		$handler = new Course_Deleted_Handler( $course_progress_repository );
+		$deleted_post = new WP_Post( (object) [ 'post_type' => 'post' ] );
+
+		/* Expect & Act. */
+		$course_progress_repository
+			->expects( $this->never() )
+			->method( 'delete_for_course' );
+		$handler->handle( 1, $deleted_post );
+	}
+
+	/**
+	 * Tests that the handler deletes progress for a course post.
+	 */
+	public function testHandle_CourseGiven_CallsDeleteMethod() {
+		$course_progress_repository = $this->createMock( Course_Progress_Repository_Interface::class );
+		$course_progress_repository->expects( $this->once() )->method( 'delete_for_course' );
+
+		$handler = new Course_Deleted_Handler( $course_progress_repository );
+		$handler->handle( 1, new WP_Post( (object) [ 'post_type' => 'course' ] ) );
+	}
+
+	public function testInit_WhenCalled_AddsAction() {
+		/* Arrange. */
+		$course_progress_repository = $this->createMock( Course_Progress_Repository_Interface::class );
+		$handler = new Course_Deleted_Handler( $course_progress_repository );
+
+		/* Act. */
+		$handler->init();
+
+		/* Assert. */
+		$actual_priority = has_action( 'deleted_post', [ $handler, 'handle' ] );
+		$this->assertEquals( 10, $actual_priority );
+	}
+}
+

--- a/tests/unit-tests/internal/student-progress/services/test-class-course-deleted-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-course-deleted-handler.php
@@ -11,7 +11,7 @@ class Course_Deleted_Handler_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$course_progress_repository = $this->createMock( Course_Progress_Repository_Interface::class );
 
-		$handler = new Course_Deleted_Handler( $course_progress_repository );
+		$handler      = new Course_Deleted_Handler( $course_progress_repository );
 		$deleted_post = new WP_Post( (object) [ 'post_type' => 'post' ] );
 
 		/* Expect & Act. */
@@ -35,7 +35,7 @@ class Course_Deleted_Handler_Test extends \WP_UnitTestCase {
 	public function testInit_WhenCalled_AddsAction() {
 		/* Arrange. */
 		$course_progress_repository = $this->createMock( Course_Progress_Repository_Interface::class );
-		$handler = new Course_Deleted_Handler( $course_progress_repository );
+		$handler                    = new Course_Deleted_Handler( $course_progress_repository );
 
 		/* Act. */
 		$handler->init();

--- a/tests/unit-tests/internal/student-progress/services/test-class-lesson-deleted-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-lesson-deleted-handler.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SenseiTest\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Services\Lesson_Deleted_Handler;
+
+class Lesson_Deleted_Handler_Test extends \WP_UnitTestCase {
+	/**
+	 * Tests that the handler is initialized.
+	 */
+	public function testInit_WhenCalled_AddsAction() {
+		/* Arrange. */
+		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
+		$handler                    = new Lesson_Deleted_Handler( $lesson_progress_repository );
+
+		/* Act. */
+		$handler->init();
+
+		/* Assert. */
+		$this->assertEquals( 10, has_action( 'deleted_post', [ $handler, 'handle' ] ) );
+	}
+
+	public function testHandle_WhenPostWasNotLesson_DoesntCallDeleteForLesson() {
+		/* Arrange. */
+		$deleted_post = new \WP_Post( (object) [ 'post_type' => 'post' ] );
+		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
+
+		$handler = new Lesson_Deleted_Handler( $lesson_progress_repository );
+
+		/* Expect & Act. */
+		$lesson_progress_repository
+			->expects( $this->never() )
+			->method( 'delete_for_lesson' );
+		$handler->handle( 1, $deleted_post );
+	}
+
+	public function testHandle_WhenLessonGiven_CallsDeleteForLesson() {
+		/* Arrange. */
+		$deleted_post = new \WP_Post( (object) [ 'post_type' => 'lesson' ] );
+		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
+
+		$handler = new Lesson_Deleted_Handler( $lesson_progress_repository );
+
+		/* Expect & Act. */
+		$lesson_progress_repository
+			->expects( $this->once() )
+			->method( 'delete_for_lesson' )
+			->with( 1 );
+		$handler->handle( 1, $deleted_post );
+	}
+}

--- a/tests/unit-tests/internal/student-progress/services/test-class-lesson-deleted-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-lesson-deleted-handler.php
@@ -23,7 +23,7 @@ class Lesson_Deleted_Handler_Test extends \WP_UnitTestCase {
 
 	public function testHandle_WhenPostWasNotLesson_DoesntCallDeleteForLesson() {
 		/* Arrange. */
-		$deleted_post = new \WP_Post( (object) [ 'post_type' => 'post' ] );
+		$deleted_post               = new \WP_Post( (object) [ 'post_type' => 'post' ] );
 		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
 
 		$handler = new Lesson_Deleted_Handler( $lesson_progress_repository );
@@ -37,7 +37,7 @@ class Lesson_Deleted_Handler_Test extends \WP_UnitTestCase {
 
 	public function testHandle_WhenLessonGiven_CallsDeleteForLesson() {
 		/* Arrange. */
-		$deleted_post = new \WP_Post( (object) [ 'post_type' => 'lesson' ] );
+		$deleted_post               = new \WP_Post( (object) [ 'post_type' => 'lesson' ] );
 		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
 
 		$handler = new Lesson_Deleted_Handler( $lesson_progress_repository );

--- a/tests/unit-tests/internal/student-progress/services/test-class-quiz-deleted-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-quiz-deleted-handler.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SenseiTest\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Services\Quiz_Deleted_Handler;
+
+class Quiz_Deleted_Handler_Test extends \WP_UnitTestCase {
+	public function testInit_WhenCalled_AddsAction(): void {
+		/* Arrange. */
+		$quiz_progress_repository = $this->createMock( \Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface::class );
+		$handler                  = new Quiz_Deleted_Handler( $quiz_progress_repository );
+
+		/* Act. */
+		$handler->init();
+
+		/* Assert. */
+		$actual_priority = has_action( 'deleted_post', [ $handler, 'handle' ] );
+		$this->assertEquals( 10, $actual_priority );
+	}
+
+	public function testHandle_NonQuizPostGiven_DoesntCallDeleteMethod(): void {
+		/* Arrange. */
+		$deleted_post             = new \WP_Post( (object) [ 'post_type' => 'post' ] );
+		$quiz_progress_repository = $this->createMock( \Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface::class );
+		$handler                  = new Quiz_Deleted_Handler( $quiz_progress_repository );
+
+		/* Expect & Act. */
+		$quiz_progress_repository
+			->expects( $this->never() )
+			->method( 'delete_for_quiz' );
+		$handler->handle( 1, $deleted_post );
+	}
+
+	public function testHandle_QuizGiven_CallsDeleteMethod(): void {
+		/* Arrange. */
+		$deleted_post             = new \WP_Post( (object) [ 'post_type' => 'quiz' ] );
+		$quiz_progress_repository = $this->createMock( \Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface::class );
+		$handler                  = new Quiz_Deleted_Handler( $quiz_progress_repository );
+
+		/* Expect & Act. */
+		$quiz_progress_repository->expects( $this->once() )->method( 'delete_for_quiz' )->with( 1 );
+		$handler->handle( 1, $deleted_post );
+	}
+}

--- a/tests/unit-tests/internal/student-progress/services/test-class-user-deleted-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-user-deleted-handler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SenseiTest\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Services\User_Deleted_Handler;
+
+class User_Deleted_Handler_Test extends \WP_UnitTestCase {
+	public function testInit_WhenCalled_AddsAction(): void {
+		/* Arrange. */
+		$course_progress_repository = $this->createMock( Course_Progress_Repository_Interface::class );
+		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
+		$quiz_progress_repository   = $this->createMock( Quiz_Progress_Repository_Interface::class );
+
+		$handler = new User_Deleted_Handler( $course_progress_repository, $lesson_progress_repository, $quiz_progress_repository );
+
+		/* Act. */
+		$handler->init();
+
+		/* Assert. */
+		$this->assertEquals( 10, has_action( 'deleted_user', [ $handler, 'handle' ] ) );
+	}
+
+	public function testHandle_WhenCalled_CallsDeleteForAllProgress(): void {
+		/* Arrange. */
+		$course_progress_repository = $this->createMock( Course_Progress_Repository_Interface::class );
+		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
+		$quiz_progress_repository   = $this->createMock( Quiz_Progress_Repository_Interface::class );
+
+		$handler = new User_Deleted_Handler( $course_progress_repository, $lesson_progress_repository, $quiz_progress_repository );
+
+		/* Expect & Act. */
+		$course_progress_repository->expects( $this->once() )->method( 'delete_for_user' )->with( 1 );
+		$lesson_progress_repository->expects( $this->once() )->method( 'delete_for_user' )->with( 1 );
+		$quiz_progress_repository->expects( $this->once() )->method( 'delete_for_user' )->with( 1 );
+		$handler->handle( 1 );
+	}
+}


### PR DESCRIPTION
Fixes #6060

When the admin deletes a course, or a lesson, or a quiz, or a user, we have to delete orphan progress. It makes no sense to keep it in DB, as it doesn't contain sensible information.

### Changes proposed in this Pull Request

* Cleanup student progress when a course/lesson/quiz/user deleted

### Testing instructions

* Add a couple of courses with lessons and quizzes.
* Add a student user (you'll need to delete it later).
* Start both courses and complete lessons.
* Start with deleting lessons: check the corresponding progress disappeared.
* Delete one course: check the corresponding progress disappeared.
* Delete the student: check all their progress disappeared.
