### PR TITLE
Ensure passing an integer module id

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -645,7 +645,7 @@ class Sensei_Core_Modules {
 		// Remove module from existing courses
 		if ( isset( $courses ) && is_array( $courses ) ) {
 			foreach ( $courses as $course ) {
-				wp_remove_object_terms( $course->ID, $module_id, $this->taxonomy );
+				wp_remove_object_terms( $course->ID, (int) $module_id, $this->taxonomy );
 			}
 		}
 


### PR DESCRIPTION
- In `Sensei_Core_Modules::save_module_course` we call `wp_set_objects_terms`, passing there `$module_id`.
- In `wp_set_objects_terms` we check if the term exists.
- `term_exists` expects an int, otherwise it considers the incoming value as a name.
For some reason, `$module_id` in some very special cases becomes a string, so it can't find the term and tries to create it.
So, cast the type to int when calling `wp_set_objects_terms` in `Sensei_Core_Modules::save_module_course`.

### Changes proposed in this Pull Request

* Ensure $module_id is an integer.

### Testing instructions

* Go to Sensei LMS -> Modules.
* Add a new module, create a child module, delete the child.
* Create a new child with the same name.
* Make sure no "additional" modules appeared with a numeric name.
