### PR TITLE
Add notice asking user for reviews/feedback

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -66,4 +66,8 @@ $sensei-notice-icon-width: 30px;
 	&.sensei-notice-info {
 		border-left-color: $notice-info;
 	}
+
+	&.sensei-notice-success {
+		border-left-color: $notice-success;
+	}
 }

--- a/assets/home/link.js
+++ b/assets/home/link.js
@@ -15,8 +15,9 @@ import { addUtms, isUrlExternal } from './utils';
  * @param {string}   props.label   The label for the link.
  * @param {string}   props.url     The target URL.
  * @param {Function} props.onClick The event listener for the click event.
+ * @param {Object}   props.dataSet Data attributes to add to the link.
  */
-const Link = ( { label, url, onClick } ) => {
+const Link = ( { label, url, onClick, dataSet } ) => {
 	const isExternal = isUrlExternal( url );
 	const linkProps = {
 		href: addUtms( url ),
@@ -24,6 +25,12 @@ const Link = ( { label, url, onClick } ) => {
 		rel: isExternal ? 'noreferrer' : undefined,
 		onClick,
 	};
+	if ( !! dataSet ) {
+		for ( const [ key, value ] of Object.entries( dataSet ) ) {
+			linkProps[ 'data-' + key ] = value;
+		}
+	}
+
 	return (
 		<div className="sensei-home__link">
 			<a { ...linkProps }>

--- a/assets/home/link.js
+++ b/assets/home/link.js
@@ -20,7 +20,7 @@ const Link = ( { label, url, onClick } ) => {
 	const isExternal = isUrlExternal( url );
 	const linkProps = {
 		href: addUtms( url ),
-		target: onClick || ! isExternal ? undefined : '_blank',
+		target: ! isExternal ? undefined : '_blank',
 		rel: isExternal ? 'noreferrer' : undefined,
 		onClick,
 	};

--- a/assets/home/notices.js
+++ b/assets/home/notices.js
@@ -17,64 +17,33 @@ import Link from './link';
 const hiddenClassName = 'sensei-notice--is-hidden';
 
 /**
- * Returns an event listener that processes a series of specified tasks.
- *
- * @param {Object} action       The action to return the event listener for.
- * @param {Array}  action.tasks The tasks to run.
- * @return {Function} The event listener that runs the specified tas.s
- */
-const useTasksCallback = ( action ) => {
-	return ( e ) => {
-		if ( ! action.tasks ) {
-			return;
-		}
-		for ( const task of action.tasks ) {
-			const noticeDom =
-				task.target_notice_id &&
-				document.querySelector(
-					`.sensei-notice[data-sensei-notice-id="${ task.target_notice_id }"]`
-				);
-			switch ( task.type ) {
-				case 'preventDefault':
-					e.preventDefault();
-					break;
-				case 'show':
-					noticeDom?.classList.remove( hiddenClassName );
-					break;
-				case 'hide':
-					noticeDom?.classList.add( hiddenClassName );
-					break;
-				case 'dismiss':
-					noticeDom?.querySelector( '.notice-dismiss' )?.click();
-					break;
-			}
-		}
-	};
-};
-
-/**
  * Component to render an action of a given notice.
  *
  * @param {Object} props        Component props.
  * @param {Object} props.action The action to render.
  */
 const NoticeAction = ( { action } ) => {
-	const onClick = useTasksCallback( action );
-
-	if ( ! action || ! action.label ) {
+	if ( ! action || ! action.label || ( ! action.url && ! action.tasks ) ) {
 		return null;
 	}
 
 	const isPrimary = action.primary ?? true;
 
 	const buttonClass = isPrimary ? 'button-primary' : 'button-secondary';
+
+	const extraProps = {};
+	if ( action.tasks ) {
+		extraProps[ 'data-sensei-notice-tasks' ] = JSON.stringify(
+			action.tasks
+		);
+	}
 	return (
 		<a
 			href={ action.url }
 			target={ action.target ?? '_self' }
 			rel="noopener noreferrer"
 			className={ classnames( 'button', buttonClass ) }
-			onClick={ onClick }
+			{ ...extraProps }
 		>
 			{ action.label }
 		</a>
@@ -107,15 +76,18 @@ const NoticeActions = ( { actions } ) => {
  * @param {Object} props.infoLink The info link to render, if any.
  */
 const NoticeInfoLink = ( { infoLink } ) => {
-	const onClick = useTasksCallback( infoLink );
 	if ( ! infoLink ) {
 		return null;
+	}
+	const dataSet = {};
+	if ( infoLink.tasks ) {
+		dataSet[ 'sensei-notice-tasks' ] = JSON.stringify( infoLink.tasks );
 	}
 	return (
 		<Link
 			label={ infoLink.label }
 			url={ infoLink.url }
-			onClick={ onClick }
+			dataSet={ dataSet }
 		/>
 	);
 };

--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -11,6 +11,10 @@
 				margin-bottom: 0;
 			}
 
+			&--is-hidden {
+				display: none;
+			}
+
 			&__icon {
 				margin-top: 0;
 				align-self: center;

--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -5,7 +5,7 @@
 
 		.sensei-notice {
 			margin: 0 0 12px;
-			padding: 10px 16px;
+			padding: 18px 24px;
 
 			&:last-child {
 				margin-bottom: 0;

--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -33,6 +33,19 @@
 					white-space: nowrap;
 				}
 			}
+
+			.button-secondary {
+				color: #155E65;
+				border-color: #43AF99;
+			}
+
+			.button {
+				margin-left: 20px;
+			}
+
+			.notice-dismiss {
+				margin-left: 18px;
+			}
 		}
 	}
 }

--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -11,6 +11,11 @@
 				margin-bottom: 0;
 			}
 
+			&__icon {
+				margin-top: 0;
+				align-self: center;
+			}
+
 			&__wrapper {
 				height: 100%;
 			}

--- a/assets/home/utils.js
+++ b/assets/home/utils.js
@@ -7,7 +7,12 @@
 export const addUtms = ( url ) => {
 	try {
 		const parsed = new URL( url );
-		if ( parsed.hostname === 'senseilms.com' ) {
+		if (
+			parsed.hostname === 'senseilms.com' &&
+			! parsed.searchParams.has( 'utm_source' ) &&
+			! parsed.searchParams.has( 'utm_medium' ) &&
+			! parsed.searchParams.has( 'utm_campaign' )
+		) {
 			parsed.searchParams.set( 'utm_source', 'plugin_sensei' );
 			parsed.searchParams.set( 'utm_medium', 'upsell' );
 			parsed.searchParams.set( 'utm_campaign', 'sensei_home' );

--- a/assets/js/admin/sensei-notice-dismiss.js
+++ b/assets/js/admin/sensei-notice-dismiss.js
@@ -4,28 +4,81 @@
 import domReady from '@wordpress/dom-ready';
 
 domReady( () => {
+	const hiddenClassName = 'sensei-notice--is-hidden';
+
+	/**
+	 * Handle tasks present on the element if the element has the attribute "data-sensei-notice-tasks".
+	 *
+	 * @param  event The event to handle.
+	 */
+	const handleTasks = ( event ) => {
+		const { target } = event;
+		if ( ! target.dataset.senseiNoticeTasks ) {
+			return;
+		}
+		const tasks = JSON.parse( target.dataset.senseiNoticeTasks );
+		if ( ! tasks ) {
+			return;
+		}
+		for ( const task of tasks ) {
+			const noticeDom =
+				task.notice_id &&
+				document.querySelector(
+					`.sensei-notice[data-sensei-notice-id="${ task.notice_id }"]`
+				);
+			switch ( task.type ) {
+				case 'preventDefault':
+					event.preventDefault();
+					break;
+				case 'show':
+					noticeDom?.classList.remove( hiddenClassName );
+					break;
+				case 'dismiss':
+					if ( noticeDom ) {
+						handleDismiss( noticeDom );
+					}
+				//  We need to also hide the notice being dismissed:
+				// eslint-disable-next-line no-fallthrough
+				case 'hide':
+					noticeDom?.classList.add( hiddenClassName );
+					break;
+			}
+		}
+	};
+
+	/**
+	 * Handle dismissing the notice by sending a request to the server.
+	 *
+	 * @param  element The DOM element of the container of the notice being dismissed.
+	 */
+	const handleDismiss = ( element ) => {
+		const formData = new FormData();
+		if ( element.dataset.dismissNotice ) {
+			formData.append( 'notice', element.dataset.dismissNotice );
+		}
+		formData.append( 'action', element.dataset.dismissAction );
+		formData.append( 'nonce', element.dataset.dismissNonce );
+
+		fetch( ajaxurl, {
+			method: 'POST',
+			body: formData,
+		} );
+	};
+
 	document.body.addEventListener( 'click', ( event ) => {
-		const element = event.target.closest( '.sensei-notice' );
-		if (
-			! element ||
-			! element.dataset.dismissNonce ||
-			! element.dataset.dismissAction
-		) {
+		const noticeContainer = event.target.closest( '.sensei-notice' );
+		if ( ! noticeContainer ) {
 			return;
 		}
 
-		if ( event.target.classList.contains( 'notice-dismiss' ) ) {
-			const formData = new FormData();
-			if ( element.dataset.dismissNotice ) {
-				formData.append( 'notice', element.dataset.dismissNotice );
-			}
-			formData.append( 'action', element.dataset.dismissAction );
-			formData.append( 'nonce', element.dataset.dismissNonce );
-
-			fetch( ajaxurl, {
-				method: 'POST',
-				body: formData,
-			} );
+		if (
+			noticeContainer.dataset.dismissNonce &&
+			noticeContainer.dataset.dismissAction &&
+			event.target.classList.contains( 'notice-dismiss' )
+		) {
+			handleDismiss( noticeContainer );
+		} else {
+			handleTasks( event );
 		}
 	} );
 } );

--- a/assets/shared/styles/_variables.scss
+++ b/assets/shared/styles/_variables.scss
@@ -27,6 +27,7 @@ $alert-red: #d94f4f;
 $notice-error: #d63638;
 $notice-warning: #dba617;
 $notice-info: #72aee6;
+$notice-success: #43af99;
 
 $gap-largest: 40px;
 $gap-larger: 36px;

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -397,6 +397,17 @@ class Sensei_Admin_Notices {
 						break 2;
 					}
 					break;
+
+				case 'installed_since':
+					if ( ! isset( $condition['installed_since'] ) ) {
+						break;
+					}
+
+					if ( ! $this->condition_installed_since( $condition['installed_since'] ) ) {
+						$can_see_notice = false;
+						break 2;
+					}
+					break;
 			}
 		}
 
@@ -475,6 +486,24 @@ class Sensei_Admin_Notices {
 		}
 
 		return $condition_pass;
+	}
+
+	/**
+	 * Check an "installed since" condition
+	 *
+	 * @param int|string $installed_since Time to check the installation time for.
+	 *
+	 * @return bool
+	 */
+	private function condition_installed_since( $installed_since ) : bool {
+		$installed_at = get_option( 'sensei_installed_at' );
+		if ( $installed_since && is_string( $installed_since ) ) {
+			$installed_since = strtotime( '-' . $installed_since );
+		}
+		if ( ! $installed_at || ! $installed_since ) {
+			return false;
+		}
+		return $installed_at <= $installed_since;
 	}
 
 	/**

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -273,12 +273,17 @@ class Sensei_Admin_Notices {
 			if ( ! empty( $notice['actions'] ) ) {
 				echo '<div class="sensei-notice__actions">';
 				foreach ( $notice['actions'] as $action ) {
-					if ( ! isset( $action['label'], $action['url'] ) ) {
+					if ( ! isset( $action['label'] ) || ( ! isset( $action['url'] ) && ! isset( $action['tasks'] ) ) ) {
 						continue;
 					}
 
 					$button_class = ! isset( $action['primary'] ) || $action['primary'] ? 'button-primary' : 'button-secondary';
-					echo '<a href="' . esc_url( $action['url'] ) . '" target="' . esc_attr( $action['target'] ?? '_self' ) . '" rel="noopener noreferrer" class="button ' . esc_attr( $button_class ) . '">';
+					$extra_attrs  = '';
+					if ( isset( $action['tasks'] ) ) {
+						wp_enqueue_script( 'sensei-dismiss-notices' );
+						$extra_attrs = ' data-sensei-notice-tasks="' . esc_attr( wp_json_encode( $action['tasks'] ) ) . '"';
+					}
+					echo '<a href="' . esc_url( $action['url'] ) . '" target="' . esc_attr( $action['target'] ?? '_self' ) . '" rel="noopener noreferrer" class="button ' . esc_attr( $button_class ) . '"' . $extra_attrs . '>';
 					echo esc_html( $action['label'] );
 					echo '</a>';
 				}

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -109,6 +109,7 @@ class Sensei_Home_Notices_Provider {
 			// If we have Sensei_Admin_Notices, we consider it as being, by default, dismissible, given that
 			// this is the default on Sensei_Admin_Notices.
 			'dismissible' => $notice['dismissible'] ?? class_exists( 'Sensei_Admin_Notices' ),
+			'parent_id'   => $notice['parent_id'] ?? null,
 		];
 	}
 }

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -82,8 +82,7 @@ class Sensei_Home_Notices_Provider {
 	public function get_badge_count(): int {
 		add_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
 		$notices                 = $this->get( DAY_IN_SECONDS );
-		$notices_with_parent_ids = array_column( $notices, 'parent_id' );
-		$notices_with_parent_ids = array_filter( $notices_with_parent_ids );
+		$notices_with_parent_ids = array_filter( array_column( $notices, 'parent_id' ) );
 
 		remove_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
 

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -81,10 +81,13 @@ class Sensei_Home_Notices_Provider {
 	 */
 	public function get_badge_count(): int {
 		add_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
-		$notices = $this->get( DAY_IN_SECONDS );
+		$notices                 = $this->get( DAY_IN_SECONDS );
+		$notices_with_parent_ids = array_column( $notices, 'parent_id' );
+		$notices_with_parent_ids = array_filter( $notices_with_parent_ids );
+
 		remove_filter( 'sensei_home_remote_data_retry_error', '__return_false' );
 
-		return count( $notices );
+		return count( $notices ) - count( $notices_with_parent_ids );
 	}
 
 	/**

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -78,8 +78,6 @@ class Sensei_Home_Notices {
 			return $notices;
 		}
 
-		$data['reviews']['show_after'] = '1 second';
-
 		$notice_id     = self::HOME_NOTICE_KEY_PREFIX . 'sensei_review';
 		$yes_notice_id = $notice_id . '_yes';
 		$no_notice_id  = $notice_id . '_no';

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -121,7 +121,7 @@ class Sensei_Home_Notices {
 			'dismissible' => true,
 			'actions'     => [],
 		];
-		$url           = false;
+
 		switch ( $review_answer ) {
 			case '':
 				$notice['message'] = __( 'Are you enjoying Sensei LMS?', 'sensei-lms' );
@@ -148,26 +148,21 @@ class Sensei_Home_Notices {
 				];
 				break;
 			case '0':
-				$url = $data['reviews']['feedback_url'];
-				// translators: Placeholder is the URL to the contact form on SenseiLMS.com.
-				$notice['message'] = __( 'Oh no, sorry to hear that. <a href="%1$s" target="_blank">Please share why with our team here</a>. We are always happy to help.', 'sensei-lms' );
+				$notice['message']   = __( "Let us know how we can improve your experience. We're always happy to help.", 'sensei-lms' );
+				$notice['info_link'] = [
+					'label' => __( 'Share with us how can we help', 'sensei-lms' ),
+					'url'   => $data['reviews']['feedback_url'],
+				];
 				break;
 			case '1':
-				$url = $data['reviews']['review_url'];
-				// translators: Placeholder is the URL to the review page on WordPress.org.
-				$notice['message'] = __( 'Great to hear! Would you be able to help us by <a href="%1$s" target="_blank">leaving a review on WordPress.org</a>?', 'sensei-lms' );
+				$notice['message']   = __( 'Great to hear! Would you be able to help us by leaving a review on WordPress.org?', 'sensei-lms' );
+				$notice['info_link'] = [
+					'label' => __( 'Write a review for us', 'sensei-lms' ),
+					'url'   => $data['reviews']['review_url'],
+				];
 				break;
 		}
 
-		$allowed_tags = [];
-		if ( $url ) {
-			$allowed_tags['a'] = [
-				'href'   => true,
-				'target' => [ '_blank' ],
-			];
-			$notice['message'] = sprintf( $notice['message'], $url );
-		}
-		$notice['message']     = wp_kses( $notice['message'], $allowed_tags );
 		$notices[ $notice_id ] = $notice;
 
 		return $notices;

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -119,12 +119,12 @@ class Sensei_Home_Notices {
 								'type' => 'preventDefault',
 							],
 							[
-								'type'             => 'hide',
-								'target_notice_id' => $notice_id,
+								'type'      => 'hide',
+								'notice_id' => $notice_id,
 							],
 							[
-								'type'             => 'show',
-								'target_notice_id' => $yes_notice_id,
+								'type'      => 'show',
+								'notice_id' => $yes_notice_id,
 							],
 						],
 					],
@@ -136,12 +136,12 @@ class Sensei_Home_Notices {
 								'type' => 'preventDefault',
 							],
 							[
-								'type'             => 'hide',
-								'target_notice_id' => $notice_id,
+								'type'      => 'hide',
+								'notice_id' => $notice_id,
 							],
 							[
-								'type'             => 'show',
-								'target_notice_id' => $no_notice_id,
+								'type'      => 'show',
+								'notice_id' => $no_notice_id,
 							],
 						],
 					],
@@ -159,8 +159,8 @@ class Sensei_Home_Notices {
 					'url'   => $data['reviews']['feedback_url'],
 					'tasks' => [
 						[
-							'type'             => 'dismiss',
-							'target_notice_id' => $no_notice_id,
+							'type'      => 'dismiss',
+							'notice_id' => $no_notice_id,
 						],
 					],
 				],
@@ -177,8 +177,8 @@ class Sensei_Home_Notices {
 					'url'   => $data['reviews']['review_url'],
 					'tasks' => [
 						[
-							'type'             => 'dismiss',
-							'target_notice_id' => $yes_notice_id,
+							'type'      => 'dismiss',
+							'notice_id' => $yes_notice_id,
 						],
 					],
 				],

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -106,7 +106,7 @@ class Sensei_Home_Notices {
 		$notice_id     = self::HOME_NOTICE_KEY_PREFIX . 'sensei_review';
 		$review_answer = $this->get_review_answer( $notice_id );
 		$notice        = [
-			'level'       => 'info',
+			'level'       => 'success',
 			'type'        => 'user',
 			'conditions'  => [
 				[

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -127,8 +127,9 @@ class Sensei_Home_Notices {
 				$notice['message'] = __( 'Are you enjoying Sensei LMS?', 'sensei-lms' );
 				$notice['actions'] = [
 					[
-						'label' => __( 'Yes', 'sensei-lms' ),
-						'url'   => add_query_arg(
+						'primary' => false,
+						'label'   => __( 'Yes', 'sensei-lms' ),
+						'url'     => add_query_arg(
 							[
 								'_wpnonce'      => wp_create_nonce( $notice_id ),
 								'review_answer' => '1',

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -55,6 +55,7 @@ class Sensei_Data_Cleaner {
 	 */
 	private static $options = array(
 		'sensei_installed',
+		'sensei_installed_at',
 		'sensei_course_enrolment_site_salt',
 		'sensei_course_order',
 		'skip_install_sensei_pages', // deprecated 3.1.0.

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -102,7 +102,7 @@ class Sensei_Updates {
 	 * Set new option to save when Sensei was installed/updated.
 	 */
 	private function v4_10_update_install_time() {
-		update_option( 'sensei_installed_at', time() );
+		add_option( 'sensei_installed_at', time() );
 	}
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -80,6 +80,7 @@ class Sensei_Updates {
 		$this->v3_7_add_comment_indexes();
 		$this->v3_9_fix_question_author();
 		$this->v3_9_remove_abandoned_multiple_question();
+		$this->v4_10_update_install_time();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
@@ -95,6 +96,13 @@ class Sensei_Updates {
 		}
 
 		Sensei_Scheduler::instance()->schedule_job( new Sensei_Update_Remove_Abandoned_Multiple_Question() );
+	}
+
+	/**
+	 * Set new option to save when Sensei was installed/updated.
+	 */
+	private function v4_10_update_install_time() {
+		update_option( 'sensei_installed_at', time() );
 	}
 
 	/**

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices-provider.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices-provider.php
@@ -104,6 +104,7 @@ class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 				'info_link'   => false,
 				'actions'     => [],
 				'dismissible' => false,
+				'parent_id'   => null,
 			],
 		];
 	}
@@ -120,6 +121,7 @@ class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 				'info_link'   => false,
 				'actions'     => [],
 				'dismissible' => false,
+				'parent_id'   => null,
 			],
 			Sensei_Home_Notices::HOME_NOTICE_KEY_PREFIX . 'test-notice-2' => [
 				'level'       => 'info',
@@ -128,6 +130,7 @@ class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 				'info_link'   => false,
 				'actions'     => [],
 				'dismissible' => false,
+				'parent_id'   => null,
 			],
 			'a-foreign-notice' => [
 				'level'       => 'info',
@@ -136,6 +139,7 @@ class Sensei_Home_Notices_Provider_Test extends WP_UnitTestCase {
 				'info_link'   => false,
 				'actions'     => [],
 				'dismissible' => false,
+				'parent_id'   => null,
 			],
 		];
 	}

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
@@ -149,7 +149,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		// Assert.
 		$this->assertArrayHasKey( $notice_id, $notices );
 		$this->assertStringContainsString( 'Great to hear', $notices[ $notice_id ]['message'] );
-		$this->assertStringContainsString( 'https://review_url', $notices[ $notice_id ]['message'] );
+		$this->assertEquals( 'https://review_url', $notices[ $notice_id ]['info_link']['url'] );
 		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
 	}
 
@@ -173,8 +173,8 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 
 		// Assert.
 		$this->assertArrayHasKey( $notice_id, $notices );
-		$this->assertStringContainsString( 'Oh no, sorry to hear that', $notices[ $notice_id ]['message'] );
-		$this->assertStringContainsString( 'https://feedback_url', $notices[ $notice_id ]['message'] );
+		$this->assertStringContainsString( 'Let us know how we can improve your experience', $notices[ $notice_id ]['message'] );
+		$this->assertEquals( 'https://feedback_url', $notices[ $notice_id ]['info_link']['url'] );
 		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
 	}
 

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
@@ -131,17 +131,13 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 
 	public function testAddReviewNotice_GivenAdministratorYesResponse_ReturnsReviewAnswer() {
 		// Arrange.
-		$notice_id = 'sensei_home_sensei_review';
+		$notice_id = 'sensei_home_sensei_review_yes';
 		update_option( 'sensei_installed_at', strtotime( '-1 year' ) );
 		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
 		$notices          = $this->getNoticesMock( $remote_data_mock );
 		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
 		grant_super_admin( $user->ID );
 		wp_set_current_user( $user->ID );
-		$_GET = [
-			'_wpnonce'      => wp_create_nonce( $notice_id ),
-			'review_answer' => '1',
-		];
 
 		// Act.
 		$notices = $notices->add_review_notice( [] );
@@ -150,23 +146,19 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( $notice_id, $notices );
 		$this->assertStringContainsString( 'Great to hear', $notices[ $notice_id ]['message'] );
 		$this->assertEquals( 'https://review_url', $notices[ $notice_id ]['info_link']['url'] );
-		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
+		$this->assertEquals( 'sensei_home_sensei_review', $notices[ $notice_id ]['parent_id'] );
 	}
 
 
 	public function testAddReviewNotice_GivenAdministratorNoResponse_ReturnsFeedbackAnswer() {
 		// Arrange.
-		$notice_id = 'sensei_home_sensei_review';
+		$notice_id = 'sensei_home_sensei_review_no';
 		update_option( 'sensei_installed_at', strtotime( '-1 year' ) );
 		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
 		$notices          = $this->getNoticesMock( $remote_data_mock );
 		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
 		grant_super_admin( $user->ID );
 		wp_set_current_user( $user->ID );
-		$_GET = [
-			'_wpnonce'      => wp_create_nonce( $notice_id ),
-			'review_answer' => '0',
-		];
 
 		// Act.
 		$notices = $notices->add_review_notice( [] );
@@ -175,7 +167,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( $notice_id, $notices );
 		$this->assertStringContainsString( 'Let us know how we can improve your experience', $notices[ $notice_id ]['message'] );
 		$this->assertEquals( 'https://feedback_url', $notices[ $notice_id ]['info_link']['url'] );
-		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
+		$this->assertEquals( 'sensei_home_sensei_review', $notices[ $notice_id ]['parent_id'] );
 	}
 
 	public function testAddUpdateNotices_GivenUnderprivUser_ReturnsEmptyArray() {

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
@@ -77,6 +77,103 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	public function testAddReviewNotice_GivenUnderprivUser_ReturnsEmptyArray() {
+		// Arrange.
+		update_option( 'sensei_installed_at', strtotime( '-1 year' ) );
+		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
+		$notices          = $this->getNoticesMock( $remote_data_mock );
+		$user             = $this->factory->user->create_and_get( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user->ID );
+
+		// Act.
+		$notices = $notices->add_review_notice( [] );
+
+		// Assert.
+		$this->assertEmpty( $notices );
+	}
+
+
+	public function testAddReviewNotice_GivenDisabledRemoteAPI_ReturnsEmptyArray() {
+		// Arrange.
+		update_option( 'sensei_installed_at', strtotime( '-1 year' ) );
+		$remote_data_mock = $this->getRemoteDataMock( [] );
+		$notices          = $this->getNoticesMock( $remote_data_mock );
+		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user->ID );
+
+		// Act.
+		$notices = $notices->add_review_notice( [] );
+
+		// Assert.
+		$this->assertEmpty( $notices );
+	}
+
+	public function testAddReviewNotice_GivenAdministrator_ReturnsCorrectNotices() {
+		// Arrange.
+		$notice_id = 'sensei_home_sensei_review';
+		update_option( 'sensei_installed_at', strtotime( '-1 year' ) );
+		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
+		$notices          = $this->getNoticesMock( $remote_data_mock );
+		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user->ID );
+
+		// Act.
+		$notices = $notices->add_review_notice( [] );
+
+		// Assert.
+		$this->assertArrayHasKey( 'sensei_home_sensei_review', $notices );
+		$this->assertStringContainsString( 'Are you enjoying', $notices[ $notice_id ]['message'] );
+		$this->assertEquals( 'Yes', $notices[ $notice_id ]['actions'][0]['label'] );
+		$this->assertEquals( 'No', $notices[ $notice_id ]['actions'][1]['label'] );
+	}
+
+	public function testAddReviewNotice_GivenAdministratorYesResponse_ReturnsReviewAnswer() {
+		// Arrange.
+		$notice_id = 'sensei_home_sensei_review';
+		update_option( 'sensei_installed_at', strtotime( '-1 year' ) );
+		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
+		$notices          = $this->getNoticesMock( $remote_data_mock );
+		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user->ID );
+		$_GET = [
+			'_wpnonce'      => wp_create_nonce( $notice_id ),
+			'review_answer' => '1',
+		];
+
+		// Act.
+		$notices = $notices->add_review_notice( [] );
+
+		// Assert.
+		$this->assertArrayHasKey( 'sensei_home_sensei_review', $notices );
+		$this->assertStringContainsString( 'Great to hear', $notices[ $notice_id ]['message'] );
+		$this->assertStringContainsString( 'https://review_url', $notices[ $notice_id ]['message'] );
+		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
+	}
+
+
+	public function testAddReviewNotice_GivenAdministratorNoResponse_ReturnsFeedbackAnswer() {
+		// Arrange.
+		$notice_id = 'sensei_home_sensei_review';
+		update_option( 'sensei_installed_at', strtotime( '-1 year' ) );
+		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
+		$notices          = $this->getNoticesMock( $remote_data_mock );
+		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user->ID );
+		$_GET = [
+			'_wpnonce'      => wp_create_nonce( $notice_id ),
+			'review_answer' => '0',
+		];
+
+		// Act.
+		$notices = $notices->add_review_notice( [] );
+
+		// Assert.
+		$this->assertArrayHasKey( 'sensei_home_sensei_review', $notices );
+		$this->assertStringContainsString( 'Oh no, sorry to hear that', $notices[ $notice_id ]['message'] );
+		$this->assertStringContainsString( 'https://feedback_url', $notices[ $notice_id ]['message'] );
+		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
+	}
+
 	public function testAddUpdateNotices_GivenUnderprivUser_ReturnsEmptyArray() {
 		// Arrange.
 		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
@@ -182,6 +279,11 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 						'licensed'  => true,
 					],
 				],
+			],
+			'reviews'  => [
+				'show_after'   => '10 days',
+				'feedback_url' => 'https://feedback_url',
+				'review_url'   => 'https://review_url',
 			],
 		];
 	}

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
@@ -121,7 +121,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$notices = $notices->add_review_notice( [] );
 
 		// Assert.
-		$this->assertArrayHasKey( 'sensei_home_sensei_review', $notices );
+		$this->assertArrayHasKey( $notice_id, $notices );
 		$this->assertStringContainsString( 'Are you enjoying', $notices[ $notice_id ]['message'] );
 		$this->assertEquals( 'Yes', $notices[ $notice_id ]['actions'][0]['label'] );
 		$this->assertEquals( 'No', $notices[ $notice_id ]['actions'][1]['label'] );
@@ -144,7 +144,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$notices = $notices->add_review_notice( [] );
 
 		// Assert.
-		$this->assertArrayHasKey( 'sensei_home_sensei_review', $notices );
+		$this->assertArrayHasKey( $notice_id, $notices );
 		$this->assertStringContainsString( 'Great to hear', $notices[ $notice_id ]['message'] );
 		$this->assertStringContainsString( 'https://review_url', $notices[ $notice_id ]['message'] );
 		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
@@ -168,7 +168,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$notices = $notices->add_review_notice( [] );
 
 		// Assert.
-		$this->assertArrayHasKey( 'sensei_home_sensei_review', $notices );
+		$this->assertArrayHasKey( $notice_id, $notices );
 		$this->assertStringContainsString( 'Oh no, sorry to hear that', $notices[ $notice_id ]['message'] );
 		$this->assertStringContainsString( 'https://feedback_url', $notices[ $notice_id ]['message'] );
 		$this->assertEmpty( $notices[ $notice_id ]['actions'] );
@@ -309,7 +309,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 	/**
 	 * The remote data API mock builder.
 	 *
-	 * @param mixed $response Resonse from remote data API.
+	 * @param mixed $response Response from remote data API.
 	 *
 	 * @return Sensei_Home_Remote_Data_API
 	 */

--- a/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
+++ b/tests/unit-tests/admin/home/notices/test-class-sensei-home-notices.php
@@ -99,6 +99,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$remote_data_mock = $this->getRemoteDataMock( [] );
 		$notices          = $this->getNoticesMock( $remote_data_mock );
 		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		grant_super_admin( $user->ID );
 		wp_set_current_user( $user->ID );
 
 		// Act.
@@ -115,6 +116,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
 		$notices          = $this->getNoticesMock( $remote_data_mock );
 		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		grant_super_admin( $user->ID );
 		wp_set_current_user( $user->ID );
 
 		// Act.
@@ -134,6 +136,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
 		$notices          = $this->getNoticesMock( $remote_data_mock );
 		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		grant_super_admin( $user->ID );
 		wp_set_current_user( $user->ID );
 		$_GET = [
 			'_wpnonce'      => wp_create_nonce( $notice_id ),
@@ -158,6 +161,7 @@ class Sensei_Home_Notices_Test extends WP_UnitTestCase {
 		$remote_data_mock = $this->getRemoteDataMock( $this->getStandardResponse() );
 		$notices          = $this->getNoticesMock( $remote_data_mock );
 		$user             = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		grant_super_admin( $user->ID );
 		wp_set_current_user( $user->ID );
 		$_GET = [
 			'_wpnonce'      => wp_create_nonce( $notice_id ),

--- a/tests/unit-tests/admin/test-class-sensei-admin-notices.php
+++ b/tests/unit-tests/admin/test-class-sensei-admin-notices.php
@@ -299,6 +299,98 @@ class Sensei_Admin_Notices_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'with-woocommerce', $notices_with_both );
 	}
 
+
+	/**
+	 * Test the `installed_since` condition.
+	 */
+	public function testConditionInstalledSince() {
+		$this->login_as_admin();
+
+		update_option( 'sensei_installed_at', 10 );
+		$all_notices = [
+			'hide-since-9'  => [
+				'message'    => 'Hide since 9',
+				'conditions' => [
+					[
+						'type'            => 'installed_since',
+						'installed_since' => 9,
+					],
+				],
+			],
+			'show-since-10' => [
+				'message'    => 'Show since 10',
+				'conditions' => [
+					[
+						'type'            => 'installed_since',
+						'installed_since' => 10,
+					],
+				],
+			],
+			'show-since-11' => [
+				'message'    => 'Show since 11',
+				'conditions' => [
+					[
+						'type'            => 'installed_since',
+						'installed_since' => 11,
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $all_notices ] );
+		$notices  = $instance->get_notices_to_display();
+
+		$this->assertArrayNotHasKey( 'hide-since-9', $notices );
+		$this->assertArrayHasKey( 'show-since-10', $notices );
+		$this->assertArrayHasKey( 'show-since-11', $notices );
+	}
+
+
+	/**
+	 * Test the `installed_since` condition with relative times.
+	 */
+	public function testConditionInstalledSinceString() {
+		$this->login_as_admin();
+
+		update_option( 'sensei_installed_at', time() - 10 );
+		$all_notices = [
+			'show-since-9'  => [
+				'message'    => 'Show since 9',
+				'conditions' => [
+					[
+						'type'            => 'installed_since',
+						'installed_since' => '9 seconds',
+					],
+				],
+			],
+			'show-since-10' => [
+				'message'    => 'Show since 10',
+				'conditions' => [
+					[
+						'type'            => 'installed_since',
+						'installed_since' => '10 seconds',
+					],
+				],
+			],
+			'hide-since-11' => [
+				'message'    => 'Hide since 11',
+				'conditions' => [
+					[
+						'type'            => 'installed_since',
+						'installed_since' => '11 seconds',
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $all_notices ] );
+		$notices  = $instance->get_notices_to_display();
+
+		$this->assertArrayHasKey( 'show-since-9', $notices );
+		$this->assertArrayHasKey( 'show-since-10', $notices );
+		$this->assertArrayNotHasKey( 'hide-since-11', $notices );
+	}
+
 	/**
 	 * Tests plugin conditions with version checks.
 	 */

--- a/tests/unit-tests/admin/test-class-sensei-admin-notices.php
+++ b/tests/unit-tests/admin/test-class-sensei-admin-notices.php
@@ -303,9 +303,9 @@ class Sensei_Admin_Notices_Test extends WP_UnitTestCase {
 	/**
 	 * Test the `installed_since` condition.
 	 */
-	public function testConditionInstalledSince() {
+	public function testGetNoticesToDisplay_GivenInstalledSince_ValidatesStrings() {
+		// Arrange.
 		$this->login_as_admin();
-
 		update_option( 'sensei_installed_at', 10 );
 		$all_notices = [
 			'hide-since-9'  => [
@@ -337,9 +337,11 @@ class Sensei_Admin_Notices_Test extends WP_UnitTestCase {
 			],
 		];
 
+		// Act.
 		$instance = $this->getMockInstance( [ 'notices' => $all_notices ] );
 		$notices  = $instance->get_notices_to_display();
 
+		// Assert.
 		$this->assertArrayNotHasKey( 'hide-since-9', $notices );
 		$this->assertArrayHasKey( 'show-since-10', $notices );
 		$this->assertArrayHasKey( 'show-since-11', $notices );
@@ -349,9 +351,9 @@ class Sensei_Admin_Notices_Test extends WP_UnitTestCase {
 	/**
 	 * Test the `installed_since` condition with relative times.
 	 */
-	public function testConditionInstalledSinceString() {
+	public function testGetNoticesToDisplay_GivenInstalledSinceString_ValidatesStrings() {
+		// Arrange.
 		$this->login_as_admin();
-
 		update_option( 'sensei_installed_at', time() - 10 );
 		$all_notices = [
 			'show-since-9'  => [
@@ -383,9 +385,11 @@ class Sensei_Admin_Notices_Test extends WP_UnitTestCase {
 			],
 		];
 
+		// Act.
 		$instance = $this->getMockInstance( [ 'notices' => $all_notices ] );
 		$notices  = $instance->get_notices_to_display();
 
+		// Assert.
 		$this->assertArrayHasKey( 'show-since-9', $notices );
 		$this->assertArrayHasKey( 'show-since-10', $notices );
 		$this->assertArrayNotHasKey( 'hide-since-11', $notices );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add option `sensei_installed_at` to save when Sensei was installed/updated for the first time;
* Add condition `installed_since` to show notice only after a given time was passed; (I accept feedback regarding this name)
* Add "interactive" dismissible notice asking the user for reviews if some time passed;
* Add way to run extra "tasks" on the frontend like show/hide a notice when clicking on a button/link in a notice;

### Testing instructions

1. Install the plugin based on this branch of the code;
2. Verify that you can visit the Sensei Home page without any issues;
3. Change the URL on the class `Sensei_Home_Remote_Data_API` to point to a WP with this plugin correctly installed 12-gh-Automattic/senseilms-com-plugins 
4. Alter the option `sensei_installed_at` to have a unix timestamp from more than 10 days ago;
5. Verify if the notice asking for reviews appears;
6. Verify that, if you click "Yes", the notice ask the user for a review;
7. Verify that, if you click "No", the notice will ask the user for feedback;
8. Verify that you can dismiss the notice;
9. Verify if the notice, after dismissed, still appears to other site admins;
10. Verify that the notice won't show for users that are not super admins;

### Screenshots

After the user installed Sensei for some time:

![Image showing notice asking the user if it likes Sensei](https://user-images.githubusercontent.com/529864/207099538-1ff118c5-3a6f-475f-acbc-2ec632d6c306.png)

Image showing notice after user clicked on "Yes" option:

![Image showing notice after user clicked on "Yes" option](https://user-images.githubusercontent.com/529864/207099791-5d083016-4f3c-4a38-8bc9-65268b1efd93.png)


Image showing notice after user clicked on "No" option:

![Image showing notice after user clicked on "No" option](https://user-images.githubusercontent.com/529864/207099645-bc1e2bfa-0bc2-44d1-8eda-f1b832eee084.png)


