### PR TITLE
Fix testimonial margin size

### DIFF
--- a/includes/block-patterns/page/templates/landing-page-grid.php
+++ b/includes/block-patterns/page/templates/landing-page-grid.php
@@ -190,8 +190,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p style="font-style:normal;font-weight:700;letter-spacing:0.02em;line-height:1">Christopher Brown</p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"}}}} -->
-			<p style="padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'sensei-lms' ); ?></p>
+			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"},"margin":{"top":"0px"}}}} -->
+			<p style="margin-top:0;padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'sensei-lms' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->

--- a/includes/block-patterns/page/templates/landing-page-list.php
+++ b/includes/block-patterns/page/templates/landing-page-list.php
@@ -193,8 +193,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p style="font-style:normal;font-weight:700;letter-spacing:0.02em;line-height:1">Christopher Brown</p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"}}}} -->
-			<p style="padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'sensei-lms' ); ?></p>
+			<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1","letterSpacing":"0.02em"},"spacing":{"padding":{"top":"10px"},"margin":{"top":"0px"}}}} -->
+			<p style="margin-top:0;padding-top:10px;letter-spacing:0.02em;line-height:1"><?php echo esc_html__( 'Founder at BeautifulWriting.com', 'sensei-lms' ); ?></p>
 			<!-- /wp:paragraph --></div>
 		<!-- /wp:column --></div>
 	<!-- /wp:columns --></div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/course/issues/133

This is for the "Landing Page" and "Landing Page - Grid" Patterns.

Before:
<img width="465" alt="Screenshot 2022-12-02 at 3 58 38 PM" src="https://user-images.githubusercontent.com/3220162/205410917-6f70be43-28ad-41e4-92bc-a99907de3475.png">


After: 
<img width="612" alt="Screenshot 2022-12-02 at 3 57 13 PM" src="https://user-images.githubusercontent.com/3220162/205410797-391143df-ba57-4d92-b328-ecab33f1ab3f.png">

There's a fix for the Testimonial Pattern in the Course theme here: https://github.com/Automattic/course/pull/139
