### PR TITLE
Rename Course Settings sidebar, show arrow

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -265,7 +265,9 @@ a.sensei-custom-navigation__info {
 	display: block;
 }
 
-.sensei-plugin-document-setting-panel button span,
+.sensei-plugin-document-setting-panel .components-panel__body-toggle.components-button .components-panel__arrow {
+	transform: translateY(-50%) rotate(-90deg);
+}
 .components-panel__body .edit-post-post-author {
 	display: none;
 }

--- a/assets/js/admin/course-settings-plugin-sidebar.js
+++ b/assets/js/admin/course-settings-plugin-sidebar.js
@@ -53,11 +53,11 @@ export const CourseSidebar = () => {
 				target={ pluginSidebarHandle }
 				icon={ <SenseiIcon height="20" width="20" color="#43AF99" /> }
 			>
-				{ __( 'Sensei Settings', 'sensei-lms' ) }
+				{ __( 'Course Settings', 'sensei-lms' ) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
 				name={ pluginSidebarHandle }
-				title={ __( 'Sensei Settings', 'sensei-lms' ) }
+				title={ __( 'Course Settings', 'sensei-lms' ) }
 				icon={ <SenseiIcon height="20" width="20" color="#43AF99" /> }
 			>
 				{ ! hideCoursePricing && <CoursePricingPromoSidebar /> }
@@ -78,7 +78,7 @@ export const SenseiSettingsDocumentSidebar = () => {
 		);
 	} );
 	if ( isSenseiEditorPanelOpen ) {
-		// when 'Sensei Settings' is clicked, isSenseiEditorPanelOpen returns true, so we open the 'Sensei Settings'
+		// when 'Course Settings' is clicked, isSenseiEditorPanelOpen returns true, so we open the 'Course Settings'
 		// plugin sidebar and then close the 'Sensei Settings' panel which sets isSenseiEditorPanelOpen back to false.
 		dispatch( 'core/edit-post' ).openGeneralSidebar(
 			`${ pluginSidebarHandle }/${ pluginSidebarHandle }`
@@ -90,7 +90,7 @@ export const SenseiSettingsDocumentSidebar = () => {
 	return (
 		<PluginDocumentSettingPanel
 			name={ pluginDocumentHandle }
-			title={ __( 'Sensei Settings', 'sensei-lms' ) }
+			title={ __( 'Course Settings', 'sensei-lms' ) }
 			className="sensei-plugin-document-setting-panel"
 		></PluginDocumentSettingPanel>
 	);


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Rename 'Sensei Settings' to 'Course Settings' for the course editor sidebar
* Show a > arrow

### Testing instructions

* Open a course in the editor
* Check link in the 'Course' document panel

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="285" alt="image" src="https://user-images.githubusercontent.com/176949/204848181-f9eafd28-f87a-46dd-8249-2c62bdbe9794.png">

