### PR TITLE
Fix start date reset

### DIFF
--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -512,14 +512,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					// Lessons.
 					$row_actions[] =
 						'<span class="delete">' .
-							'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="reset_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+							'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="reset_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '" href="#">' .
 								esc_html__( 'Reset Progress', 'sensei-lms' ) .
 							'</a>' .
 						'</span>';
 
 					$row_actions[] =
 						'<span class="delete">' .
-							'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="remove_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+							'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="remove_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '" href="#">' .
 								esc_html__( 'Remove Progress', 'sensei-lms' ) .
 							'</a>' .
 						'</span>';

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -462,7 +462,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 						$row_actions[] =
 							'<span class="delete">' .
-								'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="reset_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+								'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="reset_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '" href="#">' .
 									esc_html__( 'Reset Progress', 'sensei-lms' ) .
 								'</a>' .
 							'</span>';

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -503,7 +503,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 						$row_actions[] =
 							'<span class="delete">' .
-								'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="remove_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+								'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="remove_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '" href="#">' .
 									esc_html__( 'Remove Progress', 'sensei-lms' ) .
 								'</a>' .
 							'</span>';

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1353,7 +1353,9 @@ class Sensei_Utils {
 		if ( ! $course_progress ) {
 			$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
 		}
-		$course_progress->start();
+		if ( ! $course_progress->get_started_at() ) {
+			$course_progress->start();
+		}
 
 		$course_completion  = Sensei()->settings->settings['course_completion'];
 		$lessons_completed  = 0;

--- a/includes/internal/student-progress/course-progress/models/class-course-progress.php
+++ b/includes/internal/student-progress/course-progress/models/class-course-progress.php
@@ -124,7 +124,7 @@ class Course_Progress {
 	 * @param DateTimeInterface|null $started_at Course start date.
 	 */
 	public function start( DateTimeInterface $started_at = null ): void {
-		$this->status     = 'in-progress';
+		$this->status     = self::STATUS_IN_PROGRESS;
 		$this->started_at = $started_at ?? current_datetime();
 	}
 
@@ -136,7 +136,7 @@ class Course_Progress {
 	 * @param DateTimeInterface|null $completed_at Course completion date.
 	 */
 	public function complete( DateTimeInterface $completed_at = null ): void {
-		$this->status       = 'complete';
+		$this->status       = self::STATUS_COMPLETE;
 		$this->completed_at = $completed_at ?? current_datetime();
 	}
 


### PR DESCRIPTION
Fixes #6064

### Changes proposed in this Pull Request

* Fix the course start date resetting upon lesson completion.
* [Small] Fix the cursor on the "Reset Progress" link in Student Management.

cc @merkushin could you take a look at this and make sure I'm not misunderstanding the logic here?

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Open the Manage page for a course.
* Set a specific starting date on the course, different from today.
* (While you're there, mouse over the "Reset Progress" link and notice that the cursor is correct).
* Start the course as a user, and complete a lesson.
* Reload the Manage page and ensure that the start date for the course has not changed.
