### PR TITLE
Fix issue with YouTube adapter's setCurrentTime

### DIFF
--- a/assets/shared/helpers/player/youtube-adapter.js
+++ b/assets/shared/helpers/player/youtube-adapter.js
@@ -82,7 +82,7 @@ export const getCurrentTime = ( player ) =>
  */
 export const setCurrentTime = ( player, seconds ) =>
 	new Promise( ( resolve ) => {
-		if ( player.i.dataset.hasPlayed ) {
+		if ( player.getIframe().dataset.hasPlayed ) {
 			player.seekTo( seconds );
 			resolve();
 		} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Use `getIframe()` instead of using private attribute `i` on the YouTube Iframe API;

### Testing instructions

1. Create Interactive Video Block on Sensei Pro;
2. Put an URL to an YouTube video on the "Insert from URL" box;
3. Create a breakpoint;
4. Set the breakpoint to, let's say, 5 or 10 seconds in the video;
5. Make sure the error `player.i.dataset is undefined` doesn't appear on the console, and that the correct frame of the video is properly shown;