### PR TITLE
Log sent emails

### DIFF
--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -239,6 +239,8 @@ class Sensei_Emails {
 		if ( $send ) {
 			$email = $this->emails[ $email_type ];
 			$email->trigger( $user_id, $quiz_id, $grade, $passmark );
+
+			sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 		}
 	}
 
@@ -268,6 +270,8 @@ class Sensei_Emails {
 		if ( $send ) {
 			$email = $this->emails[ $email_type ];
 			$email->trigger( $user_id, $course_id );
+
+			sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 		}
 	}
 
@@ -297,6 +301,8 @@ class Sensei_Emails {
 		if ( $send ) {
 			$email = $this->emails[ $email_type ];
 			$email->trigger( $learner_id, $course_id );
+
+			sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 		}
 	}
 
@@ -322,6 +328,8 @@ class Sensei_Emails {
 		if ( $send ) {
 			$email = $this->emails[ $email_type ];
 			$email->trigger( $learner_id, $course_id );
+
+			sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 		}
 	}
 
@@ -350,6 +358,8 @@ class Sensei_Emails {
 		if ( $send ) {
 			$email = $this->emails[ $email_type ];
 			$email->trigger( $learner_id, $lesson_id );
+
+			sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 		}
 	}
 
@@ -380,6 +390,8 @@ class Sensei_Emails {
 			if ( $send ) {
 				$email = $this->emails[ $email_type ];
 				$email->trigger( $learner_id, $quiz_id );
+
+				sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 			}
 		}
 	}
