### PR TITLE
Update minimum WP version to 5.9 for unit tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -59,9 +59,9 @@ jobs:
                 php: ['7.2', '7.3', '7.4', '8.0']
                 include:
                     - php: 7.2
-                      wp: 5.7
+                      wp: 5.9
                     - php: 7.2
-                      wp: 5.8
+                      wp: 6.0
                     - php: 7.2
                       wp: latest
                       wpmu: 1

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -59,9 +59,9 @@ jobs:
                 php: ['7.2', '7.3', '7.4', '8.0']
                 include:
                     - php: 7.2
-                      wp: 5.9
+                      wp: '5.9'
                     - php: 7.2
-                      wp: 6.0
+                      wp: '6.0'
                     - php: 7.2
                       wp: latest
                       wpmu: 1


### PR DESCRIPTION
We support the current version of WP as well as the last two versions - so we shouldn't need to run Unit Tests for older versions.  This PR makes sure we're only testing WP 6.1 (latest), 6.0, and 5.9.