### PR TITLE
Bump Sensei version constant/header to 4.9.0

### DIFF
--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Sensei LMS
  * Plugin URI: https://senseilms.com/
  * Description: Share your knowledge, grow your network, and strengthen your brand by launching an online course.
- * Version: 4.8.1
+ * Version: 4.9.0
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'SENSEI_LMS_VERSION' ) ) {
-	define( 'SENSEI_LMS_VERSION', '4.8.1' ); // WRCS: DEFINED_VERSION.
+	define( 'SENSEI_LMS_VERSION', '4.9.0' ); // WRCS: DEFINED_VERSION.
 }
 
 if ( ! defined( 'SENSEI_LMS_PLUGIN_FILE' ) ) {


### PR DESCRIPTION
This will allow CI to run fully on Sensei Pro. 

The following version bumps will need to happen in the release branch:
- `readme.txt`'s `Stable tag`
- `package.json`/`package-lock.json`
- `$$next-version$$`

Setting this to `feature/coteachers` so the change happens when that gets merged.