### PR TITLE
Allow switching to a preview student user 

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -108,6 +108,7 @@ class Sensei_Frontend {
 		add_filter( 'wp_list_comments_args', array( $this, 'hide_sensei_activity' ) );
 
 		new Sensei_Guest_User();
+		new Sensei_Preview_User();
 	}
 
 	/**

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Preview User
+ *
+ * Handles operations related to teachers switching to a preview user.
+ *
+ * @package Sensei\Frontend
+ * @since   $$next-version$$
+ */
+
+/**
+ * Sensei Preview User Class.
+ *
+ * @author  Automattic
+ *
+ * @since   $$next-version$$
+ * @package Core
+ */
+class Sensei_Preview_User {
+
+	/**
+	 * Preview user role.
+	 */
+	const ROLE = 'preview_student';
+
+	/**
+	 * Switch to/from preview user actions.
+	 */
+	const SWITCH_ON_ACTION  = 'sensei-preview-as-student';
+	const SWITCH_OFF_ACTION = 'sensei-exit-student-preview';
+
+	/**
+	 * Meta key for the associated preview user ID.
+	 * Used to link the original teacher and the preview user, in both directions.
+	 */
+	const META = 'sensei_previewing_user';
+
+	/**
+	 * Set up preview user hooks.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function __construct() {
+		add_action( 'wp', [ $this, 'switch_to_preview_user' ], 9 );
+		add_action( 'wp', [ $this, 'switch_off_preview_user' ], 9 );
+		add_action( 'wp', [ $this, 'override_user' ], 8 );
+		add_action( 'show_admin_bar', [ $this, 'show_admin_bar_to_preview_user' ], 90 );
+		add_action( 'admin_bar_menu', [ $this, 'add_user_switch_to_admin_bar' ], 90 );
+
+		$this->create_role();
+	}
+
+	/**
+	 * Change the current user to the preview user if its set for the teacher.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 */
+	public function override_user() {
+		$preview_user = $this->get_preview_user( get_current_user_id() );
+		$course_id    = Sensei_Utils::get_current_course();
+
+		if ( ! $course_id || ! $preview_user ) {
+			return;
+		}
+
+		wp_set_current_user( $preview_user );
+	}
+
+	/**
+	 * Create and switch to a preview user.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 */
+	public function switch_to_preview_user() {
+
+		$course_id = Sensei_Utils::get_current_course();
+
+		if ( ! $course_id || ! $this->is_action( self::SWITCH_ON_ACTION ) ) {
+			return;
+		}
+
+		$preview_user_id = $this->create_preview_user();
+		$this->set_preview_user( $preview_user_id );
+
+		wp_safe_redirect( remove_query_arg( self::SWITCH_ON_ACTION ) );
+
+	}
+
+	/**
+	 * Switch back to original user and delete preview user.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 */
+	public function switch_off_preview_user() {
+
+		if ( ! $this->is_action( self::SWITCH_OFF_ACTION ) ) {
+			return;
+		}
+
+		$this->delete_preview_user();
+
+		wp_safe_redirect( remove_query_arg( self::SWITCH_OFF_ACTION ) );
+
+	}
+
+	/**
+	 * Add switch to user link to admin bar.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar The WordPress Admin Bar object.
+	 */
+	public function add_user_switch_to_admin_bar( $wp_admin_bar ) {
+
+		if ( ! Sensei_Utils::get_current_course() ) {
+			return;
+		}
+
+		if ( ! $this->is_preview_user_active() ) {
+			$wp_admin_bar->add_node(
+				[
+					'id'     => self::SWITCH_ON_ACTION,
+					'title'  => __( 'Preview as Student', 'sensei-lms' ),
+					'parent' => 'top-secondary',
+					'href'   => add_query_arg( [ self::SWITCH_ON_ACTION => wp_create_nonce( self::SWITCH_ON_ACTION ) ] ),
+					'meta'   => [
+						'class' => 'sensei-user-switch-preview',
+					],
+				]
+			);
+		} else {
+			$wp_admin_bar->add_node(
+				[
+					'id'     => self::SWITCH_OFF_ACTION,
+					'title'  => __( 'Exit Student Preview', 'sensei-lms' ),
+					'parent' => 'top-secondary',
+					'href'   => add_query_arg( [ self::SWITCH_OFF_ACTION => wp_create_nonce( self::SWITCH_OFF_ACTION ) ] ),
+					'meta'   => [
+						'class' => 'sensei-user-switch-preview',
+					],
+				]
+			);
+		}
+
+	}
+
+	/**
+	 * Enable admin bar for preview user.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 *
+	 * @param bool $show Initial state.
+	 *
+	 * @return bool
+	 */
+	public function show_admin_bar_to_preview_user( $show ) {
+		if ( $this->is_preview_user_active() ) {
+			return true;
+		}
+
+		return $show;
+	}
+
+	/**
+	 * Check if the request is for the given action.
+	 *
+	 * @param string $action Action field and nonce name.
+	 *
+	 * @return bool
+	 */
+	private function is_action( $action ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verification
+		return isset( $_REQUEST[ $action ] ) && wp_verify_nonce( wp_unslash( $_REQUEST[ $action ] ), $action );
+	}
+
+
+	/**
+	 * Create a preview user for the current teacher.
+	 *
+	 * @return int
+	 */
+	private function create_preview_user() {
+		$teacher    = wp_get_current_user();
+		$user_count = get_user_count();
+		$user_name  = 'preview_user_' . wp_rand( 10000000, 99999999 ) . '_' . $user_count;
+
+		return wp_insert_user(
+			[
+				'user_pass'    => wp_generate_password(),
+				'user_login'   => $user_name,
+				'user_email'   => $user_name . '@senseipreview.senseipreview',
+				'display_name' => 'Preview Student ' . $user_count . ' (' . $teacher->display_name . ')',
+				'role'         => self::ROLE,
+				'meta_input'   => [
+					self::META => $teacher->ID,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Delete preview user, including their course progress data.
+	 */
+	private function delete_preview_user() {
+
+		$preview_user = get_current_user_id();
+		$teacher      = $this->get_preview_user( get_current_user_id() );
+
+		// Swap the user IDs if the active user is the teacher.
+		if ( ! $this->is_preview_user_active() ) {
+			list( $preview_user, $teacher ) = [ $teacher, $preview_user ];
+		}
+
+		if ( ! $preview_user ) {
+			return;
+		}
+
+		delete_user_meta( $teacher, self::META );
+
+		$course_id = Sensei_Utils::get_current_course();
+		Sensei_Utils::sensei_remove_user_from_course( $course_id, $preview_user );
+
+		if ( ! function_exists( 'wp_delete_user' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+		wp_delete_user( $preview_user );
+
+	}
+
+	/**
+	 * Create the Guest Student role if it does not exist.
+	 *
+	 * @since $$next-version$$
+	 */
+	private function create_role() {
+		$role = get_role( self::ROLE );
+
+		if ( ! is_a( $role, 'WP_Role' ) ) {
+			add_role( self::ROLE, __( 'Preview Student', 'sensei-lms' ) );
+		}
+	}
+
+	/**
+	 * Get preview user meta for the teacher if one is active.
+	 *
+	 * @param int $user_id Teacher user ID.
+	 *
+	 * @return false|int
+	 */
+	private function get_preview_user( $user_id = null ) {
+		return get_user_meta( $user_id, self::META, true );
+	}
+
+	/**
+	 * Store preview user for the current teacher as user meta.
+	 *
+	 * @param int $preview_user_id Preview user ID.
+	 */
+	private function set_preview_user( $preview_user_id ) {
+		add_user_meta( get_current_user_id(), self::META, $preview_user_id );
+	}
+
+	/**
+	 * Check if the current user is a preview user.
+	 *
+	 * @return bool
+	 */
+	private function is_preview_user_active() {
+		$user = wp_get_current_user();
+		return in_array( self::ROLE, (array) $user->roles, true );
+	}
+
+}

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -57,10 +57,11 @@ class Sensei_Preview_User {
 	 * @access private
 	 */
 	public function override_user() {
+
 		$preview_user = $this->get_preview_user( get_current_user_id() );
 		$course_id    = Sensei_Utils::get_current_course();
 
-		if ( ! $course_id || ! $preview_user ) {
+		if ( ! $course_id || ! $preview_user || ! $this->is_preview_user( $preview_user ) ) {
 			return;
 		}
 
@@ -175,7 +176,7 @@ class Sensei_Preview_User {
 	 */
 	private function is_action( $action ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verification
-		return isset( $_REQUEST[ $action ] ) && wp_verify_nonce( wp_unslash( $_REQUEST[ $action ] ), $action );
+		return isset( $_GET[ $action ] ) && wp_verify_nonce( wp_unslash( $_GET[ $action ] ), $action );
 	}
 
 
@@ -272,6 +273,23 @@ class Sensei_Preview_User {
 	 */
 	private function is_preview_user_active() {
 		$user = wp_get_current_user();
+		return $this->is_preview_user( $user );
+	}
+
+	/**
+	 * Check if the given user is a preview user.
+	 *
+	 * @param WP_User|int $user User object or ID.
+	 *
+	 * @return bool
+	 */
+	private function is_preview_user( $user ): bool {
+		if ( is_numeric( $user ) ) {
+			$user = get_user_by( 'ID', $user );
+		}
+		if ( ! is_a( $user, 'WP_User' ) ) {
+			return false;
+		}
 		return in_array( self::ROLE, (array) $user->roles, true );
 	}
 

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * File with class for testing Sensei Preview User.
+ *
+ * @package sensei-tests
+ */
+
+/**
+ * Class for testing Sensei_Preview_User class.
+ *
+ * @group Preview User
+ */
+class Sensei_Preview_User_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Factory object.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory      = new Sensei_Factory();
+		$this->preview_user = new Sensei_Preview_User();
+	}
+
+	/**
+	 * Switch to preview user, then switch back.
+	 */
+	public function testSwitchToPreviewUser() {
+		add_filter( 'wp_redirect', '__return_false' );
+
+		$course_data = $this->factory->get_course_with_lessons();
+		$course_link = get_permalink( $course_data['course_id'] );
+		$admin_id    = $this->get_user_by_role( 'administrator' );
+		$this->login_as( $admin_id );
+
+		// Switch to preview user.
+
+		$this->go_to( add_query_arg( [ 'sensei-preview-as-student' => wp_create_nonce( 'sensei-preview-as-student' ) ], $course_link ) );
+
+		$this->go_to( $course_link );
+
+		$this->assertNotEquals( $admin_id, get_current_user_id(), 'Current user not changed.' );
+		$preview_user = wp_get_current_user();
+		$this->assertRegexp( '/^Preview Student.*$/', $preview_user->display_name, 'Current user is not a preview student.' );
+
+		// Switch off preview user.
+
+		$this->go_to( add_query_arg( [ 'sensei-exit-student-preview' => wp_create_nonce( 'sensei-exit-student-preview' ) ], $course_link ) );
+
+		wp_set_current_user( $admin_id );
+		$this->go_to( $course_link );
+
+		$this->assertEquals( $admin_id, get_current_user_id(), 'Current user is not changed back.' );
+		$this->assertEmpty( get_user_by( 'ID', $preview_user->ID ), 'Preview user is not removed.' );
+
+	}
+}


### PR DESCRIPTION
Fixes #6281 #6283 #6284

### Changes proposed in this Pull Request

* Add a 'Preview as Student' link to the admin bar when viewing a course
* Show 'Exit Student Preview' link when preview is active
* Create preview user when switching, store its ID as meta for the teacher
* When the meta is set and viewing a course, override the current user to the preview user
* Delete the user, their course progress, and the meta when switching off the user

### Moving to separate task
- #6287

### Testing instructions

* Create and publish a course, open it or its lessons on the frontend
* A Preview as Student should show up in the admin bar:   
<img width="295" alt="image" src="https://user-images.githubusercontent.com/176949/207297921-c6c2720f-db57-4150-9bf3-298640a6ea69.png">

* Clicking it should change the user to a new preview user: 
<img width="451" alt="image" src="https://user-images.githubusercontent.com/176949/207298183-c7c22a56-445f-4c3b-b4c8-c2adf612f4dd.png">

* The preview user should have its own course progress
* Clicking 'Exit Student Preview' should delete the preview user, its course progress, and switch back to the original user

* Preview user should be limited to course-related pages. Otherwise, the original user should remain

