### PR TITLE
Add/sensei contact link atomic

### DIFF
--- a/includes/admin/home/help/class-sensei-home-help-provider.php
+++ b/includes/admin/home/help/class-sensei-home-help-provider.php
@@ -101,6 +101,8 @@ class Sensei_Home_Help_Provider {
 		if ( apply_filters( 'sensei_home_support_ticket_creation_upsell_show', true ) ) {
 			$extra_link = $this->create_extra_link( __( 'Upgrade to Sensei Pro', 'sensei-lms' ), 'https://senseilms.com/pricing/' );
 			$icon       = 'lock';
+		} elseif ( Sensei_Utils::is_atomic_platform() ) {
+			$url = 'https://wordpress.com/help/contact';
 		} else {
 			$url = 'https://senseilms.com/contact/';
 		}


### PR DESCRIPTION
This depends on this PR: https://github.com/Automattic/sensei/pull/6124

### Changes proposed in this Pull Request

* Changes the "Create a Support Ticket" link on Atomic sites to point to `https://wordpress.com/help/contact`


### Testing instructions
* Install Sensei and Sensei Pro on an Atomic site
* For this I used SFTP to upload them both to the site
* Go to Sensei -> Home
* Verify the Contact support link points to `https://wordpress.com/help/contact`

### Screenshot / Video
<img width="466" alt="Screenshot 2022-11-24 at 3 23 58 PM" src="https://user-images.githubusercontent.com/3220162/203874024-b877d35a-ba88-43c6-a82c-d52b7f5d1cd5.png">