### PR TITLE
Add Sensei Home task to customize the Course theme

### DIFF
--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -71,6 +71,10 @@ class Sensei_Home_Tasks_Provider {
 			$core_tasks[] = new Sensei_Home_Task_Sell_Course_With_WooCommerce();
 		}
 
+		if ( Sensei_Home_Task_Customize_Course_Theme::is_active() ) {
+			$core_tasks[] = new Sensei_Home_Task_Customize_Course_Theme();
+		}
+
 		$tasks = [];
 		/**
 		 * Each one of the core tasks.

--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -3,13 +3,13 @@
  * File containing the Sensei_Home_Task_Customize_Course_Theme class.
  *
  * @package sensei-lms
- * @since $$next-version
+ * @since $$next-version$$
  */
 
 /**
  * Sensei_Home_Task_Customize_Course_Theme class.
  *
- * @since $$next-version
+ * @since $$next-version$$
  */
 class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	const CUSTOMIZED_COURSE_THEME_OPTION_KEY = 'sensei_home_task_visited_course_theme_customizer';

--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -38,7 +38,7 @@ class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	 * @return string
 	 */
 	public function get_title(): string {
-		return __( 'Customize the Course theme', 'sensei-lms' );
+		return __( 'Customize your theme', 'sensei-lms' );
 	}
 
 	/**

--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -47,9 +47,7 @@ class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	 * @return string
 	 */
 	public function get_url(): ?string {
-		// TODO
-		return '';
-		// return admin_url( 'admin.php?page=wc-admin' );
+		return admin_url( 'site-editor.php' );
 	}
 
 	/**
@@ -76,12 +74,6 @@ class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	 * @return bool Whether the task should be active or not.
 	 */
 	public static function is_active() {
-		// TODO: return true if Course Theme is active.
-		return true;
-		// if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-		// 	return false;
-		// }
-		// $features = Sensei_Setup_Wizard::instance()->get_wizard_user_data( 'features' );
-		// return in_array( 'woocommerce', $features['selected'], true );
+		return 'course' === wp_get_theme()->get_template();
 	}
 }

