### PR TITLE
Load persisted notices on user metas only when printing them

### DIFF
--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -68,7 +68,6 @@ class Sensei_Notices {
 		);
 
 		add_action( 'template_redirect', [ $this, 'setup_block_notices' ] );
-		add_action( 'init', [ $this, 'maybe_load_notices' ] );
 		add_action( 'shutdown', [ $this, 'maybe_persist_notices' ] );
 	}
 
@@ -129,6 +128,7 @@ class Sensei_Notices {
 	 * @return void
 	 */
 	public function maybe_print_notices() {
+		$this->maybe_load_notices();
 		if ( ! empty( $this->notices ) ) {
 			foreach ( $this->notices  as  $notice ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in generate_notice

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -168,7 +168,7 @@ class Sensei_Notices {
 	 */
 	public function maybe_persist_notices() {
 		if ( ! empty( $this->notices ) && is_user_logged_in() ) {
-			add_user_meta( get_current_user_id(), self::USER_META_KEY, $this->notices );
+			update_user_meta( get_current_user_id(), self::USER_META_KEY, $this->notices );
 			$this->clear_notices();
 		}
 	}


### PR DESCRIPTION
So, this basically avoids that the user metas will always be loaded on every request, which should also help improve performance.

Should fix this issue p9F6qB--p2_b8c

### Changes proposed in this Pull Request

* Remove `maybe_load_notices` from the `init` action and call it at the start of the `maybe_print_notices` instead;
* Use `update_user_meta` instead of `add_user_meta`;

### Testing instructions

On a WP installation containing this branch of the Sensei LMS plugin and also with a proper lesson with a quiz registered:

1. Take a lesson quiz for a quiz that can be reset;
2. Click reset at the bottom of the quiz;
3. Verify if the notice "Lesson Reset Successfully." show up correctly on the page;

Also verify if the notices aren't loaded on every page (a good place to verify this is on the wp-admin panel, for instance)