### PR TITLE
Fix home styles

### DIFF
--- a/assets/home/home.shared.scss
+++ b/assets/home/home.shared.scss
@@ -82,6 +82,7 @@
 
 		&__grid {
 			display: flex;
+			width: 100%;
 			flex-wrap: wrap;
 			margin: 0 -9px;
 

--- a/assets/home/tasks-section/style.scss
+++ b/assets/home/tasks-section/style.scss
@@ -10,6 +10,9 @@
 	background-repeat: no-repeat;
 	transition: 0.5s background-position;
 
+	// Crop first course box shadow.
+	overflow: hidden;
+
 	&--ready {
 		@media ( min-width: 1120px ) {
 			background-position: 0 0, 100% 100%;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the box shadow leaking from the tasks section.
* It also adds a `width: 100%` to fix the styles in a specific env with extra styles.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Before completing all the tasks, go to the Sensei Home. (If you already completed it, you can simulate it removing the options `sensei_home_tasks_list_is_completed` and `sensei_settings_sections_visited` from the database).
* Make sure the tasks section has the box shadow only inside the section (in the white part).
* Also, make sure that the width of the whole home is working properly (it shouldn't change anything in a normal environment).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1281" alt="Screenshot 2022-11-18 at 15 26 48" src="https://user-images.githubusercontent.com/876340/202776767-dd9efa74-b576-414b-86af-6f891ae6b002.png">
