### PR TITLE
Address testing feedback for course settings sidebar

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -264,3 +264,8 @@ a.sensei-custom-navigation__info {
 .sensei-students__enrolled-course {
 	display: block;
 }
+
+.sensei-plugin-document-setting-panel button span,
+.components-panel__body .edit-post-post-author {
+	display: none;
+}

--- a/assets/js/admin/course-access-period-promo-sidebar.js
+++ b/assets/js/admin/course-access-period-promo-sidebar.js
@@ -11,7 +11,7 @@ const CourseAccessPeriodPromoSidebar = () => {
 	return (
 		<PanelBody
 			title={ __( 'Access Period', 'sensei-lms' ) }
-			initialOpen={ false }
+			initialOpen={ true }
 		>
 			<div className="sensei-course-access-period-promo">
 				<p>

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, dispatch } from '@wordpress/data';
+import { useSelect, dispatch, select } from '@wordpress/data';
 import {
 	PanelBody,
 	CheckboxControl,
@@ -14,6 +14,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect } from '@wordpress/element';
 
 import editorLifecycle from '../../shared/helpers/editor-lifecycle';
+import {
+	extractStructure,
+	getFirstBlockByName,
+} from '../../blocks/course-outline/data';
 
 const CourseGeneralSidebar = () => {
 	const course = useSelect( ( select ) => {
@@ -47,6 +51,15 @@ const CourseGeneralSidebar = () => {
 		editorLifecycle( {
 			onSaveStart: () => {
 				if ( author !== course.author ) {
+					const outlineBlock = getFirstBlockByName(
+						'sensei-lms/course-outline',
+						select( 'core/block-editor' ).getBlocks()
+					);
+					const moduleSlugs =
+						outlineBlock &&
+						extractStructure( outlineBlock.innerBlocks )
+							.filter( ( block ) => block.slug )
+							.map( ( block ) => block.slug );
 					apiFetch( {
 						path: '/sensei-internal/v1/course-utils/update-teacher',
 						method: 'PUT',
@@ -55,6 +68,7 @@ const CourseGeneralSidebar = () => {
 								window.sensei.courseSettingsSidebar.nonce_value,
 							post_id: course.id,
 							teacher: author,
+							custom_slugs: JSON.stringify( moduleSlugs ),
 						},
 					} );
 				}

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -70,6 +70,16 @@ const CourseGeneralSidebar = () => {
 							teacher: author,
 							custom_slugs: JSON.stringify( moduleSlugs ),
 						},
+					} ).catch( ( response ) => {
+						if ( response.message ) {
+							dispatch( 'core/notices' ).createNotice(
+								'warning',
+								response.message,
+								{
+									isDismissible: true,
+								}
+							);
+						}
 					} );
 				}
 			},

--- a/assets/js/admin/course-pricing-promo-sidebar.js
+++ b/assets/js/admin/course-pricing-promo-sidebar.js
@@ -28,10 +28,7 @@ const CoursePricingPromoSidebar = () => {
 	);
 
 	return (
-		<PanelBody
-			title={ __( 'Pricing', 'sensei-lms' ) }
-			initialOpen={ false }
-		>
+		<PanelBody title={ __( 'Pricing', 'sensei-lms' ) } initialOpen={ true }>
 			<p> { escapeHTML( description ) } </p>
 			<p>
 				<ExternalLink

--- a/assets/js/admin/course-settings-plugin-sidebar.js
+++ b/assets/js/admin/course-settings-plugin-sidebar.js
@@ -10,7 +10,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { dispatch, useSelect } from '@wordpress/data';
 import { Slot } from '@wordpress/components';
-import domReady from '@wordpress/dom-ready';
 
 /**
  * Internal dependencies
@@ -27,7 +26,7 @@ export const pluginDocumentHandle = 'sensei-lms-document-settings-sidebar';
 
 export const CourseSidebar = () => {
 	/**
-	 * Filter to show or hide course pricing upsell component.
+	 * Filter to show or hide course pricing component.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -37,7 +36,7 @@ export const CourseSidebar = () => {
 	const hideCoursePricing = applyFilters( 'senseiCoursePricingHide', false );
 
 	/**
-	 * Filter to show or hide course expiration upsell component.
+	 * Filter to show or hide course expiration component.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/assets/js/admin/course-settings-plugin-sidebar.js
+++ b/assets/js/admin/course-settings-plugin-sidebar.js
@@ -26,7 +26,24 @@ export const pluginSidebarHandle = 'sensei-lms-course-settings-sidebar';
 export const pluginDocumentHandle = 'sensei-lms-document-settings-sidebar';
 
 export const CourseSidebar = () => {
+	/**
+	 * Filter to show or hide course pricing upsell component.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @hook  senseiCoursePricingHide This hook allows to pass a boolean value for hiding course pricing upsell.
+	 * @return {boolean} 			  Hide the component.
+	 */
 	const hideCoursePricing = applyFilters( 'senseiCoursePricingHide', false );
+
+	/**
+	 * Filter to show or hide course expiration upsell component.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @hook  senseiCourseAccessPeriodHide This hook allows to pass a boolean value for hiding course expiration (access period) upsell.
+	 * @return {boolean} 				   Hide the component.
+	 */
 	const hideAccessPeriod = applyFilters(
 		'senseiCourseAccessPeriodHide',
 		false

--- a/assets/js/admin/course-settings-plugin-sidebar.js
+++ b/assets/js/admin/course-settings-plugin-sidebar.js
@@ -10,6 +10,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { dispatch, useSelect } from '@wordpress/data';
 import { Slot } from '@wordpress/components';
+import domReady from '@wordpress/dom-ready';
 
 /**
  * Internal dependencies
@@ -74,6 +75,7 @@ export const SenseiSettingsDocumentSidebar = () => {
 		<PluginDocumentSettingPanel
 			name={ pluginDocumentHandle }
 			title={ __( 'Sensei Settings', 'sensei-lms' ) }
+			className="sensei-plugin-document-setting-panel"
 		></PluginDocumentSettingPanel>
 	);
 };

--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -31,7 +31,7 @@ const CourseThemeSidebar = () => {
 	return (
 		<PanelBody
 			title={ __( 'Learning Mode', 'sensei-lms' ) }
-			initialOpen={ false }
+			initialOpen={ true }
 		>
 			{ globalLearningModeEnabled ? (
 				<p>

--- a/assets/js/admin/course-video-sidebar.js
+++ b/assets/js/admin/course-video-sidebar.js
@@ -24,7 +24,7 @@ const CourseVideoSidebar = () => {
 	);
 
 	return (
-		<PanelBody title={ __( 'Video', 'sensei-lms' ) } initialOpen={ false }>
+		<PanelBody title={ __( 'Video', 'sensei-lms' ) } initialOpen={ true }>
 			<ToggleControl
 				label={ __( 'Autocomplete Lesson', 'sensei-lms' ) }
 				checked={ autocomplete }

--- a/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
@@ -109,9 +109,9 @@ class Sensei_REST_API_Course_Utils_Controller extends \WP_REST_Controller {
 				if ( $course_name ) {
 					return new WP_REST_Response(
 						[
-							'status' => 'module in use by different course and teacher',
+							'message' => 'Update Teacher Failed: Module in use by different course and teacher.',
 						],
-						WP_HTTP::OK
+						WP_HTTP::BAD_REQUEST
 					);
 				}
 			}

--- a/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
@@ -81,6 +81,10 @@ class Sensei_REST_API_Course_Utils_Controller extends \WP_REST_Controller {
 						'type'     => 'number',
 						'required' => true,
 					],
+					'custom_slugs'                    => [
+						'type'     => 'string',
+						'required' => false,
+					],
 				],
 			]
 		);
@@ -93,8 +97,25 @@ class Sensei_REST_API_Course_Utils_Controller extends \WP_REST_Controller {
 	 * @return WP_REST_Response The json response.
 	 */
 	public function update_teacher( WP_REST_Request $request ) {
-		$post_id = $request->get_param( 'post_id' );
-		$teacher = $request->get_param( 'teacher' );
+		$post_id             = $request->get_param( 'post_id' );
+		$teacher             = $request->get_param( 'teacher' );
+		$module_custom_slugs = $request->get_param( 'custom_slugs' );
+
+		// If a custom slug is of a module that belongs to another teacher from another course, don't process farther.
+		if ( isset( $module_custom_slugs ) ) {
+			$module_custom_slugs = json_decode( sanitize_text_field( wp_unslash( $module_custom_slugs ) ) );
+			foreach ( $module_custom_slugs as $module_custom_slug ) {
+				$course_name = Sensei()->teacher::is_module_in_use_by_different_course_and_teacher( $module_custom_slug, $post_id, $teacher );
+				if ( $course_name ) {
+					return new WP_REST_Response(
+						[
+							'status' => 'module in use by different course and teacher',
+						],
+						WP_HTTP::OK
+					);
+				}
+			}
+		}
 
 		Sensei()->teacher->save_teacher( $post_id, $teacher );
 		return new WP_REST_Response(


### PR DESCRIPTION
Fixes #6155 
Fixes #6071 

### Changes proposed in this Pull Request

* Documentation for course pricing and access period hooks.
* Open all panels by default.
* Hide down arrow icon in 'Sensei Settings' document panel to remove confusion about being a panel that can be opened.
* Handle course module custom slugs just like we do with meta box save teacher.