### PR TITLE
Fix YouTube embed handling on some environments

### DIFF
--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -117,7 +117,10 @@ const addScript = ( doc, src, onLoad ) => {
 const prepareYouTubeIframe = ( playerIframe, w ) => {
 	// Update the current embed to enable JS API.
 	if ( playerIframe && ! playerIframe.src.includes( 'enablejsapi=1' ) ) {
-		playerIframe.src = playerIframe.src + '&enablejsapi=1';
+		playerIframe.src =
+			playerIframe.src +
+			'&enablejsapi=1&origin=' +
+			window.location.origin;
 	}
 
 	w.senseiYouTubeIframeAPIReady =

--- a/includes/course-video/class-sensei-course-video-settings.php
+++ b/includes/course-video/class-sensei-course-video-settings.php
@@ -64,7 +64,10 @@ class Sensei_Course_Video_Settings {
 	public function init() {
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend_scripts' ] );
+		// When there's no embed handler for YouTube, it uses the oembed filter.
 		add_filter( 'embed_oembed_html', [ $this, 'enable_youtube_api' ], 11, 2 );
+		// When there is an embed handler registered, it uses the embed handler filter.
+		add_filter( 'embed_handler_html', [ $this, 'enable_youtube_api' ], 11, 2 );
 	}
 
 	/**


### PR DESCRIPTION
This PR is based on `version/4.8.1` tag. Related to 154-gh-Automattic/evergreen.

### Changes proposed in this Pull Request

* Register `enable_youtube_api` on the `embed_handler_html` filter so it can handle embed handlers automatically;
* Add origin query param to the youtube iframe on the editor player;

### Testing instructions

For testing the first change: 

1. Add the following snippet in a clean WP installation:

```php
/**
 * Extract video ID from a YouTube url.
 *
 * @param string $url YouTube URL.
 * @return bool|mixed The Youtube video ID
 */
function jetpack_get_youtube_id( $url ) {
	// Do we have an $atts array?  Get first att
	if ( is_array( $url ) ) {
		$url = reset( $url );
	}

	$url = youtube_sanitize_url( $url );
	$url = wp_parse_url( $url );
	$id  = false;

	if ( ! isset( $url['query'] ) ) {
		return false;
	}

	parse_str( $url['query'], $qargs );

	if ( ! isset( $qargs['v'] ) && ! isset( $qargs['list'] ) ) {
		return false;
	}

	if ( isset( $qargs['list'] ) ) {
		$id = preg_replace( '|[^_a-z0-9-]|i', '', $qargs['list'] );
	}

	if ( empty( $id ) ) {
		$id = preg_replace( '|[^_a-z0-9-]|i', '', $qargs['v'] );
	}

	return $id;
}

/**
 * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
 *
 * @param string $url
 * @return string The normalized URL
 */
if ( ! function_exists( 'youtube_sanitize_url' ) ) :
	/**
	 * Clean up Youtube URL to match a single format.
	 *
	 * @param string $url Youtube URL.
	 */
	function youtube_sanitize_url( $url ) {
		$url = trim( $url, ' "' );
		$url = trim( $url );
		$url = str_replace( array( 'youtu.be/', '/v/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '?v=', '&', '&', 'videoseries' ), $url );

		// Replace any extra question marks with ampersands - the result of a URL like "http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US" being passed in.
		$query_string_start = strpos( $url, '?' );

		if ( false !== $query_string_start ) {
			$url = substr( $url, 0, $query_string_start + 1 ) . str_replace( '?', '&', substr( $url, $query_string_start + 1 ) );
		}

		return $url;
	}
endif;


/**
 * Gets the args present in the YouTube shortcode URL.
 *
 * @since 8.0.0
 *
 * @param array $url The parsed URL of the shortcode.
 *
 * @return array|false The query args of the URL, or false.
 */
function jetpack_shortcode_youtube_args( $url ) {
	$qargs = array();
	if ( ! empty( $url['query'] ) ) {
		wp_parse_str( $url['query'], $qargs );
	} else {
		return false;
	}

	$fargs = array();
	if ( ! empty( $url['fragment'] ) ) {
		wp_parse_str( $url['fragment'], $fargs );
	}

	return array_merge( $fargs, $qargs );
}


/**
 * Gets the dimensions of the [youtube] shortcode.
 *
 * Calculates the width and height, taking $content_width into consideration.
 *
 * @since 8.0.0
 *
 * @param array $query_args The query args of the URL.
 *
 * @return array The width and height of the shortcode.
 */
function jetpack_shortcode_youtube_dimensions( $query_args ) {
	global $content_width;

	$input_w = ( isset( $query_args['w'] ) && (int) $query_args['w'] ) ? (int) $query_args['w'] : 0;
	$input_h = ( isset( $query_args['h'] ) && (int) $query_args['h'] ) ? (int) $query_args['h'] : 0;

	// If we have $content_width, use it.
	if ( ! empty( $content_width ) ) {
		$default_width = $content_width;
	} else {
		// Otherwise get default width from the old, now deprecated embed_size_w option.
		$default_width = get_option( 'embed_size_w' );
	}

	// If we don't know those 2 values use a hardcoded width.
	if ( empty( $default_width ) ) {
		$default_width = 640;
	}

	if ( $input_w > 0 && $input_h > 0 ) {
		$w = $input_w;
		$h = $input_h;
	} elseif ( 0 === $input_w && 0 === $input_h ) {
		if ( isset( $query_args['fmt'] ) && (int) $query_args['fmt'] ) {
			$w = ( ! empty( $content_width ) ? min( $content_width, 480 ) : 480 );
		} else {
			$w = ( ! empty( $content_width ) ? min( $content_width, $default_width ) : $default_width );
			$h = ceil( ( $w / 16 ) * 9 );
		}
	} elseif ( $input_w > 0 ) {
		$w = $input_w;
		$h = ceil( ( $w / 16 ) * 9 );
	} else {
		if ( isset( $query_args['fmt'] ) && (int) $query_args['fmt'] ) {
			$w = ( ! empty( $content_width ) ? min( $content_width, 480 ) : 480 );
		} else {
			$w = ( ! empty( $content_width ) ? min( $content_width, $default_width ) : $default_width );
			$h = $input_h;
		}
	}

	/**
	 * Filter the YouTube player width.
	 *
	 * @module shortcodes
	 *
	 * @since 1.1.0
	 *
	 * @param int $w Width of the YouTube player in pixels.
	 */
	$w = (int) apply_filters( 'youtube_width', $w );

	/**
	 * Filter the YouTube player height.
	 *
	 * @module shortcodes
	 *
	 * @since 1.1.0
	 *
	 * @param int $h Height of the YouTube player in pixels.
	 */
	$h = (int) apply_filters( 'youtube_height', $h );

	return array( $w, $h );
}

/**
 * Converts a YouTube URL into an embedded YouTube video.
 *
 * URL can be:
 *    http://www.youtube.com/embed/videoseries?list=PL94269DA08231042B&amp;hl=en_US
 *    http://www.youtube.com/watch#!v=H2Ncxw1xfck
 *    http://www.youtube.com/watch?v=H2Ncxw1xfck
 *    http://www.youtube.com/watch?v=H2Ncxw1xfck&w=320&h=240&fmt=1&rel=0&showsearch=1&hd=0
 *    http://www.youtube.com/v/jF-kELmmvgA
 *    http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US
 *    http://youtu.be/Rrohlqeir5E
 *    https://www.youtube.com/watch?v=GJNxoe-iSb4&list=PLAVZ4NFtZX0fE54mDSqNKym-o_rz-8xmk
 *
 * @param string $url Youtube URL.
 */
function youtube_id( $url ) {
	$id = jetpack_get_youtube_id( $url );

	if ( ! $id ) {
		return sprintf( '<!--%s-->', esc_html__( 'YouTube Error: bad URL entered', 'jetpack' ) );
	}

	$url = youtube_sanitize_url( $url );
	$url = wp_parse_url( $url );

	$thumbnail = "https://i.ytimg.com/vi/$id/hqdefault.jpg";
	$video_url = add_query_arg( 'v', $id, 'https://www.youtube.com/watch' );

	$args = jetpack_shortcode_youtube_args( $url );
	if ( empty( $args ) ) {
		return sprintf( '<!--%s-->', esc_html__( 'YouTube Error: empty URL args', 'jetpack' ) );
	}

	// Account for URL having both v and list, where jetpack_get_youtube_id() only accounts for one or the other.
	if ( isset( $args['list'] ) && $args['list'] === $id ) {
		$id = null;
	}
	if ( isset( $args['v'] ) ) {
		$id = $args['v'];
	}
	if ( ! $id && empty( $args['list'] ) ) {
		return sprintf( '<!--%s-->', esc_html__( 'YouTube Error: missing id and/or list', 'jetpack' ) );
	}

	list( $w, $h ) = jetpack_shortcode_youtube_dimensions( $args );

	$params = array(
		'rel'            => ( isset( $args['rel'] ) && '0' === $args['rel'] ) ? 0 : 1,
		'showsearch'     => ( isset( $args['showsearch'] ) && '1' === $args['showsearch'] ) ? 1 : 0, // Now deprecated. See https://developers.google.com/youtube/player_parameters#march-29,-2012.
		'showinfo'       => ( isset( $args['showinfo'] ) && '0' === $args['showinfo'] ) ? 0 : 1, // Now obsolete. See https://developers.google.com/youtube/player_parameters#showinfo.
		'iv_load_policy' => ( isset( $args['iv_load_policy'] ) && '3' === $args['iv_load_policy'] ) ? 3 : 1,
		'fs'             => 1,
		'hl'             => str_replace( '_', '-', get_locale() ),
	);
	if ( isset( $args['fmt'] ) && (int) $args['fmt'] ) {
		$params['fmt'] = (int) $args['fmt']; // Apparently an obsolete parameter. Not referenced on https://developers.google.com/youtube/player_parameters.
	}

	// The autohide parameter has been deprecated since 2015. See https://developers.google.com/youtube/player_parameters#august-19,-2015.
	if ( ! isset( $args['autohide'] ) || ( $args['autohide'] < 0 || 2 < $args['autohide'] ) ) {
		$params['autohide'] = 2;
	} else {
		$params['autohide'] = (int) $args['autohide'];
	}

	$start = 0;
	if ( isset( $args['start'] ) ) {
		$start = (int) $args['start'];
	} elseif ( isset( $args['t'] ) ) {
		if ( is_numeric( $args['t'] ) ) {
			$start = (int) $args['t'];
		} else {
			$time_pieces = preg_split( '/(?<=\D)(?=\d+)/', $args['t'] );

			foreach ( $time_pieces as $time_piece ) {
				$int = (int) $time_piece;
				switch ( substr( $time_piece, - 1 ) ) {
					case 'h':
						$start += $int * 3600;
						break;
					case 'm':
						$start += $int * 60;
						break;
					case 's':
						$start += $int;
						break;
				}
			}
		}
	}
	if ( $start ) {
		$params['start'] = (int) $start;
	}

	if ( isset( $args['end'] ) && (int) $args['end'] ) {
		$params['end'] = (int) $args['end'];
	}
	if ( isset( $args['hd'] ) && (int) $args['hd'] ) {
		$params['hd'] = (int) $args['hd']; // Now obsolete per https://developers.google.com/youtube/player_parameters#march-29,-2012.
	}
	if ( isset( $args['vq'] ) && in_array( $args['vq'], array( 'hd720', 'hd1080' ), true ) ) {
		$params['vq'] = $args['vq']; // Note, this appears to be obsolete. Not referenced on https://developers.google.com/youtube/player_parameters.
	}
	if ( isset( $args['cc_load_policy'] ) ) {
		$params['cc_load_policy'] = 1;
	}
	if ( isset( $args['cc_lang_pref'] ) ) {
		$params['cc_lang_pref'] = preg_replace( '/[^_a-z0-9-]/i', '', $args['cc_lang_pref'] );
	}

	// The wmode parameter appears to be obsolete. Not referenced on https://developers.google.com/youtube/player_parameters.
	if ( isset( $args['wmode'] ) && in_array( strtolower( $args['wmode'] ), array( 'opaque', 'window', 'transparent' ), true ) ) {
		$params['wmode'] = $args['wmode'];
	} else {
		$params['wmode'] = 'transparent';
	}

	// The theme parameter is obsolete per https://developers.google.com/youtube/player_parameters#august-19,-2015.
	if ( isset( $args['theme'] ) && in_array( strtolower( $args['theme'] ), array( 'dark', 'light' ), true ) ) {
		$params['theme'] = $args['theme'];
	}

	if ( isset( $args['list'] ) ) {
		$params['listType'] = 'playlist';
		$params['list']     = preg_replace( '|[^_a-z0-9-]|i', '', $args['list'] );
	}

	/**
	 * Allow YouTube videos to start playing automatically.
	 *
	 * @module shortcodes
	 *
	 * @since 2.2.2
	 *
	 * @param bool false Enable autoplay for YouTube videos.
	 */
	if ( apply_filters( 'jetpack_youtube_allow_autoplay', false ) && isset( $args['autoplay'] ) ) {
		$params['autoplay'] = (int) $args['autoplay'];
	}

	$is_amp = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();

	if ( $is_amp && $id ) {
		// Note that <amp-youtube> currently is not well suited for playlists that don't have an individual video selected, hence the $id check above.
		$placeholder = sprintf(
			'<a href="%1$s" placeholder><amp-img src="%2$s" alt="%3$s" layout="fill" object-fit="cover"><noscript><img src="%2$s" loading="lazy" decoding="async" alt="%3$s"></noscript></amp-img></a>',
			esc_url( $video_url ),
			esc_url( $thumbnail ),
			esc_attr__( 'YouTube Poster', 'jetpack' ) // Would be preferable to provide YouTube video title, but not available in this non-oEmbed context.
		);

		$html_attributes = array();
		foreach ( $params as $param_name => $param_value ) {
			$html_attributes[] = sprintf(
				'data-param-%s="%s"',
				sanitize_key( $param_name ),
				esc_attr( $param_value )
			);
		}

		$html = sprintf(
			'<amp-youtube data-videoid="%s" %s width="%d" height="%d" layout="responsive">%s</amp-youtube>',
			esc_attr( $id ),
			implode( ' ', $html_attributes ), // Note: Escaping done above.
			esc_attr( $w ),
			esc_attr( $h ),
			$placeholder
		);
	} else {
		// In AMP, the AMP_Iframe_Sanitizer will convert into <amp-iframe> as required.
		$src = 'https://www.youtube.com/embed';
		if ( $id ) {
			$src .= "/$id";
		}
		$src = add_query_arg(
			array_merge(
				array( 'version' => 3 ),
				$params
			),
			$src
		);

		$layout = $is_amp ? 'layout="responsive" ' : '';

		$html = sprintf(
			'<iframe class="youtube-player" width="%s" height="%s" %ssrc="%s" allowfullscreen="true" style="border:0;" sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"></iframe>',
			esc_attr( $w ),
			esc_attr( $h ),
			$layout,
			esc_url( $src )
		);
	}

	// Let's do some alignment wonder in a span, unless we're producing a feed.
	if ( ! is_feed() ) {
		$alignmentcss = 'text-align:center;';
		if ( isset( $args['align'] ) ) {
			switch ( $args['align'] ) {
				case 'left':
					$alignmentcss = "float:left; width:{$w}px; height:{$h}px; margin-right:10px; margin-bottom: 10px;";
					break;
				case 'right':
					$alignmentcss = "float:right; width:{$w}px; height:{$h}px; margin-left:10px; margin-bottom: 10px;";
					break;
			}
		}

		$html = sprintf(
			'<span class="embed-youtube" style="%s display: block;">%s</span>',
			esc_attr( $alignmentcss ),
			$html
		);

	}

	/**
	 * Format output for Calypso Reader/Notifications/Comments
	 */
	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
		require_once WP_CONTENT_DIR . '/lib/display-context.php';
		$context = A8C\Display_Context\get_current_context();
		if ( A8C\Display_Context\NOTIFICATIONS === $context ) {
			return sprintf(
				'<a href="%1$s" target="_blank" rel="noopener noreferrer"><img src="%2$s" alt="%3$s" /></a>',
				esc_url( $video_url ),
				esc_url( $thumbnail ),
				esc_html__( 'YouTube video', 'jetpack' )
			);
		}
	}

	/**
	 * Filter the YouTube video HTML output.
	 *
	 * @module shortcodes
	 *
	 * @since 1.2.3
	 *
	 * @param string $html YouTube video HTML output.
	 */
	$html = apply_filters( 'video_embed_html', $html );

	return $html;
}


/**
 * For bare URLs on their own line of the form
 * http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US
 *
 * @param array $matches Regex partial matches against the URL passed.
 * @param array $attr    Attributes received in embed response.
 * @param array $url     Requested URL to be embedded.
 */
function wpcom_youtube_embed_crazy_url( $matches, $attr, $url ) {
	return youtube_id( $url );
}


/**
 * Add a new handler to automatically transform custom Youtube URLs (like playlists) into embeds.
 */
function wpcom_youtube_embed_crazy_url_init() {
	wp_embed_unregister_handler( 'youtube_embed_url' );
	wp_embed_register_handler( 'wpcom_youtube_embed_crazy_url', '#https?://(?:www\.)?(?:youtube.com/(?:v/|playlist|watch[/\#?])|youtu\.be/).*#i', 'wpcom_youtube_embed_crazy_url' );
}
add_action( 'init', 'wpcom_youtube_embed_crazy_url_init' );
```

2. Create a post;
3. Put a YouTube URL on the post;
4. Publish the post;
5. Install Sensei 4.8.1;
6. Verify that the parameters `enablejsapi=1` and `origin` aren't added to the embed code generated for youtube;
7. Now, install the code from this branch;
8. Verify that the parameters are now added properly;


For testing the second change:

1. Add an interactive video block;
2. Verify if the `origin` query parameter is added to the youtube iframe on the editor;


