### PR TITLE
Install Course theme in setup wizard

### DIFF
--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -59,8 +59,11 @@ const getThemeAction = () => ( {
 	label: __( 'Installing the Course theme', 'sensei-lms' ),
 	action: () =>
 		apiFetch( {
-			path: '/sensei-internal/v1/course-theme/install',
+			path: '/sensei-internal/v1/themes/install',
 			method: 'POST',
+			data: {
+				theme: 'course',
+			},
 		} ),
 } );
 

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -57,7 +57,11 @@ const getFeatureActions = ( { selected, options } ) => {
  */
 const getThemeAction = () => ( {
 	label: __( 'Installing the Course theme', 'sensei-lms' ),
-	action: () => Promise.resolve(),
+	action: () =>
+		apiFetch( {
+			path: '/sensei-internal/v1/course-theme/install',
+			method: 'POST',
+		} ),
 } );
 
 /**

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -100,6 +100,10 @@ final class Sensei_Extensions {
 			return $this->add_installed_extensions_properties( $extensions );
 		}
 
+		if ( 'theme' === $type ) {
+			return $this->add_installed_themes_properties( $extensions );
+		}
+
 		return $extensions;
 	}
 
@@ -155,6 +159,38 @@ final class Sensei_Extensions {
 		);
 
 		return $extensions;
+	}
+
+	/**
+	 * Map the themes array, adding the installed properties.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @access private
+	 *
+	 * @param array $themes Themes from the REST API.
+	 *
+	 * @return array Themes with installed properties.
+	 */
+	public function add_installed_themes_properties( $themes ) {
+		// Includes installed version.
+		$themes = array_map(
+			function( $theme ) {
+				$theme_slug          = $theme->product_slug;
+				$theme_object        = wp_get_theme( $theme_slug );
+				$theme->is_installed = $theme_object->exists();
+				$theme->is_activated = wp_get_theme()->get_stylesheet() === $theme_slug;
+
+				if ( $theme->is_installed ) {
+					$theme->installed_version = $theme_object->get( 'Version' );
+				}
+
+				return $theme;
+			},
+			$themes
+		);
+
+		return $themes;
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-course-theme-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-theme-controller.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Course_Theme_Controller class.
+ *
+ * @package sensei-lms
+ * @since   $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly.
+
+/**
+ * A REST controller for installing the Course theme.
+ *
+ * @since $$next-version$$
+ *
+ * @see   WP_REST_Controller
+ */
+class Sensei_REST_API_Course_Theme_Controller extends WP_REST_Controller {
+	/**
+	 * Routes namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * Routes prefix.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'course-theme';
+
+	/**
+	 * Sensei_REST_API_Course_Theme_Controller constructor.
+	 *
+	 * @param string $namespace Routes namespace.
+	 */
+	public function __construct( $namespace ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Register the REST API endpoints for the Course theme.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/install',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'install_course_theme' ],
+					'permission_callback' => [ $this, 'can_user_manage_themes' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Check user permission for managing themes.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return bool|WP_Error Whether the user can manage themes.
+	 */
+	public function can_user_manage_themes( WP_REST_Request $request ) {
+		if (
+			! current_user_can( 'install_themes' )
+			|| ! current_user_can( 'switch_themes' )
+		) {
+			return new WP_Error(
+				'rest_cannot_manage_themes',
+				__( 'Sorry, you are not allowed to manage themes for this site.', 'sensei-lms' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Install theme. If the theme is already installed, just activate it.
+	 *
+	 * @access private
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function install_course_theme( WP_REST_Request $request ) {
+		// $json_params = $request->get_json_params();
+		// $plugin_slug = $json_params['plugin'];
+
+		// $plugin_to_install = array_values(
+		// 	array_filter(
+		// 		Sensei_Extensions::instance()->get_extensions_and_woocommerce( 'plugin' ),
+		// 		function( $plugin ) use ( $plugin_slug ) {
+		// 			return $plugin->product_slug === $plugin_slug;
+		// 		}
+		// 	)
+		// )[0];
+
+		// try {
+		// 	if ( ! $plugin_to_install->is_installed ) {
+		// 		Sensei_Plugins_Installation::instance()->install_plugin( $plugin_slug );
+		// 	}
+		// 	wp_clean_plugins_cache();
+		// 	Sensei_Plugins_Installation::instance()->activate_plugin( $plugin_slug, $plugin_to_install->plugin_file );
+		// } catch ( Exception $e ) {
+		// 	return new WP_Error(
+		// 		'sensei_extensions_install_error',
+		// 		$e->getMessage()
+		// 	);
+		// }
+
+		// $installed_plugins = array_filter(
+		// 	Sensei_Extensions::instance()->get_extensions_and_woocommerce( 'plugin' ),
+		// 	function( $plugin ) use ( $plugin_slug ) {
+		// 		return $plugin->product_slug === $plugin_slug;
+		// 	}
+		// );
+
+		// return $this->create_extensions_response( $installed_plugins, 'completed' );
+
+		error_log( 'Hello!' );
+
+		return new WP_REST_Response( 'ok' );
+	}
+
+}

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -51,6 +51,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Lesson_Quiz_Controller( $this->namespace ),
 			new Sensei_REST_API_Question_Options_Controller( $this->namespace ),
 			new Sensei_REST_API_Extensions_Controller( $this->namespace ),
+			new Sensei_REST_API_Course_Theme_Controller( $this->namespace ),
 			new Sensei_REST_API_Send_Message_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Students_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Progress_Controller( $this->namespace ),

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -51,7 +51,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Lesson_Quiz_Controller( $this->namespace ),
 			new Sensei_REST_API_Question_Options_Controller( $this->namespace ),
 			new Sensei_REST_API_Extensions_Controller( $this->namespace ),
-			new Sensei_REST_API_Course_Theme_Controller( $this->namespace ),
+			new Sensei_REST_API_Theme_Controller( $this->namespace ),
 			new Sensei_REST_API_Send_Message_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Students_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Progress_Controller( $this->namespace ),

--- a/includes/rest-api/class-sensei-rest-api-theme-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-theme-controller.php
@@ -155,7 +155,7 @@ class Sensei_REST_API_Theme_Controller extends WP_REST_Controller {
 					sprintf(
 						// translators: Placeholder is the theme slug.
 						__( 'The requested theme `%s` could not be installed.', 'sensei-lms' ),
-						$theme
+						$theme_slug
 					),
 					500
 				);

--- a/includes/rest-api/class-sensei-rest-api-theme-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-theme-controller.php
@@ -101,16 +101,16 @@ class Sensei_REST_API_Theme_Controller extends WP_REST_Controller {
 		$allowed_themes = Sensei_Extensions::instance()->get_extensions( 'theme' );
 
 		// Get the info for the theme to install.
-		$theme_to_install = array_values(
+		$filtered_themes = array_values(
 			array_filter(
 				$allowed_themes,
 				function( $theme ) use ( $theme_slug ) {
 					return $theme->product_slug === $theme_slug;
 				}
 			)
-		)[0];
+		);
 
-		if ( empty( $theme_to_install ) ) {
+		if ( empty( $filtered_themes ) ) {
 			return new WP_Error(
 				'sensei_theme_invalid',
 				// translators: Placeholder is the theme slug.
@@ -118,6 +118,8 @@ class Sensei_REST_API_Theme_Controller extends WP_REST_Controller {
 				[ 'status' => 400 ]
 			);
 		}
+
+		$theme_to_install = $filtered_themes[0];
 
 		// If the theme is not already installed, install it.
 		if ( ! $theme_to_install->is_installed ) {

--- a/includes/rest-api/class-sensei-rest-api-theme-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-theme-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei REST API: Sensei_REST_API_Course_Theme_Controller class.
+ * Sensei REST API: Sensei_REST_API_Theme_Controller class.
  *
  * @package sensei-lms
  * @since   $$next-version$$
@@ -11,13 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly.
 
 /**
- * A REST controller for installing the Course theme.
+ * A REST controller for installing themes.
  *
  * @since $$next-version$$
  *
  * @see   WP_REST_Controller
  */
-class Sensei_REST_API_Course_Theme_Controller extends WP_REST_Controller {
+class Sensei_REST_API_Theme_Controller extends WP_REST_Controller {
 	/**
 	 * Routes namespace.
 	 *
@@ -30,7 +30,7 @@ class Sensei_REST_API_Course_Theme_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'course-theme';
+	protected $rest_base = 'themes';
 
 	/**
 	 * Sensei_REST_API_Course_Theme_Controller constructor.
@@ -53,6 +53,12 @@ class Sensei_REST_API_Course_Theme_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => [ $this, 'install_course_theme' ],
 					'permission_callback' => [ $this, 'can_user_manage_themes' ],
+					'args'                => [
+						'theme' => [
+							'required' => true,
+							'type'     => 'string',
+						],
+					],
 				],
 			]
 		);
@@ -90,41 +96,13 @@ class Sensei_REST_API_Course_Theme_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function install_course_theme( WP_REST_Request $request ) {
-		// $json_params = $request->get_json_params();
-		// $plugin_slug = $json_params['plugin'];
+		$json_params = $request->get_json_params();
+		$theme_slug = $json_params['theme'];
 
-		// $plugin_to_install = array_values(
-		// 	array_filter(
-		// 		Sensei_Extensions::instance()->get_extensions_and_woocommerce( 'plugin' ),
-		// 		function( $plugin ) use ( $plugin_slug ) {
-		// 			return $plugin->product_slug === $plugin_slug;
-		// 		}
-		// 	)
-		// )[0];
+		$themes = Sensei_Extensions::instance()->get_extensions( 'theme' );
 
-		// try {
-		// 	if ( ! $plugin_to_install->is_installed ) {
-		// 		Sensei_Plugins_Installation::instance()->install_plugin( $plugin_slug );
-		// 	}
-		// 	wp_clean_plugins_cache();
-		// 	Sensei_Plugins_Installation::instance()->activate_plugin( $plugin_slug, $plugin_to_install->plugin_file );
-		// } catch ( Exception $e ) {
-		// 	return new WP_Error(
-		// 		'sensei_extensions_install_error',
-		// 		$e->getMessage()
-		// 	);
-		// }
-
-		// $installed_plugins = array_filter(
-		// 	Sensei_Extensions::instance()->get_extensions_and_woocommerce( 'plugin' ),
-		// 	function( $plugin ) use ( $plugin_slug ) {
-		// 		return $plugin->product_slug === $plugin_slug;
-		// 	}
-		// );
-
-		// return $this->create_extensions_response( $installed_plugins, 'completed' );
-
-		error_log( 'Hello!' );
+		error_log( 'Got themes:' );
+		error_log( print_r( $themes, true ) );
 
 		return new WP_REST_Response( 'ok' );
 	}


### PR DESCRIPTION
Fixes #6224 

### Changes proposed in this Pull Request

When the user chooses to use the Course theme in the Setup Wizard, we install the theme in the last step of the wizard.

### Testing instructions

- Ensure that the Course theme is not installed.
- Run the setup wizard, and choose to install the Course theme.
- Confirm that the theme is installed and activated.
- Switch to a different theme, but do not uninstall the theme.
- Run the wizard again, choosing to install the Course theme.
- Confirm that your theme is switched to Course.
- Switch to a different theme, and delete the Course theme.
- Run the Setup Wizard again, and choose NOT to install the Course theme.
- Ensure that your theme is unaffected.