### PR TITLE
Fix SQL performance issue on the student reports page

### DIFF
--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
@@ -201,6 +201,7 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 		$query->query_fields .= ", (
 			SELECT MAX({$wpdb->comments}.comment_date_gmt)
 			FROM {$wpdb->comments}
+			USE INDEX (sensei_comment_type_user_id)
 			WHERE {$wpdb->comments}.user_id = {$wpdb->users}.ID
 			AND {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
 			AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'


### PR DESCRIPTION
Fixes #6122

### Changes proposed in this Pull Request

The fix hints to the SQL optimizer to use the `sensei_comment_type_user_id` index. This is the default behavior on newer versions of MySQL/MariaDB but older versions use the `woo_idx_comment_type` index which leads to major performance issues.

The problem was spotted on a website using MariaDB 10.4.25.

### Testing instructions

* Make sure the Reports -> Students screen works as before and there are no performance issues.

The lovely folks at Team 51 confirmed that this fixes the issue on their client's site. For more info, check [this thread](https://href.li/?https://a8c.slack.com/archives/C02P7FHLVR9/p1668540147192489) below.

### Context

p1668540147192489-slack-C02P7FHLVR9