### PR TITLE
Make upgrade CTA for co-teachers consistent with other CTAs.

### DIFF
--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -8,6 +8,7 @@ import {
 	CheckboxControl,
 	SelectControl,
 	HorizontalRule,
+	ExternalLink,
 } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
@@ -137,13 +138,9 @@ const CourseGeneralSidebar = () => {
 			{ ! hideCoteachersUpgrade && (
 				<div className="sensei-course-coteachers-wrapper">
 					{ __( 'Multiple teachers?', 'sensei-lms' ) }{ ' ' }
-					<a
-						href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=co-teachers"
-						target="_blank"
-						rel="noreferrer"
-					>
-						{ __( 'Upgrade to Pro!', 'sensei-lms' ) }
-					</a>
+					<ExternalLink href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=co-teachers">
+						{ __( 'Upgrade to Sensei Pro', 'sensei-lms' ) }
+					</ExternalLink>
 				</div>
 			) }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Use `ExternalLink` component and re-word to have the same translation as the rest of upgrade CTAs.
* Context: p6rkRX-52H-p2#comment-5289

### Testing instructions
* Install Sensei without Sensei Pro.
* Go to a Course settings sidebar.
* Check that new text for upgrade under co-teachers section reads "Upgrade to Sensei Pro" and contains the external icon.

### Screenshot / Video
![image](https://user-images.githubusercontent.com/799065/205266531-81f3f701-204d-414a-9d87-9b3dcbb54381.png)
