### PR TITLE
Make the view quiz button behave as a complete lesson button when watching a video is required

### DIFF
--- a/includes/blocks/class-sensei-view-quiz-block.php
+++ b/includes/blocks/class-sensei-view-quiz-block.php
@@ -59,6 +59,13 @@ class Sensei_View_Quiz_Block {
 			);
 		}
 
-		return '<a href="' . esc_url( $quiz_permalink ) . '" >' . $content . '</a>';
+		$content = preg_replace(
+			'/<(button|a)/',
+			'<$1 data-id="complete-lesson-button"',
+			$content,
+			1
+		);
+
+		return '<form class="lesson_button_form" data-id="complete-lesson-form" method="GET" action="' . $quiz_permalink . '">' . $content . '</form>';
 	}
 }


### PR DESCRIPTION
Fixes #5303 

It has been working in the Learning mode already.
I duplicated the behaviour of the Complete Lesson button block for the View Quiz button block. 

### Changes proposed in this Pull Request

* Turn "View Quiz" link into a form.
* Add the same `data-id` property to the "View Quiz" button as for the "Complete Lesson" button.

### Testing instructions

* Disable the Learning mode: go to `Sensei LMS -> Settings -> Appearance` and uncheck `Enable for all courses`.
* Create a course. Set video required in the course settings.
* Add a lesson with a video and a quiz (at least one question required).
* Publish the course and the lesson.
* Go to frontend, start the course.
* On the lesson page, make sure both the view quiz button and the complete lesson button are disabled.
* Watch the video till the end ;)
* Check the view quiz button is enabled and clicking on it navigates to the lesson quiz.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
*Before watching*
<img width="861" alt="CleanShot 2022-11-17 at 18 22 39@2x" src="https://user-images.githubusercontent.com/329356/202421307-8024ace3-3b89-4b8e-bcab-454f900d5d2b.png">

*After watching*
<img width="859" alt="CleanShot 2022-11-17 at 18 23 59@2x" src="https://user-images.githubusercontent.com/329356/202421727-ce14753f-7150-4d1b-9fe6-383240ba1b87.png">


