### PR TITLE
Add usage tracking for Setup Wizard Course Theme step

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -523,6 +523,16 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 			);
 		}
 
+		$theme_data = $this->setup_wizard->get_wizard_user_data( 'theme' );
+		if ( $theme_data['install_sensei_theme'] ) {
+			sensei_log_event(
+				'setup_wizard_install_theme',
+				[
+					'theme' => 'course',
+				]
+			);
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #6227

### Changes proposed in this Pull Request

* Log an event when user chooses to install the Course Theme from the Setup Wizard.

### Testing instructions

- Set up your testing environment to log usage tracking events. You can use [event-monitor](https://github.com/automattic/event-monitor) for this, or simply log to the error_log. Here is an example code snippet which does both.

```php
add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
  	$event_monitor_url = 'http://localhost:8888/pixel/';
  	$host              = parse_url( $url, PHP_URL_HOST );
  	$path              = parse_url( $url, PHP_URL_PATH );
  	if ( 'pixel.wp.com' === $host && '/t.gif' === $path ) {
  		error_log( 'Logging Tracks event:' );
  		error_log( $url );
  		
  		$http    = _wp_http_get_object();
  		$new_url = $event_monitor_url . '?' . parse_url( $url, PHP_URL_QUERY );

  		error_log( $new_url );

  		return $http->request( $new_url, $r );
  	}
  	return $preempt;
  }, 10, 3 );
```

- Walk through the Setup Wizard. Choose to install the theme. Ensure the`sensei_setup_wizard_install_theme` event is logged.
- Walk through the Setup Wizard again. Choose NOT to install the theme. Ensure the `sensei_setup_wizard_install_theme` event is not logged.