### PR TITLE
Fix setup wizard images

### DIFF
--- a/assets/setup-wizard/style.scss
+++ b/assets/setup-wizard/style.scss
@@ -25,6 +25,7 @@ $page-background: #b7c9be;
 }
 
 .sensei-setup-wizard {
+	display: flex;
 	min-height: 100vh;
 	color: #000;
 	font-size: 16px;


### PR DESCRIPTION
Fixes #6272 

### Changes proposed in this Pull Request

* Reintroduce flexbox for Setup Wizard wrapper. Fixes images.

### Testing instructions

Walk through the setup wizard and ensure all of the animated images appear as they should. In particular, the images on the `tracking` and `newsletter` steps were not showing up.

h/t @Luchadores 