### PR TITLE
Update Featured label and course categories block styles

### DIFF
--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -85,7 +85,7 @@ export function CourseCategoryEdit( props ) {
 				href={ category.link }
 				onClick={ ( event ) => event.preventDefault() }
 			>
-				<span>{ unescape( category.name ) }</span>
+				{ unescape( category.name ) }
 			</a>
 		) );
 	};

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -39,11 +39,7 @@ export function CourseCategoryEdit( props ) {
 
 	const { textAlign, previewCategories, options } = attributes;
 	const { postId, postType } = context;
-	const {
-		postTerms: categories,
-		hasPostTerms: hasCategories,
-		isLoading,
-	} = useCourseCategories( postId );
+	const { postTerms: categories, isLoading } = useCourseCategories( postId );
 
 	const { __unstableMarkNextChangeAsNotPersistent = noop } = useDispatch(
 		blockEditorStore
@@ -119,9 +115,6 @@ export function CourseCategoryEdit( props ) {
 			<div { ...blockProps }>
 				{ isLoading && <Spinner /> }
 				{ ! isLoading && getCategories( categories ) }
-				{ ! isLoading && ! hasCategories && (
-					<p>{ __( 'No course category', 'sensei-lms' ) }</p>
-				) }
 			</div>
 		</>
 	);

--- a/assets/blocks/course-categories-block/course-categories-edit.test.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.test.js
@@ -89,20 +89,6 @@ describe( 'CourseCategoryEdit', () => {
 		expect( getByText( message ) ).toBeInTheDocument();
 	} );
 
-	it( 'should render a placeholder when there are no course categories', () => {
-		useCourseCategories.mockReturnValue( {
-			isLoading: false,
-			hasPostTerms: false,
-			postTerms: [],
-		} );
-
-		const { getByText } = render(
-			<CourseCategoryEdit { ...defaultProps } />
-		);
-
-		expect( getByText( 'No course category' ) ).toBeInTheDocument();
-	} );
-
 	it( 'should update the color attributes during the component loading', () => {
 		const setBackgroundColor = jest.fn();
 		const setTextColor = jest.fn();

--- a/assets/blocks/course-categories-block/course-categories-editor.scss
+++ b/assets/blocks/course-categories-block/course-categories-editor.scss
@@ -1,0 +1,5 @@
+:root .editor-styles-wrapper .wp-block-sensei-lms-course-categories > a {
+	background-color: var(--sensei-lms-course-categories-background-color);
+	color: var(--sensei-lms-course-categories-text-color);
+	text-decoration: none;
+}

--- a/assets/blocks/course-categories-block/course-categories.scss
+++ b/assets/blocks/course-categories-block/course-categories.scss
@@ -3,19 +3,20 @@ $block: 'sensei-lms-course-categories';
 // :root selector increases the CSS specificity,
 // without it the text-decoration: none; for links is ignored.
 :root .wp-block-#{$block} {
-	--#{$block}-text-color: #ffffff;
-	--#{$block}-background-color: #0170B9;
+	--#{$block}-text-color: var(--wp--preset--color--background, #fffff);
+	--#{$block}-background-color: var(--wp--preset--color--foreground, #0170B9);
 
 	margin: 10px 0;
 	width: 100%;
+
 	> a {
+		background-color: var( --#{$block}-background-color );
+		border-radius: 2px;
 		display: inline-flex;
+		margin-bottom: 5px;
 		padding: 3px 6px;
 		text-decoration: none;
-		border-radius: 2px;
 		white-space: nowrap;
-		margin-bottom: 5px;
-		background-color: var( --#{$block}-background-color );
 
 		&:not( :last-child ) {
 			margin-right: 10px;
@@ -23,6 +24,9 @@ $block: 'sensei-lms-course-categories';
 
 		& span {
 			color: var( --#{$block}-text-color );
+			font-size: 11px;
+			letter-spacing: normal;
+			line-height: 16px;
 		}
 	}
 }

--- a/assets/blocks/course-categories-block/course-categories.scss
+++ b/assets/blocks/course-categories-block/course-categories.scss
@@ -3,30 +3,25 @@ $block: 'sensei-lms-course-categories';
 // :root selector increases the CSS specificity,
 // without it the text-decoration: none; for links is ignored.
 :root .wp-block-#{$block} {
-	--#{$block}-text-color: var(--wp--preset--color--background, #fffff);
+	--#{$block}-text-color: var(--wp--preset--color--background, #ffffff);
 	--#{$block}-background-color: var(--wp--preset--color--foreground, #0170B9);
 
-	margin: 10px 0;
 	width: 100%;
 
 	> a {
-		background-color: var( --#{$block}-background-color );
+		background-color: var(--#{$block}-background-color);
 		border-radius: 2px;
-		display: inline-flex;
-		margin-bottom: 5px;
+		color: var(--#{$block}-text-color);
+		display: inline-block;
+		font-size: 11px;
+		line-height: 16px;
 		padding: 3px 6px;
 		text-decoration: none;
+		vertical-align: top;
 		white-space: nowrap;
 
-		&:not( :last-child ) {
+		&:not(:last-child) {
 			margin-right: 10px;
-		}
-
-		& span {
-			color: var( --#{$block}-text-color );
-			font-size: 11px;
-			letter-spacing: normal;
-			line-height: 16px;
 		}
 	}
 }

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -1,11 +1,13 @@
 $block: '.wp-block-sensei-lms-course-list';
 
 @mixin featured-badge-format {
-	background-color: #1d2327;
-	color: #fff;
+	background-color: var(--wp--preset--color--background,  #1d2327);
+	border-radius: 2px;
+	color: var(--wp--preset--color--foreground, #ffffff);
+	font-size: 11px;
+	line-height: 16px;
 	padding: 3px 6px;
 	text-decoration: none;
-	border-radius: 2px;
 	white-space: nowrap;
 	z-index: 1000;
 }

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -1,7 +1,7 @@
 $block: '.wp-block-sensei-lms-course-list';
 
-@mixin featured-badge-format {
-	background-color: var(--wp--preset--color--background,  #1d2327);
+@mixin featured-label {
+	background-color: var(--wp--preset--color--background, #1d2327);
 	border-radius: 2px;
 	color: var(--wp--preset--color--foreground, #ffffff);
 	font-size: 11px;
@@ -30,62 +30,31 @@ $block: '.wp-block-sensei-lms-course-list';
 		}
 	}
 
-	.featured-image-wrapper {
+	/* Featured label overlaid on image. */
+	.sensei-lms-course-list-featured-label__image-wrapper {
 		position: relative;
 
-		.sensei-lms-featured-badge {
+		.sensei-lms-course-list-featured-label__text {
+			@include featured-label;
+
 			display: block;
 			position: absolute;
 			top: 18px;
 			left: 18px;
-			@include featured-badge-format;
 		}
 	}
 
-	.featured-category-wrapper {
+	/* Featured label beside course categories. */
+	.sensei-lms-course-list-featured-label__meta-wrapper {
 		display: flex;
 		flex-direction: row;
 
-		.sensei-lms-featured-badge {
+		.sensei-lms-course-list-featured-label__text {
+			@include featured-label;
+
 			display: block;
-			margin-right: 10px;
-			margin-top: 10px;
 			height: max-content;
-			@include featured-badge-format;
-		}
-	}
-
-	.featured-course-wrapper__featured-image {
-		position: relative;
-
-		.course-list-featured-label__featured-image {
-			position: absolute;
-			top: 18px;
-			left: 18px;
-			background-color: #1d2327;
-			color: #fff;
-			padding: 5px;
-			z-index: 999;
-			display: block;
-		}
-	}
-
-	.featured-course-wrapper__course-categories {
-		display: flex;
-		flex-direction: row;
-
-		.course-list-featured-label__course-categories {
-			display: block;
 			margin-right: 10px;
-			height: max-content;
-			margin-top: 10px;
-			color: #fff;
-			background-color: #1d2327;
-			padding: 3px 6px;
-			text-decoration: none;
-			border-radius: 2px;
-			white-space: nowrap;
-			display: block;
 		}
 	}
 
@@ -124,13 +93,13 @@ $block: '.wp-block-sensei-lms-course-list';
 
 					figure,
 					.wp-block,
-					.course-list-featured-label__course-categories,
+					.sensei-lms-course-list-featured-label__text,
 					.wp-block-post-featured-image,
 					.wp-block-sensei-lms-course-progress{
 						margin: 0;
 					}
 
-					.course-list-featured-label__course-categories {
+					.sensei-lms-course-list-featured-label__text {
 						margin-right: 10px;
 					}
 
@@ -173,15 +142,4 @@ $block: '.wp-block-sensei-lms-course-list';
 		margin-left: 0;
 		padding: 1.25em;
 	}
-}
-
-.course-list-featured-label__featured-image {
-	display: none;
-}
-.course-list-featured-label__course-categories {
-	display: none;
-}
-
-.sensei-lms-featured-badge {
-	display: none;
 }

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -143,3 +143,8 @@ $block: '.wp-block-sensei-lms-course-list';
 		padding: 1.25em;
 	}
 }
+
+/* Hide featured label when not inside Course List. */
+.sensei-lms-course-list-featured-label__text {
+	display: none;
+}

--- a/assets/blocks/course-list-block/featured-label/index.js
+++ b/assets/blocks/course-list-block/featured-label/index.js
@@ -24,18 +24,15 @@ const FeaturedLabel = ( { postId, isFeaturedImage, children } ) => {
 	const hasImage = media > 0;
 
 	const wrapperClassName = isFeaturedImage
-		? 'featured-course-wrapper__featured-image'
-		: 'featured-course-wrapper__course-categories';
-	const featuredLabelClassName = isFeaturedImage
-		? 'course-list-featured-label__featured-image'
-		: 'course-list-featured-label__course-categories';
+		? 'sensei-lms-course-list-featured-label__image-wrapper'
+		: 'sensei-lms-course-list-featured-label__meta-wrapper';
 
 	const shouldDisplayFeatureLabel =
 		( hasImage && isFeaturedImage ) || ( ! hasImage && ! isFeaturedImage );
 	return (
 		<div className={ wrapperClassName }>
 			{ isFeatured && shouldDisplayFeatureLabel && (
-				<span className={ featuredLabelClassName }>
+				<span className="sensei-lms-course-list-featured-label__text">
 					{ __( 'Featured', 'sensei-lms' ) }
 				</span>
 			) }

--- a/assets/blocks/global-blocks-style-editor.scss
+++ b/assets/blocks/global-blocks-style-editor.scss
@@ -1,5 +1,6 @@
 @import 'button/button-editor';
 @import 'course-actions-block/course-actions/course-actions-editor';
-@import 'course-progress-block/course-progress-editor';
+@import 'course-categories-block/course-categories-editor';
 @import 'course-list-block/course-list-block-editor';
 @import 'course-list-filter-block/course-list-filter-editor';
+@import 'course-progress-block/course-progress-editor';

--- a/includes/blocks/class-sensei-course-categories-block.php
+++ b/includes/blocks/class-sensei-course-categories-block.php
@@ -77,7 +77,7 @@ class Sensei_Course_Categories_Block {
 		);
 
 		$pattern     = '/<a (.*?)>(.*?)<\/a>/i';
-		$replacement = '<a $1><span>$2</span></a>';
+		$replacement = '<a $1>$2</a>';
 
 		return preg_replace( $pattern, $replacement, $terms );
 	}

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -24,8 +24,8 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 		$version = str_replace( '-src', '', $wp_version );
 
 		if ( ! version_compare( $version, '5.9', '<' ) ) {
-			add_filter( 'render_block', array( $this, 'add_featured_label_to_course_categories' ), 11, 3 );
-			add_filter( 'render_block_core/post-featured-image', [ $this, 'add_featured_label_to_featured_image' ], 10, 3 );
+			add_filter( 'render_block', array( $this, 'add_course_featured_badge' ), 11, 3 );
+			add_filter( 'render_block_core/post-featured-image', [ $this, 'add_badge' ], 10, 3 );
 		}
 	}
 
@@ -41,7 +41,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 *
 	 * @return string
 	 */
-	public function add_featured_label_to_featured_image( string $block_content, array $block, WP_Block $instance ) {
+	public function add_badge( string $block_content, array $block, WP_Block $instance ) {
 		if ( ! isset( $instance->context['postId'] ) ) {
 			return $block_content;
 		}
@@ -70,7 +70,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 *
 	 * @return string $block_content block content.
 	 */
-	public function add_featured_label_to_course_categories( $block_content, $block_parent, WP_Block $instance ): string {
+	public function add_course_featured_badge( $block_content, $block_parent, WP_Block $instance ): string {
 
 		if ( ! isset( $instance->context['postId'] ) ) {
 			return $block_content;

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -50,7 +50,12 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 			return $block_content;
 		}
 
-		return '<div class="featured-image-wrapper"><div class="sensei-lms-featured-badge">' . __( 'Featured', 'sensei-lms' ) . '</div>' . $block_content . '</div>';
+		return '<div class="sensei-lms-course-list-featured-label__image-wrapper">' .
+			'<span class="sensei-lms-course-list-featured-label__text">' .
+				__( 'Featured', 'sensei-lms' ) .
+			'</span>' .
+			$block_content .
+		'</div>';
 	}
 
 	/**
@@ -84,7 +89,12 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 			return $block_content;
 		}
 
-		return '<div class="featured-category-wrapper"><div class="sensei-lms-featured-badge">' . __( 'Featured', 'sensei-lms' ) . '</div>' . $block_content . '</div>';
+		return '<div class="sensei-lms-course-list-featured-label__meta-wrapper">' .
+			'<span class="sensei-lms-course-list-featured-label__text">' .
+				__( 'Featured', 'sensei-lms' ) .
+			'</span>' .
+			$block_content .
+		'</div>';
 	}
 
 	/**

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -24,13 +24,13 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 		$version = str_replace( '-src', '', $wp_version );
 
 		if ( ! version_compare( $version, '5.9', '<' ) ) {
-			add_filter( 'render_block', array( $this, 'add_course_featured_badge' ), 11, 3 );
-			add_filter( 'render_block_core/post-featured-image', [ $this, 'add_badge' ], 10, 3 );
+			add_filter( 'render_block', array( $this, 'add_featured_label_to_course_categories' ), 11, 3 );
+			add_filter( 'render_block_core/post-featured-image', [ $this, 'add_featured_label_to_featured_image' ], 10, 3 );
 		}
 	}
 
 	/**
-	 * Function to add a Featured Course badge to block.
+	 * Add featured label to the featured image block.
 	 *
 	 * @access private
 	 * @since 4.6.4
@@ -41,11 +41,11 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 *
 	 * @return string
 	 */
-	public function add_badge( string $block_content, array $block, WP_Block $instance ) {
+	public function add_featured_label_to_featured_image( string $block_content, array $block, WP_Block $instance ) {
 		if ( ! isset( $instance->context['postId'] ) ) {
 			return $block_content;
 		}
-		// Add featured course badge to a featured image block.
+
 		if ( empty( $block_content ) || 'featured' !== get_post_meta( $instance->context['postId'], '_course_featured', true ) ) {
 			return $block_content;
 		}
@@ -59,7 +59,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	}
 
 	/**
-	 * A function to add a course Featured course badge to the course categories block.
+	 * Add featured label to the course categories block.
 	 *
 	 * @access private
 	 * @since 4.6.4
@@ -70,7 +70,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 *
 	 * @return string $block_content block content.
 	 */
-	public function add_course_featured_badge( $block_content, $block_parent, WP_Block $instance ): string {
+	public function add_featured_label_to_course_categories( $block_content, $block_parent, WP_Block $instance ): string {
 
 		if ( ! isset( $instance->context['postId'] ) ) {
 			return $block_content;
@@ -80,7 +80,6 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 			return $block_content;
 		}
 
-		// Add featured course badge to a featured image block.
 		if ( 'featured' !== get_post_meta( $instance->context['postId'], '_course_featured', true ) ) {
 			return $block_content;
 		}


### PR DESCRIPTION
- Applied styling changes to the featured label and course categories block that are needed for the Course theme. It appears that some styles from the [original design](https://www.figma.com/file/tjUTCmwuHXQHnuA1nVt8dy/Courses-Block?node-id=20017295%3A6109) were missed (e.g. font size, line height), so I've applied these changes globally in the plugin. Other CSS changes specific to the theme are part of https://github.com/Automattic/course/pull/79.
- Enabled the use of the theme's background and foreground colors for the featured label and categories.
- Simplified the markup used in the course category block.
- Made the CSS class names and markup consistent in both the editor and the frontend.
  - **This is a best practice as it makes the CSS simpler and the code easier to maintain.**
- Removed the "No course category" found message from the editor.
- Added a `course-categories-editor.scss` file to ensure styles are applied there as well, as some themes had more specific styles that were overwriting the block's.

## Testing Instructions
- Check out [this branch](https://github.com/Automattic/course/pull/79) to test the Course theme.
- Create multiple courses, each using a different combination of - featured images (some with, some without), course categories (some with, some without), and _Featured Course_ checkbox (some disabled, some enabled).
- Add the Course List block to a page.
- Ensure the editor and front end match in the editor and on the frontend.
- Test on multiple themes, including the Course theme as well as other block-based and classic themes.
- For block-based themes that have defined a color palette entry for `foreground` or `background`, the featured label and course categories block will use those colors.
- For classic themes or block-based themes that have NOT defined a color palette entry for `foreground` or `background`, the featured label will be white text on a black background, while the course categories will be white text on a blue background.

## Course
![Screenshot 2022-11-09 at 2 16 10 PM](https://user-images.githubusercontent.com/1190420/200921027-d91cd29a-ef80-43d5-850c-ddedb2b537e5.jpg)

## Astra
![Screenshot 2022-11-09 at 1 48 21 PM](https://user-images.githubusercontent.com/1190420/200915485-d49178db-da06-472d-a65f-bc9d64fdefca.jpg)

## Divi
![Screenshot 2022-11-09 at 1 49 21 PM](https://user-images.githubusercontent.com/1190420/200915668-f57fce2e-0458-4056-bee5-06edcb437916.jpg)

## Twenty Twenty Two