### PR TITLE
Add null-check for focus-mode event listener.

### DIFF
--- a/assets/course-theme/focus-mode.js
+++ b/assets/course-theme/focus-mode.js
@@ -61,7 +61,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 
 	document
 		.querySelector( '.sensei-course-theme__sidebar' )
-		.addEventListener( 'transitionend', ( e ) => {
+		?.addEventListener( 'transitionend', ( e ) => {
 			if (
 				'left' === e.propertyName &&
 				document.body.classList.contains( FOCUS_MODE_CLASS )


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Add null-check to focus-mode event listener registration.

### Testing instructions
* Enable learning mode.
* Create a lesson.
* Go to Preview the lesson.
* Check that the following error does not appear in the JS console:
```
 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
```

### Discussion
Not sure if this is the best approach or if there is something better we can do.