### PR TITLE
Add feature flag for using tables-based repositories

### DIFF
--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -54,6 +54,7 @@ class Sensei_Feature_Flags {
 			'sensei_default_feature_flag_settings',
 			[
 				'enrolment_provider_tooltip' => false,
+				'tables_based_progress'      => false,
 			]
 		);
 	}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -554,7 +554,7 @@ class Sensei_Main {
 		$this->quiz_progress_repository   = ( new Quiz_Progress_Repository_Factory( $use_tables ) )->create();
 
 		// Quiz submission repositories.
-		$this->quiz_submission_repository = ( new Submission_Repository_Factory() )->create();
+		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $use_tables ) )->create();
 		$this->quiz_answer_repository     = ( new Answer_Repository_Factory() )->create();
 		$this->quiz_grade_repository      = ( new Grade_Repository_Factory() )->create();
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -548,9 +548,10 @@ class Sensei_Main {
 		$this->rest_api_internal = new Sensei_REST_API_Internal();
 
 		// Student progress repositories.
-		$this->course_progress_repository = ( new Course_Progress_Repository_Factory() )->create();
-		$this->lesson_progress_repository = ( new Lesson_Progress_Repository_Factory() )->create();
-		$this->quiz_progress_repository   = ( new Quiz_Progress_Repository_Factory() )->create();
+		$use_tables                       = $this->feature_flags->is_enabled( 'tables_based_progress' );
+		$this->course_progress_repository = ( new Course_Progress_Repository_Factory( $use_tables ) )->create();
+		$this->lesson_progress_repository = ( new Lesson_Progress_Repository_Factory( $use_tables ) )->create();
+		$this->quiz_progress_repository   = ( new Quiz_Progress_Repository_Factory( $use_tables ) )->create();
 
 		// Quiz submission repositories.
 		$this->quiz_submission_repository = ( new Submission_Repository_Factory() )->create();

--- a/includes/internal/quiz-submission/submission/repositories/class-submission-repository-factory.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-submission-repository-factory.php
@@ -20,6 +20,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Submission_Repository_Factory {
 	/**
+	 * Use tables-based repository.
+	 *
+	 * @var bool
+	 */
+	private $use_tables;
+
+	/**
+	 * Submission_Repository_Factory constructor.
+	 *
+	 * @param bool $use_tables Use tables-based repository.
+	 */
+	public function __construct( $use_tables = false ) {
+		$this->use_tables = $use_tables;
+	}
+
+	/**
 	 * Create a repository for the quiz submissions.
 	 *
 	 * @internal
@@ -32,7 +48,7 @@ class Submission_Repository_Factory {
 		return new Aggregate_Submission_Repository(
 			new Comments_Based_Submission_Repository(),
 			new Tables_Based_Submission_Repository( $wpdb ),
-			true
+			$this->use_tables
 		);
 	}
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-factory.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-factory.php
@@ -20,6 +20,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Course_Progress_Repository_Factory {
 	/**
+	 * Use tables based progress flag.
+	 *
+	 * @var bool
+	 */
+	private $use_tables;
+
+	/**
+	 * Course_Progress_Repository_Factory constructor.
+	 *
+	 * @param bool $use_tables Use tables based progress flag.
+	 */
+	public function __construct( bool $use_tables ) {
+		$this->use_tables = $use_tables;
+	}
+
+	/**
 	 * Create a repository for a course progress.
 	 *
 	 * @internal
@@ -32,7 +48,7 @@ class Course_Progress_Repository_Factory {
 		return new Aggregate_Course_Progress_Repository(
 			new Comments_Based_Course_Progress_Repository(),
 			new Tables_Based_Course_Progress_Repository( $wpdb ),
-			true
+			$this->use_tables
 		);
 	}
 }

--- a/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-factory.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-factory.php
@@ -20,6 +20,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Lesson_Progress_Repository_Factory {
 	/**
+	 * Use tables based progress flag.
+	 *
+	 * @var bool
+	 */
+	private $use_tables;
+
+	/**
+	 * Lesson_Progress_Repository_Factory constructor.
+	 *
+	 * @param bool $use_tables Use tables based progress flag.
+	 */
+	public function __construct( bool $use_tables ) {
+		$this->use_tables = $use_tables;
+	}
+
+	/**
 	 * Creates a new lesson progress repository.
 	 *
 	 * @internal
@@ -32,7 +48,7 @@ class Lesson_Progress_Repository_Factory {
 		return new Aggregate_Lesson_Progress_Repository(
 			new Comments_Based_Lesson_Progress_Repository(),
 			new Tables_Based_Lesson_Progress_Repository( $wpdb ),
-			true
+			$this->use_tables
 		);
 	}
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -160,6 +160,7 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 		];
 		$comments      = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 		foreach ( $comments as $comment ) {
+			$this->delete_grade_and_answers( $comment->comment_ID );
 			Sensei_Utils::sensei_delete_quiz_answers( $quiz_id, $comment->user_id );
 		}
 	}

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
@@ -18,7 +18,7 @@ class Quiz_Progress_Repository_Factory {
 
 	/**
 	 * Use tables based progress flag.
-	 * 
+	 *
 	 * @var bool
 	 */
 	private $use_tables;

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
@@ -15,6 +15,23 @@ namespace Sensei\Internal\Student_Progress\Quiz_Progress\Repositories;
  * @since $$next-version$$
  */
 class Quiz_Progress_Repository_Factory {
+
+	/**
+	 * Use tables based progress flag.
+	 * 
+	 * @var bool
+	 */
+	private $use_tables;
+
+	/**
+	 * Quiz_Progress_Repository_Factory constructor.
+	 *
+	 * @param bool $use_tables Use tables based progress flag.
+	 */
+	public function __construct( bool $use_tables ) {
+		$this->use_tables = $use_tables;
+	}
+
 	/**
 	 * Creates a new quiz progress repository.
 	 *
@@ -28,7 +45,7 @@ class Quiz_Progress_Repository_Factory {
 		return new Aggregate_Quiz_Progress_Repository(
 			new Comments_Based_Quiz_Progress_Repository(),
 			new Tables_Based_Quiz_Progress_Repository( $wpdb ),
-			true
+			$this->use_tables
 		);
 	}
 }

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-submission-repository-factory.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-submission-repository-factory.php
@@ -12,9 +12,14 @@ use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repositor
  */
 class Submission_Repository_Factory_Test extends \WP_UnitTestCase {
 
-	public function testCreate_WhenCalled_ReturnsSubmissionRepository(): void {
+	/**
+	 * Tests that the factory creates the correct repository.
+	 *
+	 * @dataProvider providerCreate_WhenCalled_ReturnsSubmissionRepository
+	 */
+	public function testCreate_WhenCalled_ReturnsSubmissionRepository( bool $use_tables ): void {
 		/* Arrange. */
-		$factory = new Submission_Repository_Factory();
+		$factory = new Submission_Repository_Factory( $use_tables );
 
 		/* Act. */
 		$actual = $factory->create();
@@ -23,4 +28,10 @@ class Submission_Repository_Factory_Test extends \WP_UnitTestCase {
 		self::assertInstanceOf( Submission_Repository_Interface::class, $actual );
 	}
 
+	public function providerCreate_WhenCalled_ReturnsSubmissionRepository(): array {
+		return [
+			'use tables'        => [ true ],
+			'do not use tables' => [ false ],
+		];
+	}
 }

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-course-progress-repository-factory.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-course-progress-repository-factory.php
@@ -11,9 +11,14 @@ use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progres
  * @covers \Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Factory
  */
 class Course_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
-	public function testCreate_WhenCalled_ReturnsCourseProgressRepository(): void {
+	/**
+	 * Tests that the factory creates the correct repository.
+	 *
+	 * @dataProvider providerCreate_WhenCalled_ReturnsCourseProgressRepository
+	 */
+	public function testCreate_WhenCalled_ReturnsCourseProgressRepository( bool $use_tables ): void {
 		/* Arrange. */
-		$factory = new Course_Progress_Repository_Factory();
+		$factory = new Course_Progress_Repository_Factory( $use_tables );
 
 		/* Act. */
 		$actual = $factory->create();
@@ -22,4 +27,10 @@ class Course_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 		self::assertInstanceOf( Aggregate_Course_Progress_Repository::class, $actual );
 	}
 
+	public function providerCreate_WhenCalled_ReturnsCourseProgressRepository(): array {
+		return [
+			'use tables'        => [ true ],
+			'do not use tables' => [ false ],
+		];
+	}
 }

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-lesson-progress-repository-factory.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-lesson-progress-repository-factory.php
@@ -11,14 +11,26 @@ use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progres
  * @covers \Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Factory
  */
 class Lesson_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
-	public function testCreate_WhenCalled_ReturnsLessonProgressRepository(): void {
+	/**
+	 * Tests that the factory creates the correct repository.
+	 *
+	 * @dataProvider providerCreate_WhenCalled_ReturnsLessonProgressRepository
+	 */
+	public function testCreate_WhenCalled_ReturnsLessonProgressRepository( bool $use_tables ): void {
 		/* Arrange. */
-		$factory = new Lesson_Progress_Repository_Factory();
+		$factory = new Lesson_Progress_Repository_Factory( $use_tables );
 
 		/* Act. */
 		$actual_repository = $factory->create();
 
 		/* Assert. */
 		$this->assertInstanceOf( Aggregate_Lesson_Progress_Repository::class, $actual_repository );
+	}
+
+	public function providerCreate_WhenCalled_ReturnsLessonProgressRepository(): array {
+		return [
+			'use tables'        => [ true ],
+			'do not use tables' => [ false ],
+		];
 	}
 }

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-quiz-progress-repository-factory.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-quiz-progress-repository-factory.php
@@ -11,14 +11,27 @@ use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Re
  * @covers \Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory
  */
 class Quiz_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
-	public function testCreate_WhenCalled_ReturnsQuizProgressRepository(): void {
+
+	/**
+	 * Tests that the factory creates the correct repository.
+	 *
+	 * @dataProvider providerCreate_WhenCalled_ReturnsQuizProgressRepository
+	 */
+	public function testCreate_WhenCalled_ReturnsQuizProgressRepository( bool $use_tables ): void {
 		/* Arrange. */
-		$factory = new Quiz_Progress_Repository_Factory();
+		$factory = new Quiz_Progress_Repository_Factory( $use_tables );
 
 		/* Act. */
 		$actual_repository = $factory->create();
 
 		/* Assert. */
 		$this->assertInstanceOf( Aggregate_Quiz_Progress_Repository::class, $actual_repository );
+	}
+
+	public function providerCreate_WhenCalled_ReturnsQuizProgressRepository(): array {
+		return [
+			'use tables'        => [ true ],
+			'do not use tables' => [ false ],
+		];
 	}
 }


### PR DESCRIPTION
Fixes #5975 

### Changes proposed in this Pull Request

* Add `tables_based_progress` feature flag.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );`
* Add a course with lessons and quizzes.
* Take a course, lesson, quiz.
* Check there are corresponding rows in custom tables.
* Remove the feature flag, truncate custom tables.
* Add a new course with lessons and quizzes.
* Take the course, lesson, quiz.
* Check custom tables are empty.
