### PR TITLE
Avoid defining already defined constants

### DIFF
--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -35,8 +35,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'SENSEI_LMS_VERSION', '4.8.0' ); // WRCS: DEFINED_VERSION.
-define( 'SENSEI_LMS_PLUGIN_FILE', __FILE__ );
+if ( ! defined( 'SENSEI_LMS_VERSION' ) ) {
+	define( 'SENSEI_LMS_VERSION', '4.8.0' ); // WRCS: DEFINED_VERSION.
+}
+
+if ( ! defined( 'SENSEI_LMS_PLUGIN_FILE' ) ) {
+	define( 'SENSEI_LMS_PLUGIN_FILE', __FILE__ );
+}
 
 if ( class_exists( 'Sensei_Main' ) ) {
 	if ( ! function_exists( 'is_sensei_activating' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It avoids defining already defined constants when a site has Sensei LMS + Sensei Pro (WC Paid Courses) installed.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Build Sensei Pro (WC Paid Courses) and Sensei LMS from this branch.
* Install and activate Sensei Pro (WC Paid Courses).
* Install and activate Sensei LMS.
* Make sure you don't see the constants error (see screenshots for the error that used to happen before this PR).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Error before this PR:

<img width="1308" alt="Screenshot 2022-11-08 at 15 32 12" src="https://user-images.githubusercontent.com/876340/200649093-cec04d7a-90ca-4450-97ef-9c6b9483f39d.png">

<img width="1306" alt="Screenshot 2022-11-08 at 15 32 30" src="https://user-images.githubusercontent.com/876340/200649100-effdb8fc-6f42-4eed-8e6b-3a19c5220ae2.png">

### Context

p1667932042678629/1667921227.206959-slack-C02P7FHLVR9