### PR TITLE
Auto select course template depending on selected course pattern

### DIFF
--- a/assets/admin/editor-wizard/patterns-list.js
+++ b/assets/admin/editor-wizard/patterns-list.js
@@ -83,7 +83,14 @@ const PatternsList = ( { onChoose } ) => {
 						categories && categories.includes( 'sensei-lms' )
 				)
 				.map(
-					( { name, title, description, blocks, viewportWidth } ) => (
+					( {
+						name,
+						title,
+						description,
+						blocks,
+						viewportWidth,
+						template,
+					} ) => (
 						// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 						<div
 							key={ name }
@@ -92,7 +99,7 @@ const PatternsList = ( { onChoose } ) => {
 							role="option"
 							tabIndex={ 0 }
 							{ ...accessibleClick( () => {
-								onChoose( blocks, name );
+								onChoose( blocks, name, template );
 							} ) }
 						>
 							<div className="sensei-patterns-list__item-preview">

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -3,7 +3,7 @@
  */
 import { Button, createSlotFill } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -25,16 +25,27 @@ const { Fill, Slot } = createSlotFill( 'Patterns Upsell' );
  * @param {Function} props.onCompletion On completion callback.
  */
 const PatternsStep = ( { title, replaces, onCompletion } ) => {
-	const { resetEditorBlocks } = useDispatch( editorStore );
+	const { resetEditorBlocks, editPost } = useDispatch( editorStore );
 	const logEvent = useLogEvent();
+	const editorSettings = useSelect( ( select ) =>
+		select( editorStore ).getEditorSettings()
+	);
+	const availableTemplates = editorSettings.availableTemplates;
 
-	const onChoose = ( blocks, name ) => {
+	const onChoose = ( blocks, name, template ) => {
 		const newBlocks = replaces
 			? replacePlaceholders( blocks, replaces )
 			: blocks;
 
 		resetEditorBlocks( newBlocks );
 		onCompletion();
+
+		const templateSlug =
+			template && Object.keys( availableTemplates ).includes( template )
+				? template
+				: '';
+
+		editPost( { template: templateSlug } );
 
 		logEvent( 'editor_wizard_choose_pattern', { name } );
 	};

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -40,12 +40,13 @@ const PatternsStep = ( { title, replaces, onCompletion } ) => {
 		resetEditorBlocks( newBlocks );
 		onCompletion();
 
-		const templateSlug =
-			template && Object.keys( availableTemplates ).includes( template )
-				? template
-				: '';
-
-		editPost( { template: templateSlug } );
+		//Auto select a template if the pattern specifies an available one.
+		if (
+			template &&
+			Object.keys( availableTemplates ).includes( template )
+		) {
+			editPost( { template } );
+		}
 
 		logEvent( 'editor_wizard_choose_pattern', { name } );
 	};


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/6192

### Changes proposed in this Pull Request

* If a template is specified in a course pattern selected while creating a course, that template will be auto-selected provided that template exists.

### Testing instructions

- Have the [Course](https://github.com/Automattic/course) theme selected as your theme, check out [this branch](https://github.com/Automattic/course/pull/126) (Not necessary, but makes testing easy)

- Now in Sensei's `includes->block-patterns->course` folder, add an additional key-value pair `'template'   => 'single-column-title',` to one of the templates. For example, you can edit the 'long-sales-page.php' file and add that line. You can edit any other template or use any other available template slug.
![image](https://user-images.githubusercontent.com/6820724/204899785-a3775e61-96b5-4c9c-912a-0c62e709ad20.png)

- Now go to wp-admin and create a new course. On the course creator popup, select a pattern that you didn't change. Make sure your course editor is still using the default template

- Now create another course and this time select the edited pattern that specifies a template. Make sure the new template is shown as selected in the editor