### PR TITLE
Always initialize question blocks in frontend

### DIFF
--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -68,7 +68,7 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 	 * Initializes quiz blocks.
 	 */
 	public function initialize_blocks() {
-		if ( ! Sensei()->quiz->is_block_based_editor_enabled() ) {
+		if ( is_admin() && ! Sensei()->quiz->is_block_based_editor_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei-pro/issues/1972

### Changes proposed in this Pull Request

* In https://github.com/Automattic/sensei-pro/pull/1641 we started enabling block editor in block editor pages only.
* This caused the blocks to not initialize in the frontend and by default their content was rendered.
* With this change we always initialize the blocks when not admin.

### Testing instructions

- Follow the instructions in https://github.com/Automattic/sensei-pro/issues/1972 and make sure that question content is not displayed in the lessons.
- Follow the instruction in https://github.com/Automattic/sensei-pro/pull/1641 and make sure that classic editor support is not broken.
