### PR TITLE
Some fixes for task list in Sensei Home

### DIFF
--- a/assets/home/tasks-section/first-course.scss
+++ b/assets/home/tasks-section/first-course.scss
@@ -6,6 +6,7 @@ $medium-padding: 48px;
 	display: flex;
 	flex-direction: column;
 	box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
+	border-top-left-radius: 15px;
 
 	&__site-header {
 		display: flex;

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -126,9 +126,10 @@ class Sensei_Home_Tasks_Provider {
 			if ( null === $post_id ) {
 				$result = null;
 			} else {
+				$post   = get_post( $post_id );
 				$image  = get_the_post_thumbnail_url( $post_id, 'full' );
 				$result = [
-					'title'     => get_the_title( $post_id ),
+					'title'     => $post->post_title,
 					'permalink' => get_permalink( $post_id ),
 					'image'     => $image ? $image : null,
 				];

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -103,7 +103,8 @@ class Sensei_Home_Tasks_Provider {
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 		$image          = wp_get_attachment_image_src( $custom_logo_id, 'full' );
 		return [
-			'title' => get_bloginfo( 'name' ),
+			// Title is persisted with encoded specialchars. We need to decode so that consumer decides what to do with it.
+			'title' => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
 			'image' => $image ? $image[0] : null,
 		];
 	}


### PR DESCRIPTION
Fixes #6082

### Changes proposed in this Pull Request
* Fix border radius for shadow in Course preview.
* Fix title encoding for course in Course preview.

### Testing instructions
* You can force the Task List to be shown by running this snippet once:
```
update_option( 'sensei_settings_sections_visited', []);
update_option( 'sensei_home_tasks_list_is_completed', false );
```
- Go to Sensei Home.
- Check the Course preview (make sure your first course has some quotes included in the title).

### Screenshot / Video
![image](https://user-images.githubusercontent.com/799065/200871110-8e962fba-bbf6-4a5d-bfeb-7c3b17a9d2bb.png)
