### PR TITLE
Fix the docs build command not working again

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -834,8 +834,8 @@ class Sensei_Teacher {
 			 * @hook   sensei_grading_allowed_user_ids
 			 * @since  $$next-version$$
 			 *
-			 * @param int[] The list of user IDs with access granted. By default the course author.
-			 * @param int The course ID.
+			 * @param {int[]} $user_ids The list of user IDs with access granted. By default the course author.
+			 * @param {int} $course_id The course ID.
 			 */
 			$allowed_user_ids = apply_filters( 'sensei_grading_allowed_user_ids', [ intval( $course->post_author ) ], $course_id );
 			if ( ! isset( $course->post_author ) || ! in_array( intval( get_current_user_id() ), $allowed_user_ids, true ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

Make the jsdoc command (and our CI) happy by using the proper docblock syntax.

### Testing instructions

* Run the `npm run build:docs` command.
* There should be no errors.
* Open `hookdocs/index.html`.
* Make sure the `sensei_grading_allowed_user_ids` hook has the correct docs.