### PR TITLE
Create user and enrol on lesson and quiz actions

### DIFF
--- a/includes/blocks/course-theme/class-quiz-actions.php
+++ b/includes/blocks/course-theme/class-quiz-actions.php
@@ -56,13 +56,15 @@ class Quiz_Actions {
 		$pagination_enabled = $sensei_question_loop && $sensei_question_loop['total_pages'] > 1;
 
 		$lesson_id = \Sensei_Utils::get_current_lesson();
-		$status    = \Sensei_Utils::user_lesson_status( $lesson_id );
+
+		$sensei_is_quiz_available = Sensei_Quiz::is_quiz_available();
+		$sensei_is_quiz_completed = Sensei_Quiz::is_quiz_completed();
 
 		// Get quiz actions. Either actions with pagination
 		// or only action if pagination is not enabled.
 		// Also, don't paginate if quiz has been completed.
 		ob_start();
-		if ( $pagination_enabled && $status && 'in-progress' === $status->comment_approved ) {
+		if ( $pagination_enabled && $sensei_is_quiz_available && ! $sensei_is_quiz_completed ) {
 			Sensei_Quiz::the_quiz_pagination();
 			Sensei_Quiz::output_quiz_hidden_fields();
 		} else {

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -42,24 +42,34 @@ class Sensei_Guest_User {
 	 * }
 	 */
 	protected $supported_actions = [
+		// Take course.
 		[
 			'field' => 'course_start',
 			'nonce' => 'woothemes_sensei_start_course_noonce',
 			'enrol' => false,
 		],
+		// Lesson complete.
 		[
 			'field' => 'quiz_action',
 			'nonce' => 'woothemes_sensei_complete_lesson_noonce',
 			'enrol' => true,
 		],
+		// Quiz complete.
 		[
 			'field' => 'quiz_complete',
 			'nonce' => 'woothemes_sensei_complete_quiz_nonce',
 			'enrol' => true,
 		],
+		// Quiz save.
 		[
 			'field' => 'quiz_save',
 			'nonce' => 'woothemes_sensei_save_quiz_nonce',
+			'enrol' => true,
+		],
+		// Quiz pagination. (Saves answers on the page).
+		[
+			'field' => 'quiz_target_page',
+			'nonce' => 'sensei_quiz_page_change_nonce',
 			'enrol' => true,
 		],
 	];

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -53,12 +53,12 @@ class Sensei_Guest_User {
 			'enrol' => true,
 		],
 		[
-			'field' => 'course_start',
+			'field' => 'quiz_complete',
 			'nonce' => 'woothemes_sensei_complete_quiz_nonce',
 			'enrol' => true,
 		],
 		[
-			'field' => 'course_start',
+			'field' => 'quiz_save',
 			'nonce' => 'woothemes_sensei_save_quiz_nonce',
 			'enrol' => true,
 		],

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * File with class for testing Sensei Guest User.
+ *
+ * @package sensei-tests
+ */
+
+/**
+ * Class for testing Sensei_Guest_Users class.
+ *
+ * @group Guest User
+ */
+class Sensei_Guest_User_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Factory object.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory    = new Sensei_Factory();
+		$this->guest_user = new Sensei_Guest_User();
+	}
+
+	private function setup_course( $open_access ) {
+		$course_data = $this->factory->get_course_with_lessons();
+		$course_id   = $course_data['course_id'];
+		update_post_meta( $course_id, 'open_access', $open_access );
+		global $post;
+		$post = get_post( $course_id );
+
+		return $course_data;
+	}
+
+	/**
+	 * Test if guest is created for take course requests when course is open access.
+	 *
+	 * @testWith [ true ]
+	 *           [ false ]
+	 *
+	 * @param bool $open_access
+	 */
+	public function testGuestUserCreatedOnTakeCourseRequest( $open_access ) {
+
+		$this->setup_course( $open_access );
+		$this->logout();
+
+		$_POST['course_start']                         = 1;
+		$_POST['woothemes_sensei_start_course_noonce'] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
+
+		do_action( 'wp' );
+
+		$this->assertEquals( is_user_logged_in(), $open_access );
+		if ( $open_access ) {
+			$this->assertRegexp( '/^guest_user_.*$/', wp_get_current_user()->user_login );
+		}
+
+	}
+
+	/**
+	 * Test that a guest user is created, enrolled and completes lesson when clicking complete lesson.
+	 */
+	public function testGuestUserEnrolledOnCompleteLessonRequest() {
+
+		[ 'course_id' => $course_id, 'lesson_ids' => [ $lesson_id ] ] = $this->setup_course( true );
+		$this->logout();
+
+		global $post;
+		$post = get_post( $lesson_id );
+
+		$_POST['quiz_action']                             = 'lesson-complete';
+		$_POST['woothemes_sensei_complete_lesson_noonce'] = wp_create_nonce( 'woothemes_sensei_complete_lesson_noonce' );
+
+		do_action( 'wp' );
+
+		// Guest user is created and enrolled.
+		$this->assertTrue( is_user_logged_in(), 'Guest user was not created' );
+		$this->assertTrue( Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() ), 'Guest user was not enrolled' );
+
+		// The 'complete lesson' action is also executed.
+		$this->assertTrue( Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() ), 'Lesson was not completed' );
+
+	}
+
+}


### PR DESCRIPTION
Fixes #6265 

### Changes proposed in this Pull Request

* Create guest user on a 'Complete Lesson' action for a lesson, and on Save or Complete actions for a quiz
* Also enrol them on the course before continuing with the original action

* Make the `Sensei_Guest_User` class a bit more generic to support these new actions
* Add some unit tests

### Testing instructions

- Create a course with lesson, quiz, make it open access
- Start logged out session
- Open a lesson in the course and click 'Complete Lesson' 
   ↳ The user should now see the lesson as completed 
- Log out/ start new logged out session
- Open a quiz in the course and click Complete|Save
   ↳ Quiz answers should be submitted/saved
- In both cases a guest user should be created and enrolled in the course

