### PR TITLE
Add InstaWP GitHubAction

### DIFF
--- a/.github/workflows/instawp.yml
+++ b/.github/workflows/instawp.yml
@@ -2,16 +2,31 @@ name: InstaWP WordPress Testing
 
 on:
     pull_request:
-        types: [ opened ]
+        types: [ opened, closed, merged ]
 
 jobs:
     create-wp-for-testing:
         runs-on: ubuntu-latest
         steps:
             -   uses: instawp/wordpress-testing-automation@main
+                if: github.event.action == 'opened'
                 with:
                     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
                     INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
                     INSTAWP_TEMPLATE_SLUG: default2
                     REPO_ID: 47
                     INSTAWP_ACTION: create-site-template
+    
+    destroy-wp-after-testing:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: instawp/wordpress-testing-automation@main
+                if: github.event.action == 'closed' || github.event.action == 'merged'
+                id: detroy-wp
+                with:
+                    GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+                    INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
+                    INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
+                    INSTAWP_TEMPLATE_SLUG: gutenawithkit
+                    REPO_ID: 22
+                    INSTAWP_ACTION: destroy-site

--- a/.github/workflows/instawp.yml
+++ b/.github/workflows/instawp.yml
@@ -1,0 +1,17 @@
+name: InstaWP WordPress Testing
+
+on:
+    pull_request:
+        types: [ opened ]
+
+jobs:
+    create-wp-for-testing:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: instawp/wordpress-testing-automation@main
+                with:
+                    GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+                    INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
+                    INSTAWP_TEMPLATE_SLUG: default2
+                    REPO_ID: 47
+                    INSTAWP_ACTION: create-site-template


### PR DESCRIPTION
## There is a bug on the InstaWP side and the action fails. However, it creates a website. I contacted InstaWP's support to find a solution.

We add an InstaWP GitHub Action for creating a website for each pull request.
In this configuration, it won't update a website on the PR update.
But it will destroy the website once the PR was merged or closed.
The website will be deleted automatically after 15 days.

### Changes proposed in this Pull Request

* Add configuration for the InstaWP GitHub Action.

### Testing instructions

* It must add a comment to the PR with links to the created website and for the auto-login.
* Find those links and follow them :)


### Screenshot / Video