@@ -406,6 +418,8 @@ class Sensei_Emails {
 		if ( $send ) {
 			$email = $this->emails[ $email_type ];
 			$email->trigger( $message_id );
+
+			sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 		} else {
 			wp_safe_redirect( esc_url_raw( add_query_arg( array( 'send' => 'complete' ) ) ) );
 			exit;
@@ -434,6 +448,8 @@ class Sensei_Emails {
 		if ( $send ) {
 			$email = $this->emails[ $email_type ];
 			$email->trigger( $comment, $message );
+
+			sensei_log_event( 'email_send', [ 'type' => $email_type ] );
 		}
 	}
 

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -225,10 +225,11 @@ class Sensei_Emails {
 	 */
 	function learner_graded_quiz( $user_id, $quiz_id, $grade, $passmark ) {
 
-		$send = false;
+		$email_type = 'learner-graded-quiz';
+		$send       = false;
 
 		if ( isset( Sensei()->settings->settings['email_learners'] ) ) {
-			if ( in_array( 'learner-graded-quiz', (array) Sensei()->settings->settings['email_learners'] ) ) {
+			if ( in_array( $email_type, (array) Sensei()->settings->settings['email_learners'], true ) ) {
 				$send = true;
 			}
 		} else {
@@ -236,7 +237,7 @@ class Sensei_Emails {
 		}
 
 		if ( $send ) {
-			$email = $this->emails['learner-graded-quiz'];
+			$email = $this->emails[ $email_type ];
 			$email->trigger( $user_id, $quiz_id, $grade, $passmark );
 		}
 	}
@@ -249,14 +250,15 @@ class Sensei_Emails {
 	 */
 	function learner_completed_course( $status = 'in-progress', $user_id = 0, $course_id = 0, $comment_id = 0 ) {
 
-		if ( 'complete' != $status ) {
+		if ( 'complete' !== $status ) {
 			return;
 		}
 
-		$send = false;
+		$email_type = 'learner-completed-course';
+		$send       = false;
 
 		if ( isset( Sensei()->settings->settings['email_learners'] ) ) {
-			if ( in_array( 'learner-completed-course', (array) Sensei()->settings->settings['email_learners'] ) ) {
+			if ( in_array( $email_type, (array) Sensei()->settings->settings['email_learners'], true ) ) {
 				$send = true;
 			}
 		} else {
@@ -264,7 +266,7 @@ class Sensei_Emails {
 		}
 
 		if ( $send ) {
-			$email = $this->emails['learner-completed-course'];
+			$email = $this->emails[ $email_type ];
 			$email->trigger( $user_id, $course_id );
 		}
 	}
@@ -277,14 +279,15 @@ class Sensei_Emails {
 	 */
 	function teacher_completed_course( $status = 'in-progress', $learner_id = 0, $course_id = 0, $comment_id = 0 ) {
 
-		if ( 'complete' != $status ) {
+		if ( 'complete' !== $status ) {
 			return;
 		}
 
-		$send = false;
+		$email_type = 'teacher-completed-course';
+		$send       = false;
 
 		if ( isset( Sensei()->settings->settings['email_teachers'] ) ) {
-			if ( in_array( 'teacher-completed-course', (array) Sensei()->settings->settings['email_teachers'] ) ) {
+			if ( in_array( $email_type, (array) Sensei()->settings->settings['email_teachers'], true ) ) {
 				$send = true;
 			}
 		} else {
@@ -292,7 +295,7 @@ class Sensei_Emails {
 		}
 
 		if ( $send ) {
-			$email = $this->emails['teacher-completed-course'];
+			$email = $this->emails[ $email_type ];
 			$email->trigger( $learner_id, $course_id );
 		}
 	}
@@ -305,10 +308,11 @@ class Sensei_Emails {
 	 */
 	function teacher_started_course( $learner_id = 0, $course_id = 0 ) {
 
-		$send = false;
+		$email_type = 'teacher-started-course';
+		$send       = false;
 
 		if ( isset( Sensei()->settings->settings['email_teachers'] ) ) {
-			if ( in_array( 'teacher-started-course', (array) Sensei()->settings->settings['email_teachers'] ) ) {
+			if ( in_array( $email_type, (array) Sensei()->settings->settings['email_teachers'], true ) ) {
 				$send = true;
 			}
 		} else {
@@ -316,7 +320,7 @@ class Sensei_Emails {
 		}
 
 		if ( $send ) {
-			$email = $this->emails['teacher-started-course'];
+			$email = $this->emails[ $email_type ];
 			$email->trigger( $learner_id, $course_id );
 		}
 	}
@@ -332,10 +336,11 @@ class Sensei_Emails {
 	 */
 	function teacher_completed_lesson( $learner_id = 0, $lesson_id = 0 ) {
 
-		$send = false;
+		$email_type = 'teacher-completed-lesson';
+		$send       = false;
 
 		if ( isset( Sensei()->settings->settings['email_teachers'] ) ) {
-			if ( in_array( 'teacher-completed-lesson', (array) Sensei()->settings->settings['email_teachers'] ) ) {
+			if ( in_array( $email_type, (array) Sensei()->settings->settings['email_teachers'], true ) ) {
 				$send = true;
 			}
 		} else {
@@ -343,7 +348,7 @@ class Sensei_Emails {
 		}
 
 		if ( $send ) {
-			$email = $this->emails['teacher-completed-lesson'];
+			$email = $this->emails[ $email_type ];
 			$email->trigger( $learner_id, $lesson_id );
 		}
 	}
@@ -359,12 +364,13 @@ class Sensei_Emails {
 	 */
 	function teacher_quiz_submitted( $learner_id = 0, $quiz_id = 0, $grade = 0, $passmark = 0, $quiz_grade_type = 'manual' ) {
 
-		$send = false;
+		$email_type = 'teacher-quiz-submitted';
+		$send       = false;
 
 		// Only trigger if the quiz was marked as manual grading, or auto grading didn't complete
-		if ( 'manual' == $quiz_grade_type || is_wp_error( $grade ) ) {
+		if ( 'manual' === $quiz_grade_type || is_wp_error( $grade ) ) {
 			if ( isset( Sensei()->settings->settings['email_teachers'] ) ) {
-				if ( in_array( 'teacher-quiz-submitted', (array) Sensei()->settings->settings['email_teachers'] ) ) {
+				if ( in_array( $email_type, (array) Sensei()->settings->settings['email_teachers'], true ) ) {
 					$send = true;
 				}
 			} else {
@@ -372,7 +378,7 @@ class Sensei_Emails {
 			}
 
 			if ( $send ) {
-				$email = $this->emails['teacher-quiz-submitted'];
+				$email = $this->emails[ $email_type ];
 				$email->trigger( $learner_id, $quiz_id );
 			}
 		}
@@ -386,10 +392,11 @@ class Sensei_Emails {
 	 */
 	function teacher_new_message( $message_id = 0 ) {
 
-		$send = false;
+		$email_type = 'teacher-new-message';
+		$send       = false;
 
 		if ( isset( Sensei()->settings->settings['email_teachers'] ) ) {
-			if ( in_array( 'teacher-new-message', (array) Sensei()->settings->settings['email_teachers'] ) ) {
+			if ( in_array( $email_type, (array) Sensei()->settings->settings['email_teachers'], true ) ) {
 				$send = true;
 			}
 		} else {
@@ -397,7 +404,7 @@ class Sensei_Emails {
 		}
 
 		if ( $send ) {
-			$email = $this->emails['teacher-new-message'];
+			$email = $this->emails[ $email_type ];
 			$email->trigger( $message_id );
 		} else {
 			wp_safe_redirect( esc_url_raw( add_query_arg( array( 'send' => 'complete' ) ) ) );
@@ -413,10 +420,11 @@ class Sensei_Emails {
 	 */
 	function new_message_reply( $comment, $message ) {
 
-		$send = false;
+		$email_type = 'new-message-reply';
+		$send       = false;
 
 		if ( isset( Sensei()->settings->settings['email_global'] ) ) {
-			if ( in_array( 'new-message-reply', (array) Sensei()->settings->settings['email_global'] ) ) {
+			if ( in_array( $email_type, (array) Sensei()->settings->settings['email_global'], true ) ) {
 				$send = true;
 			}
 		} else {
@@ -424,7 +432,7 @@ class Sensei_Emails {
 		}
 
 		if ( $send ) {
-			$email = $this->emails['new-message-reply'];
+			$email = $this->emails[ $email_type ];
 			$email->trigger( $comment, $message );
 		}
 	}


### PR DESCRIPTION
Fixes #6222

### Changes proposed in this Pull Request

* Log an event when an email is sent.
* The log event contains the email `type`.
* Small refactoring of the `Sensei_Emails` class.

### Testing instructions

* Enable usage tracking.
* [Enable all email notifications](https://user-images.githubusercontent.com/1190420/205724572-1634111d-7930-461d-bb81-95cde46fc712.jpg).
* Trigger the email notifications.
* Make sure a `sensei_email_send` event is logged in tracker.
* Make sure each event has the proper `type`.

