### PR TITLE
Update composer dependencies and fix tests

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -49,19 +49,6 @@ jobs:
             -   name: Install PHP dependencies
                 run: composer install --no-ansi --no-interaction --prefer-dist --no-progress --ignore-platform-reqs
 
-            -   name: Add PHP 7.4+ compatibility
-                run: |
-                    if [ "$(php -r "echo version_compare(PHP_VERSION,'7.4','>=');")" ]; then
-                        curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
-                        unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-                        rm ./vendor/bin/phpunit
-                        composer bin phpunit config --unset platform
-                        composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-                        composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
-                        rm -rf ./vendor/phpunit/
-                        composer dump-autoload
-                    fi
-
             -   name: Setup test environment
                 run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 $WP_VERSION
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,7 @@ jobs:
               run: git checkout -b trunk refs/remotes/origin/trunk && git checkout -
 
             - name: Install PHP dependencies
-              run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress
+              run: composer self-update && composer install --no-ansi --no-interaction --prefer-dist --no-progress
 
             - name: Check for new issues
               run: ./scripts/linter-ci

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -109,19 +109,6 @@ jobs:
             - name: Install PHP dependencies
               run: composer install --no-ansi --no-interaction --prefer-dist --no-progress --ignore-platform-reqs
 
-            - name: Add PHP 7.4+ compatibility
-              run: |
-                  if [ "$(php -r "echo version_compare(PHP_VERSION,'7.4','>=');")" ]; then
-                      curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
-                      unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-                      rm ./vendor/bin/phpunit
-                      composer bin phpunit config --unset platform
-                      composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-                      composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
-                      rm -rf ./vendor/phpunit/
-                      composer dump-autoload
-                  fi
-
             - name: Setup test environment
               run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 $WP_VERSION
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .idea
 .cache
+.phpunit.result.cache
 .wp-env.override.json
 assets/dist
 build

--- a/composer.json
+++ b/composer.json
@@ -2,15 +2,15 @@
 	"name": "automattic/sensei-lms",
 	"description": "A learning management plugin for WordPress, which provides the smoothest platform for helping you teach anything.",
 	"require-dev": {
-		"php": "^7.2 || ^8",
-		"bamarni/composer-bin-plugin": "^1.4",
-		"dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
-		"phpcompatibility/phpcompatibility-wp": "2.1.2",
+		"php": "^7.2.5 || ^8",
+		"bamarni/composer-bin-plugin": "1.8.2",
+		"dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
+		"phpcompatibility/phpcompatibility-wp": "2.1.4",
 		"sirbrillig/phpcs-no-get-current-user": "1.1.0",
-		"sirbrillig/phpcs-variable-analysis": "2.11.2",
-		"squizlabs/php_codesniffer": "3.6.0",
+		"sirbrillig/phpcs-variable-analysis": "2.11.9",
+		"squizlabs/php_codesniffer": "3.7.1",
 		"wp-coding-standards/wpcs": "2.3.0",
-		"yoast/phpunit-polyfills": "1.0.3"
+		"yoast/phpunit-polyfills": "1.0.4"
 	},
 	"prefer-stable": true,
 	"archive": {
@@ -49,7 +49,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "7.2"
+			"php": "7.2.5"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 		"php": "^7.2.5 || ^8",
 		"bamarni/composer-bin-plugin": "1.8.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
+		"dms/phpunit-arraysubset-asserts": "^0.4.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.4",
 		"sirbrillig/phpcs-no-get-current-user": "1.1.0",
 		"sirbrillig/phpcs-variable-analysis": "2.11.9",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 		"php": "^7.2.5 || ^8",
 		"bamarni/composer-bin-plugin": "1.8.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
-		"dms/phpunit-arraysubset-asserts": "^0.4.0",
+		"dms/phpunit-arraysubset-asserts": "0.4.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.4",
 		"sirbrillig/phpcs-no-get-current-user": "1.1.0",
 		"sirbrillig/phpcs-variable-analysis": "2.11.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5883666d73da1d3ccfc4897236823cef",
+    "content-hash": "e8f1e5794eb24c690cb7f22b226ff927",
     "packages": [],
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "1.4.1",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225"
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": "^5.5.9 || ^7.0 || ^8.0"
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "^1.0 || ^2.0",
-                "symfony/console": "^2.5 || ^3.0 || ^4.0"
+                "composer/composer": "^2.0",
+                "ext-json": "*",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.5",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Bamarni\\Composer\\Bin\\Plugin"
+                "class": "Bamarni\\Composer\\Bin\\BamarniBinPlugin"
             },
             "autoload": {
                 "psr-4": {
@@ -53,33 +60,33 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.2"
             },
-            "time": "2020-05-03T08:27:20+00:00"
+            "time": "2022-10-31T08:38:03+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -100,6 +107,10 @@
                     "email": "franck.nijhof@dealerdirect.com",
                     "homepage": "http://www.frenck.nl",
                     "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -111,6 +122,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -125,38 +137,36 @@
                 "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2020-12-07T18:04:37+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -170,51 +180,69 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/master"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
-            "time": "2015-06-14T21:17:01+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -230,34 +258,41 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
-            "time": "2017-10-19T19:58:43+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -289,26 +324,26 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -340,9 +375,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/master"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -408,16 +443,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
@@ -454,26 +489,27 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2021-02-15T10:24:51+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.2",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75"
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/a792ab623069f0ce971b2417edef8d9632e32f75",
-                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
@@ -508,280 +544,51 @@
                 "compatibility",
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-07-21T11:09:57+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
-            },
-            "time": "2017-09-11T18:02:19+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpdocumentor/type-resolver": "0.4.*",
-                "phpunit/phpunit": "^6.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/4.x"
-            },
-            "time": "2019-12-28T18:55:12+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "cf842904952e64e703800d094cdf34e715a8a3ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/cf842904952e64e703800d094cdf34e715a8a3ae",
-                "reference": "cf842904952e64e703800d094cdf34e715a8a3ae",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/master"
-            },
-            "time": "2017-12-30T13:23:38+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.10.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
-            },
-            "time": "2020-03-05T15:02:03+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "7.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/819f92bba8b001d4363065928088de22f25a3a48",
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -809,31 +616,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/5.3"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.15"
             },
-            "time": "2018-04-06T15:36:58+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-26T12:20:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -848,7 +664,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -859,11 +675,16 @@
                 "iterator"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.5"
             },
-            "time": "2017-11-27T13:52:08+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:42:26+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -912,28 +733,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -948,7 +769,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -959,35 +780,41 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
             },
-            "time": "2017-02-26T11:10:40+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -1012,60 +839,61 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "abandoned": true,
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2021-07-26T12:15:06+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.14",
+            "version": "8.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+                "reference": "33c126b09a42de5c99e5e8032b54e8221264a74e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33c126b09a42de5c99e5e8032b54e8221264a74e",
+                "reference": "33c126b09a42de5c99e5e8032b54e8221264a74e",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.0",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.2",
+                "phpunit/php-code-coverage": "^7.0.12",
+                "phpunit/php-file-iterator": "^2.0.4",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.5",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.5",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
             },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
-            },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -1073,7 +901,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -1101,73 +929,23 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/6.5.14"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.31"
             },
-            "time": "2019-02-01T05:22:47+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/5.0.10"
-            },
-            "abandoned": true,
-            "time": "2018-08-09T05:50:03+00:00"
+            "time": "2022-10-28T05:57:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1226,30 +1004,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1262,6 +1040,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -1273,10 +1055,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -1288,34 +1066,41 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/master"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.5"
             },
-            "time": "2018-02-01T13:46:46+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T12:31:48+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1329,49 +1114,61 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/master"
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
             },
-            "time": "2017-08-03T08:09:46+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1398,22 +1195,28 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/master"
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
             },
-            "time": "2017-07-01T08:51:00+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.4",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db"
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
-                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/73a9676f2833b9a7c36968f9d882589cd75511e6",
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6",
                 "shasum": ""
             },
             "require": {
@@ -1469,7 +1272,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.5"
             },
             "funding": [
                 {
@@ -1477,27 +1280,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T13:51:24+00:00"
+            "time": "2022-09-14T06:00:17+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1505,7 +1311,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1530,9 +1336,15 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.2"
             },
-            "time": "2017-04-27T15:39:26+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-10T06:55:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1711,25 +1523,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1751,9 +1563,71 @@
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
             },
-            "time": "2015-07-28T20:34:47+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/1.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:25:11+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1851,28 +1725,29 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.2",
+            "version": "v2.11.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e"
+                "reference": "62730888d225d55a613854b6a76fb1f9f57d1618"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/62730888d225d55a613854b6a76fb1f9f57d1618",
+                "reference": "62730888d225d55a613854b6a76fb1f9f57d1618",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^3.5.6"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
-                "phpstan/phpstan": "^0.11.8",
-                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
-                "sirbrillig/phpcs-import-detection": "^1.1"
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -1895,25 +1770,29 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2021-07-06T23:45:17+00:00"
+            "time": "2022-10-05T23:31:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -1956,106 +1835,27 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.19.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
-                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.19-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-23T09:01:57+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.3",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2077,62 +1877,15 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
-            "time": "2019-06-13T22:48:21+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
+                    "url": "https://github.com/theseer",
+                    "type": "github"
                 }
             ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
