### PR TITLE
Fix the docs build command not working

### DIFF
--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -93,15 +93,9 @@ class Sensei_Notices {
 		 * @since 4.7.0
 		 * @hook sensei_notice
 		 *
-		 * @param array $notice {
-		 *     The notice data with the following properties.
+		 * @param {array} $notice The notice data.
 		 *
-		 *     @type string $content The message text of the notice.
-		 *     @type string $type    The type of the notice. Default: "alert".
-		 *     @type string $key     Optional. The identifier key for the notice.
-		 * }
-		 *
-		 * @return array|null The notice data. Or return null if you want to prevent the notice showing up.
+		 * @return {array|null} The notice data. Or return null if you want to prevent the notice showing up.
 		 */
 		$notice = apply_filters( 'sensei_notice', $notice );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Make the jsdoc command (and our CI) happy by using the proper docblock syntax.

### Testing instructions

* Run the `npm run build:docs` command.
* There should be no errors.
* Open `hookdocs/index.html`.
* Make sure the `sensei_notice` hook has the correct docs.