--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * File containing the Sensei_Home_Task_Customize_Course_Theme class.
+ *
+ * @package sensei-lms
+ * @since $$next-version
+ */
+
+/**
+ * Sensei_Home_Task_Customize_Course_Theme class.
+ *
+ * @since $$next-version
+ */
+class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
+	const CUSTOMIZED_COURSE_THEME_OPTION_KEY = 'sensei_home_task_visited_course_theme_customizer';
+
+	/**
+	 * The ID for the task.
+	 *
+	 * @return string
+	 */
+	public static function get_id(): string {
+		return 'customize-course-theme';
+	}
+
+	/**
+	 * Number used to sort in frontend.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return 400;
+	}
+
+	/**
+	 * Task title.
+	 *
+	 * @return string
+	 */
+	public function get_title(): string {
+		return __( 'Customize the Course theme', 'sensei-lms' );
+	}
+
+	/**
+	 * Task url.
+	 *
+	 * @return string
+	 */
+	public function get_url(): ?string {
+		// TODO
+		return '';
+		// return admin_url( 'admin.php?page=wc-admin' );
+	}
+
+	/**
+	 * Whether the task is completed or not.
+	 *
+	 * @return bool
+	 */
+	public function is_completed(): bool {
+		return (bool) get_option( self::CUSTOMIZED_COURSE_THEME_OPTION_KEY, false );
+	}
+
+	/**
+	 * Mark the task as completed.
+	 *
+	 * @return void
+	 */
+	public static function mark_completed() {
+		update_option( self::CUSTOMIZED_COURSE_THEME_OPTION_KEY, true, false );
+	}
+
+	/**
+	 * Test if this task should be active or not.
+	 *
+	 * @return bool Whether the task should be active or not.
+	 */
+	public static function is_active() {
+		// TODO: return true if Course Theme is active.
+		return true;
+		// if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+		// 	return false;
+		// }
+		// $features = Sensei_Setup_Wizard::instance()->get_wizard_user_data( 'features' );
+		// return in_array( 'woocommerce', $features['selected'], true );
+	}
+}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1837,16 +1837,27 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Registers the hook to call mark_completed when the wc-admin page on WooCommerce is visited.
+	 * Registers the hook to call mark_completed on tasks that have been
+	 * completed.
 	 *
 	 * @access private
 	 * @return void
 	 */
 	public function admin_init() {
+		global $pagenow;
+
 		if ( Sensei_Home_Task_Sell_Course_With_WooCommerce::is_active() ) {
 			$hook = get_plugin_page_hook( 'wc-admin', 'woocommerce' );
 			if ( null !== $hook ) {
 				add_action( $hook, [ Sensei_Home_Task_Sell_Course_With_WooCommerce::class, 'mark_completed' ] );
+			}
+		}
+
+		// Mark the Course Theme Customization as completed if we are visiting
+		// the site editor or the customizer with the Course theme installed.
+		if ( Sensei_Home_Task_Customize_Course_Theme::is_active() ) {
+			if ( in_array( $pagenow, [ 'site-editor.php', 'customize.php' ], true ) ) {
+				Sensei_Home_Task_Customize_Course_Theme::mark_completed();
 			}
 		}
 	}

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -91,6 +91,7 @@ class Sensei_Data_Cleaner {
 		'sensei_home_tasks_list_is_completed',
 		'sensei_home_tasks_dismissed',
 		'sensei_home_task_visited_woocommerce',
+		'sensei_home_task_visited_course_theme_customizer',
 	);
 
 	/**

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file contains the Sensei_Home_Task_Customize_Course_Theme class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Tests for Sensei_Home_Task_Customize_Course_Theme class.
+ *
+ * @covers Sensei_Home_Task_Customize_Course_Theme
+ */
+class Sensei_Home_Task_Customize_Course_Theme_Test extends WP_UnitTestCase {
+
+	/**
+	 * The task under test.
+	 *
+	 * @var Sensei_Home_Task_Customize_Course_Theme
+	 */
+	private $task;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->task = new Sensei_Home_Task_Customize_Course_Theme();
+	}
+
+	public function tearDown(): void {
+		delete_option( Sensei_Home_Task_Customize_Course_Theme::CUSTOMIZED_COURSE_THEME_OPTION_KEY );
+		parent::tearDown();
+	}
+
+	public function testIsCompleted_WhenCalledInitially_ReturnsFalse() {
+		// Assert.
+		$this->assertFalse( $this->task->is_completed() );
+	}
+
+	public function testIsCompleted_AfterMarkCompletedIsCalled_ReturnsTrue() {
+		// Act.
+		$this->task->mark_completed();
+
+		// Assert.
+		$this->assertTrue( $this->task->is_completed() );
+	}
+
+	public function testIsActive_WhenCourseThemeIsNotInstalled_ReturnsFalse() {
+		// Assert.
+		$this->assertFalse( $this->task->is_active() );
+	}
+
+	public function testIsActive_WhenCourseThemeIsInstalled_ReturnsTrue() {
+		// Arrange.
+		$course_theme = 'course';
+		switch_theme( $course_theme );
+
+		// Assert.
+		$this->assertTrue( $this->task->is_active() );
+	}
+}

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
@@ -23,13 +23,20 @@ class Sensei_Home_Task_Customize_Course_Theme_Test extends WP_UnitTestCase {
 	 */
 	private $task;
 
+	/**
+	 * The original theme.
+	 */
+	protected $original_theme;
+
 	public function setUp(): void {
 		parent::setUp();
-		$this->task = new Sensei_Home_Task_Customize_Course_Theme();
+		$this->task           = new Sensei_Home_Task_Customize_Course_Theme();
+		$this->original_theme = get_stylesheet();
 	}
 
 	public function tearDown(): void {
 		delete_option( Sensei_Home_Task_Customize_Course_Theme::CUSTOMIZED_COURSE_THEME_OPTION_KEY );
+		switch_theme( $this->original_theme );
 		parent::tearDown();
 	}
 

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -32,6 +32,11 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 	 */
 	protected $factory;
 
+	/**
+	 * The original theme.
+	 */
+	protected $original_theme;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->provider = new Sensei_Home_Tasks_Provider();

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -39,8 +39,8 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->provider = new Sensei_Home_Tasks_Provider();
-		$this->factory  = new Sensei_Factory();
+		$this->provider       = new Sensei_Home_Tasks_Provider();
+		$this->factory        = new Sensei_Factory();
 		$this->original_theme = get_stylesheet();
 	}
 

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -36,11 +36,13 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		parent::setUp();
 		$this->provider = new Sensei_Home_Tasks_Provider();
 		$this->factory  = new Sensei_Factory();
+		$this->original_theme = get_stylesheet();
 	}
 
 	public function tearDown(): void {
 		remove_filter( 'sensei_home_tasks', [ $this, 'overrideWithFakeTask' ] );
 		remove_filter( 'wp_get_attachment_image_src', [ $this, 'overrideWithCustomImage' ] );
+		switch_theme( $this->original_theme );
 		parent::tearDown();
 	}
 
@@ -58,6 +60,19 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( Sensei_Home_Task_Create_First_Course::get_id(), $items );
 		$this->assertArrayHasKey( Sensei_Home_Task_Configure_Learning_Mode::get_id(), $items );
 		$this->assertArrayHasKey( Sensei_Home_Task_Publish_First_Course::get_id(), $items );
+	}
+
+	public function testGetTasks_WhenCalledWhileCourseThemeActive_IncludesCourseThemeCustomizationTask() {
+		// Arrange
+		switch_theme( 'course' );
+
+		// Act
+		$result = $this->provider->get();
+
+		// Assert
+		$items = $result['items'];
+		$this->assertIsArray( $items );
+		$this->assertArrayHasKey( Sensei_Home_Task_Customize_Course_Theme::get_id(), $items );
 	}
 
 	public function testGet_GivenAFilterThatOverridesTasks_ReturnSingleOverriddenResult() {


### PR DESCRIPTION
Fixes #6225

### Changes proposed in this Pull Request

Create a new task on the Sensei Home page for customizing the Course theme, if it's active. The task is marked complete when either the Site Editor or the Customizer is opened while Course is the active theme.

### Testing instructions

- Install the Course theme on your Sensei site.
- Clear all options from the DB starting with `sensei_home_task_` or `sensei_home_tasks_`.
- Load the Sensei Home page. Ensure that there is a task for customizing the Course theme.
- Click on the task. Ensure that it opens the Site Editor.
- Go back to Sensei Home. Ensure that the task is completed.
- Clear the DB options again.
- Manually load the Customizer (Appearance > Customizer).
- Go back to Sensei Home. Ensure that the task is completed.
