### PR TITLE
Adapt co-teachers to new sidebar

### DIFF
--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -83,7 +83,7 @@ const CourseGeneralSidebar = () => {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param {boolean} Whether the upgrade should be hidden or not. Default false. True will hide the upgrade.
+	 * @param {Function} The existing component hooked into the filter.
 	 */
 	const AfterTeachersSection = useMemo(
 		() => applyFilters( 'senseiCourseSettingsTeachersAfter', () => null ),

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -95,7 +95,6 @@ const CourseGeneralSidebar = () => {
 			<h3>{ __( 'Teacher', 'sensei-lms' ) }</h3>
 			{ teachers.length ? (
 				<SelectControl
-					id="sensei-course-teacher-author"
 					value={ author }
 					options={ teachers }
 					onChange={ ( new_author ) => {

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -13,7 +13,11 @@ import { useEntityProp } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
 import editorLifecycle from '../../shared/helpers/editor-lifecycle';
+import { applyFilters, doAction } from '@wordpress/hooks';
 
 const CourseGeneralSidebar = () => {
 	const course = useSelect( ( select ) => {
@@ -62,11 +66,36 @@ const CourseGeneralSidebar = () => {
 		} )
 	);
 
+	/**
+	 * Allows to show or hide the multiple teachers upgrade.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param {boolean} Whether the upgrade should be hidden or not. Default false. True will hide the upgrade.
+	 */
+	const hideCoteachersUpgrade = applyFilters(
+		'senseiCourseSettingsMultipleTeachersUpgradeHide',
+		false
+	);
+
+	/**
+	 * Returns the component to render after the teacher course setting.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param {boolean} Whether the upgrade should be hidden or not. Default false. True will hide the upgrade.
+	 */
+	const teacherSettingAfter = applyFilters(
+		'senseiCourseSettingsTeachersAfter',
+		null
+	);
+
 	return (
 		<PanelBody title={ __( 'General', 'sensei-lms' ) } initialOpen={ true }>
 			<h3>{ __( 'Teacher', 'sensei-lms' ) }</h3>
 			{ teachers.length ? (
 				<SelectControl
+					id="sensei-course-teacher-author"
 					value={ author }
 					options={ teachers }
 					onChange={ ( new_author ) => {
@@ -80,6 +109,21 @@ const CourseGeneralSidebar = () => {
 					} }
 				/>
 			) : null }
+
+			{ ! hideCoteachersUpgrade && (
+				<div className="sensei-course-coteachers-wrapper">
+					{ __( 'Multiple teachers?', 'sensei-lms' ) }{ ' ' }
+					<a
+						href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=co-teachers"
+						target="_blank"
+						rel="noreferrer"
+					>
+						{ __( 'Upgrade to Pro!', 'sensei-lms' ) }
+					</a>
+				</div>
+			) }
+
+			{ teacherSettingAfter }
 
 			<HorizontalRule />
 

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -86,7 +86,7 @@ const CourseGeneralSidebar = () => {
 	 * @param {boolean} Whether the upgrade should be hidden or not. Default false. True will hide the upgrade.
 	 */
 	const AfterTeachersSection = useMemo(
-		() => applyFilters( 'senseiCourseSettingsTeachersAfter', null ),
+		() => applyFilters( 'senseiCourseSettingsTeachersAfter', () => null ),
 		[]
 	);
 

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -122,7 +122,10 @@ const CourseGeneralSidebar = () => {
 				</div>
 			) }
 
-			<AfterTeachersSection courseAuthorId={ author } />
+			<AfterTeachersSection
+				courseAuthorId={ author }
+				courseId={ course.id }
+			/>
 
 			<HorizontalRule />
 

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -85,9 +85,9 @@ const CourseGeneralSidebar = () => {
 	 *
 	 * @param {boolean} Whether the upgrade should be hidden or not. Default false. True will hide the upgrade.
 	 */
-	const AfterTeachersSection = applyFilters(
-		'senseiCourseSettingsTeachersAfter',
-		null
+	const AfterTeachersSection = useMemo(
+		() => applyFilters( 'senseiCourseSettingsTeachersAfter', null ),
+		[]
 	);
 
 	return (

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -85,7 +85,7 @@ const CourseGeneralSidebar = () => {
 	 *
 	 * @param {boolean} Whether the upgrade should be hidden or not. Default false. True will hide the upgrade.
 	 */
-	const teacherSettingAfter = applyFilters(
+	const AfterTeachersSection = applyFilters(
 		'senseiCourseSettingsTeachersAfter',
 		null
 	);
@@ -122,7 +122,7 @@ const CourseGeneralSidebar = () => {
 				</div>
 			) }
 
-			{ teacherSettingAfter }
+			<AfterTeachersSection courseAuthorId={ author } />
 
 			<HorizontalRule />
 

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -98,6 +98,7 @@ const CourseGeneralSidebar = () => {
 					value={ author }
 					options={ teachers }
 					onChange={ ( new_author ) => {
+						new_author = parseInt( new_author );
 						setAuthor( new_author );
 						dispatch( 'core' ).editEntityRecord(
 							'postType',

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -17,7 +17,7 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import editorLifecycle from '../../shared/helpers/editor-lifecycle';
-import { applyFilters, doAction } from '@wordpress/hooks';
+import { applyFilters } from '@wordpress/hooks';
 
 const CourseGeneralSidebar = () => {
 	const course = useSelect( ( select ) => {

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -298,47 +298,6 @@ class Sensei_Teacher {
 		</select>
 
 		<?php
-
-		/**
-		 * Filters the Co-Teachers upgrade link toggle.
-		 *
-		 * @hook   sensei_course_coteachers_hide
-		 * @since  $$next-version$$
-		 *
-		 * @param  {bool} $hide_co_teachers_upgrade_link Whether to hide the Co-Teachers upgrade link.
-		 * @return {bool} Whether to hide the Co-Teachers upgrade link.
-		 */
-		if ( ! apply_filters( 'sensei_course_coteachers_hide', false ) ) {
-			?>
-			<div class="sensei-course-coteachers-wrapper">
-				<?php
-				echo wp_kses(
-					sprintf(
-					// translators: The href tag contains the url to the Sensei Pro landing page.
-						__( 'Multiple teachers? <a href="%s" target="_blank">Upgrade to Pro!</a>', 'sensei-lms' ),
-						'https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=co-teachers'
-					),
-					[
-						'a' => [
-							'href'   => [],
-							'target' => [],
-						],
-					]
-				);
-				?>
-			</div>
-			<?php
-		}
-
-		/**
-		 * Adds additional content to the end of the Teacher meta box.
-		 *
-		 * @hook   sensei_teacher_meta_box_after
-		 * @since  $$next-version$$
-		 *
-		 * @param  {WP_Post} $post The current post.
-		 */
-		do_action( 'sensei_teacher_meta_box_after', $post );
 	}
 
 	/**


### PR DESCRIPTION
Fixes 1930-gh-Automattic/sensei-pro

### Changes proposed in this Pull Request

* Add Multiple Teachers upgrade to sidebar with filter to disable it.
* Add filter to include content _after_ the teachers selector is displayed.

### Testing instructions
- Verify tests pass.
- Verify that sidebar settings are working correctly.
- Verify that Multiple Teachers upgrade appear by default and disappears when setting `senseiCourseSettingsMultipleTeachersUpgradeHide` filter to true.
- Verify that you can add content _after_ the teachers section in the sidebar by adding to the `senseiCourseSettingsTeachersAfter` filter.

### New/Updated Hooks
* `senseiCourseSettingsMultipleTeachersUpgradeHide`: Allows to hide/show the multiple teachers upgrade CTA.
* `senseiCourseSettingsTeachersAfter`: Allows to include content _after_ the teacher section in course settings is rendered.