### PR TITLE
Fix warning when missing update attributes.

### DIFF
--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -140,9 +140,9 @@ class Sensei_Home_Notices {
 
 			$available_updates = get_plugin_updates();
 			foreach ( $available_updates as $plugin_data ) {
-				$plugin_slug    = dirname( $plugin_data->update->plugin );
-				$update_version = $plugin_data->update->new_version;
-				$update_package = $plugin_data->update->package;
+				$plugin_slug    = dirname( $plugin_data->update->plugin ?? null );
+				$update_version = $plugin_data->update->new_version ?? null;
+				$update_package = $plugin_data->update->package ?? null;
 
 				if ( ! $plugin_slug || ! $update_version || ! $update_package ) {
 					continue;


### PR DESCRIPTION
Fixes #6102

### Changes proposed in this Pull Request
- Some updates might come with missing attributes like `package`.
- Added null coalescing operators. 
- Checked that `dirname` behaves correctly (empty result) with a `null`.


### Testing instructions
* Go to `Sensei_Home_Notices` class method `get_local_plugin_updates`.
* Modify to include `$plugin_data = new stdClass()` as the first line inside the foreach.
* Check that no notices appear (even in the extreme case of an empty object).
