### PR TITLE
Enrol guest users in course after creation

### DIFF
--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -46,7 +46,7 @@ class Sensei_Guest_User {
 	/**
 	 * Create a guest user for open access courses if no user is logged in.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 */
 	public function sensei_create_guest_user_and_login_for_open_course() {
 		global $post;
@@ -59,18 +59,34 @@ class Sensei_Guest_User {
 		) {
 			$user_id = $this->create_guest_student_user();
 			$this->login_user( $user_id );
+			$this->recreate_nonces();
 		}
 	}
 
 	/**
 	 * Check if the course is open access.
 	 *
-	 * @param int $course_id ID of the course.
+	 * @param  int $course_id ID of the course.
 	 * @since  $$next-version$$
 	 * @return boolean|mixed
 	 */
 	private function is_course_open_access( $course_id ) {
 		return get_post_meta( $course_id, 'open_access', true );
+	}
+
+	/**
+	 * Recreate nonce after logging in user invalidates existing one.
+	 *
+	 * @since $$next-version$$
+	 */
+	private function recreate_nonces() {
+		$nonce_field = wp_nonce_field( 'woothemes_sensei_start_course_noonce', 'woothemes_sensei_start_course_noonce', false, false );
+		$pattern     = '/value="([^"]*)"/';
+
+		preg_match( $pattern, $nonce_field, $matches );
+		$_POST['woothemes_sensei_start_course_noonce'] = $matches[1];
+
+		unset( $matches );
 	}
 
 	/**
@@ -97,7 +113,7 @@ class Sensei_Guest_User {
 	 * Log a user in.
 	 *
 	 * @param int $user_id ID of the user.
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 */
 	private function login_user( $user_id ) {
 		wp_set_current_user( $user_id );
@@ -123,7 +139,7 @@ class Sensei_Guest_User {
 	/**
 	 * Create the Guest Student role if it does not exist.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 */
 	private function create_guest_student_role_if_not_exists() {
 		// Check if the Guest Student role exists.

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -80,13 +80,7 @@ class Sensei_Guest_User {
 	 * @since $$next-version$$
 	 */
 	private function recreate_nonces() {
-		$nonce_field = wp_nonce_field( 'woothemes_sensei_start_course_noonce', 'woothemes_sensei_start_course_noonce', false, false );
-		$pattern     = '/value="([^"]*)"/';
-
-		preg_match( $pattern, $nonce_field, $matches );
-		$_POST['woothemes_sensei_start_course_noonce'] = $matches[1];
-
-		unset( $matches );
+		$_POST['woothemes_sensei_start_course_noonce'] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
 	}
 
 	/**


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/6244

### Changes proposed in this Pull Request

* Recreates nonce after logging the Guest user in because it was getting invalidated. Also, this automatically enrolls the Guest user in the course

-- Tests TBA
### Testing instructions

- Create a course
- Mark it "Open Access" from the settings and publish it
- Go to the course page in the front end, and make sure you are not logged in
- Click on the Take Course button
- Make sure you got enrolled in the course as a guest
- Now log out and go to any non open-access course and click Take Course
- Make sure it behaves as before

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/206711964-61b398a8-2803-4c98-a30e-6c072d108679.mov