### PR TITLE
Avoid quiz check when it's in a preview

### DIFF
--- a/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
+++ b/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
@@ -9,6 +9,10 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { isQuestionEmpty } from '../data';
 
+const isPreview = document.documentElement.classList.contains(
+	'block-editor-block-preview__content-iframe'
+);
+
 /**
  * Monitor for questions and disable the lesson quiz when none have been added.
  *
@@ -32,6 +36,10 @@ export const useUpdateQuizHasQuestionsMeta = ( clientId ) => {
 	const { editPost } = useDispatch( 'core/editor' );
 	const setQuizHasQuestionsMeta = useCallback(
 		( enable ) => {
+			if ( isPreview ) {
+				return;
+			}
+
 			return editPost( {
 				meta: { [ META_KEY ]: enable ? 1 : 0 },
 			} );

--- a/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
+++ b/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
@@ -2,7 +2,9 @@
  * WordPress dependencies
  */
 import { useCallback, useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select as dataSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -16,32 +18,28 @@ import { isQuestionEmpty } from '../data';
  */
 export const useUpdateQuizHasQuestionsMeta = ( clientId ) => {
 	const META_KEY = '_quiz_has_questions';
-	const questionBlocks = useSelect( ( select ) =>
-		select( 'core/block-editor' )
-			.getBlocks( clientId )
-			.filter( ( block ) => ! isQuestionEmpty( block.attributes ) )
-	);
+
+	// It doesn't use the `useSelect` to get the blocks from the main registry.
+	// It avoids getting the blocks from the preview thumbnails.
+	const questionBlocks = dataSelect( blockEditorStore )
+		.getBlocks( clientId )
+		.filter( ( block ) => ! isQuestionEmpty( block.attributes ) );
 
 	const { editedValue: quizHasQuestionsMeta } = useSelect( ( select ) => {
-		const editor = select( 'core/editor' );
+		const editor = select( editorStore );
 		return {
 			editedValue: editor.getEditedPostAttribute( 'meta' )[ META_KEY ],
 		};
 	} );
 
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost } = useDispatch( editorStore );
 	const setQuizHasQuestionsMeta = useCallback(
 		( enable ) => {
-			// Check if block is in the DOM (it skips cases in preview iframes).
-			if ( ! document.getElementById( `block-${ clientId }` ) ) {
-				return;
-			}
-
 			return editPost( {
 				meta: { [ META_KEY ]: enable ? 1 : 0 },
 			} );
 		},
-		[ editPost, clientId ]
+		[ editPost ]
 	);
 
 	// Monitor for valid questions.

--- a/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
+++ b/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
@@ -9,10 +9,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { isQuestionEmpty } from '../data';
 
-const isPreview = document.documentElement.classList.contains(
-	'block-editor-block-preview__content-iframe'
-);
-
 /**
  * Monitor for questions and disable the lesson quiz when none have been added.
  *
@@ -36,7 +32,8 @@ export const useUpdateQuizHasQuestionsMeta = ( clientId ) => {
 	const { editPost } = useDispatch( 'core/editor' );
 	const setQuizHasQuestionsMeta = useCallback(
 		( enable ) => {
-			if ( isPreview ) {
+			// Check if block is in the DOM (it skips cases in preview iframes).
+			if ( ! document.getElementById( `block-${ clientId }` ) ) {
 				return;
 			}
 
@@ -44,7 +41,7 @@ export const useUpdateQuizHasQuestionsMeta = ( clientId ) => {
 				meta: { [ META_KEY ]: enable ? 1 : 0 },
 			} );
 		},
-		[ editPost ]
+		[ editPost, clientId ]
 	);
 
 	// Monitor for valid questions.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -642,7 +642,8 @@ class Sensei_Lesson {
 	public function meta_box_save( $post_id ) {
 
 		// Verify the nonce before proceeding.
-		if ( ( get_post_type( $post_id ) !== $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_nonce' ], 'sensei-save-post-meta' ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Do not change the nonce.
+		if ( ( get_post_type( $post_id ) !== $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( wp_unslash( $_POST[ 'woo_' . $this->token . '_nonce' ] ), 'sensei-save-post-meta' ) ) {
 			return $post_id;
 		}
 		// Get the post type object.


### PR DESCRIPTION
This PR is based on the tag [version/4.8.1](https://github.com/Automattic/sensei/tree/version/4.8.1)

### Changes proposed in this Pull Request

* It avoids setting that a lesson has a quiz when the check is coming from a preview.
* It also fixes a PHPCS issue.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Debug the function `setQuizHasQuestionsMeta` in `useUpdateQuizHasQuestionsMeta`. You can add a `console.log( enable ? 1 : 0 );` before the call to the `editPost` function to monitor it.
* Create a new lesson. In the lesson wizard modal, navigate to the last step.
* Make sure the quiz is not set to enable when it's coming from the preview (thumbnails in the last step of the modal).
* Close the modal.
* Make sure the Lesson Actions block doesn't show the button "View Quiz".
* Add a quiz block with a question.
* Make sure the "View Quiz" is displayed.
* Remove the quiz, and make sure the "View Quiz" is not displayed again.

---

Make sure the PHPCS fix didn't break the meta box save function.

* Edit any lesson.
* In the sidebar, check the setting "Allow this lesson to be viewed without login".
* Save it and refresh the editor.
* Make sure the option was updated.