### PR TITLE
Fix issue with outdated NodeJS versions being used on Github Actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - name: Updates the npm version
-              run: npm install -g npm@8.9.0
+              run: npm install -g npm@^8
             - name: npm install, and build docs
               run: |
                   npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Decompress plugin
               run: unzip sensei-lms.zip -d sensei-lms
             - name: Store Artifact
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: sensei-lms-${{ github.event.pull_request.head.sha }}
                   path: ${{ github.workspace }}/sensei-lms/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
             - name: Get npm cache directory
               id: npm-cache
               run: |
-                  echo "::set-output name=dir::$(npm config get cache)"
+                  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v3
               with:
                   path: ${{ steps.npm-cache.outputs.dir }}
@@ -25,7 +25,7 @@ jobs:
                   coverage: none
             - name: Get composer cache directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Updates the npm version
               run: npm install -g npm@8.9.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Updates the npm version
-              run: npm install -g npm@8.9.0
+              run: npm install -g npm@^8
 
             - uses: actions/cache@v3
               with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -24,11 +24,11 @@ jobs:
                 uses: actions/checkout@v3
 
             -   name: Get cached composer directories
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ~/.cache/composer/
                     key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v3
                 with:
                     path: vendor/
                     key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -69,7 +69,7 @@ jobs:
                 run: php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover ./coverage.xml
 
             -   name: Updates the npm version
-                run: npm install -g npm@8.9.0
+                run: npm install -g npm@^8
 
             -   uses: actions/cache@v3
                 with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -21,7 +21,7 @@ jobs:
                 options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: Get cached composer directories
                 uses: actions/cache@v2

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -22,7 +22,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Updates the npm version
-              run: npm install -g npm@8.9.0
+              run: npm install -g npm@^8
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -43,7 +43,7 @@ jobs:
               run: CI=true npm run test:e2e -- --grep-invert @setup
 
             - name: Archive report
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                   name: playwright-report

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -10,7 +10,7 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Updates the CI npm
-              run: npm install -g npm@8.9.0
+              run: npm install -g npm@^8
 
             - uses: actions/cache@v3
               with:
@@ -33,7 +33,7 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Updates the npm version
-              run: npm install -g npm@8.9.0
+              run: npm install -g npm@^8
 
             - uses: actions/cache@v3
               with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
                 options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Get cached composer directories
               uses: actions/cache@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,11 +13,11 @@ jobs:
                   fetch-depth: 0
 
             - name: Get cached composer directories
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.cache/composer/
                   key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               with:
                   path: vendor/
                   key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -84,11 +84,11 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Get cached composer directories
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.cache/composer/
                   key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               with:
                   path: vendor/
                   key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -11,7 +11,7 @@ jobs:
         name: Report Plugin Build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Publish commit status with the link to download the plugin
               id: plugin_artifact
               uses: fjorgemota/github-action-report-artifact@v0


### PR DESCRIPTION
Fixes #5937 

### Changes proposed in this Pull Request

* Use `checkout@v3` instead of `checkout@v2`;
* Use `cache@v3` instead of `cache@v2`;
* Use `upload-artifact@v3` instead of `upload-artifact@v2`;
* Fix `set-output` commands to use environment files instead;


### Testing instructions

Verify if all the tests pass and if there are no warnings like the ones shown in #5397 in the "Summary" page.

### Note

This PR is very similar to 1894-gh-Automattic/sensei-pro.