### PR TITLE
Convert quiz submission dates to UTC when saving to tables

### DIFF
--- a/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
@@ -7,6 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
 
+use DateTimeImmutable;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -140,13 +141,18 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 			$tables_based_submission = $this->tables_based_repository->get( $submission->get_quiz_id(), $submission->get_user_id() );
 
 			if ( $tables_based_submission ) {
+				// Make sure the dates are in UTC.
+				// This is not the case if the submission is originating from the comments based repository.
+				$created_at = new DateTimeImmutable( '@' . $submission->get_created_at()->getTimestamp() );
+				$updated_at = new DateTimeImmutable( '@' . $submission->get_updated_at()->getTimestamp() );
+
 				$submission_to_save = new Submission(
 					$tables_based_submission->get_id(),
 					$submission->get_quiz_id(),
 					$submission->get_user_id(),
 					$submission->get_final_grade(),
-					$submission->get_created_at(),
-					$submission->get_updated_at()
+					$created_at,
+					$updated_at
 				);
 
 				$this->tables_based_repository->save( $submission_to_save );

--- a/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
@@ -142,7 +142,6 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 
 			if ( $tables_based_submission ) {
 				// Make sure the dates are in UTC.
-				// This is not the case if the submission is originating from the comments based repository.
 				$created_at = new DateTimeImmutable( '@' . $submission->get_created_at()->getTimestamp() );
 				$updated_at = new DateTimeImmutable( '@' . $submission->get_updated_at()->getTimestamp() );
 

--- a/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
@@ -7,7 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
 
-use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use RuntimeException;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
@@ -203,7 +203,7 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 		$start_date = get_comment_meta( $status_comment->comment_ID, 'start', true );
 
 		return $start_date
-			? new DateTime( $start_date, wp_timezone() )
-			: current_datetime();
+			? new DateTimeImmutable( $start_date, wp_timezone() )
+			: new DateTimeImmutable( 'now', wp_timezone() );
 	}
 }

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-aggregate-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-aggregate-submission-repository.php
@@ -2,6 +2,8 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Aggregate_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
@@ -203,7 +205,7 @@ class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
 
 	public function testSave_UseTablesOnAndSubmissionNotFound_DoesntCallTablesBasedRepository(): void {
 		/* Arrange. */
-		$progress       = $this->create_submission();
+		$submission     = $this->create_submission();
 		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
 		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
 		$tables_based
@@ -218,7 +220,45 @@ class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'save' );
 
-		$repository->save( $progress );
+		$repository->save( $submission );
+	}
+
+	public function testSave_WhenSubmissionWithNonUTCDatesGiven_ConvertsDatesToUTC() {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
+		$submission     = new Submission(
+			1,
+			2,
+			3,
+			12.34,
+			new DateTimeImmutable( 'now', new DateTimeZone( 'US/Central' ) ),
+			new DateTimeImmutable( 'now', new DateTimeZone( 'US/Central' ) )
+		);
+
+		$tables_based
+			->method( 'get' )
+			->with( 2, 3 )
+			->willReturn( $submission );
+
+		$repository = new Aggregate_Submission_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->callback(
+					function ( Submission $submission_to_save ) {
+						$this->assertSame( '+00:00', $submission_to_save->get_created_at()->getTimezone()->getName() );
+						$this->assertSame( '+00:00', $submission_to_save->get_updated_at()->getTimezone()->getName() );
+
+						return true;
+					}
+				)
+			);
+
+		$repository->save( $submission );
 	}
 
 	public function testDelete_UseTablesOff_DoesntCallTablesBasedRepository(): void {


### PR DESCRIPTION
Fixes #6093

### Changes proposed in this Pull Request

* Convert the quiz submission dates to UTC when saving to tables. This is needed because when the submission is originating from the comments based repository.

### Testing instructions

* Submit a quiz.
* Check the quiz submission `wp_sensei_lms_quiz_submissions` and make sure the dates are in UTC.