### PR TITLE
Ensure quiz author is set correctly when the quiz is initially created

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -57,6 +57,7 @@ class Sensei_Quiz {
 			'show_questions',
 			'random_question_order',
 		);
+		add_filter( 'wp_insert_post_data', [ $this, 'set_quiz_author_on_create' ], 10, 4 );
 		add_action( 'save_post', array( $this, 'update_after_lesson_change' ) );
 
 		// Redirect if the lesson is protected.
@@ -114,6 +115,38 @@ class Sensei_Quiz {
 		 * @return {bool}
 		 */
 		return apply_filters( 'sensei_quiz_enable_block_based_editor', $is_block_based_editor_enabled );
+	}
+
+	/**
+	 * Hooks into `wp_insert_post_data` and updates the quiz author to the lesson author on create.
+	 *
+	 * @param mixed $data                The data to be saved.
+	 * @param mixed $postarr             The post data.
+	 * @param mixed $unsanitized_postarr Unsanitized post data.
+	 * @param bool  $update              Whether the action is for an existing post being updated or not.
+	 * @return mixed
+	 */
+	public function set_quiz_author_on_create( $data, $postarr, $unsanitized_postarr, $update ) {
+		// Only handle new posts.
+		if ( $update ) {
+			return $data;
+		}
+
+		// Only handle quizzes.
+		if ( 'quiz' !== $data['post_type'] ) {
+			return $data;
+		}
+
+		// Set author to lesson author.
+		$lesson_id = $postarr['post_parent'] ?? null;
+		if ( $lesson_id ) {
+			$lesson = get_post( $lesson_id );
+			if ( $lesson ) {
+				$data['post_author'] = $lesson->post_author;
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1723,4 +1723,41 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEmpty( $quiz_grades );
 	}
+
+	public function testCreatingQuizSetsAuthorToLessonTeacher() {
+		$main_teacher_id = $this->factory->user->create( [ 'role' => 'teacher' ] );
+		$other_teacher_id = $this->factory->user->create( [ 'role' => 'teacher' ] );
+
+		$data = $this->factory->get_course_with_lessons(
+			[
+				'course_args' => [
+					'post_author' => $main_teacher_id,
+				],
+				'lesson_args' => [
+					'post_author' => $main_teacher_id,
+				],
+			]
+		);
+
+		// Log in as other teacher.
+		wp_set_current_user( $other_teacher_id );
+
+		// Create a quiz for the Lesson.
+		$lesson_id = $data['lesson_ids'][0];
+		$quiz_id = wp_insert_post(
+			[
+				'post_type'   => 'quiz',
+				'post_title'  => 'Lesson Quiz',
+				'post_author' => $other_teacher_id,
+				'post_status' => 'publish',
+				'post_parent' => $lesson_id,
+				'meta_input'  => [
+					'_quiz_lesson' => $lesson_id,
+				],
+			]
+		);
+
+		// Ensure the quiz author is changed to main_teacher_id.
+		$this->assertEquals( $main_teacher_id, get_post_field( 'post_author', $quiz_id ) );
+	}
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1724,7 +1724,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $quiz_grades );
 	}
 
-	public function testCreatingQuizSetsAuthorToLessonTeacher() {
+	public function testSetQuizAuthorOnCreate_WhenCreatingQuiz_SetsAuthorToLessonTeacher() {
+		// Arrange.
 		$main_teacher_id  = $this->factory->user->create( [ 'role' => 'teacher' ] );
 		$other_teacher_id = $this->factory->user->create( [ 'role' => 'teacher' ] );
 
@@ -1742,6 +1743,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		// Log in as other teacher.
 		wp_set_current_user( $other_teacher_id );
 
+		// Act.
+
 		// Create a quiz for the Lesson.
 		$lesson_id = $data['lesson_ids'][0];
 		$quiz_id   = wp_insert_post(
@@ -1756,6 +1759,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 				],
 			]
 		);
+
+		// Assert.
 
 		// Ensure the quiz author is changed to main_teacher_id.
 		$this->assertEquals( $main_teacher_id, get_post_field( 'post_author', $quiz_id ) );

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1725,7 +1725,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	public function testCreatingQuizSetsAuthorToLessonTeacher() {
-		$main_teacher_id = $this->factory->user->create( [ 'role' => 'teacher' ] );
+		$main_teacher_id  = $this->factory->user->create( [ 'role' => 'teacher' ] );
 		$other_teacher_id = $this->factory->user->create( [ 'role' => 'teacher' ] );
 
 		$data = $this->factory->get_course_with_lessons(
@@ -1744,7 +1744,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		// Create a quiz for the Lesson.
 		$lesson_id = $data['lesson_ids'][0];
-		$quiz_id = wp_insert_post(
+		$quiz_id   = wp_insert_post(
 			[
 				'post_type'   => 'quiz',
 				'post_title'  => 'Lesson Quiz',


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Ensure the author for a Quiz is set to be the same as the author for its Lesson as soon as the Quiz is created.

### Testing instructions

- Ensure tests pass.
- This is part of the Co-Teacher functionality in Sensei Pro. Please follow further testing instructions [here](https://github.com/Automattic/sensei-pro/pull/1918).
