### PR TITLE
Fix some issues with the teacher's Students view 

### DIFF
--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -112,6 +112,7 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 			const query = {
 				per_page: 100,
 				search: searchQuery,
+				filter: 'teacher',
 			};
 
 			return {

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -440,7 +440,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	private function get_learner_courses_html( $user_id ) {
 		$base_query_args = [ 'posts_per_page' => 3 ];
 		$query           = $this->learner->get_enrolled_courses_query( $user_id, $base_query_args );
-		$courses         = $query->get_posts();
+		$courses         = $query->posts;
 
 		if ( empty( $courses ) ) {
 			return __( 'N/A', 'sensei-lms' );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -222,8 +222,13 @@ class Sensei_Learner {
 	 */
 	public function filter_rest_course_query( $args, $request ) {
 		$filter = $request->get_param( 'filter' );
-		if ( 'teacher' === $filter && ! current_user_can( 'manage_sensei' ) ) {
-			$args['author'] = get_current_user_id();
+		if (
+			'teacher' === $filter
+			&& ! current_user_can( 'manage_sensei' )
+			&& current_user_can( 'manage_sensei_grades' )
+		) {
+			$args['context'] = 'teacher-filter';
+			$args['author']  = get_current_user_id();
 		}
 
 		return $args;

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -57,6 +57,7 @@ class Sensei_Learner {
 	 * @since 3.0.0
 	 */
 	public function init() {
+		add_filter( 'rest_course_query', array( $this, 'filter_rest_course_query' ), 10, 2 );
 		add_action( 'wp_ajax_get_course_list', array( $this, 'get_course_list' ) );
 
 		// Delete user activity and enrolment terms when user is deleted.
@@ -209,6 +210,23 @@ class Sensei_Learner {
 		}
 
 		return $dataset_changes;
+	}
+
+	/**
+	 * Filter the courses returned by the REST API to just ones that can be managed.
+	 *
+	 * @param array           $args    Array of arguments for WP_Query.
+	 * @param WP_REST_Request $request The REST API request.
+	 *
+	 * @return array
+	 */
+	public function filter_rest_course_query( $args, $request ) {
+		$filter = $request->get_param( 'filter' );
+		if ( 'teacher' === $filter && ! current_user_can( 'manage_sensei' ) ) {
+			$args['author'] = get_current_user_id();
+		}
+
+		return $args;
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
@@ -90,8 +90,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View_Test extends WP_UnitTestCase {
 		$controller         = $this->createMock( Sensei_Learners_Admin_Bulk_Actions_Controller::class );
 		$learner_management = $this->createMock( Sensei_Learner_Management::class );
 
-		$enrolled_courses_query = $this->createMock( WP_Query::class );
-		$enrolled_courses_query->method( 'get_posts' )->willReturn( $enrolled_courses );
+		$enrolled_courses_query        = $this->createMock( WP_Query::class );
+		$enrolled_courses_query->posts = $enrolled_courses;
 
 		$learner = $this->createMock( Sensei_Learner::class );
 		$learner


### PR DESCRIPTION
Part of 1905-gh-Automattic/sensei-pro
Fixes #6116 

### Changes proposed in this Pull Request

* Prevent double querying for enrolled courses for each student. Calling `WP_Query::get_posts` on a query that had args on construction will double-query. That double query seems to break our co-teacher hack, but I think it should be fixed here. We're doing this a number of places in Sensei, but I'll fix the other places in a separate PR.
* Passes a `filter=teacher` so that when a teacher goes to enroll students here, they just see their own courses. This fixes it for normal teachers and also works with our co-teacher functionality. We also pass a new `context` argument to hint to Sensei Pro that this should show all teachers. 

### Testing instructions
* Make sure Sensei Pro is set to branch in 1936-gh-Automattic/sensei-pro
* Set a course by Teacher A to have a co-teacher Teacher B.
* Log in as Teacher B.
* Go to Sensei LMS > Students > ... next to student and click `Add to Course` (same modal as used in the bulk enrollment, too).
* Enroll student in the shared course.
* Ensure the course is listed for the student under `Enrolled Courses`