### PR TITLE
Show lesson and quiz as if enrolled for open access lessons

### DIFF
--- a/includes/blocks/class-sensei-view-quiz-block.php
+++ b/includes/blocks/class-sensei-view-quiz-block.php
@@ -40,13 +40,13 @@ class Sensei_View_Quiz_Block {
 	public function render( array $attributes, string $content ) : string {
 		$lesson_id = get_the_ID();
 
-		if ( empty( $lesson_id ) ) {
+		if ( empty( $lesson_id ) || ! Sensei_Lesson::should_show_lesson_actions( $lesson_id ) ) {
 			return '';
 		}
 
 		$quiz_permalink = Sensei()->lesson->get_quiz_permalink( $lesson_id );
 
-		if ( ! $quiz_permalink || ! Sensei()->access_settings() ) {
+		if ( ! $quiz_permalink ) {
 			return '';
 		}
 

--- a/includes/blocks/class-sensei-view-quiz-block.php
+++ b/includes/blocks/class-sensei-view-quiz-block.php
@@ -40,7 +40,7 @@ class Sensei_View_Quiz_Block {
 	public function render( array $attributes, string $content ) : string {
 		$lesson_id = get_the_ID();
 
-		if ( empty( $lesson_id ) || ! Sensei_Lesson::should_show_lesson_actions( $lesson_id ) ) {
+		if ( empty( $lesson_id ) || ! sensei_can_user_view_lesson( $lesson_id ) ) {
 			return '';
 		}
 

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -141,7 +141,7 @@ class Lesson_Actions {
 		$actions = [];
 		$class   = [ 'sensei-course-theme-lesson-actions' ];
 
-		if ( empty( $lesson_id ) || empty( $user_id ) ) {
+		if ( empty( $lesson_id ) ) {
 			return '';
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -152,6 +152,17 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Is the course accessible to logged-out users.
+	 *
+	 * @param int $course_id
+	 *
+	 * @return bool
+	 */
+	public static function is_open_access( $course_id ) {
+		return ! empty( $course_id ) && get_post_meta( $course_id, 'open_access', true );
+	}
+
+	/**
 	 * Highlight the menu item for the course pages.
 	 *
 	 * @deprecated 4.8.0

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -152,17 +152,6 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Is the course accessible to logged-out users.
-	 *
-	 * @param int $course_id
-	 *
-	 * @return bool
-	 */
-	public static function is_open_access( $course_id ) {
-		return ! empty( $course_id ) && get_post_meta( $course_id, 'open_access', true );
-	}
-
-	/**
 	 * Highlight the menu item for the course pages.
 	 *
 	 * @deprecated 4.8.0

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -39,8 +39,35 @@ class Sensei_Guest_User {
 	 */
 	public function __construct() {
 		add_action( 'wp', array( $this, 'sensei_create_guest_user_and_login_for_open_course' ), 9 );
+		add_action( 'sensei_is_enrolled', [ self::class, 'open_course_always_enrolled' ], 10, 3 );
+		add_action( 'sensei_can_access_course_content', [ self::class, 'open_course_enable_course_access' ], 10, 2 );
 
 		$this->create_guest_student_role_if_not_exists();
+	}
+
+	/**
+	 * Filter enrolment check to always return true if the course is open access.
+	 *
+	 * @param bool $is_enrolled Initial value.
+	 * @param int  $user_id     User ID. Unused.
+	 * @param int  $course_id   Course ID.
+	 *
+	 * @return bool
+	 */
+	public static function open_course_always_enrolled( $is_enrolled, $user_id, $course_id ) {
+		return Sensei_Course::is_open_access( $course_id ) ? true : $is_enrolled;
+	}
+
+	/**
+	 * Filter course access check to always return true if the course is open access.
+	 *
+	 * @param bool $can_view_course_content Initial value.
+	 * @param int  $course_id               Course ID.
+	 *
+	 * @return bool
+	 */
+	public static function open_course_enable_course_access( $can_view_course_content, $course_id ) {
+		return Sensei_Course::is_open_access( $course_id ) ? true : $can_view_course_content;
 	}
 
 	/**

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -57,7 +57,8 @@ class Sensei_Guest_User {
 	 * @return bool
 	 */
 	public function open_course_always_enrolled( $is_enrolled, $user_id, $course_id ) {
-		return $this->is_course_open_access( $course_id ) ? true : $is_enrolled;
+		$in_course_content = is_singular( [ 'lesson', 'quiz' ] );
+		return ( $in_course_content && $this->is_course_open_access( $course_id ) ) ? true : $is_enrolled;
 	}
 
 	/**

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -39,8 +39,8 @@ class Sensei_Guest_User {
 	 */
 	public function __construct() {
 		add_action( 'wp', array( $this, 'sensei_create_guest_user_and_login_for_open_course' ), 9 );
-		add_action( 'sensei_is_enrolled', [ self::class, 'open_course_always_enrolled' ], 10, 3 );
-		add_action( 'sensei_can_access_course_content', [ self::class, 'open_course_enable_course_access' ], 10, 2 );
+		add_action( 'sensei_is_enrolled', [ $this, 'open_course_always_enrolled' ], 10, 3 );
+		add_action( 'sensei_can_access_course_content', [ $this, 'open_course_enable_course_access' ], 10, 2 );
 
 		$this->create_guest_student_role_if_not_exists();
 	}
@@ -48,26 +48,30 @@ class Sensei_Guest_User {
 	/**
 	 * Filter enrolment check to always return true if the course is open access.
 	 *
+	 * @since  $$next-version$$
+	 *
 	 * @param bool $is_enrolled Initial value.
 	 * @param int  $user_id     User ID. Unused.
 	 * @param int  $course_id   Course ID.
 	 *
 	 * @return bool
 	 */
-	public static function open_course_always_enrolled( $is_enrolled, $user_id, $course_id ) {
-		return Sensei_Course::is_open_access( $course_id ) ? true : $is_enrolled;
+	public function open_course_always_enrolled( $is_enrolled, $user_id, $course_id ) {
+		return $this->is_course_open_access( $course_id ) ? true : $is_enrolled;
 	}
 
 	/**
 	 * Filter course access check to always return true if the course is open access.
+	 *
+	 * @since  $$next-version$$
 	 *
 	 * @param bool $can_view_course_content Initial value.
 	 * @param int  $course_id               Course ID.
 	 *
 	 * @return bool
 	 */
-	public static function open_course_enable_course_access( $can_view_course_content, $course_id ) {
-		return Sensei_Course::is_open_access( $course_id ) ? true : $can_view_course_content;
+	public function open_course_enable_course_access( $can_view_course_content, $course_id ) {
+		return $this->is_course_open_access( $course_id ) ? true : $can_view_course_content;
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4936,12 +4936,6 @@ class Sensei_Lesson {
 	public static function should_show_lesson_actions( int $lesson_id, int $user_id = 0 ) : bool {
 		$user_id = empty( $user_id ) ? get_current_user_id() : $user_id;
 
-		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
-
-		if ( ! Sensei_Course::is_user_enrolled( $course_id ) ) {
-			return '';
-		}
-
 		$lesson_prerequisite = (int) get_post_meta( $lesson_id, '_lesson_prerequisite', true );
 
 		if ( $lesson_prerequisite > 0 ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4608,12 +4608,8 @@ class Sensei_Lesson {
 	 */
 	public static function is_prerequisite_complete( $lesson_id, $user_id ) {
 
-		if ( empty( $lesson_id ) || empty( $user_id )
-		|| 'lesson' != get_post_type( $lesson_id )
-		|| ! is_a( get_user_by( 'id', $user_id ), 'WP_User' ) ) {
-
+		if ( empty( $lesson_id ) || ( 'lesson' !== get_post_type( $lesson_id ) ) ) {
 			return false;
-
 		}
 
 		$pre_requisite_id = (string) self::get_lesson_prerequisite_id( $lesson_id );
@@ -4624,6 +4620,10 @@ class Sensei_Lesson {
 
 			return true;
 
+		}
+
+		if ( empty( $user_id ) || ! is_a( get_user_by( 'id', $user_id ), 'WP_User' ) ) {
+			return false;
 		}
 
 		return Sensei_Utils::user_completed_lesson( $pre_requisite_id, $user_id );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4888,7 +4888,7 @@ class Sensei_Lesson {
 		<footer>
 
 			<?php
-			if ( $show_actions && $quiz_id && Sensei()->access_settings() ) {
+			if ( $show_actions && $quiz_id ) {
 
 				if ( self::lesson_quiz_has_questions( $lesson_id ) ) {
 					?>
@@ -4936,8 +4936,10 @@ class Sensei_Lesson {
 	public static function should_show_lesson_actions( int $lesson_id, int $user_id = 0 ) : bool {
 		$user_id = empty( $user_id ) ? get_current_user_id() : $user_id;
 
-		if ( 0 === $user_id ) {
-			return false;
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+
+		if ( ! Sensei_Course::is_user_enrolled( $course_id ) ) {
+			return '';
 		}
 
 		$lesson_prerequisite = (int) get_post_meta( $lesson_id, '_lesson_prerequisite', true );

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1501,10 +1501,6 @@ class Sensei_Quiz {
 		$quiz_id = $quiz_id ? $quiz_id : get_the_ID();
 		$user_id = $user_id ? $user_id : get_current_user_id();
 
-		if ( ! $user_id ) {
-			return false;
-		}
-
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
 		$course_id = (int) get_post_meta( $lesson_id, '_lesson_course', true );
 

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -103,9 +103,6 @@ class Sensei_Course_Enrolment {
 	 * @return bool
 	 */
 	public function is_enrolled( $user_id, $check_cache = true ) {
-		if ( ! $user_id ) {
-			return false;
-		}
 
 		/**
 		 * Allow complete side-stepping of enrolment handling in Sensei.
@@ -125,6 +122,10 @@ class Sensei_Course_Enrolment {
 		$is_enrolled = apply_filters( 'sensei_is_enrolled', null, $user_id, $this->course_id, $check_cache );
 		if ( null !== $is_enrolled ) {
 			return $is_enrolled;
+		}
+
+		if ( ! $user_id ) {
+			return false;
 		}
 
 		// User is not enrolled if the course is not published or he is removed.

--- a/templates/single-quiz/question-type-boolean.php
+++ b/templates/single-quiz/question-type-boolean.php
@@ -72,7 +72,7 @@ $boolean_options = array( 'true', 'false' );
 			   name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
 			   value="<?php echo esc_attr( $option_value ); ?>"
 			<?php echo checked( $question_data['user_answer_entry'], $option_value, false ); ?>
-			<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
+			<?php echo $question_data['quiz_is_completed'] || ! Sensei_Quiz::is_quiz_available() ? 'disabled' : ''; ?>
 		/>
 		<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $option_value ); ?>">
 			<?php

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -29,7 +29,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 			name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
 			value="<?php echo esc_attr( $question_data['user_answer_entry'] ); ?>"
 			class="gapfill-answer-gap"
-			<?php echo $question_data['quiz_is_completed'] || ! Sensei_Quiz::is_quiz_available()  ? 'disabled' : ''; ?>
+			<?php echo $question_data['quiz_is_completed'] || ! Sensei_Quiz::is_quiz_available() ? 'disabled' : ''; ?>
 		/>
 		<span class="gapfill-answer-post">
 			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_post'] ) ) ); ?>

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -29,7 +29,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 			name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
 			value="<?php echo esc_attr( $question_data['user_answer_entry'] ); ?>"
 			class="gapfill-answer-gap"
-			<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
+			<?php echo $question_data['quiz_is_completed'] || ! Sensei_Quiz::is_quiz_available()  ? 'disabled' : ''; ?>
 		/>
 		<span class="gapfill-answer-post">
 			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_post'] ) ) ); ?>

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -30,7 +30,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 		?>
 
 		<li class="<?php echo esc_attr( $option['option_class'] ); ?>">
-			<input type="<?php echo esc_attr( $option['type'] ); ?>" id="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>" name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>[]" value="<?php echo esc_attr( $option['answer'] ); ?>" <?php echo esc_attr( $option['checked'] ); ?> <?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?> />
+			<input type="<?php echo esc_attr( $option['type'] ); ?>" id="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>" name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>[]" value="<?php echo esc_attr( $option['answer'] ); ?>" <?php echo esc_attr( $option['checked'] ); ?> <?php echo $question_data['quiz_is_completed'] || ! Sensei_Quiz::is_quiz_available() ? 'disabled' : ''; ?> />
 
 			<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
 				<?php

--- a/templates/single-quiz/question-type-single-line.php
+++ b/templates/single-quiz/question-type-single-line.php
@@ -31,7 +31,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 	<input type="text" id="<?php echo esc_attr( 'question_' . $question_data['ID'] ); ?>"
 		name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
 		value="<?php echo esc_attr( $question_data['user_answer_entry'] ); ?>"
-		<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
+		<?php echo $question_data['quiz_is_completed'] || ! Sensei_Quiz::is_quiz_available() ? 'disabled' : ''; ?>
 		/>
 
 </div>


### PR DESCRIPTION
Fixes #6247

### Changes proposed in this Pull Request

- Move/remove user id checks that were returning early before a filter could be applied
   — All of them have user id checks later or somewhere deeper, so behavior shouldn't change
- Add filters to allow access to lesson content, display actions, status icons, notices when the course is open access
- Also tweak a few more complicated user checks for the complete lesson, view quiz button blocks. I changed these to use the same access checks as the other two places where these buttons are added. 

### Checklist

- [x] Learning mode
- [x] Template mode
- [x] Blocks mode
- [x] Testing

### Testing instructions

* Set a course to open access
* Visit one of its lessons
* It shouldn't display a notice to sign up
* Lesson content should be visible
* In learning mode's course navigation, lessons shouldn't be shown as locked
* Complete lesson, take quiz buttons should show (but not work)

--
* Visit a quiz in the open access course
* It should be submittable with save/complete buttons (but not actually save)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![image](https://user-images.githubusercontent.com/176949/206591170-b827d588-47b1-4e52-abe3-ceb419c98e60.png)
