### PR TITLE
Do not redirect on login when Jetpack handles redirection

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1587,6 +1587,10 @@ class Sensei_Teacher {
 	 * @return void
 	 */
 	public function teacher_login_redirect( $user_login, $user ) {
+		// If Jetpack's redirection cookie is set, let Jetpack handle redirection.
+		if ( ! empty( $_COOKIE['jetpack_sso_redirect_to'] ) ) {
+			return;
+		}
 
 		if ( user_can( $user, 'edit_courses' ) ) {
 


### PR DESCRIPTION
Fixes [this issue](https://github.com/Automattic/sensei-pro/issues/1916).

### Overview
More context and more details on how to reproduce the issue [here](https://zenteamp2.wordpress.com/2022/11/21/sensei-launchpad-cant-go-to-custom-admin-page-in-atomic-sites-if-its-users-first-visit/). On atomic sites, Jetpack does a couple of redirections during login in order to authenticate the user with WP.com. During this request, it stores the final redirect url to a cookie. Sensei adds a hook to `wp_login` to redirect teachers to admin. 

I tried removing the hook entirely and it seems that teachers are still redirected to wp-admin when they log in. However I was a bit unsure if we should actually remove it as there might be cases where this is useful.

### Changes proposed in this Pull Request
* It adds a check to skip doing any redirections when Jetpack is in the middle of doing a redirection.

### Testing instructions
- Create a site in WordPress.com and attach a business plan to it.
- Go to .com's marketplace and install Sensei.
- Go to 'Plugins' -> 'Plugin File Editor'
- Select Sensei and apply this patch to `class-sensei-teacher.php`
- Log out from .com
- Login again but avoid visiting at all the site you created in the first step.
- Open a link in another window like the following: `https://<your site>/wp-admin/post-new.php?post_type=course`
- Observe that you are redirected normally to the course creation wizard.