### PR TITLE
Add meta checkbox for course open access

### DIFF
--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -51,6 +51,7 @@ const CourseGeneralSidebar = () => {
 	const featured = meta._course_featured;
 	const prerequisite = meta._course_prerequisite;
 	const notification = meta.disable_notification;
+	const openAccess = meta.open_access;
 
 	useEffect( () =>
 		editorLifecycle( {
@@ -169,6 +170,21 @@ const CourseGeneralSidebar = () => {
 					}
 				/>
 			) : null }
+
+			<HorizontalRule />
+
+			<h3>{ __( 'Access', 'sensei-lms' ) }</h3>
+			<CheckboxControl
+				label={ __( 'Open Access', 'sensei-lms' ) }
+				checked={ openAccess }
+				onChange={ ( checked ) =>
+					setMeta( { ...meta, open_access: checked } )
+				}
+				help={ __(
+					'Visitors can take this course without signing up.',
+					'sensei-lms'
+				) }
+			/>
 
 			<HorizontalRule />
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -442,6 +442,18 @@ class Sensei_Course {
 				},
 			]
 		);
+		register_post_meta(
+			'course',
+			'open_access',
+			[
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'boolean',
+				'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
+					return current_user_can( 'edit_post', $post_id );
+				},
+			]
+		);
 		/**
 		 * Sets up the meta fields saved on course save in WP admin.
 		 *


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/6240

### Changes proposed in this Pull Request

* Added a checkbox in the course settings sidebar to save the meta of whether the course has open access or not

### Testing instructions

- Go to the editing page of a Course
- Open course settings in the right sidebar
- Make sure there is a checkbox labeled Open Access in the sidebar under General category
- Check and uncheck the checkbox and make sure the value stays saved in database

### Screenshot / Video
![image](https://user-images.githubusercontent.com/6820724/206426782-aabdd823-b648-4169-9af7-fd306b9373d1.png)