-            },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2187,16 +1940,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
+                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
                 "shasum": ""
             },
             "require": {
@@ -2204,7 +1957,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "yoast/yoastcs": "^2.2.1"
             },
             "type": "library",
             "extra": {
@@ -2244,7 +1997,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2022-11-16T09:07:52+00:00"
         }
     ],
     "aliases": [],
@@ -2257,7 +2010,7 @@
         "php": "^7.2 || ^8"
     },
     "platform-overrides": {
-        "php": "7.2"
+        "php": "7.2.5"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8f1e5794eb24c690cb7f22b226ff927",
+    "content-hash": "aaef64f37e29b984dc5dfebfa368cf7c",
     "packages": [],
     "packages-dev": [
         {
@@ -138,6 +138,51 @@
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
             "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "dms/phpunit-arraysubset-asserts",
+            "version": "v0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rdohms/phpunit-arraysubset-asserts.git",
+                "reference": "428293c2a00eceefbad71a2dbdfb913febb35de2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/428293c2a00eceefbad71a2dbdfb913febb35de2",
+                "reference": "428293c2a00eceefbad71a2dbdfb913febb35de2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0 || ^8.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "dms/coding-standard": "^9",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "assertarraysubset-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rafael Dohms",
+                    "email": "rdohms@gmail.com"
+                }
+            ],
+            "description": "This package provides ArraySubset and related asserts once deprecated in PHPUnit 8",
+            "support": {
+                "issues": "https://github.com/rdohms/phpunit-arraysubset-asserts/issues",
+                "source": "https://github.com/rdohms/phpunit-arraysubset-asserts/tree/v0.4.0"
+            },
+            "time": "2022-02-13T15:00:28+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2007,7 +2052,7 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": {
-        "php": "^7.2 || ^8"
+        "php": "^7.2.5 || ^8"
     },
     "platform-overrides": {
         "php": "7.2.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aaef64f37e29b984dc5dfebfa368cf7c",
+    "content-hash": "72a3a16cb6d4d87e7f62a4e5ce14ef5b",
     "packages": [],
     "packages-dev": [
         {

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -1,5 +1,7 @@
 <?php
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
 require_once dirname( __FILE__ ) . '/support/class-usage-tracking-test-subclass.php';
 require_once dirname( __FILE__ ) . '/support/wp-die-exception.php';
 
@@ -13,6 +15,8 @@ Usage_Tracking_Test_Subclass::get_instance();
  * @group usage-tracking
  */
 class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
+	use ArraySubsetAsserts;
+
 	private $event_counts       = array();
 	private $track_http_request = array();
 
@@ -89,23 +93,20 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 		$query = array();
 		parse_str( $parsed_url['query'], $query );
 
-		// Older versions (for PHP 5.2) of PHPUnit do not have this method
-		if ( method_exists( $this, 'assertArraySubset' ) ) {
-			$this->assertArraySubset(
-				array(
-					'button_clicked' => 'my_button',
-					'admin_email'    => 'admin@example.org',
-					'_ut'            => $this->usage_tracking->get_prefix() . ':site_url',
-					'_ui'            => 'example.org',
-					'_ul'            => '',
-					'_en'            => $this->usage_tracking->get_prefix() . '_my_event',
-					'_ts'            => '1234000',
-					'_'              => '_',
-				),
-				$query,
-				'Query parameters'
-			);
-		}
+		$this->assertArraySubset(
+			array(
+				'button_clicked' => 'my_button',
+				'admin_email'    => 'admin@example.org',
+				'_ut'            => $this->usage_tracking->get_prefix() . ':site_url',
+				'_ui'            => 'example.org',
+				'_ul'            => '',
+				'_en'            => $this->usage_tracking->get_prefix() . '_my_event',
+				'_ts'            => '1234000',
+				'_'              => '_',
+			),
+			$query,
+			'Query parameters'
+		);
 	}
 
 	/**
@@ -166,7 +167,7 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 
 		$system_data = $this->usage_tracking->get_system_data();
 
-		$this->assertInternalType( 'array', $system_data, 'System data must be returned as an array' );
+		$this->assertIsArray( $system_data, 'System data must be returned as an array' );
 
 		$this->assertArrayHasKey( 'wp_version', $system_data, '`wp_version` key must exist in system data' );
 		$this->assertEquals( $wp_version, $system_data['wp_version'], '`wp_version` does not match expected value' );

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -16,7 +16,7 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 	private $event_counts       = array();
 	private $track_http_request = array();
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		// Update the class name here to match the Usage Tracking class.
 		$this->usage_tracking = Usage_Tracking_Test_Subclass::get_instance();

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -147,7 +147,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 	/**
 	 * Teardown data that the factory creates.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		if ( empty( $this->basic_test_course_ids ) ) {
 			return;
 		}

--- a/tests/unit-tests/admin/home/help/test-class-sensei-home-help-provider.php
+++ b/tests/unit-tests/admin/home/help/test-class-sensei-home-help-provider.php
@@ -30,7 +30,7 @@ class Sensei_Home_Help_Provider_Test extends WP_UnitTestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->had_upsell_filter_overridden = has_filter( 'sensei_home_support_ticket_creation_upsell_show', '__return_false' );
@@ -40,7 +40,7 @@ class Sensei_Home_Help_Provider_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		// Clean filter after test if it wasn't set initially.
 		if ( ! $this->had_upsell_filter_overridden ) {
 			remove_filter( 'sensei_home_support_ticket_creation_upsell_show', '__return_false' );

--- a/tests/unit-tests/admin/home/promo-banner/test-class-sensei-home-promo-banner-provider.php
+++ b/tests/unit-tests/admin/home/promo-banner/test-class-sensei-home-promo-banner-provider.php
@@ -30,7 +30,7 @@ class Sensei_Home_Promo_Banner_Provider_Test extends WP_UnitTestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->had_promo_banner_filter_overridden = has_filter( 'sensei_home_promo_banner_show', '__return_false' );
 		$this->provider                           = new Sensei_Home_Promo_Banner_Provider();
@@ -39,7 +39,7 @@ class Sensei_Home_Promo_Banner_Provider_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		// Clean filter after test if it wasn't set initially.
 		if ( ! $this->had_promo_banner_filter_overridden ) {
 			remove_filter( 'sensei_home_promo_banner_show', '__return_false' );

--- a/tests/unit-tests/admin/home/quick-links/test-class-sensei-home-quick-links-provider.php
+++ b/tests/unit-tests/admin/home/quick-links/test-class-sensei-home-quick-links-provider.php
@@ -23,7 +23,7 @@ class Sensei_Home_Quick_Links_Provider_Test extends WP_UnitTestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->provider = new Sensei_Home_Quick_Links_Provider();
 	}

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-configure-learning-mode.php
@@ -23,12 +23,12 @@ class Sensei_Home_Task_Configure_Learning_Mode_Test extends WP_UnitTestCase {
 	 */
 	private $task;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->task = new Sensei_Home_Task_Configure_Learning_Mode();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		delete_option( Sensei_Settings::VISITED_SECTIONS_OPTION_KEY );
 		parent::tearDown();
 	}

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-create-first-course.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-create-first-course.php
@@ -32,7 +32,7 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->task    = new Sensei_Home_Task_Create_First_Course();
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-publish-first-course.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-publish-first-course.php
@@ -32,7 +32,7 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->task    = new Sensei_Home_Task_Publish_First_Course();
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-publish-first-course.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-publish-first-course.php
@@ -281,7 +281,7 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 		$url = $this->task->get_url();
 
 		// Assert
-		$this->assertContains( 'post-new.php', $url );
+		$this->assertStringContainsString( 'post-new.php', $url );
 	}
 
 	/***
@@ -297,7 +297,7 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 		$url = $this->task->get_url();
 
 		// Assert
-		$this->assertContains( 'post-new.php', $url );
+		$this->assertStringContainsString( 'post-new.php', $url );
 	}
 
 	/***
@@ -321,8 +321,8 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 		$url = $this->task->get_url();
 
 		// Assert
-		$this->assertContains( 'post.php', $url );
-		$this->assertContains( 'action=edit', $url );
+		$this->assertStringContainsString( 'post.php', $url );
+		$this->assertStringContainsString( 'action=edit', $url );
 	}
 
 	/**
@@ -344,6 +344,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 		$url = $this->task->get_url();
 
 		// Assert
-		$this->assertContains( 'post-new.php', $url );
+		$this->assertStringContainsString( 'post-new.php', $url );
 	}
 }

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -32,13 +32,13 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->provider = new Sensei_Home_Tasks_Provider();
 		$this->factory  = new Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		remove_filter( 'sensei_home_tasks', [ $this, 'overrideWithFakeTask' ] );
 		remove_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomImage' ] );
 		parent::tearDown();

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -11,7 +11,7 @@
 class Sensei_Extensions_Test extends WP_UnitTestCase {
 	use Sensei_Test_Login_Helpers;
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		global $submenu;

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -49,13 +49,13 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 		}
 		$response = json_decode( $this->_last_response );
 
-		$this->assertInternalType( 'object', $response );
+		$this->assertIsObject( $response );
 		$this->assertObjectHasAttribute( 'success', $response );
 		$this->assertTrue( $response->success );
 		$this->assertCount( 9, $response->data );
 
 		foreach ( $response->data as $item ) {
-			$this->assertContains( 'Course title', $item );
+			$this->assertStringContainsString( 'Course title', $item );
 		}
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-view.php
@@ -23,19 +23,19 @@ class Sensei_Learners_Admin_Bulk_Actions_View_Test extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
 		$GLOBALS['hook_suffix']    = null;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
 	}
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 		self::resetEnrolmentProviders();

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -24,7 +24,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	/**
 	 * Set up before the class.
 	 */
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		// Mock WooCommerce plugin information.
 		set_transient(
 			Sensei_Utils::WC_INFORMATION_TRANSIENT,
@@ -44,7 +44,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		self::resetEnrolmentProviders();
@@ -66,7 +66,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific teardown.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		global $wp_rest_server;
@@ -76,7 +76,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 		Sensei()->usage_tracking->set_tracking_enabled( true );
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -217,8 +217,8 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		$data = Sensei()->setup_wizard->get_wizard_user_data();
 
-		$this->assertNotContains( [ 'invalid_data' ], $data['purpose']['selected'] );
-		$this->assertNotContains( [ 'invalid_data' ], $data['features']['selected'] );
+		$this->assertEmpty( $data['purpose']['selected'] );
+		$this->assertEmpty( $data['features']['selected'] );
 	}
 
 

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -14,7 +14,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before the class.
 	 */
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		// Mock WooCommerce plugin information.
 		set_transient(
 			Sensei_Utils::WC_INFORMATION_TRANSIENT,
@@ -33,8 +33,8 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before each test.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		// Save original current screen.
 		global $current_screen;
@@ -46,7 +46,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		// Restore current screen.

--- a/tests/unit-tests/admin/test-class-sensei-status.php
+++ b/tests/unit-tests/admin/test-class-sensei-status.php
@@ -15,13 +15,13 @@ require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-he
 class Sensei_Status_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		self::resetEnrolmentProviders();
 		$this->prepareEnrolmentManager();
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
+++ b/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
@@ -18,7 +18,7 @@ class Sensei_Tool_Module_Slugs_Mismatch_Tests extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/admin/tools/test-class-sensei-tool-remove-deleted-user-data.php
+++ b/tests/unit-tests/admin/tools/test-class-sensei-tool-remove-deleted-user-data.php
@@ -18,7 +18,7 @@ class Sensei_Tool_Remove_Deleted_User_Data_Tests extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler-action-scheduler.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler-action-scheduler.php
@@ -17,7 +17,7 @@ class Sensei_Scheduler_Action_Scheduler_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down the test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		_as_reset();
@@ -26,21 +26,21 @@ class Sensei_Scheduler_Action_Scheduler_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before all tests.
 	 */
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		self::createMocks();
 		self::resetScheduler();
 		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_action_scheduler' ] );
 
-		return parent::setUpBeforeClass();
+		parent::setUpBeforeClass();
 	}
 
 	/**
 	 * Tear down after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		self::restoreShimScheduler();
 
-		return parent::tearDownAfterClass();
+		parent::tearDownAfterClass();
 	}
 
 	/**

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler-wp-cron.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler-wp-cron.php
@@ -18,24 +18,24 @@ class Sensei_Scheduler_WP_Cron_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before all tests.
 	 */
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		self::resetScheduler();
 		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_wp_cron' ] );
 
 		self::$original_cron = get_option( 'cron' );
 
-		return parent::setUpBeforeClass();
+		parent::setUpBeforeClass();
 	}
 
 	/**
 	 * Tear down after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		self::restoreShimScheduler();
 
 		update_option( 'cron', self::$original_cron );
 
-		return parent::tearDownAfterClass();
+		parent::tearDownAfterClass();
 	}
 
 	/**

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
@@ -18,7 +18,7 @@ class Sensei_Scheduler_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		self::resetScheduler();
@@ -28,10 +28,10 @@ class Sensei_Scheduler_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		self::restoreShimScheduler();
 
-		return parent::tearDownAfterClass();
+		parent::tearDownAfterClass();
 	}
 
 	/**

--- a/tests/unit-tests/blocks/course-theme/test-class-course-progress-bar.php
+++ b/tests/unit-tests/blocks/course-theme/test-class-course-progress-bar.php
@@ -21,8 +21,8 @@ class Course_Progress_Bar_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 
@@ -32,7 +32,7 @@ class Course_Progress_Bar_Test extends WP_UnitTestCase {
 		];
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		WP_Block_Supports::$block_to_render = null;
 	}

--- a/tests/unit-tests/blocks/course-theme/test-class-course-progress-bar.php
+++ b/tests/unit-tests/blocks/course-theme/test-class-course-progress-bar.php
@@ -59,15 +59,15 @@ class Course_Progress_Bar_Test extends WP_UnitTestCase {
 		$block           = new Course_Progress_Bar();
 
 		// check for 0% width
-		$this->assertContains( 'width: 0%', $block->render(), 'The course progress bar width should be 0%.' );
+		$this->assertStringContainsString( 'width: 0%', $block->render(), 'The course progress bar width should be 0%.' );
 
 		// check for 50% width
 		\Sensei_Utils::sensei_start_lesson( $lesson1->ID, get_current_user_id(), true );
-		$this->assertContains( 'width: 50%', $block->render(), 'The course progress bar width should be 50%.' );
+		$this->assertStringContainsString( 'width: 50%', $block->render(), 'The course progress bar width should be 50%.' );
 
 		// check for 100% width
 		\Sensei_Utils::sensei_start_lesson( $lesson2->ID, get_current_user_id(), true );
-		$this->assertContains( 'width: 100%', $block->render(), 'The course progress bar width should be 100%.' );
+		$this->assertStringContainsString( 'width: 100%', $block->render(), 'The course progress bar width should be 100%.' );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/course-theme/test-class-lesson-actions.php
+++ b/tests/unit-tests/blocks/course-theme/test-class-lesson-actions.php
@@ -107,7 +107,7 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 
 		// Check for is-secondary class suffix.
 		$this->assertRegExp( '/<button.*is-secondary.*>.*\n.*Complete Lesson/', $block_html, 'Should render complete button as secondary CTA' );
-		$this->assertContains( 'Take Quiz', $block_html, 'Should render the take quiz button' );
+		$this->assertStringContainsString( 'Take Quiz', $block_html, 'Should render the take quiz button' );
 	}
 
 	/**
@@ -124,8 +124,8 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 		$block = new Lesson_Actions();
 
 		// Check for empty response.
-		$this->assertNotContains( 'Complete Lesson', $block->render(), 'Should not render the complete lesson button.' );
-		$this->assertContains( 'Take Quiz', $block->render(), 'Should render the take quiz button.' );
+		$this->assertStringNotContainsString( 'Complete Lesson', $block->render(), 'Should not render the complete lesson button.' );
+		$this->assertStringContainsString( 'Take Quiz', $block->render(), 'Should render the take quiz button.' );
 	}
 
 	/**
@@ -154,7 +154,7 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 
 		$block = new Lesson_Actions();
 
-		$this->assertContains( 'Completed', $block->render(), 'Should render "Completed" button if user already completed the lesson.' );
+		$this->assertStringContainsString( 'Completed', $block->render(), 'Should render "Completed" button if user already completed the lesson.' );
 	}
 
 	/**
@@ -176,7 +176,7 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 
 		$block = new Lesson_Actions();
 
-		$this->assertContains( 'Next Lesson', $block->render( [ 'options' => [ 'nextLesson' => true ] ] ), 'Should render "Next Lesson" link if the option is enabled and there is a next lesson in the course.' );
+		$this->assertStringContainsString( 'Next Lesson', $block->render( [ 'options' => [ 'nextLesson' => true ] ] ), 'Should render "Next Lesson" link if the option is enabled and there is a next lesson in the course.' );
 	}
 
 	/**
@@ -187,7 +187,7 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 
 		$block = new Lesson_Actions();
 
-		$this->assertNotContains( 'Next Lesson', $block->render( [ 'options' => [ 'nextLesson' => true ] ] ), 'Should not render "Next Lesson" link if the option is enabled but there is no next lesson in the course.' );
+		$this->assertStringNotContainsString( 'Next Lesson', $block->render( [ 'options' => [ 'nextLesson' => true ] ] ), 'Should not render "Next Lesson" link if the option is enabled but there is no next lesson in the course.' );
 	}
 
 	/**
@@ -213,8 +213,8 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 		$block           = new Lesson_Actions();
 
 		// Check for disabled button.
-		$this->assertContains( ' disabled', $block->render(), 'Should render disabled button if lesson has a pre-requisite.' );
-		$this->assertContains( 'aria-disabled="true"', $block->render(), 'Should render disabled button if lesson has a pre-requisite.' );
+		$this->assertStringContainsString( ' disabled', $block->render(), 'Should render disabled button if lesson has a pre-requisite.' );
+		$this->assertStringContainsString( 'aria-disabled="true"', $block->render(), 'Should render disabled button if lesson has a pre-requisite.' );
 	}
 
 	/**
@@ -226,7 +226,7 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 		$block = new Lesson_Actions();
 
 		// Check for Complete lesson button.
-		$this->assertContains( 'Complete Lesson', $block->render(), 'Should render "Complete lesson" button if user can mark lesson as complete.' );
+		$this->assertStringContainsString( 'Complete Lesson', $block->render(), 'Should render "Complete lesson" button if user can mark lesson as complete.' );
 	}
 
 

--- a/tests/unit-tests/blocks/course-theme/test-class-lesson-actions.php
+++ b/tests/unit-tests/blocks/course-theme/test-class-lesson-actions.php
@@ -25,8 +25,8 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 		self::resetEnrolmentProviders();
@@ -42,7 +42,7 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 		];
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 		WP_Block_Supports::$block_to_render = null;

--- a/tests/unit-tests/blocks/course-theme/test-class-quiz-back-to-lesson.php
+++ b/tests/unit-tests/blocks/course-theme/test-class-quiz-back-to-lesson.php
@@ -55,7 +55,7 @@ class Quiz_Back_To_Lesson_Test extends WP_UnitTestCase {
 		$block = new Quiz_Back_To_Lesson();
 		$html  = $block->render();
 
-		$this->assertContains( get_permalink( $lesson_id ), $html );
+		$this->assertStringContainsString( get_permalink( $lesson_id ), $html );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/course-theme/test-class-quiz-back-to-lesson.php
+++ b/tests/unit-tests/blocks/course-theme/test-class-quiz-back-to-lesson.php
@@ -20,8 +20,8 @@ class Quiz_Back_To_Lesson_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 
@@ -31,7 +31,7 @@ class Quiz_Back_To_Lesson_Test extends WP_UnitTestCase {
 		];
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		WP_Block_Supports::$block_to_render = null;
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-block-course-progress.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-course-progress.php
@@ -18,7 +18,7 @@ class Sensei_Course_Progress_Block_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -28,7 +28,7 @@ class Sensei_Course_Progress_Block_Test extends WP_UnitTestCase {
 		$GLOBALS['post'] = $this->course;
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/course-progress' );
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
@@ -20,7 +20,7 @@ class Sensei_Block_Learner_Courses_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
@@ -32,12 +32,12 @@ class Sensei_Block_Learner_Courses_Test extends WP_UnitTestCase {
 		$GLOBALS['post'] = $this->course;
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/learner-courses' );
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
@@ -52,9 +52,9 @@ class Sensei_Block_Learner_Courses_Test extends WP_UnitTestCase {
 
 		$result = do_blocks( $post_content );
 
-		$this->assertContains( 'All', $result );
-		$this->assertContains( 'Active', $result );
-		$this->assertContains( 'Completed', $result );
+		$this->assertStringContainsString( 'All', $result );
+		$this->assertStringContainsString( 'Active', $result );
+		$this->assertStringContainsString( 'Completed', $result );
 	}
 
 	/**
@@ -68,7 +68,7 @@ class Sensei_Block_Learner_Courses_Test extends WP_UnitTestCase {
 
 		$result = $this->block->render( [], '' );
 
-		$this->assertContains( $course->post_title, $result );
+		$this->assertStringContainsString( $course->post_title, $result );
 
 	}
 

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -62,8 +62,8 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$result = do_blocks( $post_content );
 
-		$this->assertContains( '<form', $result );
-		$this->assertContains( 'Take Course</button>', $result );
+		$this->assertStringContainsString( '<form', $result );
+		$this->assertStringContainsString( 'Take Course</button>', $result );
 	}
 
 	/**
@@ -80,9 +80,9 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 		$action = '<input type="hidden" name="course_start" value="1" />';
 
 		$this->assertRegExp( $form, $result, 'Should be wrapped in a form tag' );
-		$this->assertContains( $action, $result, 'Should have course_start action input field' );
+		$this->assertStringContainsString( $action, $result, 'Should have course_start action input field' );
 		$this->assertRegExp( $nonce, $result, 'Should have nonce input field' );
-		$this->assertContains( '<button class="sensei-stop-double-submission sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Should contain block content' );
+		$this->assertStringContainsString( '<button class="sensei-stop-double-submission sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Should contain block content' );
 
 	}
 
@@ -108,7 +108,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 		$form = '/^\s*<form method="GET" action=".*page_id=' . $my_courses_page_id . '">.+<\/form>\s*$/ms';
 
 		$this->assertRegExp( $form, $result, 'Should be wrapped in a form tag' );
-		$this->assertContains( '<button class="sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Should contain block content' );
+		$this->assertStringContainsString( '<button class="sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Should contain block content' );
 	}
 
 	/**
@@ -126,7 +126,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$result = do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
 
-		$this->assertContains( '<button disabled="disabled" class="sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Button should be disabled' );
+		$this->assertStringContainsString( '<button disabled="disabled" class="sensei-stop-double-submission wp-block-button__link">Take Course</button>', $result, 'Button should be disabled' );
 
 		ob_start();
 		Sensei()->notices->maybe_print_notices();

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -29,7 +29,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
@@ -42,12 +42,12 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/button-take-course' );
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
@@ -27,7 +27,7 @@ class Sensei_Block_View_Results_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		self::resetEnrolmentProviders();
 		$this->prepareEnrolmentManager();
@@ -39,12 +39,12 @@ class Sensei_Block_View_Results_Test extends WP_UnitTestCase {
 		$GLOBALS['post'] = $this->course;
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/button-view-results' );
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
@@ -10,7 +10,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;
 	use Sensei_Test_Login_Helpers;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$GLOBALS['post']        = (object) [
@@ -22,7 +22,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 		$this->login_as_student();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/button-contact-teacher' );
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
@@ -53,7 +53,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 		Sensei()->notices->maybe_print_notices();
 		$notices = ob_get_clean();
 
-		$this->assertContains( 'Your private message has been sent.', $notices );
+		$this->assertStringContainsString( 'Your private message has been sent.', $notices );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
@@ -27,7 +27,7 @@ class Sensei_Continue_Course_Block_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		self::resetEnrolmentProviders();
 		$this->prepareEnrolmentManager();
@@ -39,12 +39,12 @@ class Sensei_Continue_Course_Block_Test extends WP_UnitTestCase {
 		$GLOBALS['post'] = $this->course;
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/button-continue-course' );
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
@@ -36,7 +36,7 @@ class Sensei_Course_Categories_Block_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory  = new Sensei_Factory();
 		$this->block    = new Sensei_Course_Categories_Block();
@@ -47,7 +47,7 @@ class Sensei_Course_Categories_Block_Test extends WP_UnitTestCase {
 		$GLOBALS['post'] = $course;
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/course-categories' );
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
@@ -80,8 +80,8 @@ class Sensei_Course_Categories_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( self::CONTENT );
 
 		/* Assert */
