### PR TITLE
Ensure is_plugin_active call doesn't give an error

### DIFF
--- a/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
@@ -74,6 +74,10 @@ class Sensei_Home_Task_Sell_Course_With_WooCommerce implements Sensei_Home_Task 
 	 * @return bool Whether the task should be active or not.
 	 */
 	public static function is_active() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 			return false;
 		}

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -1,4 +1,5 @@
 <?php
+// Temporary change
 /**
  * Plugin Name: Sensei LMS
  * Plugin URI: https://senseilms.com/

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -1,5 +1,4 @@
 <?php
-// Temporary change
 /**
  * Plugin Name: Sensei LMS
  * Plugin URI: https://senseilms.com/


### PR DESCRIPTION


### Changes proposed in this Pull Request

Ensure the `is_plugin_active` call in the Sensei Home REST API works correctly and doesn't return an error. Note that this issue was being masked by the fact that we preload this REST API call, and it was working in the preload context.

### Testing instructions

* Install a fresh Sensei (e.g. on a Jurassic Ninja site). Go through the Setup Wizard.
* On the home page, ensure that the "Tasks" are being displayed.
* Open a browser console and run the following code:

```javascript
wp.apiFetch( {
  path: '/sensei-internal/v1/home',
  method: 'GET',
} );
```

* Ensure that the call returns without a server-side error.