### PR TITLE
Confine guest user to open course only and persist lesson and quiz progress states

### DIFF
--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -192,18 +192,6 @@ class Sensei_Guest_User {
 	}
 
 	/**
-	 * Creates a new guest user if there isn't a guest user already created by the end user that exists.
-	 *
-	 * @since $$next-version$$
-	 * @access private
-	 * @return int
-	 */
-	private function create_guest_student() {
-		$user_id = $this->create_guest_student_user();
-		return $user_id;
-	}
-
-	/**
 	 * Checks if the current user is a guest.
 	 *
 	 * @since $$next-version$$

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -12,6 +12,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+// Only works when added outside of class.
+// TODO Check the reason later.
+add_action( 'init', 'sensei_start_session' );
+
+/**
+ * Starts the session if already not started.
+ *
+ * @since $$next-version$$
+ * @access private
+ */
+function sensei_start_session() {
+	if ( ! session_id() ) {
+		session_start();
+	}
+}
+
 /**
  * Sensei Guest User Class.
  *

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -125,28 +125,7 @@ class Sensei_Guest_User {
 			return false;
 		}
 
-		return $this->is_course_open_access( $this->get_course_id_for_course_related_pages() );
-	}
-
-	/**
-	 * Finds out the course id for open course, lesson and quiz pages.
-	 *
-	 * @since $$next-version$$
-	 * @access private
-	 * @return int
-	 */
-	private function get_course_id_for_course_related_pages() {
-		global $post;
-
-		$course_id = $post->ID;
-
-		if ( is_singular( [ 'lesson' ] ) ) {
-			$course_id = get_post_meta( $post->ID, '_lesson_course', true );
-		} elseif ( is_singular( [ 'quiz' ] ) ) {
-			$lesson_id = get_post_meta( $post->ID, '_quiz_lesson', true );
-			$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
-		}
-		return $course_id;
+		return $this->is_course_open_access( Sensei_Utils::get_current_course() );
 	}
 
 	/**


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/6246, 

### Changes proposed in this Pull Request

- If the guest user goes outside of the open-access course's context (i.e. anywhere except for the open course's course, lesson, and quiz pages), set the current user as none, so it seems the user is not logged in
- If the user moves back to the previously enrolled course's course, lesson, or quiz page, re-login the user using the same guest user. So the quiz or lesson progress won't be lost if the user accidentally or intentionally just clicks on another link that takes the user out of the course's context

### Testing instructions

- Create a course with multiple lessons and quizzes
- Mark it as Open Access from the settings and publish
- Go the course page as a logged-out user (Can use the incognito mode)
- Click the Take Course button, complete some lessons and quizzes
- Now go to the My Account page and make sure it shows no user is logged in
- Try to checkout and make sure it works the same as when no user is logged in
- Go to a course that is not Open Access. Make sure the "Take Course" button takes you to a login page
- Go back to the Open Access course you made some progress in, make sure the progress is still there
- Now go to the login page and log in as an actual student (Not guest student)
- Now go to the Open Access course, make some progress, make sure the progresses are being made by and stored for the logged in student user and not any guest user.
- Now log out and make sure you can still use the Open Access course as a guest user

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/207138373-14be0682-8460-4ae3-88d2-9d943c1b5ceb.mov