### PR TITLE
Make Last Activity column non-sortable

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -152,7 +152,6 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	public function get_sortable_columns() {
 		$columns = array(
 			'learner'            => array( 'learner', false ),
-			'last_activity_date' => array( 'last_activity_date', false ),
 		);
 		return apply_filters( 'sensei_learner_admin_default_columns_sortable', $columns, $this );
 	}

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -151,7 +151,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 */
 	public function get_sortable_columns() {
 		$columns = array(
-			'learner'            => array( 'learner', false ),
+			'learner' => array( 'learner', false ),
 		);
 		return apply_filters( 'sensei_learner_admin_default_columns_sortable', $columns, $this );
 	}

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
@@ -156,4 +156,22 @@ class Sensei_Learners_Admin_Bulk_Actions_View_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	public function testGetSortableColumns_WhenCalled_ReturnsMatchingColumns() {
+		/* Arrange. */
+		$controller         = $this->createMock( Sensei_Learners_Admin_Bulk_Actions_Controller::class );
+		$learner_management = $this->createMock( Sensei_Learner_Management::class );
+		$learner = $this->createMock( Sensei_Learner::class );
+		$view = new Sensei_Learners_Admin_Bulk_Actions_View( $controller, $learner_management, $learner );
+
+		/* Act. */
+		$actual = $view->get_sortable_columns();
+
+		/* Assert. */
+		$expected = [
+			'learner' => [ 'learner', false ],
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
@@ -161,8 +161,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$controller         = $this->createMock( Sensei_Learners_Admin_Bulk_Actions_Controller::class );
 		$learner_management = $this->createMock( Sensei_Learner_Management::class );
-		$learner = $this->createMock( Sensei_Learner::class );
-		$view = new Sensei_Learners_Admin_Bulk_Actions_View( $controller, $learner_management, $learner );
+		$learner            = $this->createMock( Sensei_Learner::class );
+		$view               = new Sensei_Learners_Admin_Bulk_Actions_View( $controller, $learner_management, $learner );
 
 		/* Act. */
 		$actual = $view->get_sortable_columns();


### PR DESCRIPTION
Fixes #5613

The sorting doesn't work now. Removing the sorting by this field looks like the easiest and best working solution. We can return it after migrating to custom tables for the student's progress.

### Changes proposed in this Pull Request

* Make Last Activity column non-sortable

### Testing instructions

* Add a few courses with lessons, add a few students. (optional)
* Take courses with each of them. (optional)
* Go to Sensei LMS -> Students and check it the Last Activity column is not sortable (the heading of the column isn't a link).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="1244" alt="CleanShot 2022-11-17 at 22 20 24@2x" src="https://user-images.githubusercontent.com/329356/202470886-3f0d7afc-ed53-41f2-a599-b312f0f80a4f.png">


