### PR TITLE
Fix ownership for draft lessons when changing teacher. 

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -607,7 +607,7 @@ class Sensei_Teacher {
 		}
 
 		// Get a list of course lessons.
-		$lessons = Sensei()->course->course_lessons( $course_id, null );
+		$lessons = Sensei()->course->course_lessons( $course_id, 'any' );
 
 		if ( empty( $lessons ) || ! is_array( $lessons ) ) {
 			return false;

--- a/tests/unit-tests/test-class-teacher.php
+++ b/tests/unit-tests/test-class-teacher.php
@@ -479,4 +479,26 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 		$term_meta = get_term_meta( $new_term['term_id'], 'module_author', true );
 		$this->assertEquals( $current_user_id, $term_meta );
 	}
+
+	/**
+	 * Test to make sure that author for all lessons is updated including drafts.
+	 */
+	public function testUpdateCourseLessonsAuthor_WhenLessonsAreInDraftStatus_GetAuthorUpdatedToTheNewValue() {
+		$this->login_as_teacher_b();
+		$new_teacher_id = get_current_user_id();
+		$this->login_as_teacher();
+
+		$course = $this->factory->get_course_with_lessons(
+			[
+				'multiple_question_count' => 1,
+				'lesson_count'            => 3,
+				'lesson_args'             => [ 'post_status' => 'draft' ],
+			]
+		);
+
+		$this->login_as_admin();
+		Sensei()->teacher->update_course_lessons_author( $course['course_id'], $new_teacher_id );
+
+		$this->assertPostAuthor( $new_teacher_id, $course['lesson_ids'], 'All lessons must be from teacher B now' );
+	}
 }


### PR DESCRIPTION
Fixes #6179

### Changes proposed in this Pull Request
* Replace 'null' `post_status` when querying all the lessons to update the author for them with 'any`.

### Testing instructions
* Follow steps in #6179