### PR TITLE
Release 4.8.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,20 @@
 *** Changelog ***
 
-2022-10-27 - Version 4.8.0
+2022-11-10 - version 4.8.1
+* New: Course Overview block for the Course List block [#5996](https://github.com/Automattic/sensei/pull/5996)
+* Add: Message for users without JavaScript enabled on Sensei Home [#6059](https://github.com/Automattic/sensei/pull/6059)
+* Fix: Course start date reset on lesson completion [#6079](https://github.com/Automattic/sensei/pull/6079)
+* Fix: Contact Teacher block not working [#6058](https://github.com/Automattic/sensei/pull/6058)
+* Fix: Random questions change for answered quizzes [#6088](https://github.com/Automattic/sensei/pull/6088)
+* Fix: Issue with enrolling students in the course view in a course with no students [#5583](https://github.com/Automattic/sensei/pull/5583)
+* Fix: Disable broken sorting under Reports [#6094](https://github.com/Automattic/sensei/pull/6094)
+* Fix: Course List buttons extending outside container [#6010](https://github.com/Automattic/sensei/pull/6010)
+* Fix: Checks for modules when adding author name to module name [#6034](https://github.com/Automattic/sensei/pull/6034)
+* Fix: PHP notice on course category archive view [#6069](https://github.com/Automattic/sensei/pull/6069)
+* Fix: Error when activating Sensei LMS + Sensei Pro (WC Paid Courses) [#6080](https://github.com/Automattic/sensei/pull/6080)
+* Fix: Minor cosmetic changes to task list in Sensei Home [#6083](https://github.com/Automattic/sensei/pull/6083)
+
+2022-10-27 - version 4.8.0
 * New: Onboarding Wizard - replaces the older onboarding with a modern flow to help new users get started.
 * New: Sensei Home - replaces the older 'Extensions' menu item with links to support, documentation, and a checklist for new users.
 
@@ -24,7 +38,7 @@
     * Add 'Completed' and 'Next Lesson' button to Lesson Actions [#5784](https://github.com/Automattic/sensei/pull/5784)
     * Handle logged out users for video lessons [#5851](https://github.com/Automattic/sensei/pull/5851)
     * Remove empty style block [#5860](https://github.com/Automattic/sensei/pull/5860)
-    * Fix lesson complete overlay width [#5844](https://github.com/Automattic/sensei/pull/5844) 
+    * Fix lesson complete overlay width [#5844](https://github.com/Automattic/sensei/pull/5844)
     * Improve LM theme compatibilty [#5846](https://github.com/Automattic/sensei/pull/5846)
     * Fix message sent notice [#5843](https://github.com/Automattic/sensei/pull/5843)
     * Replace customize links [#5842](https://github.com/Automattic/sensei/pull/5842)
@@ -63,7 +77,7 @@
 * Fix: Remove the check so that meta data can be saved again [#5830](https://github.com/Automattic/sensei/pull/5830)
 * Fix: Prevent modules to be linked in learning mode [#5809](https://github.com/Automattic/sensei/pull/5809)
 * Fix: Fix draft lessons not getting duplicated with course [#5764](https://github.com/Automattic/sensei/pull/5558com/Automattic/sensei/pull/5764)
-* Fix: Move blocks title, description, keywords to block.json and fix localization [#5782](https://github.com/Automattic/sensei/pull/5558com/Automattic/sensei/pull/5782) 
+* Fix: Move blocks title, description, keywords to block.json and fix localization [#5782](https://github.com/Automattic/sensei/pull/5558com/Automattic/sensei/pull/5782)
 
 2022-09-26 - version 4.6.4
 * Add: Show Course Categories preview [#5513](https://github.com/Automattic/sensei/pull/5513)
@@ -138,16 +152,16 @@
 * Fix: Fix url encoding of timezone for reports [#5362](https://github.com/Automattic/sensei/pull/5362)
 * Fix: Fix Gutenberg compatibility issue [#5379](https://github.com/Automattic/sensei/pull/5379)
 * Fix: Render additional css on feedback answers block [#5371](https://github.com/Automattic/sensei/pull/5371)
-* Fix: Remove additional line from login redirection code [#5380](https://github.com/Automattic/sensei/pull/5380) 
+* Fix: Remove additional line from login redirection code [#5380](https://github.com/Automattic/sensei/pull/5380)
 * Fix: Modules loosing configuration when module is changed [#5387](https://github.com/Automattic/sensei/pull/5387)
 * Tweak: Hide action buttons' notification [#5386](https://github.com/Automattic/sensei/pull/5386)
 
 2022-07-14 - version 4.5.2
 * Add: New upsells students group page
 * Add: `sensei_user_course_end' hook before redirecting to completed page
-* Add: Bump the minimum required PHP version to 7.2 
+* Add: Bump the minimum required PHP version to 7.2
 * Fix: Placeholder images for courses
-* Fix: Update the course Editor to display 'Learners' instead of Students 
+* Fix: Update the course Editor to display 'Learners' instead of Students
 * Fix: Bulk Edit options (on Lessons menu) do not work
 * Fix: Change 'Manage Learners' to 'Manage Students' on the course management meta box
 * Fix: Quiz questions not being properly saved.
@@ -1514,35 +1528,35 @@ Sensei 4.0 is here! This is a major release, which includes a new theme for your
 * Fix: Learner Profiles: display correct url pattern when wp in custom folder. Learner Profiles Settings showing wrong learner URL Pattern when WP installation in custom location
 * Fix: Ordering courses using "menu_order" and Courses > Order Courses doesn't work. WC: Don't construct WC_Orders
 * Fix: Replace 'new WC_Order' with wc_get_order() function.
-* Fix: Course not showing in My Courses if order is manually Completed 
+* Fix: Course not showing in My Courses if order is manually Completed
 * Fix: Simplify CSS for displaying answer feedback
 - Change purchase button text when a course is free. Change "purchase this course" for free products. Change "purchase this course" for free products
 * Fix: Link course to a single variation of a variable WooCommerce product.
 * Fix: Removed learner from Course comeback if see course single page
 * Fix: Scheduled lessons not added to course page. Scheduled lessons should be added to course page
-* Fix: Always show answers filter doesn't work for zero grade questions 
+* Fix: Always show answers filter doesn't work for zero grade questions
 * Fix: Single quotes in video embed HTML breaks on save
 * Fix: WP_Query not getting reset on My Courses page. Reset postdata after resetting $wp_query
 * Fix: Messaging issue on preview lessons. Correct the phrasing for lesson previews on Purchasable courses.
 - Add: Learner Bulk Actions: Make Learner search more flexible.
-- Add: filter sensei_send_message_link 
-* Fix: Learner Profiles can handle email-like usernames. 
+- Add: filter sensei_send_message_link
+* Fix: Learner Profiles can handle email-like usernames.
 * Fix: Lesson: Allow Completing if Quiz has no questions
 * Fix: "Complete Lesson" button missing
-* Fix: Videos visible when prerequisites have not been completed  
+* Fix: Videos visible when prerequisites have not been completed
 * Fix: Modification to users displayed in Analysis?
 * Fix: some of the columns to be sortable for Learners in Analysis overview
-* Fix: Weird html in shortcodes. Fixes excerpts in template to properly nest within paragraphs. 
+* Fix: Weird html in shortcodes. Fixes excerpts in template to properly nest within paragraphs.
 * Fix: New lesson: cannot assign to a module unless a draft is saved first. Lesson Admin: Populate modules on course change
 * Fix: Pagination not working on course archive front page
-* Fix: Featured course filter gives 404 on home page 
+* Fix: Featured course filter gives 404 on home page
 * Fix: Multi Line Quiz responses displayed as HTML if saved and resumed
 * Fix: Can't delete answer feedback
 * Fix: Courses page sorting dropdown problems
 * Fix: Autocomplete processing virtual orders not working
-* Fix: "Free" Course filter displays courses linked to product variations  
+* Fix: "Free" Course filter displays courses linked to product variations
 * Fix: Menu should not collapse when navigated to Messages
-* Fix: Quiz Multiline as HTML is saved for teacher as plaintext- 
+* Fix: Quiz Multiline as HTML is saved for teacher as plaintext-
 * Fix: Sensei/WC Variable product: Start courses only when their variation is purchased
 * Fix: issue preventing course author from syncing with lesson author
 * Fix: Update name of WooThemes Updater plugin in notices

--- a/lang/sensei-lms.pot
+++ b/lang/sensei-lms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sensei LMS 4.8.0\n"
+"Project-Id-Version: Sensei LMS 4.8.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sensei-lms\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-10-27T16:25:33-03:00\n"
+"POT-Creation-Date: 2022-11-10T17:46:50+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: sensei-lms\n"
@@ -69,10 +69,10 @@ msgstr ""
 #: includes/admin/class-sensei-learners-main.php:387
 #: includes/admin/tools/class-sensei-tool-enrolment-debug.php:214
 #: includes/blocks/class-sensei-course-outline-module-block.php:132
-#: includes/class-sensei-analysis-course-list-table.php:353
-#: includes/class-sensei-analysis-course-list-table.php:446
-#: includes/class-sensei-analysis-lesson-list-table.php:224
-#: includes/class-sensei-analysis-user-profile-list-table.php:216
+#: includes/class-sensei-analysis-course-list-table.php:338
+#: includes/class-sensei-analysis-course-list-table.php:431
+#: includes/class-sensei-analysis-lesson-list-table.php:220
+#: includes/class-sensei-analysis-user-profile-list-table.php:212
 #: includes/class-sensei-course.php:3194
 #: includes/class-sensei-grading-main.php:254
 #: includes/class-sensei-grading-main.php:517
@@ -127,7 +127,7 @@ msgstr ""
 #: includes/class-sensei-lesson.php:479
 #: includes/class-sensei-lesson.php:1686
 #: includes/class-sensei-modules.php:296
-#: includes/class-sensei-utils.php:2090
+#: includes/class-sensei-utils.php:2092
 #: assets/blocks/lesson-properties/constants.js:9
 #: assets/dist/blocks/single-lesson.js:360
 #: assets/dist/course-theme/blocks/index.js:212
@@ -232,9 +232,9 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:106
 #: includes/admin/class-sensei-learners-main.php:1068
-#: includes/class-sensei-analysis-course-list-table.php:741
-#: includes/class-sensei-analysis-lesson-list-table.php:373
-#: includes/class-sensei-analysis-user-profile-list-table.php:355
+#: includes/class-sensei-analysis-course-list-table.php:727
+#: includes/class-sensei-analysis-lesson-list-table.php:369
+#: includes/class-sensei-analysis-user-profile-list-table.php:351
 #: includes/class-sensei-grading-main.php:419
 #: includes/class-sensei-list-table.php:127
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:265
@@ -246,6 +246,7 @@ msgstr ""
 msgid "Students (%d)"
 msgstr ""
 
+#. translators: Placeholder value is total count of students.
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:138
 #: includes/class-sensei-analysis-course-list-table.php:104
 #: includes/class-sensei-analysis-overview-list-table.php:121
@@ -276,7 +277,7 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:204
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:444
-#: includes/class-sensei-analysis-course-list-table.php:501
+#: includes/class-sensei-analysis-course-list-table.php:486
 #: includes/class-sensei-analysis-overview-list-table.php:164
 #: includes/class-sensei-analysis-overview-list-table.php:376
 #: includes/class-sensei-analysis-overview-list-table.php:393
@@ -310,8 +311,8 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:308
 #: includes/admin/class-sensei-learners-main.php:963
-#: includes/class-sensei-analysis-course-list-table.php:659
-#: includes/class-sensei-analysis-lesson-list-table.php:338
+#: includes/class-sensei-analysis-course-list-table.php:645
+#: includes/class-sensei-analysis-lesson-list-table.php:334
 msgid "No students found."
 msgstr ""
 
@@ -340,7 +341,7 @@ msgid "Filter By Course"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:417
-#: includes/class-sensei-analysis-course-list-table.php:773
+#: includes/class-sensei-analysis-course-list-table.php:759
 #: includes/class-sensei-analysis-overview-list-table.php:923
 #: includes/class-sensei-lesson.php:1754
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:354
@@ -349,8 +350,8 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:429
 #: includes/admin/class-sensei-learners-main.php:1228
-#: includes/class-sensei-analysis-course-list-table.php:823
-#: includes/class-sensei-analysis-lesson-list-table.php:404
+#: includes/class-sensei-analysis-course-list-table.php:809
+#: includes/class-sensei-analysis-lesson-list-table.php:400
 #: includes/class-sensei-analysis-overview-list-table.php:1058
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php:205
 msgid "Search Students"
@@ -395,7 +396,7 @@ msgstr ""
 #: includes/admin/class-sensei-learners-main.php:171
 #: includes/class-sensei-analysis-course-list-table.php:105
 #: includes/class-sensei-analysis-course-list-table.php:118
-#: includes/class-sensei-analysis-course-list-table.php:750
+#: includes/class-sensei-analysis-course-list-table.php:736
 #: includes/class-sensei-analysis-lesson-list-table.php:50
 #: includes/class-sensei-analysis-user-profile-list-table.php:49
 msgid "Date Started"
@@ -464,9 +465,9 @@ msgstr ""
 #: assets/blocks/course-completed-actions/index.js:23
 #: assets/blocks/course-list-block/index.js:49
 #: assets/blocks/take-course-block/index.js:28
-#: assets/dist/blocks/global-blocks.js:186
-#: assets/dist/blocks/global-blocks.js:309
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:200
+#: assets/dist/blocks/global-blocks.js:323
+#: assets/dist/blocks/global-blocks.js:584
 #: assets/dist/blocks/shared.js:239
 #: assets/dist/blocks/single-page.js:213
 msgid "Course"
@@ -497,11 +498,11 @@ msgstr[1] ""
 #: includes/blocks/course-list/class-sensei-course-list-student-course-filter.php:43
 #: includes/blocks/course-theme/class-lesson-actions.php:77
 #: includes/class-sensei-analysis-course-list-table.php:129
-#: includes/class-sensei-analysis-course-list-table.php:348
-#: includes/class-sensei-analysis-course-list-table.php:422
-#: includes/class-sensei-analysis-lesson-list-table.php:210
+#: includes/class-sensei-analysis-course-list-table.php:333
+#: includes/class-sensei-analysis-course-list-table.php:407
+#: includes/class-sensei-analysis-lesson-list-table.php:206
 #: includes/class-sensei-analysis-overview-list-table.php:93
-#: includes/class-sensei-analysis-user-profile-list-table.php:209
+#: includes/class-sensei-analysis-user-profile-list-table.php:205
 #: includes/class-sensei-course.php:3170
 #: includes/class-sensei-grading-main.php:239
 #: includes/class-sensei-modules.php:863
@@ -513,7 +514,7 @@ msgstr[1] ""
 #: assets/blocks/course-outline/status-preview/status-control/index.js:18
 #: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:44
 #: assets/data-port/import/done/done-page.js:91
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 #: assets/dist/blocks/single-course.js:500
 #: assets/dist/blocks/single-lesson.js:270
 #: assets/dist/blocks/single-page.js:213
@@ -558,7 +559,7 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:471
 #: assets/blocks/take-course-block/index.js:27
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Enroll"
 msgstr ""
 
@@ -590,12 +591,12 @@ msgid "Update Student"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:967
-#: includes/class-sensei-analysis-course-list-table.php:664
+#: includes/class-sensei-analysis-course-list-table.php:650
 msgid "No lessons found."
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:973
-#: includes/class-sensei-analysis-user-profile-list-table.php:320
+#: includes/class-sensei-analysis-user-profile-list-table.php:316
 #: assets/admin/students/student-modal/course-list.js:37
 #: assets/dist/admin/students/student-action-menu/index.js:59
 #: assets/dist/admin/students/student-bulk-action-button/index.js:45
@@ -675,7 +676,7 @@ msgid "Student will also be added to the course '%1$s' if they are not already t
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1232
-#: includes/class-sensei-analysis-course-list-table.php:828
+#: includes/class-sensei-analysis-course-list-table.php:814
 #: includes/class-sensei-analysis-overview-list-table.php:1053
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php:235
 msgid "Search Lessons"
@@ -683,7 +684,7 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1236
 #: includes/class-sensei-analysis-overview-list-table.php:1049
-#: includes/class-sensei-analysis-user-profile-list-table.php:385
+#: includes/class-sensei-analysis-user-profile-list-table.php:381
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:439
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php:274
 msgid "Search Courses"
@@ -708,7 +709,7 @@ msgstr ""
 #: includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php:24
 #: includes/class-sensei-admin.php:1854
 #: includes/class-sensei-analysis-overview-list-table.php:989
-#: includes/class-sensei-analysis-user-profile-list-table.php:330
+#: includes/class-sensei-analysis-user-profile-list-table.php:326
 #: includes/class-sensei-analysis.php:111
 #: includes/class-sensei-course.php:205
 #: includes/class-sensei-course.php:2933
@@ -720,7 +721,7 @@ msgstr ""
 #: includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php:55
 #: assets/blocks/course-completed-actions/index.js:49
 #: assets/blocks/course-list-block/index.js:51
-#: assets/dist/blocks/global-blocks.js:309
+#: assets/dist/blocks/global-blocks.js:323
 #: assets/dist/blocks/shared.js:239
 #: assets/dist/blocks/single-page.js:213
 #: assets/dist/data-port/export.js:187
@@ -1314,12 +1315,16 @@ msgstr ""
 msgid "Trigger Course Enrollment Recalculation"
 msgstr ""
 
-#: includes/admin/views/html-admin-page-home-messages.php:23
-msgid "More Information &rarr;"
+#: includes/admin/views/html-admin-page-home.php:14
+msgid "Sensei Home"
 msgstr ""
 
-#: includes/admin/views/html-admin-page-home.php:13
-msgid "Sensei Home"
+#: includes/admin/views/html-admin-page-home.php:19
+msgid "Error while loading Sensei Home"
+msgstr ""
+
+#: includes/admin/views/html-admin-page-home.php:21
+msgid "This page requires JavaScript to work. Please enable JavaScript in your browser settings."
 msgstr ""
 
 #: includes/admin/views/html-admin-page-tools-header.php:26
@@ -1342,7 +1347,7 @@ msgstr ""
 msgid "Courses displayed in a list"
 msgstr ""
 
-#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:102
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:104
 msgid "Courses displayed in a grid"
 msgstr ""
 
@@ -1374,7 +1379,7 @@ msgstr ""
 #: includes/block-patterns/course/templates/video-hero.php:139
 #: includes/block-patterns/course/templates/video-hero.php:182
 #: assets/blocks/take-course-block/index.js:33
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Take Course"
 msgstr ""
 
@@ -1556,7 +1561,7 @@ msgstr ""
 
 #: includes/block-patterns/course/templates/long-sales-page.php:200
 #: includes/block-patterns/course/templates/video-hero.php:186
-#: includes/blocks/class-sensei-block-contact-teacher.php:70
+#: includes/blocks/class-sensei-block-contact-teacher.php:71
 #: includes/class-sensei-messages.php:271
 #: assets/blocks/contact-teacher-block/index.js:13
 #: assets/blocks/contact-teacher-block/index.js:27
@@ -1746,29 +1751,29 @@ msgstr ""
 msgid "Zoom/Meeting"
 msgstr ""
 
-#: includes/blocks/class-sensei-block-contact-teacher.php:47
+#: includes/blocks/class-sensei-block-contact-teacher.php:48
 msgid "Your private message has been sent."
 msgstr ""
 
-#: includes/blocks/class-sensei-block-contact-teacher.php:80
+#: includes/blocks/class-sensei-block-contact-teacher.php:81
 #: assets/shared/components/modal/index.js:63
 msgid "Close"
 msgstr ""
 
-#: includes/blocks/class-sensei-block-contact-teacher.php:108
+#: includes/blocks/class-sensei-block-contact-teacher.php:109
 msgid "Contact your teacher"
 msgstr ""
 
-#: includes/blocks/class-sensei-block-contact-teacher.php:109
+#: includes/blocks/class-sensei-block-contact-teacher.php:110
 msgid "Enter your message"
 msgstr ""
 
-#: includes/blocks/class-sensei-block-contact-teacher.php:115
+#: includes/blocks/class-sensei-block-contact-teacher.php:116
 #: includes/class-sensei-messages.php:346
 msgid "Send Message"
 msgstr ""
 
-#: includes/blocks/class-sensei-block-contact-teacher.php:119
+#: includes/blocks/class-sensei-block-contact-teacher.php:120
 msgid "Your message has been sent"
 msgstr ""
 
@@ -1793,6 +1798,7 @@ msgstr ""
 msgid "Cannot register for an unpublished course.  Please publish the course first."
 msgstr ""
 
+#. Translators: placeholder is the lesson title.
 #: includes/blocks/class-sensei-course-outline-lesson-block.php:47
 #: includes/blocks/course-theme/class-course-navigation.php:256
 #: includes/class-sensei-frontend.php:1122
@@ -1812,6 +1818,12 @@ msgstr ""
 #: assets/blocks/course-outline/module-block/module-edit.js:211
 #: assets/dist/blocks/single-course.js:381
 msgid "Toggle module content"
+msgstr ""
+
+#: includes/blocks/class-sensei-course-overview-block.php:51
+#: assets/blocks/course-overview-block/course-overview-edit.js:36
+#: assets/dist/blocks/global-blocks.js:521
+msgid "Course Overview"
 msgstr ""
 
 #. translators: %1$d number of lessons completed, %2$d number of total lessons, %3$s percentage.
@@ -1865,8 +1877,8 @@ msgstr ""
 #: assets/blocks/course-list-block/featured-label/index.js:39
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:45
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:52
-#: assets/dist/blocks/global-blocks.js:290
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:304
+#: assets/dist/blocks/global-blocks.js:358
 #: assets/dist/blocks/shared.js:220
 msgid "Featured"
 msgstr ""
@@ -1874,7 +1886,7 @@ msgstr ""
 #: includes/blocks/course-list/class-sensei-course-list-categories-filter.php:45
 #: includes/class-sensei-lesson.php:1748
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:37
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 msgid "All Categories"
 msgstr ""
 
@@ -1884,7 +1896,7 @@ msgstr ""
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:48
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:62
 #: assets/blocks/learner-courses-block/learner-courses-edit.js:99
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 #: assets/dist/blocks/single-page.js:264
 msgid "All Courses"
 msgstr ""
@@ -1893,7 +1905,7 @@ msgstr ""
 #: includes/shortcodes/class-sensei-shortcode-user-courses.php:569
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:66
 #: assets/course-theme/learning-mode-templates/template-option/template-option-footer.js:40
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 #: assets/dist/course-theme/learning-mode-templates/index.js:38
 msgid "Active"
 msgstr ""
@@ -1926,6 +1938,7 @@ msgstr ""
 msgid "View quiz for %s"
 msgstr ""
 
+#. Translators: placeholder is the lesson title.
 #: includes/blocks/course-theme/class-course-navigation.php:260
 #: includes/class-sensei-posttypes.php:809
 #: assets/blocks/lesson-actions/view-quiz-block/index.js:21
@@ -2164,77 +2177,77 @@ msgstr ""
 msgid "Average Grade"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:406
+#: includes/class-sensei-analysis-course-list-table.php:391
 msgid "Not started"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:425
-#: includes/class-sensei-analysis-lesson-list-table.php:211
+#: includes/class-sensei-analysis-course-list-table.php:410
+#: includes/class-sensei-analysis-lesson-list-table.php:207
 #: includes/class-sensei-grading-main.php:240
 msgid "No Grade"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:427
-#: includes/class-sensei-analysis-lesson-list-table.php:213
+#: includes/class-sensei-analysis-course-list-table.php:412
+#: includes/class-sensei-analysis-lesson-list-table.php:209
 #: includes/class-sensei-grading-main.php:242
 #: includes/class-sensei-grading-main.php:510
 msgid "Graded"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:432
-#: includes/class-sensei-analysis-lesson-list-table.php:216
+#: includes/class-sensei-analysis-course-list-table.php:417
+#: includes/class-sensei-analysis-lesson-list-table.php:212
 #: includes/class-sensei-grading-main.php:245
 msgid "Passed"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:437
-#: includes/class-sensei-analysis-lesson-list-table.php:219
+#: includes/class-sensei-analysis-course-list-table.php:422
+#: includes/class-sensei-analysis-lesson-list-table.php:215
 #: includes/class-sensei-grading-main.php:248
 #: assets/data-port/import/done/done-page.js:38
 #: assets/dist/data-port/import.js:393
 msgid "Failed"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:442
-#: includes/class-sensei-analysis-lesson-list-table.php:222
+#: includes/class-sensei-analysis-course-list-table.php:427
+#: includes/class-sensei-analysis-lesson-list-table.php:218
 #: includes/class-sensei-grading-main.php:251
 #: includes/class-sensei-grading-main.php:503
 msgid "Ungraded"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:687
+#: includes/class-sensei-analysis-course-list-table.php:673
 msgid "Other Students taking this Course"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:689
+#: includes/class-sensei-analysis-course-list-table.php:675
 msgid "Students taking this Course"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:691
+#: includes/class-sensei-analysis-course-list-table.php:677
 msgid "Lessons in this Course"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:759
+#: includes/class-sensei-analysis-course-list-table.php:745
 #: includes/class-sensei-analysis-overview-list-table.php:908
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:323
 msgid "Start Date"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:769
+#: includes/class-sensei-analysis-course-list-table.php:755
 #: includes/class-sensei-analysis-overview-list-table.php:918
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:333
 msgid "End Date"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:811
-#: includes/class-sensei-analysis-lesson-list-table.php:393
+#: includes/class-sensei-analysis-course-list-table.php:797
+#: includes/class-sensei-analysis-lesson-list-table.php:389
 #: includes/class-sensei-analysis-overview-list-table.php:1037
-#: includes/class-sensei-analysis-user-profile-list-table.php:375
+#: includes/class-sensei-analysis-user-profile-list-table.php:371
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:432
 msgid "Export all rows (CSV)"
 msgstr ""
 
-#: includes/class-sensei-analysis-lesson-list-table.php:348
+#: includes/class-sensei-analysis-lesson-list-table.php:344
 msgid "Students taking this Lesson"
 msgstr ""
 
@@ -2557,7 +2570,7 @@ msgstr ""
 #: assets/blocks/learner-courses-block/learner-courses-edit.js:180
 #: assets/blocks/view-results-block/index.js:22
 #: assets/blocks/view-results-block/index.js:25
-#: assets/dist/blocks/global-blocks.js:558
+#: assets/dist/blocks/global-blocks.js:596
 #: assets/dist/blocks/single-page.js:267
 msgid "View Results"
 msgstr ""
@@ -2819,6 +2832,7 @@ msgstr ""
 msgid "Part of: %s"
 msgstr ""
 
+#. translators: Placeholder is a link to the Course permalink.
 #: includes/class-sensei-frontend.php:1108
 #: widgets/class-sensei-lesson-component-widget.php:223
 msgid "View course"
@@ -3196,7 +3210,6 @@ msgid "Control how students progress through the course based on their interacti
 msgstr ""
 
 #: includes/class-sensei-lesson.php:590
-#: includes/class-sensei-settings.php:941
 #: assets/course-theme/learning-mode-templates/template-actions.js:59
 #: assets/dist/course-theme/learning-mode-templates/index.js:30
 msgid "Customize"
@@ -3937,7 +3950,7 @@ msgid "&larr; Back to Modules"
 msgstr ""
 
 #. translators: %s: add new taxonomy label
-#: includes/class-sensei-modules.php:2266
+#: includes/class-sensei-modules.php:2269
 msgid "+ %s"
 msgstr ""
 
@@ -4176,7 +4189,7 @@ msgstr ""
 
 #: includes/class-sensei-posttypes.php:717
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:34
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 msgid "Categories"
 msgstr ""
 
@@ -4308,6 +4321,7 @@ msgstr ""
 msgid "%1$s updated. %2$sView %1$s%3$s."
 msgstr ""
 
+#. translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
 #: includes/class-sensei-posttypes.php:905
 msgid "Custom field updated."
 msgstr ""
@@ -4980,8 +4994,12 @@ msgstr ""
 msgid "Select a Page:"
 msgstr ""
 
-#: includes/class-sensei-settings.php:933
+#: includes/class-sensei-settings.php:938
 msgid "Enable for all courses"
+msgstr ""
+
+#: includes/class-sensei-settings.php:947
+msgid "Customize Colors"
 msgstr ""
 
 #: includes/class-sensei-teacher.php:120
@@ -5126,7 +5144,7 @@ msgid "View the lesson quiz"
 msgstr ""
 
 #. translators: Time difference between two dates. %s: Number of seconds/minutes/etc.
-#: includes/class-sensei-utils.php:2607
+#: includes/class-sensei-utils.php:2609
 msgid "%s ago"
 msgstr ""
 
@@ -5217,7 +5235,7 @@ msgstr ""
 #: includes/course-theme/class-sensei-course-theme-lesson.php:279
 #: includes/course-theme/class-sensei-course-theme-lesson.php:315
 #: assets/blocks/take-course-block/index.js:29
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Take course"
 msgstr ""
 
@@ -5297,6 +5315,7 @@ msgstr ""
 msgid "Lesson (Learning Mode - %1$s)"
 msgstr ""
 
+#. translators: %1$s is the block template name.
 #: includes/course-theme/class-sensei-course-theme-templates.php:199
 msgid "Displays course content."
 msgstr ""
@@ -5306,11 +5325,12 @@ msgstr ""
 msgid "Quiz (Learning Mode - %1$s)"
 msgstr ""
 
+#. translators: %1$s is the block template name.
 #: includes/course-theme/class-sensei-course-theme-templates.php:211
 msgid "Displays a lesson quiz."
 msgstr ""
 
-#: includes/course-theme/class-sensei-course-theme.php:508
+#: includes/course-theme/class-sensei-course-theme.php:522
 msgid "Edit Site"
 msgstr ""
 
@@ -5567,6 +5587,7 @@ msgstr ""
 msgid "[%1$s] You have completed a course"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-learner-completed-course.php:64
 msgid "You have completed a course"
 msgstr ""
@@ -5588,6 +5609,7 @@ msgstr ""
 msgid "[%1$s] Your quiz has been graded"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-learner-graded-quiz.php:66
 msgid "Your quiz has been graded"
 msgstr ""
@@ -5597,6 +5619,7 @@ msgstr ""
 msgid "[%1$s] You have completed a quiz"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-learner-graded-quiz.php:80
 msgid "You have completed a quiz"
 msgstr ""
@@ -5606,6 +5629,7 @@ msgstr ""
 msgid "[%1$s] You have a new message"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-new-message-reply.php:98
 msgid "You have received a reply to your private message"
 msgstr ""
@@ -5615,6 +5639,7 @@ msgstr ""
 msgid "[%1$s] Your student has completed a course"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-teacher-completed-course.php:65
 msgid "Your student has completed a course"
 msgstr ""
@@ -5624,6 +5649,7 @@ msgstr ""
 msgid "[%1$s] Your student has completed a lesson"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-teacher-completed-lesson.php:35
 msgid "Your student has completed a lesson"
 msgstr ""
@@ -5641,6 +5667,7 @@ msgstr ""
 msgid "[%1$s] You have received a new private message"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-teacher-new-message.php:61
 msgid "Your student has sent you a private message"
 msgstr ""
@@ -5650,6 +5677,7 @@ msgstr ""
 msgid "[%1$s] Your student has submitted a quiz for grading"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-teacher-quiz-submitted.php:67
 msgid "Your student has submitted a quiz for grading"
 msgstr ""
@@ -5659,6 +5687,7 @@ msgstr ""
 msgid "[%1$s] Your student has started a course"
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/emails/class-sensei-email-teacher-started-course.php:60
 msgid "Your student has started a course"
 msgstr ""
@@ -6034,7 +6063,7 @@ msgstr ""
 msgid "Take This Course"
 msgstr ""
 
-#: sensei-lms.php:73
+#: sensei-lms.php:78
 msgid "Deactivate other instances of Sensei LMS before activating this plugin."
 msgstr ""
 
@@ -6335,7 +6364,7 @@ msgstr ""
 #: assets/data-port/import/upload/upload-page.js:72
 #: assets/dist/admin/editor-wizard/index.js:73
 #: assets/dist/admin/editor-wizard/index.js:107
-#: assets/dist/blocks/global-blocks.js:186
+#: assets/dist/blocks/global-blocks.js:200
 #: assets/dist/blocks/single-lesson.js:329
 #: assets/dist/data-port/export.js:33
 #: assets/dist/data-port/import.js:532
@@ -6627,7 +6656,7 @@ msgid "Search courses"
 msgstr ""
 
 #: assets/blocks/button/button-edit.js:36
-#: assets/dist/blocks/global-blocks.js:97
+#: assets/dist/blocks/global-blocks.js:111
 #: assets/dist/blocks/shared.js:77
 #: assets/dist/blocks/single-lesson.js:77
 #: assets/dist/blocks/single-page.js:129
@@ -6636,7 +6665,7 @@ msgstr ""
 
 #: assets/blocks/button/button-settings.js:24
 #: assets/blocks/course-outline/module-block/module-settings.js:25
-#: assets/dist/blocks/global-blocks.js:146
+#: assets/dist/blocks/global-blocks.js:160
 #: assets/dist/blocks/shared.js:126
 #: assets/dist/blocks/single-course.js:390
 #: assets/dist/blocks/single-lesson.js:126
@@ -6645,8 +6674,8 @@ msgid "Border settings"
 msgstr ""
 
 #: assets/blocks/button/button-settings.js:28
-#: assets/dist/blocks/global-blocks.js:146
-#: assets/dist/blocks/global-blocks.js:591
+#: assets/dist/blocks/global-blocks.js:160
+#: assets/dist/blocks/global-blocks.js:629
 #: assets/dist/blocks/shared.js:126
 #: assets/dist/blocks/single-lesson.js:126
 #: assets/dist/blocks/single-page.js:178
@@ -6656,7 +6685,7 @@ msgid "Border radius"
 msgstr ""
 
 #: assets/blocks/button/button-settings.js:55
-#: assets/dist/blocks/global-blocks.js:148
+#: assets/dist/blocks/global-blocks.js:162
 #: assets/dist/blocks/shared.js:128
 #: assets/dist/blocks/single-lesson.js:128
 #: assets/dist/blocks/single-page.js:180
@@ -6666,8 +6695,8 @@ msgstr ""
 #: assets/blocks/button/color-hooks.js:43
 #: assets/blocks/course-categories-block/course-categories-edit.js:138
 #: assets/blocks/course-outline/lesson-block/lesson-edit.js:123
-#: assets/dist/blocks/global-blocks.js:154
-#: assets/dist/blocks/global-blocks.js:238
+#: assets/dist/blocks/global-blocks.js:168
+#: assets/dist/blocks/global-blocks.js:252
 #: assets/dist/blocks/shared.js:134
 #: assets/dist/blocks/single-course.js:328
 #: assets/dist/blocks/single-lesson.js:134
@@ -6680,9 +6709,9 @@ msgstr ""
 #: assets/blocks/course-outline/lesson-block/lesson-edit.js:127
 #: assets/blocks/course-outline/module-block/module-edit.js:254
 #: assets/blocks/course-progress-block/course-progress-edit.js:131
-#: assets/dist/blocks/global-blocks.js:154
-#: assets/dist/blocks/global-blocks.js:238
-#: assets/dist/blocks/global-blocks.js:508
+#: assets/dist/blocks/global-blocks.js:168
+#: assets/dist/blocks/global-blocks.js:252
+#: assets/dist/blocks/global-blocks.js:546
 #: assets/dist/blocks/shared.js:134
 #: assets/dist/blocks/single-course.js:328
 #: assets/dist/blocks/single-course.js:370
@@ -6692,7 +6721,7 @@ msgid "Text color"
 msgstr ""
 
 #: assets/blocks/button/index.js:29
-#: assets/dist/blocks/global-blocks.js:173
+#: assets/dist/blocks/global-blocks.js:187
 #: assets/dist/blocks/shared.js:153
 #: assets/dist/blocks/single-lesson.js:153
 #: assets/dist/blocks/single-page.js:205
@@ -6700,7 +6729,7 @@ msgid "Fill"
 msgstr ""
 
 #: assets/blocks/button/index.js:33
-#: assets/dist/blocks/global-blocks.js:173
+#: assets/dist/blocks/global-blocks.js:187
 #: assets/dist/blocks/shared.js:153
 #: assets/dist/blocks/single-lesson.js:153
 #: assets/dist/blocks/single-page.js:205
@@ -6708,7 +6737,7 @@ msgid "Outline"
 msgstr ""
 
 #: assets/blocks/button/index.js:37
-#: assets/dist/blocks/global-blocks.js:173
+#: assets/dist/blocks/global-blocks.js:187
 #: assets/dist/blocks/shared.js:153
 #: assets/dist/blocks/single-lesson.js:153
 #: assets/dist/blocks/single-page.js:205
@@ -6716,7 +6745,7 @@ msgid "Link"
 msgstr ""
 
 #: assets/blocks/button/index.js:145
-#: assets/dist/blocks/global-blocks.js:173
+#: assets/dist/blocks/global-blocks.js:187
 #: assets/dist/blocks/shared.js:153
 #: assets/dist/blocks/single-lesson.js:153
 #: assets/dist/blocks/single-page.js:205
@@ -6739,12 +6768,12 @@ msgid "Enable a registered user to contact the teacher. This block is only displ
 msgstr ""
 
 #: assets/blocks/course-actions-block/continue-course/index.js:19
-#: assets/dist/blocks/global-blocks.js:186
+#: assets/dist/blocks/global-blocks.js:200
 msgid "Continue Course"
 msgstr ""
 
 #: assets/blocks/course-actions-block/continue-course/index.js:20
-#: assets/dist/blocks/global-blocks.js:186
+#: assets/dist/blocks/global-blocks.js:200
 msgid "Enable a student to pick up where they left off in a course."
 msgstr ""
 
@@ -6753,7 +6782,7 @@ msgstr ""
 #: assets/blocks/lesson-actions/next-lesson-block/index.js:27
 #: assets/blocks/lesson-actions/reset-lesson-block/index.js:29
 #: assets/blocks/lesson-actions/view-quiz-block/index.js:23
-#: assets/dist/blocks/global-blocks.js:186
+#: assets/dist/blocks/global-blocks.js:200
 #: assets/dist/blocks/single-lesson.js:202
 #: assets/dist/blocks/single-lesson.js:329
 #: assets/dist/blocks/single-lesson.js:341
@@ -6763,38 +6792,38 @@ msgstr ""
 
 #: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:15
 #: assets/blocks/course-actions-block/course-actions/index.js:22
-#: assets/dist/blocks/global-blocks.js:193
-#: assets/dist/blocks/global-blocks.js:216
+#: assets/dist/blocks/global-blocks.js:207
+#: assets/dist/blocks/global-blocks.js:230
 msgid "Start Course"
 msgstr ""
 
 #: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:22
-#: assets/dist/blocks/global-blocks.js:193
+#: assets/dist/blocks/global-blocks.js:207
 msgid "Visit Results"
 msgstr ""
 
 #: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:39
-#: assets/dist/blocks/global-blocks.js:195
+#: assets/dist/blocks/global-blocks.js:209
 msgid "The Course Actions block can only be used inside the Course List block."
 msgstr ""
 
 #: assets/blocks/course-categories-block/course-categories-edit.js:102
-#: assets/dist/blocks/global-blocks.js:245
+#: assets/dist/blocks/global-blocks.js:259
 msgid "The Course Categories block can only be used inside the Course List block."
 msgstr ""
 
 #: assets/blocks/course-categories-block/course-categories-edit.js:123
-#: assets/dist/blocks/global-blocks.js:245
+#: assets/dist/blocks/global-blocks.js:259
 msgid "No course category"
 msgstr ""
 
 #: assets/blocks/course-categories-block/index.js:23
-#: assets/dist/blocks/global-blocks.js:273
+#: assets/dist/blocks/global-blocks.js:287
 msgid "Music"
 msgstr ""
 
 #: assets/blocks/course-categories-block/index.js:27
-#: assets/dist/blocks/global-blocks.js:273
+#: assets/dist/blocks/global-blocks.js:287
 msgid "Movies"
 msgstr ""
 
@@ -6835,42 +6864,42 @@ msgstr ""
 
 #: assets/blocks/course-list-block/hooks.js:88
 #: assets/blocks/learner-courses-block/learner-courses-settings.js:60
-#: assets/dist/blocks/global-blocks.js:297
+#: assets/dist/blocks/global-blocks.js:311
 #: assets/dist/blocks/shared.js:227
 #: assets/dist/blocks/single-page.js:276
 msgid "Grid view"
 msgstr ""
 
 #: assets/blocks/course-list-block/index.js:44
-#: assets/dist/blocks/global-blocks.js:309
+#: assets/dist/blocks/global-blocks.js:323
 #: assets/dist/blocks/shared.js:239
 msgid "Course List"
 msgstr ""
 
 #: assets/blocks/course-list-block/index.js:45
-#: assets/dist/blocks/global-blocks.js:309
+#: assets/dist/blocks/global-blocks.js:323
 #: assets/dist/blocks/shared.js:239
 msgid "Show a list of courses."
 msgstr ""
 
 #: assets/blocks/course-list-block/index.js:50
-#: assets/dist/blocks/global-blocks.js:309
+#: assets/dist/blocks/global-blocks.js:323
 #: assets/dist/blocks/shared.js:239
 msgid "List"
 msgstr ""
 
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:59
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 msgid "Student Courses"
 msgstr ""
 
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:118
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 msgid "The Course List Filter block can only be used inside the Course List block."
 msgstr ""
 
 #: assets/blocks/course-list-filter-block/course-list-filter-edit.js:129
-#: assets/dist/blocks/global-blocks.js:344
+#: assets/dist/blocks/global-blocks.js:358
 msgid "Filter Type"
 msgstr ""
 
@@ -7045,28 +7074,33 @@ msgstr ""
 msgid "Preview a status. The actual status that the student sees is determined by their progress in the course."
 msgstr ""
 
+#: assets/blocks/course-overview-block/course-overview-edit.js:25
+#: assets/dist/blocks/global-blocks.js:521
+msgid "The Course Overview block can only be used inside the Course List block."
+msgstr ""
+
 #: assets/blocks/course-progress-block/course-progress-edit.js:85
-#: assets/dist/blocks/global-blocks.js:508
+#: assets/dist/blocks/global-blocks.js:546
 msgid "The Course Progress block can only be used inside the Course List block."
 msgstr ""
 
 #: assets/blocks/course-progress-block/course-progress-edit.js:102
 #: assets/blocks/learner-courses-block/learner-courses-edit.js:168
-#: assets/dist/blocks/global-blocks.js:508
+#: assets/dist/blocks/global-blocks.js:546
 #: assets/dist/blocks/single-page.js:267
 msgid "lessons"
 msgstr ""
 
 #: assets/blocks/course-progress-block/course-progress-edit.js:123
 #: assets/blocks/quiz/quiz-block/quiz-settings.js:297
-#: assets/dist/blocks/global-blocks.js:508
+#: assets/dist/blocks/global-blocks.js:546
 #: assets/dist/blocks/quiz/index.js:855
 msgid "Progress bar color"
 msgstr ""
 
 #: assets/blocks/course-progress-block/course-progress-edit.js:127
 #: assets/blocks/quiz/quiz-block/quiz-settings.js:306
-#: assets/dist/blocks/global-blocks.js:508
+#: assets/dist/blocks/global-blocks.js:546
 #: assets/dist/blocks/quiz/index.js:855
 msgid "Progress bar background color"
 msgstr ""
@@ -7180,7 +7214,7 @@ msgstr ""
 
 #: assets/blocks/learner-courses-block/learner-courses-settings.js:138
 #: assets/blocks/quiz/quiz-block/quiz-settings.js:275
-#: assets/dist/blocks/global-blocks.js:611
+#: assets/dist/blocks/global-blocks.js:649
 #: assets/dist/blocks/quiz/index.js:855
 #: assets/dist/blocks/shared.js:309
 #: assets/dist/blocks/single-course.js:688
@@ -7628,7 +7662,7 @@ msgid "PX"
 msgstr ""
 
 #: assets/blocks/quiz/quiz-block/pagination-settings.js:143
-#: assets/dist/blocks/global-blocks.js:591
+#: assets/dist/blocks/global-blocks.js:629
 #: assets/dist/blocks/quiz/index.js:777
 #: assets/dist/blocks/single-page.js:346
 #: assets/shared/blocks/progress-bar/progress-bar-settings.js:50
@@ -7815,47 +7849,47 @@ msgid "Quiz settings and questions could not be updated. %s"
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:17
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Course Signup"
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:18
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Enable a registered user to start the course. This block is only displayed if the user is not already enrolled."
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:23
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Start"
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:24
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Sign up"
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:25
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Signup"
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:26
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "Enrol"
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:38
-#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/global-blocks.js:584
 msgid "The Course Signup block can only be used inside the Course List block."
 msgstr ""
 
 #: assets/blocks/view-results-block/index.js:18
-#: assets/dist/blocks/global-blocks.js:558
+#: assets/dist/blocks/global-blocks.js:596
 msgid "Enable a student to view their course results."
 msgstr ""
 
 #: assets/blocks/view-results-block/index.js:35
-#: assets/dist/blocks/global-blocks.js:558
+#: assets/dist/blocks/global-blocks.js:596
 msgid "The View Results block can only be used inside the Course List block."
 msgstr ""
 
@@ -8378,14 +8412,14 @@ msgstr ""
 msgid "There was an error while installing the plugin: %1$s"
 msgstr ""
 
-#: assets/dist/blocks/global-blocks.js:591
+#: assets/dist/blocks/global-blocks.js:629
 #: assets/dist/blocks/single-page.js:346
 #: assets/shared/blocks/progress-bar/progress-bar-settings.js:33
 msgid "Progress bar settings"
 msgstr ""
 
 #. translators: Placeholder %1$d is the completed progress count, %2$d is the total count and %3$s is the label for progress bar.
-#: assets/dist/blocks/global-blocks.js:601
+#: assets/dist/blocks/global-blocks.js:639
 #: assets/dist/blocks/quiz/index.js:1054
 #: assets/dist/blocks/single-page.js:356
 #: assets/shared/blocks/progress-bar/progress-bar.js:57
@@ -9074,6 +9108,16 @@ msgstr ""
 #: assets/blocks/course-outline/outline-block/block.json
 msgctxt "block keyword"
 msgid "structure"
+msgstr ""
+
+#: assets/blocks/course-overview-block/block.json
+msgctxt "block title"
+msgid "Course Overview"
+msgstr ""
+
+#: assets/blocks/course-overview-block/block.json
+msgctxt "block description"
+msgid "Displays a link to the course."
 msgstr ""
 
 #: assets/blocks/course-progress-block/block.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sensei-lms",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sensei-lms",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/api-fetch": "wp-5.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sensei-lms",
   "title": "Sensei LMS",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Sensei LMS",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: lms, eLearning, teach, online courses, woocommerce
 Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.2
-Stable tag: 4.8.0
+Stable tag: 4.8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -27,7 +27,7 @@ Your knowledge is worth teaching - teach freely with Sensei LMS!
 - Embed videos from YouTube, Vimeo, and VideoPress for video-based courses.
 - Add the Course List block to any page or post to display available courses.
 - Customize the look and feel to match your branding and site style.
-- Enable the optional Learning Mode for a distraction free and immersive learning experience. 
+- Enable the optional Learning Mode for a distraction free and immersive learning experience.
 
 ### Quizzes That Reinforce ###
 Leverage the power of quizzes to strengthen your students’ understanding of key concepts and evaluate their progress.
@@ -46,12 +46,12 @@ Do more and sell courses with Sensei Pro, which includes:
 
 https://videopress.com/v/tLYw7R27
 
-**Advanced Quiz Features:** Enable a quiz timer and add an ordering quiz question type. With Pro, you can add individual quiz questions to any WordPress content, not just in a quiz. 
+**Advanced Quiz Features:** Enable a quiz timer and add an ordering quiz question type. With Pro, you can add individual quiz questions to any WordPress content, not just in a quiz.
 
-**Groups & Cohorts:** Organize students into groups and cohorts to manage access and customize learning experiences. 
+**Groups & Cohorts:** Organize students into groups and cohorts to manage access and customize learning experiences.
 
 **Course Access Periods:** Select a start date, end date, or a specific amount of time that courses will remain accessible to students.
- 
+
 **Conditional Content:** Hide and show lessons and content in lessons based on groups, enrollment status, and date.
 
 **Priority Support:** Our team of expert and friendly engineers are standing by and ready to help!

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,21 @@ Please visit the [Sensei Blog](https://senseilms.com/blog/) or sign up for our [
 
 == Changelog ==
 
-2022-10-27 - Version 4.8.0
+2022-11-10 - version 4.8.1
+* New: Course Overview block for the Course List block [#5996](https://github.com/Automattic/sensei/pull/5996)
+* Add: Message for users without JavaScript enabled on Sensei Home [#6059](https://github.com/Automattic/sensei/pull/6059)
+* Fix: Course start date reset on lesson completion [#6079](https://github.com/Automattic/sensei/pull/6079)
+* Fix: Contact Teacher block not working [#6058](https://github.com/Automattic/sensei/pull/6058)
+* Fix: Random questions change for answered quizzes [#6088](https://github.com/Automattic/sensei/pull/6088)
+* Fix: Issue with enrolling students in the course view in a course with no students [#5583](https://github.com/Automattic/sensei/pull/5583)
+* Fix: Disable broken sorting under Reports [#6094](https://github.com/Automattic/sensei/pull/6094)
+* Fix: Course List buttons extending outside container [#6010](https://github.com/Automattic/sensei/pull/6010)
+* Fix: Checks for modules when adding author name to module name [#6034](https://github.com/Automattic/sensei/pull/6034)
+* Fix: PHP notice on course category archive view [#6069](https://github.com/Automattic/sensei/pull/6069)
+* Fix: Error when activating Sensei LMS + Sensei Pro (WC Paid Courses) [#6080](https://github.com/Automattic/sensei/pull/6080)
+* Fix: Minor cosmetic changes to task list in Sensei Home [#6083](https://github.com/Automattic/sensei/pull/6083)
+
+2022-10-27 - version 4.8.0
 * New: Onboarding Wizard - replaces the older onboarding with a modern flow to help new users get started.
 * New: Sensei Home - replaces the older 'Extensions' menu item with links to support, documentation, and a checklist for new users.
 

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Sensei LMS
  * Plugin URI: https://senseilms.com/
  * Description: Share your knowledge, grow your network, and strengthen your brand by launching an online course.
- * Version: 4.8.0
+ * Version: 4.8.1
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'SENSEI_LMS_VERSION' ) ) {
-	define( 'SENSEI_LMS_VERSION', '4.8.0' ); // WRCS: DEFINED_VERSION.
+	define( 'SENSEI_LMS_VERSION', '4.8.1' ); // WRCS: DEFINED_VERSION.
 }
 
 if ( ! defined( 'SENSEI_LMS_PLUGIN_FILE' ) ) {


### PR DESCRIPTION
[PRs](https://github.com/Automattic/sensei/pulls?q=is%3Apr+milestone%3A4.8.1+is%3Aclosed) | [Diff from 4.8.0](https://github.com/Automattic/sensei/compare/version/4.8.0...release/4.8.1) | [Build 5f3d9d2](https://github.com/Automattic/sensei/files/9983503/sensei-lms.zip)



* New: Course Overview block for the Course List block [#5996](https://github.com/Automattic/sensei/pull/5996)
* Add: Message for users without JavaScript enabled on Sensei Home [#6059](https://github.com/Automattic/sensei/pull/6059)
* Fix: Course start date reset on lesson completion [#6079](https://github.com/Automattic/sensei/pull/6079)
* Fix: Contact Teacher block not working [#6058](https://github.com/Automattic/sensei/pull/6058)
* Fix: Random questions change for answered quizzes [#6088](https://github.com/Automattic/sensei/pull/6088)
* Fix: Issue with enrolling students in the course view in a course with no students [#5583](https://github.com/Automattic/sensei/pull/5583)
* Fix: Disable broken sorting under Reports [#6094](https://github.com/Automattic/sensei/pull/6094)
* Fix: Course List buttons extending outside container [#6010](https://github.com/Automattic/sensei/pull/6010)
* Fix: Checks for modules when adding author name to module name [#6034](https://github.com/Automattic/sensei/pull/6034)
* Fix: PHP notice on course category archive view [#6069](https://github.com/Automattic/sensei/pull/6069)
* Fix: Error when activating Sensei LMS + Sensei Pro (WC Paid Courses) [#6080](https://github.com/Automattic/sensei/pull/6080)
* Fix: Minor cosmetic changes to task list in Sensei Home [#6083](https://github.com/Automattic/sensei/pull/6083)
