### PR TITLE
Fix double query when calling `WP_Query::get_posts`

### DIFF
--- a/includes/admin/tools/class-sensei-tool-enrolment-debug.php
+++ b/includes/admin/tools/class-sensei-tool-enrolment-debug.php
@@ -96,7 +96,7 @@ class Sensei_Tool_Enrolment_Debug implements Sensei_Tool_Interface, Sensei_Tool_
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Variable used in view.
 		$courses = false;
 		if ( $course_search->found_posts < 100 ) {
-			$courses = $course_search->get_posts();
+			$courses = $course_search->posts;
 		}
 
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Variable used in view.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -542,7 +542,7 @@ class Sensei_Lesson {
 					$lesson_status
 				);
 
-				$in_module_lessons = array_merge( $in_module_lessons, $module_lessons_query->get_posts() );
+				$in_module_lessons = array_merge( $in_module_lessons, $module_lessons_query->posts );
 			}
 
 			$lessons = array_merge( $in_module_lessons, $lessons );

--- a/includes/data-port/export-tasks/class-sensei-export-courses.php
+++ b/includes/data-port/export-tasks/class-sensei-export-courses.php
@@ -103,7 +103,7 @@ class Sensei_Export_Courses
 			);
 
 			$lessons_query   = new WP_Query( $args );
-			$ordered_lessons = array_merge( $ordered_lessons, $lessons_query->get_posts() );
+			$ordered_lessons = array_merge( $ordered_lessons, $lessons_query->posts );
 		}
 
 		// We cannot use $no_module_lessons directly since it's unordered. Instead we intersect it with $all_lessons which is ordered.


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Generally, we rarely/never want to call `WP_Query::get_posts` after constructing a `WP_Query` with query args. `WP_Query` already calls `get_posts` when constructed with query args.
- Removes instance of calling `get_posts` when checking prerequisites on modules. 
- Removes instance of calling `get_posts` when exporting courses.
- Removes instance of calling `get_posts` when using course recalculation tool.

Notes:
- One other instance is fixed by https://github.com/Automattic/sensei/pull/6167.
- There a couple more usages of `get_posts` that seem fine. One is after a `clone` and the other is in our seeder, which uses it to refresh the results at one point.

### Testing instructions
- Create a course with lessons. Go to Sensei LMS > Tools > Export and export the course, lessons, questions. Check `courses.csv` and make sure the lessons IDs are listed in the correct order under the lessons column.
- Go to Sensei LMS > Tools > Recalculate Course Enrollment > Visit Tool and make sure the courses show up in the dropdown (if you have fewer than 100).
- Follow testing instructions in https://github.com/Automattic/sensei/pull/4410 to make sure prereq selector works as expected.