-		$this->assertContains( $this->category->name, $result );
-		$this->assertContains( $this->category->slug, $result );
+		$this->assertStringContainsString( $this->category->name, $result );
+		$this->assertStringContainsString( $this->category->slug, $result );
 	}
 
 	/**
@@ -95,8 +95,8 @@ class Sensei_Course_Categories_Block_Test extends WP_UnitTestCase {
 		$result                  = do_blocks( $content_with_attributes );
 
 		/* Assert */
-		$this->assertContains( 'class="some-class"', $result );
-		$this->assertContains( 'style="some-style"', $result );
+		$this->assertStringContainsString( 'class="some-class"', $result );
+		$this->assertStringContainsString( 'style="some-style"', $result );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -100,9 +100,9 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->category->name, $result );
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->category->name, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenCalledWithNonCategoryFilterParam_ShowsAllCourses() {
@@ -116,8 +116,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenCalledWithCategoryFilterParam_ShowsOnlyFilteredCourses() {
@@ -131,8 +131,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertNotContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenCalledWithFeaturedFilterParam_ShowsOnlyFeaturedCourses() {
@@ -147,8 +147,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertNotContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenCalledWithFeaturedFilterParamSetAll_ShowsAllCourses() {
@@ -163,8 +163,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenCalledFeaturedAndCategoryFilterTogether_ShowsFilteredCoursesProperly() {
@@ -180,8 +180,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertNotContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenCalledFeaturedAndCategoryFilterTogether_ShowsNoCoursesWhenApplicable() {
@@ -197,8 +197,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertNotContains( $this->course1->post_title, $result );
-		$this->assertNotContains( $this->course2->post_title, $result );
+		$this->assertStringNotContainsString( $this->course1->post_title, $result );
+		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenRenderingStudentCourseBlock_DoesNotRenderIfNotLoggedIn() {
@@ -210,7 +210,7 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertNotContains( 'Completed', $result );
+		$this->assertStringNotContainsString( 'Completed', $result );
 	}
 
 	public function testCourseFilterBlock_WhenRenderingStudentCourseBlock_RendersWhenLoggedIn() {
@@ -224,7 +224,7 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( 'Completed', $result );
+		$this->assertStringContainsString( 'Completed', $result );
 	}
 
 	public function testCourseFilterBlock_WhenFilteredForActiveCourses_RendersTheActiveCoursesOnly() {
@@ -241,8 +241,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertNotContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenFilteredForCompletedCourses_RendersTheCompletedCoursesOnly() {
@@ -261,8 +261,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course2->post_title, $result );
-		$this->assertNotContains( $this->course1->post_title, $result );
+		$this->assertStringContainsString( $this->course2->post_title, $result );
+		$this->assertStringNotContainsString( $this->course1->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenFilteredForCompletedFeaturedAndCategory_RendersProperly() {
@@ -290,8 +290,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertContains( $this->course1->post_title, $result );
-		$this->assertNotContains( $this->course2->post_title, $result );
+		$this->assertStringContainsString( $this->course1->post_title, $result );
+		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
 
 	public function testCourseFilterBlock_WhenFilteredForCompletedFeaturedAndCategory_RendersEmptyWhenApplicable() {
@@ -319,7 +319,7 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$result = do_blocks( $this->content );
 
 		/* ASSERT */
-		$this->assertNotContains( $this->course1->post_title, $result );
-		$this->assertNotContains( $this->course2->post_title, $result );
+		$this->assertStringNotContainsString( $this->course1->post_title, $result );
+		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
 }

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -62,7 +62,7 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		global $wp_version;
 
 		$version = str_replace( '-src', '', $wp_version );
@@ -82,12 +82,12 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->factory->course_category->add_post_terms( $this->course1->ID, [ $this->category->term_id ], 'course-category' );
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/course-list-filter' );
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -1,11 +1,15 @@
 <?php
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
 /**
  * Tests for Sensei_Course_Outline_Block class.
  *
  * @group course-structure
  */
 class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
+
+	use ArraySubsetAsserts;
 
 	/**
 	 * Initialize the blocks once.
@@ -41,7 +45,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		Sensei()->notices->maybe_print_notices();
 		$result = ob_get_clean();
 
-		$this->assertContains( 'There is no published content in this course yet.', $result );
+		$this->assertStringContainsString( 'There is no published content in this course yet.', $result );
 	}
 
 	/**
@@ -61,7 +65,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		);
 		$result = do_blocks( $post_content );
 
-		$this->assertContains( 'Test Lesson', $result );
+		$this->assertStringContainsString( 'Test Lesson', $result );
 	}
 
 	/**
@@ -82,7 +86,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		);
 		$result = do_blocks( $post_content );
 
-		$this->assertContains( 'Preview', $result );
+		$this->assertStringContainsString( 'Preview', $result );
 	}
 
 	/**
@@ -108,7 +112,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		);
 		$result = do_blocks( $post_content );
 
-		$this->assertNotContains( 'Preview', $result );
+		$this->assertStringNotContainsString( 'Preview', $result );
 	}
 
 	/**
@@ -139,10 +143,10 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		$result      = do_blocks( $post_content );
 		$module_link = get_term_link( $module->term_id, Sensei()->modules->taxonomy );
 
-		$this->assertContains( $module->name, $result );
-		$this->assertContains( $module->description, $result );
-		$this->assertContains( $module_link, $result );
-		$this->assertContains( 'Test Lesson', $result );
+		$this->assertStringContainsString( $module->name, $result );
+		$this->assertStringContainsString( $module->description, $result );
+		$this->assertStringContainsString( $module_link, $result );
+		$this->assertStringContainsString( 'Test Lesson', $result );
 	}
 
 	/**
@@ -173,8 +177,8 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		$result      = do_blocks( $post_content );
 		$module_link = get_term_link( $module->term_id, Sensei()->modules->taxonomy );
 
-		$this->assertContains( $module->name, $result );
-		$this->assertNotContains( $module_link, $result );
+		$this->assertStringContainsString( $module->name, $result );
+		$this->assertStringNotContainsString( $module_link, $result );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -10,14 +10,14 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 	/**
 	 * Initialize the blocks once.
 	 */
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		Sensei()->blocks->course->initialize_blocks();
 	}
 
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 

--- a/tests/unit-tests/blocks/test-class-sensei-course-overview-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-overview-block.php
@@ -18,14 +18,14 @@ class Sensei_Course_Overview_Block_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 		$this->block   = new Sensei_Course_Overview_Block();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/course-overview' );
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-global-blocks.php
+++ b/tests/unit-tests/blocks/test-class-sensei-global-blocks.php
@@ -22,7 +22,7 @@ class Sensei_Global_Blocks_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->global_blocks = new Sensei_Global_Blocks();
 		$this->blocks        = [
 			'sensei-lms/button-take-course',

--- a/tests/unit-tests/blocks/test-class-sensei-lesson-actions-blocks.php
+++ b/tests/unit-tests/blocks/test-class-sensei-lesson-actions-blocks.php
@@ -20,7 +20,7 @@ class Sensei_Lesson_Actions_Blocks extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
@@ -28,7 +28,7 @@ class Sensei_Lesson_Actions_Blocks extends WP_UnitTestCase {
 		$this->prepareEnrolmentManager();
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -67,9 +67,9 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		\Sensei_Course_Theme_Lesson::instance()->init();
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertContains( 'Lesson quiz in progress', $html, 'Should return quiz progress notice' );
-		$this->assertContains( '2 of 3', $html, 'Should return quiz progress notice' );
-		$this->assertContains( 'quiz-page=2', $html, 'Should have the link to quiz page with the first unanswered question' );
+		$this->assertStringContainsString( 'Lesson quiz in progress', $html, 'Should return quiz progress notice' );
+		$this->assertStringContainsString( '2 of 3', $html, 'Should return quiz progress notice' );
+		$this->assertStringContainsString( 'quiz-page=2', $html, 'Should have the link to quiz page with the first unanswered question' );
 
 		// Set second question as unanswered.
 		$user_quiz_answers = [
@@ -82,7 +82,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		\Sensei_Course_Theme_Lesson::instance()->init();
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertContains( 'quiz-page=1', $html, 'Should have the link to quiz page with the first unanswered question' );
+		$this->assertStringContainsString( 'quiz-page=1', $html, 'Should have the link to quiz page with the first unanswered question' );
 
 		// Remove quiz pagination.
 		delete_post_meta( $quiz_id, '_pagination' );
@@ -90,7 +90,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		\Sensei_Course_Theme_Lesson::instance()->init();
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertNotContains( 'quiz-page=', $html, 'Should not have the link to a specific page' );
+		$this->assertStringNotContainsString( 'quiz-page=', $html, 'Should not have the link to a specific page' );
 	}
 
 	/**
@@ -104,7 +104,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertContains( 'Awaiting grade', $html, 'Should return quiz ungraded notice' );
+		$this->assertStringContainsString( 'Awaiting grade', $html, 'Should return quiz ungraded notice' );
 	}
 
 	/**
@@ -119,7 +119,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertContains( 'You require <strong>80</strong>% to pass this lesson\'s quiz. Your grade is <strong>0</strong>%.', $html, 'Should return quiz failed notice' );
+		$this->assertStringContainsString( 'You require <strong>80</strong>% to pass this lesson\'s quiz. Your grade is <strong>0</strong>%.', $html, 'Should return quiz failed notice' );
 	}
 
 	/**
@@ -134,7 +134,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertContains( 'Your Grade: <strong class="sensei-course-theme-lesson-quiz-notice__grade">0</strong>%', $html, 'Should return quiz graded notice' );
+		$this->assertStringContainsString( 'Your Grade: <strong class="sensei-course-theme-lesson-quiz-notice__grade">0</strong>%', $html, 'Should return quiz graded notice' );
 	}
 
 	/**
@@ -228,7 +228,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertContains( 'Please register or sign in to access the course content.', $html, 'Should return logged out notice' );
+		$this->assertStringContainsString( 'Please register or sign in to access the course content.', $html, 'Should return logged out notice' );
 	}
 
 	/**
@@ -249,7 +249,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertContains( 'Register or sign in to take this lesson.', $html, 'Should return logged out preview notice' );
+		$this->assertStringContainsString( 'Register or sign in to take this lesson.', $html, 'Should return logged out preview notice' );
 	}
 
 	/**
@@ -264,7 +264,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertContains( 'Please register for this course to access the content.', $html, 'Should return not enrolled notice' );
+		$this->assertStringContainsString( 'Please register for this course to access the content.', $html, 'Should return not enrolled notice' );
 	}
 
 	/**
@@ -285,7 +285,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertContains( 'Register for this course to take this lesson.', $html, 'Should return not enrolled preview notice' );
+		$this->assertStringContainsString( 'Register for this course to take this lesson.', $html, 'Should return not enrolled preview notice' );
 	}
 
 	/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -20,8 +20,8 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 	}

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
@@ -27,15 +27,15 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 	/**
 	 * Setup method. Run first on every test execution.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new Sensei_Factory();
 	}
 
 	/**
 	 * Cleanup/teardown after class.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		\Sensei()->settings->set( 'sensei_learning_mode_all', false );
 	}

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
@@ -37,8 +37,8 @@ class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 	/**
 	 * Setup method. Run first on every test execution.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory  = new Sensei_Factory();
 		$this->instance = Sensei_Course_Theme::instance();
 		$this->prepareEnrolmentManager();

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
@@ -28,7 +28,7 @@ class Sensei_Export_Courses_Tests extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		if ( ! isset( Sensei()->admin ) ) {

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
@@ -9,13 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
 /**
  * Tests for Sensei_Export_Courses class.
  *
  * @group data-port
  */
 class Sensei_Export_Courses_Tests extends WP_UnitTestCase {
-
+	use ArraySubsetAsserts;
 	use Sensei_Export_Task_Tests;
 
 	/**

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
@@ -28,7 +28,7 @@ class Sensei_Export_Lessons_Tests extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
@@ -9,13 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
 /**
  * Tests for Sensei_Export_Lessons class.
  *
  * @group data-port
  */
 class Sensei_Export_Lessons_Tests extends WP_UnitTestCase {
-
+	use ArraySubsetAsserts;
 	use Sensei_Export_Task_Tests;
 
 	/**

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-package.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-package.php
@@ -18,7 +18,7 @@ class Sensei_Export_Package_Tests extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		if ( ! class_exists( 'ZipArchive' ) ) {

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -28,7 +28,7 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -9,13 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
 /**
  * Tests for Sensei_Export_Questions class.
  *
  * @group data-port
  */
 class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
-
+	use ArraySubsetAsserts;
 	use Sensei_Export_Task_Tests;
 
 	/**

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-associations.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-associations.php
@@ -19,7 +19,7 @@ class Sensei_Import_Associations_Tests extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
@@ -19,7 +19,7 @@ class Sensei_Import_Courses_Tests extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-file-process-task.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-file-process-task.php
@@ -19,7 +19,7 @@ class Sensei_Import_File_Process_Task_Tests extends WP_UnitTestCase {
 	/**
 	 * Set up before class.
 	 */
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-import-file-process-task-mock.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-job-mock.php';
 	}

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-lessons.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-lessons.php
@@ -19,7 +19,7 @@ class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -27,7 +27,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -9,12 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
 /**
  * Tests for Sensei_Import_Lesson_Model class.
  *
  * @group data-port
  */
 class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
+	use ArraySubsetAsserts;
 	use Sensei_Data_Port_Test_Helpers;
 
 	/**

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -27,7 +27,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -25,7 +25,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -22,17 +22,17 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		// Make sure CSVs are allowed on WordPress multi-site.
 		update_site_option( 'upload_filetypes', 'csv' );
 
-		return parent::setUp();
+		parent::setUp();
 	}
 
 	/**
 	 * Tear down after tests.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		delete_site_option( 'upload_filetypes' );

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
@@ -21,13 +21,13 @@ class Sensei_Data_Port_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		Sensei_Test_Events::reset();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->set_data_port_jobs( [] );

--- a/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
@@ -23,7 +23,7 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -19,7 +19,7 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		// Make sure CSVs are allowed on WordPress multi-site.
@@ -30,7 +30,7 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down after tests.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		delete_site_option( 'upload_filetypes' );

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -12,7 +12,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -25,7 +25,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->clearEnrolmentCheckDeferred();
@@ -35,7 +35,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-provider-results.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-provider-results.php
@@ -29,8 +29,8 @@ class Sensei_Course_Enrolment_Provider_Results_Test extends WP_UnitTestCase {
 		];
 
 		$provider_results = Sensei_Course_Enrolment_Provider_Results::from_json( wp_json_encode( $base ) );
-		$this->assertTrue( $provider_results instanceof Sensei_Course_Enrolment_Provider_Results );
-		$this->assertEquals( round( $base['t'], 3 ), round( $provider_results->get_time(), 3 ), 'Time (`t`) should match what it was initially set to', 0.1 );
+		$this->assertInstanceOf( Sensei_Course_Enrolment_Provider_Results::class, $provider_results );
+		$this->assertEqualsWithDelta( round( $base['t'], 3 ), round( $provider_results->get_time(), 3 ), 0.1, 'Time (`t`) should match what it was initially set to' );
 		$this->assertEquals( $base['v'], $provider_results->get_version_hash(), 'Version (`v`) should match what it was initially set to' );
 		$this->assertEquals( $base['r'], $provider_results->get_provider_results(), 'Results (`r`) should match what it was initially set to' );
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-provider-results.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-provider-results.php
@@ -9,8 +9,8 @@ class Sensei_Course_Enrolment_Provider_Results_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-stored-status-provider.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-stored-status-provider.php
@@ -11,7 +11,7 @@ class Sensei_Course_Enrolment_Stored_Status_Provider_Test extends WP_UnitTestCas
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -12,7 +12,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -24,7 +24,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
@@ -10,7 +10,7 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -24,7 +24,7 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetSiteWideLegacyEnrolmentFlag();
 		self::resetCourseEnrolmentProviders();

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
@@ -10,7 +10,7 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -20,7 +20,7 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		remove_all_filters( 'sensei_enrolment_course_calculation_job_batch_size' );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -12,7 +12,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -22,7 +22,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		Sensei_Scheduler_Shim::reset();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		Sensei_Scheduler_Shim::reset();

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
@@ -12,7 +12,7 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -22,7 +22,7 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		remove_all_filters( 'sensei_enrolment_learner_calculation_job_batch_size' );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
@@ -14,7 +14,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -26,7 +26,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 
 		self::resetEnrolmentJournalStores();

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
@@ -11,7 +11,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -23,7 +23,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 
 		self::resetEnrolmentStateStores();

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
@@ -11,7 +11,7 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		self::resetEnrolmentStateStores();
@@ -20,7 +20,7 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentStateStores();
 	}

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-comments-based-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-comments-based-answer-repository.php
@@ -15,12 +15,12 @@ class Comments_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	protected $factory;
 
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new \Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
@@ -15,12 +15,12 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	protected $factory;
 
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new \Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
@@ -16,12 +16,12 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 
 	protected $factory;
 
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new \Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
@@ -13,12 +13,12 @@ use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Comments_Based
 class Comments_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 	protected $factory;
 
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new \Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
@@ -13,12 +13,12 @@ use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comments_Based
 class Comments_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 	protected $factory;
 
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new \Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -18,12 +18,12 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new \Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/renderers/test-class-sensei-renderer-single-post.php
+++ b/tests/unit-tests/renderers/test-class-sensei-renderer-single-post.php
@@ -100,7 +100,7 @@ class Sensei_Renderer_Single_Post_Test extends WP_UnitTestCase {
 		$renderer = new Sensei_Renderer_Single_Post( $this->post_id, 'single-course.php' );
 		$output   = $renderer->render();
 
-		$this->assertNotContains(
+		$this->assertStringNotContainsString(
 			$this->get_fake_title(),
 			$output,
 			'Post title should not be rendered'

--- a/tests/unit-tests/renderers/test-class-sensei-renderer-single-post.php
+++ b/tests/unit-tests/renderers/test-class-sensei-renderer-single-post.php
@@ -7,7 +7,7 @@ class Sensei_Renderer_Single_Post_Test extends WP_UnitTestCase {
 	 */
 	private $post_id;
 
-	public function setUp() {
+	public function setUp(): void {
 		global $post, $page, $wp_query, $wp_the_query;
 
 		parent::setUp();

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-courses.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-courses.php
@@ -16,7 +16,7 @@ class Sensei_Reports_Overview_Data_Provider_Courses_Test extends WP_UnitTestCase
 	/**
 	 * Set up before each test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -25,7 +25,7 @@ class Sensei_Reports_Overview_Data_Provider_Courses_Test extends WP_UnitTestCase
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->factory->tearDown();

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-lessons.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-lessons.php
@@ -16,7 +16,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons_Test extends WP_UnitTestCase
 	/**
 	 * Set up before each test.
 	 */
-	public function setup() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -25,7 +25,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons_Test extends WP_UnitTestCase
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->factory->tearDown();

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
@@ -18,7 +18,7 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	/**
 	 * Set up before each test.
 	 */
-	public function setup() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->resetCourseEnrolmentManager();
 
@@ -30,7 +30,7 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->factory->tearDown();

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
@@ -3,13 +3,13 @@
 class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 	private static $initial_hook_suffix;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
 		$GLOBALS['hook_suffix']    = null;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
 	}

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -16,13 +16,13 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
 		$GLOBALS['hook_suffix']    = null;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
 	}
@@ -30,7 +30,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before each test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -39,7 +39,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->factory->tearDown();

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-factory.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-factory.php
@@ -8,13 +8,13 @@
 class Sensei_Reports_Overview_List_Table_Factory_Test extends WP_UnitTestCase {
 	private static $initial_hook_suffix;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
 		$GLOBALS['hook_suffix']    = null;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
 	}

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
@@ -16,7 +16,7 @@ class Sensei_Reports_Overview_List_Table_Lessons_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before each test.
 	 */
-	public function setup() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -25,7 +25,7 @@ class Sensei_Reports_Overview_List_Table_Lessons_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->factory->tearDown();

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -17,7 +17,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before each test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -26,7 +26,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->factory->tearDown();

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
@@ -16,13 +16,13 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
 		$GLOBALS['hook_suffix']    = null;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
 	}
@@ -30,7 +30,7 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before each test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -39,7 +39,7 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$this->factory->tearDown();

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
@@ -26,7 +26,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;
@@ -41,7 +41,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->prepareEnrolmentManager();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
@@ -32,7 +32,7 @@ class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_Tes
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
@@ -26,7 +26,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;
@@ -41,7 +41,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->prepareEnrolmentManager();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-utils-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-utils-controller.php
@@ -25,7 +25,7 @@ class Sensei_REST_API_Course_Utils_Controller_Test extends WP_Test_REST_TestCase
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;
@@ -37,7 +37,7 @@ class Sensei_REST_API_Course_Utils_Controller_Test extends WP_Test_REST_TestCase
 		$this->factory = new Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-export-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-export-controller.php
@@ -22,7 +22,7 @@ class Sensei_REST_API_Export_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;
@@ -40,7 +40,7 @@ class Sensei_REST_API_Export_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific teardown.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-home-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-home-controller.php
@@ -71,7 +71,7 @@ class Sensei_REST_API_Home_Controller_Test extends WP_UnitTestCase {
 	private $controller;
 
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->quick_links_provider_mock = $this->createMock( Sensei_Home_Quick_Links_Provider::class );

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -22,7 +22,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;
@@ -43,7 +43,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific teardown.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -36,7 +36,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-messages-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-messages-controller.php
@@ -21,7 +21,7 @@ class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;
@@ -37,7 +37,7 @@ class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific teardown.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
@@ -37,7 +37,7 @@ class Sensei_REST_API_Question_Options_Controller_Tests extends WP_Test_REST_Tes
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
@@ -31,7 +31,7 @@ class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;
@@ -49,7 +49,7 @@ class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific teardown.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
+++ b/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
@@ -23,7 +23,7 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 
 	const REST_ROUTE = '/sensei-internal/v1/home';
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		// Setup REST server for integration tests.
@@ -33,7 +33,7 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 		do_action( 'rest_api_init' );
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		// Unregister REST server.
 		global $wp_rest_server;
 		$wp_rest_server = null;

--- a/tests/unit-tests/rest-api/test-sensei-rest-api.php
+++ b/tests/unit-tests/rest-api/test-sensei-rest-api.php
@@ -21,7 +21,7 @@ class Sensei_REST_API_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Test specific setup.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		global $wp_rest_server;

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -10,13 +10,13 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -17,14 +17,14 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Test_Events::reset();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -9,14 +9,14 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setUp() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		Sensei()->grading = new WooThemes_Sensei_Grading( '' );
 		$this->factory    = new Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -17,15 +17,15 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setUp() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 
 		self::resetEnrolmentProviders();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 		self::resetEnrolmentProviders();

--- a/tests/unit-tests/test-class-lesson-modules.php
+++ b/tests/unit-tests/test-class-lesson-modules.php
@@ -16,8 +16,8 @@ class Sensei_Class_Lesson_Modules_Test extends WP_UnitTestCase {
 		parent::__construct();
 	}
 
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 
@@ -38,7 +38,7 @@ class Sensei_Class_Lesson_Modules_Test extends WP_UnitTestCase {
 		$this->lesson_modules = new Sensei_Core_Lesson_Modules( $this->lesson_id );
 	}
 
-	public function teardown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 		wp_delete_term( $this->module_id, $this->module_taxonomy );

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -70,8 +70,8 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Test_Events::reset();
@@ -88,7 +88,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$this->initial_notices  = Sensei()->notices;
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -16,7 +16,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setup() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -25,7 +25,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 	/**
 	 * tearDown function
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -167,10 +167,10 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$column_output = ob_get_clean();
 
 		foreach ( $modules as $module ) {
-			$this->assertContains( $module->name, $column_output, 'The module link should be present.' );
+			$this->assertStringContainsString( $module->name, $column_output, 'The module link should be present.' );
 		}
 
-		$this->assertContains( '+1 more', $column_output, 'The "+1 more" link should be present.' );
+		$this->assertStringContainsString( '+1 more', $column_output, 'The "+1 more" link should be present.' );
 	}
 
 	/**
@@ -195,10 +195,10 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$column_output = ob_get_clean();
 
 		foreach ( $modules as $module ) {
-			$this->assertContains( $module->name, $column_output, 'The module link should be present.' );
+			$this->assertStringContainsString( $module->name, $column_output, 'The module link should be present.' );
 		}
 
-		$this->assertNotContains( 'more', $column_output, 'The "more" link shouldn\'t be present.' );
+		$this->assertStringNotContainsString( 'more', $column_output, 'The "more" link shouldn\'t be present.' );
 	}
 
 	public function testModuleTeacherMeta_WhenAddedToACourse_TeacherIdGetsAddedToMeta() {

--- a/tests/unit-tests/test-class-posttypes.php
+++ b/tests/unit-tests/test-class-posttypes.php
@@ -12,15 +12,15 @@ class Sensei_Class_PostTypes extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new Sensei_Factory();
 	}
 
 	/**
 	 * Tear down function.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->factory->tearDown();
 		parent::tearDown();
 	}

--- a/tests/unit-tests/test-class-question.php
+++ b/tests/unit-tests/test-class-question.php
@@ -16,14 +16,14 @@ class Sensei_Class_Question_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Test_Events::reset();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -19,8 +19,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class.
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 
@@ -38,7 +38,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -15,13 +15,13 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
 		$GLOBALS['hook_suffix']    = null;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
 	}
@@ -29,7 +29,7 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/test-class-sensei-analysis.php
+++ b/tests/unit-tests/test-class-sensei-analysis.php
@@ -10,13 +10,13 @@ class Sensei_Analysis_Test extends WP_UnitTestCase {
 
 	private static $initial_hook_suffix;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
 		$GLOBALS['hook_suffix']    = null;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
 	}

--- a/tests/unit-tests/test-class-sensei-context-notices.php
+++ b/tests/unit-tests/test-class-sensei-context-notices.php
@@ -33,10 +33,10 @@ class Sensei_Context_Notices_Test extends WP_UnitTestCase {
 
 		$html = $notices->get_notices_html( self::TEMPLATE );
 
-		$this->assertContains( 'Text', $html );
-		$this->assertContains( 'Title', $html );
-		$this->assertContains( 'Action label', $html );
-		$this->assertContains( 'Custom action', $html );
+		$this->assertStringContainsString( 'Text', $html );
+		$this->assertStringContainsString( 'Title', $html );
+		$this->assertStringContainsString( 'Action label', $html );
+		$this->assertStringContainsString( 'Custom action', $html );
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Sensei_Context_Notices_Test extends WP_UnitTestCase {
 
 		$html = $notices->get_notices_html( self::TEMPLATE );
 
-		$this->assertNotContains( 'Text', $html );
+		$this->assertStringNotContainsString( 'Text', $html );
 	}
 
 	/**
@@ -67,9 +67,9 @@ class Sensei_Context_Notices_Test extends WP_UnitTestCase {
 
 		$html = $notices->get_notices_html( self::TEMPLATE );
 
-		$this->assertNotContains( 'X', $html );
-		$this->assertContains( 'Y', $html );
-		$this->assertContains( 'Z', $html );
+		$this->assertStringNotContainsString( 'X', $html );
+		$this->assertStringContainsString( 'Y', $html );
+		$this->assertStringContainsString( 'Z', $html );
 	}
 
 	/**
@@ -85,10 +85,10 @@ class Sensei_Context_Notices_Test extends WP_UnitTestCase {
 		$html_x = $notices_x->get_notices_html( self::TEMPLATE );
 		$html_y = $notices_y->get_notices_html( self::TEMPLATE );
 
-		$this->assertContains( 'X', $html_x );
-		$this->assertNotContains( 'Y', $html_x );
+		$this->assertStringContainsString( 'X', $html_x );
+		$this->assertStringNotContainsString( 'Y', $html_x );
 
-		$this->assertContains( 'Y', $html_y );
-		$this->assertNotContains( 'X', $html_y );
+		$this->assertStringContainsString( 'Y', $html_y );
+		$this->assertStringNotContainsString( 'X', $html_y );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -11,7 +11,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		if ( ! isset( Sensei()->admin ) ) {

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -1705,11 +1705,11 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 
 		//For edit mode.
 		$this->assertEquals( 'teacher1', $edit_output[0]['teacher'] );
-		$this->assertNotContains( 'teacher1', $edit_output[0]['title'] );
+		$this->assertStringNotContainsString( 'teacher1', $edit_output[0]['title'] );
 
 		//For view mode.
 		$this->assertEquals( 'teacher1', $view_output[0]['teacher'] );
-		$this->assertContains( 'teacher1', $view_output[0]['title'] );
+		$this->assertStringContainsString( 'teacher1', $view_output[0]['title'] );
 
 		// Reset $current_screen. This is needed for WordPress <= 5.8.
 		// @see https://core.trac.wordpress.org/ticket/53431

--- a/tests/unit-tests/test-class-sensei-customizer.php
+++ b/tests/unit-tests/test-class-sensei-customizer.php
@@ -5,12 +5,12 @@ class Sensei_Customizer_Test extends WP_UnitTestCase {
 
 	private $customizer;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->customizer = new Sensei_Customizer();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		remove_action( 'customize_register', array( $this->customizer, 'add_customizer_settings' ) );
 		remove_action( 'customize_preview_init', array( $this->customizer, 'enqueue_customizer_helper' ) );

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -27,7 +27,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	private $regular_user_id;
 	private $teacher_user_id;
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		$GLOBALS['wp_roles']->for_site();
@@ -248,7 +248,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	/**
 	 * Set up for tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->setupPosts();

--- a/tests/unit-tests/test-class-sensei-db-query-learners.php
+++ b/tests/unit-tests/test-class-sensei-db-query-learners.php
@@ -1,12 +1,12 @@
 <?php
 
 class Sensei_Db_Query_Learners_Test extends WP_UnitTestCase {
-	public function setUp() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 		$this->factory = new Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
+++ b/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
@@ -13,7 +13,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 
 	private $controller;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -30,7 +30,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/test-class-sensei-learners-main.php
+++ b/tests/unit-tests/test-class-sensei-learners-main.php
@@ -18,7 +18,7 @@ class Sensei_Learners_Main_Test extends WP_UnitTestCase {
 
 	private $course_id;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 		$this->login_as_teacher();
@@ -28,7 +28,7 @@ class Sensei_Learners_Main_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		self::resetEnrolmentProviders();
 	}

--- a/tests/unit-tests/test-class-sensei-messages.php
+++ b/tests/unit-tests/test-class-sensei-messages.php
@@ -23,7 +23,7 @@ class Sensei_Messages_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -26,7 +26,7 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 	/**
 	 * Set up for tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		Sensei_Test_Events::reset();
 		$this->resetSimulateSettingsRequest();
 
@@ -36,7 +36,7 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 	/**
 	 * Tear down after tests.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		Sensei_Test_Events::reset();

--- a/tests/unit-tests/test-class-sensei-unsupported-themes.php
+++ b/tests/unit-tests/test-class-sensei-unsupported-themes.php
@@ -2,7 +2,7 @@
 
 class Sensei_Unsupported_Themes_Test extends WP_UnitTestCase {
 
-	public function tearDown() {
+	public function tearDown(): void {
 		Sensei_Unsupported_Themes::reset();
 
 		parent::tearDown();

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -24,7 +24,7 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		Sensei_Test_Events::reset();
@@ -37,10 +37,10 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after all tests.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		self::resetScheduler();
 
-		return parent::tearDownAfterClass();
+		parent::tearDownAfterClass();
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -12,14 +12,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up the factory.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 		self::resetCourseEnrolmentManager();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-sensei-usage-tracking.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking.php
@@ -15,7 +15,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before each test.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		Sensei_Test_Events::reset();

--- a/tests/unit-tests/test-class-sensei-view-helper.php
+++ b/tests/unit-tests/test-class-sensei-view-helper.php
@@ -14,12 +14,12 @@ class Sensei_View_Helper_Test extends WP_UnitTestCase {
 	 */
 	private static $initial_settings;
 
-	public static function setUpBeforeClass() {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		self::$initial_settings = Sensei()->settings->settings;
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 		Sensei()->settings->settings = self::$initial_settings;
 	}

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -4,7 +4,7 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 	/**
 	 * Setup function.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/test-class-teacher.php
+++ b/tests/unit-tests/test-class-teacher.php
@@ -23,7 +23,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setup() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -32,7 +32,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 	/**
 	 *
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -8,8 +8,8 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 	 * This function sets up the lessons, quizzes and their questions. This function runs before
 	 * every single test in this class
 	 */
-	public function setup() {
-		parent::setup();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 
@@ -18,7 +18,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -246,8 +246,8 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		/* Assert. */
-		$this->assertContains( '<input type="hidden" name="param_1" value="value_1">', $output, 'Output should contain the query param input with the correct value.' );
-		$this->assertNotContains( 'param_2', $output, 'Output should not contain the excluded query param input.' );
+		$this->assertStringContainsString( '<input type="hidden" name="param_1" value="value_1">', $output, 'Output should contain the query param input with the correct value.' );
+		$this->assertStringNotContainsString( 'param_2', $output, 'Output should not contain the excluded query param input.' );
 	}
 
 	/**

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -2,7 +2,7 @@
 
 class Sensei_Functions_Test extends WP_UnitTestCase {
 
-	public function tearDown() {
+	public function tearDown(): void {
 		// Ensure explicit theme support is removed.
 		remove_theme_support( 'sensei' );
 

--- a/tests/unit-tests/test-template-functions.php
+++ b/tests/unit-tests/test-template-functions.php
@@ -1,13 +1,13 @@
 <?php
 
 class Sensei_Template_Functions_Test extends WP_UnitTestCase {
-	public function setup() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-course-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-course-archive.php
@@ -14,7 +14,7 @@ class Sensei_Unsupported_Theme_Handler_Course_Archive_Test extends WP_UnitTestCa
 	 */
 	private $course;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 
@@ -25,7 +25,7 @@ class Sensei_Unsupported_Theme_Handler_Course_Archive_Test extends WP_UnitTestCa
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Course_Archive();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-course-results.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-course-results.php
@@ -14,7 +14,7 @@ class Sensei_Unsupported_Theme_Handler_Course_Results_Test extends WP_UnitTestCa
 	 */
 	private $course;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 
@@ -25,7 +25,7 @@ class Sensei_Unsupported_Theme_Handler_Course_Results_Test extends WP_UnitTestCa
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Course_Results();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-cpt.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-cpt.php
@@ -14,7 +14,7 @@ class Sensei_Unsupported_Theme_Handler_CPT_Test extends WP_UnitTestCase {
 	 */
 	private $course;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		// We'll use a Course post and handler to test this.
@@ -22,7 +22,7 @@ class Sensei_Unsupported_Theme_Handler_CPT_Test extends WP_UnitTestCase {
 		$this->handler = new Sensei_Unsupported_Theme_Handler_CPT( 'course' );
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		parent::tearDown();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-learner-profile.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-learner-profile.php
@@ -14,7 +14,7 @@ class Sensei_Unsupported_Theme_Handler_Learner_Profile_Test extends WP_UnitTestC
 	 */
 	private $learner_user;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 
@@ -25,7 +25,7 @@ class Sensei_Unsupported_Theme_Handler_Learner_Profile_Test extends WP_UnitTestC
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Learner_Profile();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-lesson-tag-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-lesson-tag-archive.php
@@ -14,7 +14,7 @@ class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive_Test extends WP_UnitTe
 	 */
 	private $term;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -25,7 +25,7 @@ class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive_Test extends WP_UnitTe
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-message-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-message-archive.php
@@ -9,7 +9,7 @@ class Sensei_Unsupported_Theme_Handler_Message_Archive_Test extends WP_UnitTestC
 	 */
 	private $handler;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
@@ -20,7 +20,7 @@ class Sensei_Unsupported_Theme_Handler_Message_Archive_Test extends WP_UnitTestC
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Message_Archive();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-module.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-module.php
@@ -19,7 +19,7 @@ class Sensei_Unsupported_Theme_Handler_Module_Test extends WP_UnitTestCase {
 	 */
 	private $modules;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->setupModulePage();
@@ -29,7 +29,7 @@ class Sensei_Unsupported_Theme_Handler_Module_Test extends WP_UnitTestCase {
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Module();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-page-imitator.php
@@ -15,7 +15,7 @@ class Sensei_Unsupported_Theme_Handler_Page_Imitator_Test extends WP_UnitTestCas
 	 */
 	private $course;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 
@@ -25,7 +25,7 @@ class Sensei_Unsupported_Theme_Handler_Page_Imitator_Test extends WP_UnitTestCas
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Faux_Page_Imitator( $this->course );
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		self::delete_page_template();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -14,7 +14,7 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive_Test extends WP_UnitTestC
 	 */
 	private $teacher_user;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		Sensei()->teacher->create_role();
 
@@ -26,7 +26,7 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive_Test extends WP_UnitTestC
 		$this->handler = new Sensei_Unsupported_Theme_Handler_Teacher_Archive();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->handler = null;
 
 		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-fix-question-author.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-fix-question-author.php
@@ -24,7 +24,7 @@ class Sensei_Update_Fix_Question_Author_Test extends WP_UnitTestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory   = new Sensei_Factory();
 		$this->quiz_mock = Sensei()->quiz = $this->getMockBuilder( Sensei_Quiz::class )->setMethods( [ 'update_quiz_author' ] )->getMock();

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-remove-abandoned-multiple-question.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-remove-abandoned-multiple-question.php
@@ -18,7 +18,7 @@ class Sensei_Update_Remove_Abandoned_Multiple_Question_Test extends WP_UnitTestC
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 	}


### PR DESCRIPTION
This is a fun one. 🙂 

### Changes proposed in this Pull Request

* Update all composer dependencies.
* Update PHPUnit from 6 to 8.
* Fix all the failing tests and PHPUnit warnings.
* Replace the deprecated `assertContains`/`assertNotContains` methods.
* Remove the PHPUnit compatibility CI fix which was needed for PHPUnit 6.
* Update composer to version 2 in CI.

### Testing instructions

* Run `composer install`
* Make sure the tests are passing without warnings.