### PR TITLE
Move usage tracking for purpose step to usage tracking save

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -444,14 +444,6 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 			$json['purpose']['other'] = '';
 		}
 
-		sensei_log_event(
-			'setup_wizard_purpose_continue',
-			[
-				'purpose'         => join( ',', $json['purpose']['selected'] ),
-				'purpose_details' => $json['purpose']['other'],
-			]
-		);
-
 		return $this->setup_wizard->update_wizard_user_data( $json );
 	}
 
@@ -465,6 +457,17 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	public function submit_tracking( $data ) {
 		Sensei()->usage_tracking->set_tracking_enabled( (bool) $data['tracking']['usage_tracking'] );
 		Sensei()->usage_tracking->send_usage_data();
+
+		$setup_purpose_data = $this->setup_wizard->get_wizard_user_data( 'purpose' );
+		if ( $setup_purpose_data ) {
+			sensei_log_event(
+				'setup_wizard_purpose_continue',
+				[
+					'purpose'         => join( ',', $setup_purpose_data['selected'] ?? [] ),
+					'purpose_details' => $setup_purpose_data['other'] ?? '',
+				]
+			);
+		}
 
 		return true;
 	}

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -274,19 +274,6 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	 */
 	public function testSubmitTrackingUpdatesUsageTrackingSetting() {
 
-		Sensei()->usage_tracking->set_tracking_enabled( false );
-		$this->request( 'POST', 'tracking', [ 'tracking' => [ 'usage_tracking' => true ] ] );
-
-		$this->assertEquals( true, Sensei()->usage_tracking->get_tracking_enabled() );
-	}
-
-	/**
-	 * Tests that submitting to features endpoint validates input against whitelist
-	 *
-	 * @covers Sensei_REST_API_Setup_Wizard_Controller::submit_purpose
-	 */
-	public function testSubmitPurposeLogged() {
-
 		$this->request(
 			'POST',
 			'purpose',
@@ -297,6 +284,11 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 				],
 			]
 		);
+
+		Sensei()->usage_tracking->set_tracking_enabled( false );
+		$this->request( 'POST', 'tracking', [ 'tracking' => [ 'usage_tracking' => true ] ] );
+
+		$this->assertEquals( true, Sensei()->usage_tracking->get_tracking_enabled() );
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_setup_wizard_purpose_continue' );
 		$this->assertCount( 1, $events );


### PR DESCRIPTION
Fixes #5717

Right now, `sensei_setup_wizard_purpose_continue` is never firing because we make the attempt before we have saved the consent.

cc: @donnapep This should fix that table issue until we have to probably rejig this again for WPCOM onboarding.

### Changes proposed in this Pull Request

* Moves our `sensei_setup_wizard_purpose_continue` event until after we have consent so that it actually fires.

### Testing instructions

- To test it you can use: https://github.com/automattic/event-monitor And or a filter to also log it. Here's what I use (change host if you use docker, but yarn is very easy):
```
  add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
  	$event_monitor_url = 'http://128.0.0.1:8888/pixel/';
  	$host              = parse_url( $url, PHP_URL_HOST );
  	$path              = parse_url( $url, PHP_URL_PATH );
  	if ( 'pixel.wp.com' === $host && '/t.gif' === $path ) {
  		error_log( 'Logging Tracks event:' );
  		error_log( $url );
  		
  		$http    = _wp_http_get_object();
  		$new_url = $event_monitor_url . '?' . parse_url( $url, PHP_URL_QUERY );

  		error_log( $new_url );

  		return $http->request( $new_url, $r );
  	}
  	return $preempt;
  }, 10, 3 );
```
- Visit `/wp-admin/admin.php?page=sensei_setup_wizard` and go through purpose step (select other as well and enter text). Consent to usage tracking.
- Ensure the event fires with accurate data.