### PR TITLE
Fix random question set displayed for answered quizzes.

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3634,12 +3634,12 @@ class Sensei_Lesson {
 		if ( ! is_admin() || ( is_admin() && isset( $_GET['page'] ) && 'sensei_grading' === $_GET['page'] && isset( $_GET['user'] ) && isset( $_GET['quiz_id'] ) ) ) {
 
 			// Fetch the questions that the user was asked in their quiz if they have already completed it.
-			$quiz_submission_question_ids = Sensei()->quiz_submission_repository->get_question_ids( $quiz_id, $user_id );
+			$selected_questions = Sensei()->quiz_submission_repository->get_question_ids( $quiz_id, $user_id );
 
-			if ( $quiz_submission_question_ids ) {
+			if ( $selected_questions ) {
 				// Fetch each question in the order in which they were asked.
 				$questions = [];
-				foreach ( $quiz_submission_question_ids as $question_id ) {
+				foreach ( $selected_questions as $question_id ) {
 					$question = get_post( $question_id );
 					if ( ! isset( $question ) || ! isset( $question->ID ) ) {
 						continue;
@@ -3661,7 +3661,7 @@ class Sensei_Lesson {
 				// Include only single questions in the return array.
 				$questions_loop  = $questions_array;
 				$questions_array = [];
-				foreach ( $questions_loop as $k => $question ) {
+				foreach ( $questions_loop as $question ) {
 
 					// If this is a single question then include it.
 					if ( 'question' === $question->post_type ) {


### PR DESCRIPTION
Fixes #6045

### Changes proposed in this Pull Request
- After [last refactor](https://github.com/Automattic/sensei/pull/5631) a condition that was done later was being skipped because the variable name was changed. Reverting variable name to previous one.

### Testing instructions
* Create a Lesson containing a Quiz.
* Add 3 questions to the Quiz.
* Enable "random questions" and limit it to 1 or 2 (less than the total of three).
* As a student answer the quiz.
* Go preview your responses.
* Preview must contain only the previously answered responses.

### Screenshot / Video
![image](https://user-images.githubusercontent.com/799065/201067738-86ad41ed-9a1c-480d-9678-4efd62a8deb2.png)

(Same questions after multiple refreshes)