### PR TITLE
Add compatibility for WP < 6.0 on quiz author fix

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -120,13 +120,18 @@ class Sensei_Quiz {
 	/**
 	 * Hooks into `wp_insert_post_data` and updates the quiz author to the lesson author on create.
 	 *
-	 * @param mixed $data                The data to be saved.
-	 * @param mixed $postarr             The post data.
-	 * @param mixed $unsanitized_postarr Unsanitized post data.
-	 * @param bool  $update              Whether the action is for an existing post being updated or not.
+	 * @param mixed     $data                The data to be saved.
+	 * @param mixed     $postarr             The post data.
+	 * @param mixed     $unsanitized_postarr Unsanitized post data.
+	 * @param bool|null $update              Whether the action is for an existing post being updated or not.
 	 * @return mixed
 	 */
-	public function set_quiz_author_on_create( $data, $postarr, $unsanitized_postarr, $update ) {
+	public function set_quiz_author_on_create( $data, $postarr, $unsanitized_postarr, $update = null ) {
+		// Compatibility for WP < 6.0
+		if ( null === $update ) {
+			$update = ! empty( $postarr['ID'] );
+		}
+
 		// Only handle new posts.
 		if ( $update ) {
 			return $data;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -127,7 +127,7 @@ class Sensei_Quiz {
 	 * @return mixed
 	 */
 	public function set_quiz_author_on_create( $data, $postarr, $unsanitized_postarr, $update = null ) {
-		// Compatibility for WP < 6.0
+		// Compatibility for WP < 6.0.
 		if ( null === $update ) {
 			$update = ! empty( $postarr['ID'] );
 		}


### PR DESCRIPTION


### Changes proposed in this Pull Request

Add compatibility for WordPress < 6.0 to the fix implemented in https://github.com/Automattic/sensei/pull/6129. H/T @renatho for catching this!

### Testing instructions

Run the unit tests against WordPress 5.9 and ensure that everything passes. note that all of the tests may or may not run properly in CI (see https://github.com/Automattic/sensei/issues/6152) so make sure to run them locally.
