### PR TITLE
Fix spacing in Take Course block

### DIFF
--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -75,7 +75,7 @@ class Sensei_Block_Take_Course {
 			$html = $this->render_with_login( $content );
 		}
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'sensei-block-wrapper sensei-cta' ) );
-		return ! empty( $html ) ? '<div' . $wrapper_attributes . '>' . $html . '</div>' : '';
+		return ! empty( $html ) ? '<div ' . $wrapper_attributes . '>' . $html . '</div>' : '';
 	}
 
 	/**
@@ -109,8 +109,8 @@ class Sensei_Block_Take_Course {
 
 		if ( preg_match( '/<button(.*)class="(.*)"/', $button ) ) {
 			return preg_replace(
-				'/<button(.*)class="(.*)"/',
-				'<button $1 class="sensei-stop-double-submission $2"',
+				'/<button(.*) class="(.*)"/',
+				'<button$1 class="sensei-stop-double-submission $2"',
 				$button,
 				1
 			);

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -62,7 +62,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$result = do_blocks( $post_content );
 
-		$this->assertContains( '<form'p, $result );
+		$this->assertContains( '<form', $result );
 		$this->assertContains( 'Take Course</button>', $result );
 	}
 

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -56,13 +56,13 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	 * The take course block is registered and renders content.
 	 */
 	public function testBlockRegistered() {
-		$post_content = '<!-- wp:sensei-lms/button-take-course {"style":{"color":{"text":"#d03f3f"}},"className":"is-style-outline"} -->
-<div class="wp-block-sensei-lms-button-take-course wp-block-sensei-button has-text-align-full is-style-outline"><button class="wp-block-button__link has-text-color" style="color:#d03f3f">Take Course</button></div>
+		$post_content = '<!-- wp:sensei-lms/button-take-course {"style":{"color":{"text":"#d03f3f"}},"className":"has-text-align-full is-style-outline"} -->
+<div class="wp-block-sensei-lms-button-take-course has-text-align-full is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link has-text-color" style="color:#d03f3f">Take Course</button></div>
 <!-- /wp:sensei-lms/button-take-course -->';
 
 		$result = do_blocks( $post_content );
 
-		$this->assertContains( '<form', $result );
+		$this->assertContains( '<form'p, $result );
 		$this->assertContains( 'Take Course</button>', $result );
 	}
 
@@ -73,7 +73,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$this->login_as_student();
 
-		$result = $this->block->render_take_course_block( [], '<button>Take Course</button>' );
+		$result = do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
 
 		$form   = '/^\s*<form method="POST" action=".*\/\?course=take-block-course">.+<\/form>$/ms';
 		$nonce  = '/<input type="hidden" id="woothemes_sensei_start_course_noonce" name="woothemes_sensei_start_course_noonce" value=".+" \/>/';
@@ -82,7 +82,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 		$this->assertRegExp( $form, $result, 'Should be wrapped in a form tag' );
 		$this->assertContains( $action, $result, 'Should have course_start action input field' );
 		$this->assertRegExp( $nonce, $result, 'Should have nonce input field' );
-		$this->assertContains( '<button class="sensei-stop-double-submission" >Take Course</button>', $result, 'Should contain block content' );
+		$this->assertContains( '<button class="sensei-stop-double-submission sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Should contain block content' );
 
 	}
 
@@ -103,12 +103,12 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$this->logout();
 
-		$result = $this->block->render_take_course_block( [], '<button>Take Course</button>' );
+		$result = do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
 
 		$form = '/^\s*<form method="GET" action=".*page_id=' . $my_courses_page_id . '">.+<\/form>\s*$/ms';
 
 		$this->assertRegExp( $form, $result, 'Should be wrapped in a form tag' );
-		$this->assertContains( '<button>Take Course</button>', $result, 'Should contain block content' );
+		$this->assertContains( '<button class="sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Should contain block content' );
 	}
 
 	/**
@@ -124,9 +124,9 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$this->login_as_student();
 
-		$result = $this->block->render_take_course_block( [], '<button>Take Course</button>' );
+		$result = do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
 
-		$this->assertContains( '<button disabled="disabled">Take Course</button>', $result, 'Button should be disabled' );
+		$this->assertContains( '<button disabled="disabled" class="sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Button should be disabled' );
 
 		ob_start();
 		Sensei()->notices->maybe_print_notices();
@@ -147,7 +147,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$this->login_as( $student );
 
-		$result = $this->block->render_take_course_block( [], '<button>Take Course</button>' );
+		$result = do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
 
 		$this->assertEmpty( $result );
 	}
@@ -163,7 +163,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 			'post_type' => 'page',
 		];
 
-		$result = $this->block->render_take_course_block( [], '<button>Take Course</button>' );
+		$result = do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
 
 		$this->assertEmpty( $result );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Use the WP do_blocks to simulate the block rendering, instead of calling the render method directly.
*  Fix an extra lack of spacing here https://github.com/Automattic/sensei/pull/6163/files#diff-b981e2bbec3c37011de89cb5a29cb17879558d14f81a44e59e670a90e17f67caR78
* Fix an extra spacing here https://github.com/Automattic/sensei/pull/6163/files#diff-b981e2bbec3c37011de89cb5a29cb17879558d14f81a44e59e670a90e17f67caR113 

### Testing instructions
npm run test-php ./tests/unit-tests/blocks/test-class-sensei-block-take-course.php
Check if the tests are passing

