### PR TITLE
Prevent multiple actions being enqueued at the same time.

### DIFF
--- a/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
@@ -71,7 +71,7 @@ class Sensei_Scheduler_Action_Scheduler implements Sensei_Scheduler_Interface {
 			}
 		} else {
 			// Re-schedule immediately.
-			$this->schedule_job( $job, time() );
+			$this->schedule_job( $job );
 		}
 
 		$this->current_job = null;

--- a/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
@@ -29,8 +29,6 @@ class Sensei_Scheduler_Action_Scheduler implements Sensei_Scheduler_Interface {
 	 *
 	 * @param Sensei_Background_Job_Interface $job  Job object.
 	 * @param int|null                        $time Time when the job should run. Defaults to now.
-	 *
-	 * @return mixed
 	 */
 	public function schedule_job( Sensei_Background_Job_Interface $job, $time = null ) {
 		if ( null === $time ) {
@@ -59,16 +57,21 @@ class Sensei_Scheduler_Action_Scheduler implements Sensei_Scheduler_Interface {
 	public function run( Sensei_Background_Job_Interface $job, $completion_callback = null ) {
 		$this->current_job = $job;
 
-		$this->schedule_job( $job );
+		// Schedule action 60 seconds in the future as fallback.
+		$this->schedule_job( $job, time() + 60 );
 
 		$job->run();
 
-		if ( $job->is_complete() ) {
-			$this->cancel_scheduled_job( $job );
+		// Clean scheduled jobs (remove fallback).
+		$this->cancel_scheduled_job( $job );
 
+		if ( $job->is_complete() ) {
 			if ( is_callable( $completion_callback ) ) {
 				call_user_func( $completion_callback );
 			}
+		} else {
+			// Re-schedule immediately.
+			$this->schedule_job( $job, time() );
 		}
 
 		$this->current_job = null;


### PR DESCRIPTION
Fixes #6075

### Changes proposed in this Pull Request
- Previously first thing when running a job with Action Scheduler was to enqueue the next single_action.
- This behaviour made that next requests to the site could trigger a job concurrently.
- Some jobs like `Sensei_Enrolment_Course_Calculation_Job` did some process in batch relying on a "last_user_id" counter. These jobs would collide when running in parallel consuming resources by repeating the same user IDs multiple times.
- New approach enqueues a fallback action 60 seconds in the future first (so in case execution breaks we will re-try) and then right after completing the process clears enqueued actions and re-enqueues but this time immediately.
- We are enqueuing immediately to take profit of the AS capability to run multiple jobs per request

### Testing instructions
Instructions to test this are a little bit cumbersome. You can find them [here](https://github.com/Automattic/sensei/issues/6075).