### PR TITLE
Change preview users to be per course

### DIFF
--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -237,12 +237,10 @@ class Sensei_Preview_User {
 				require_once ABSPATH . '/wp-admin/includes/ms.php';
 			}
 			wpmu_delete_user( $user_id );
-
 		} else {
 			if ( ! function_exists( 'wp_delete_user' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/user.php';
 			}
-
 			wp_delete_user( $user_id );
 		}
 	}

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -230,11 +230,19 @@ class Sensei_Preview_User {
 
 		Sensei_Utils::sensei_remove_user_from_course( $course_id, $user_id );
 
-		if ( ! function_exists( 'wp_delete_user' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/user.php';
-		}
+		if ( is_multisite() ) {
+			if ( ! function_exists( 'wpmu_delete_user' ) ) {
+				require_once ABSPATH . '/wp-admin/includes/ms.php';
+			}
+			wpmu_delete_user( $user_id );
 
-		wp_delete_user( $user_id );
+		} else {
+			if ( ! function_exists( 'wp_delete_user' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/user.php';
+			}
+
+			wp_delete_user( $user_id );
+		}
 	}
 
 	/**

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -192,16 +192,15 @@ class Sensei_Preview_User {
 	 * @return int
 	 */
 	private function create_preview_user( $course_id ) {
-		$teacher    = wp_get_current_user();
-		$user_count = get_user_count();
-		$user_name  = 'preview_user_' . wp_rand( 10000000, 99999999 ) . '_' . $user_count;
+		$teacher   = wp_get_current_user();
+		$user_name = 'preview_user_' . wp_rand( 10000000, 99999999 ) . '_' . $teacher->ID . '_' . $course_id;
 
 		return wp_insert_user(
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,
 				'user_email'   => $user_name . '@senseipreview.senseipreview',
-				'display_name' => 'Preview Student ' . $user_count . ' (' . $teacher->display_name . ')',
+				'display_name' => 'Preview Student ' . $course_id . $teacher->ID . ' (' . $teacher->display_name . ')',
 				'role'         => self::ROLE,
 				'meta_input'   => [
 					self::META => self::meta_value( $teacher->ID, $course_id ),

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -58,10 +58,14 @@ class Sensei_Preview_User {
 	 */
 	public function override_user() {
 
-		$course_id    = Sensei_Utils::get_current_course();
+		$course_id = Sensei_Utils::get_current_course();
+		if ( ! $course_id ) {
+			return;
+		}
+
 		$preview_user = $this->get_preview_user( get_current_user_id(), $course_id );
 
-		if ( ! $course_id || ! $preview_user || ! $this->is_preview_user( $preview_user ) ) {
+		if ( ! $preview_user || ! $this->is_preview_user( $preview_user ) ) {
 			return;
 		}
 
@@ -257,6 +261,9 @@ class Sensei_Preview_User {
 	 */
 	private function get_preview_user( $user_id, $course_id ) {
 		$preview_users = get_user_meta( $user_id, self::META, false );
+		if ( empty( $preview_users ) || ! $course_id ) {
+			return false;
+		}
 		foreach ( $preview_users as $preview_user ) {
 			if ( $preview_user['course'] === $course_id ) {
 				return $preview_user['user'];
@@ -323,8 +330,8 @@ class Sensei_Preview_User {
 	 */
 	private static function meta_value( $user_id, $course_id ) {
 		return [
-			'user'   => $user_id,
-			'course' => $course_id,
+			'user'   => absint( $user_id ),
+			'course' => absint( $course_id ),
 		];
 	}
 

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -192,15 +192,17 @@ class Sensei_Preview_User {
 	 * @return int
 	 */
 	private function create_preview_user( $course_id ) {
-		$teacher   = wp_get_current_user();
-		$user_name = 'preview_user_' . wp_rand( 10000000, 99999999 ) . '_' . $teacher->ID . '_' . $course_id;
+		$teacher      = wp_get_current_user();
+		$user_name    = 'preview_user_' . wp_rand( 10000000, 99999999 ) . '_' . $teacher->ID . '_' . $course_id;
+		$display_name = 'Preview Student ' . $course_id . $teacher->ID . ' (' . $teacher->display_name . ')';
 
 		return wp_insert_user(
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,
 				'user_email'   => $user_name . '@senseipreview.senseipreview',
-				'display_name' => 'Preview Student ' . $course_id . $teacher->ID . ' (' . $teacher->display_name . ')',
+				'display_name' => $display_name,
+				'last_name'    => $display_name,
 				'role'         => self::ROLE,
 				'meta_input'   => [
 					self::META => self::meta_value( $teacher->ID, $course_id ),

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2212,7 +2212,7 @@ class Sensei_Utils {
 				break;
 		}
 
-		return $course_id ? $course_id : null;
+		return $course_id ? absint( $course_id ) : null;
 	}
 
 

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -103,6 +103,26 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	}
 
+
+	/**
+	 * Switch to preview user, then switch back.
+	 */
+	public function testPreviewUserForLessons() {
+
+		list( 'course_id' => $course_id, 'lesson_ids' => list( $lesson_id ) ) = $this->factory->get_course_with_lessons();
+		$admin_id = $this->get_user_by_role( 'administrator' );
+		$this->login_as( $admin_id );
+
+		// Switch to preview user.
+
+		$this->go_to( add_query_arg( [ 'sensei-preview-as-student' => wp_create_nonce( 'sensei-preview-as-student' ) ], get_permalink( $course_id ) ) );
+
+		$this->go_to( get_permalink( $lesson_id ) );
+
+		$this->assertNotEquals( $admin_id, get_current_user_id(), 'Preview user is not used for the lesson.' );
+
+	}
+
 	/**
 	 * Reset user ID when navigating to a new page.
 	 *

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -34,18 +34,16 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 	 * Switch to preview user, then switch back.
 	 */
 	public function testSwitchToPreviewUser() {
-		add_filter( 'wp_redirect', '__return_false' );
+		add_filter( 'wp_redirect', [ $this, 'go_to' ] );
 
-		$course_data = $this->factory->get_course_with_lessons();
-		$course_link = get_permalink( $course_data['course_id'] );
+		$course_id   = $this->factory->course->create();
+		$course_link = get_permalink( $course_id );
 		$admin_id    = $this->get_user_by_role( 'administrator' );
 		$this->login_as( $admin_id );
 
 		// Switch to preview user.
 
 		$this->go_to( add_query_arg( [ 'sensei-preview-as-student' => wp_create_nonce( 'sensei-preview-as-student' ) ], $course_link ) );
-
-		$this->go_to( $course_link );
 
 		$this->assertNotEquals( $admin_id, get_current_user_id(), 'Current user not changed.' );
 		$preview_user = wp_get_current_user();
@@ -55,11 +53,59 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 		$this->go_to( add_query_arg( [ 'sensei-exit-student-preview' => wp_create_nonce( 'sensei-exit-student-preview' ) ], $course_link ) );
 
-		wp_set_current_user( $admin_id );
-		$this->go_to( $course_link );
-
 		$this->assertEquals( $admin_id, get_current_user_id(), 'Current user is not changed back.' );
 		$this->assertEmpty( get_user_by( 'ID', $preview_user->ID ), 'Preview user is not removed.' );
 
 	}
+
+	/**
+	 * Courses should have independent preview users.
+	 */
+	public function testPreviewUserPerCourse() {
+		add_filter( 'wp_redirect', [ $this, 'go_to' ] );
+
+		$course_1 = $this->factory->course->create();
+		$course_2 = $this->factory->course->create();
+		$admin_id = $this->get_user_by_role( 'administrator' );
+		$this->login_as( $admin_id );
+
+		// Switch to preview user for course 1.
+
+		$this->go_to( add_query_arg( [ 'sensei-preview-as-student' => wp_create_nonce( 'sensei-preview-as-student' ) ], get_permalink( $course_1 ) ) );
+
+		$preview_user_1 = get_current_user_id();
+		wp_set_current_user( $admin_id );
+		$this->go_to( get_permalink( $course_2 ) );
+
+		$this->assertNotEquals( $preview_user_1, get_current_user_id(), 'Course 2 should not use course 1\'s preview user.' );
+
+		// Switch to preview user for course 2.
+
+		$this->go_to( add_query_arg( [ 'sensei-preview-as-student' => wp_create_nonce( 'sensei-preview-as-student' ) ], get_permalink( $course_2 ) ) );
+
+		$preview_user_2 = get_current_user_id();
+		wp_set_current_user( $admin_id );
+		$this->go_to( get_permalink( $course_2 ) );
+
+		$this->assertEquals( $preview_user_2, get_current_user_id(), 'Course 2 should use its own preview user.' );
+
+		wp_set_current_user( $admin_id );
+		$this->go_to( get_permalink( $course_1 ) );
+
+		$this->assertNotEquals( $preview_user_2, get_current_user_id(), 'Course 1 should not use course 2\'s preview user.' );
+
+	}
+
+	/**
+	 * Reset user ID when navigating to a new page.
+	 *
+	 * Normally when the tested class changes the user, it should be for the current request only. It is however persisted in the test environment, so we need to set it back to the original user (admin) when using go_to() or on redirects.
+	 *
+	 * @param string $url URL.
+	 */
+	public function go_to( $url ) {
+		wp_set_current_user( $this->get_user_by_role( 'administrator' ) );
+		parent::go_to( $url );
+	}
+
 }

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -28,13 +28,21 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 		$this->factory      = new Sensei_Factory();
 		$this->preview_user = new Sensei_Preview_User();
+		add_filter( 'wp_redirect', [ $this, 'go_to' ] );
+	}
+
+	/**
+	 * Clean up after the test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_filter( 'wp_redirect', [ $this, 'go_to' ] );
 	}
 
 	/**
 	 * Switch to preview user, then switch back.
 	 */
 	public function testSwitchToPreviewUser() {
-		add_filter( 'wp_redirect', [ $this, 'go_to' ] );
 
 		$course_id   = $this->factory->course->create();
 		$course_link = get_permalink( $course_id );
@@ -62,7 +70,6 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 	 * Courses should have independent preview users.
 	 */
 	public function testPreviewUserPerCourse() {
-		add_filter( 'wp_redirect', [ $this, 'go_to' ] );
 
 		$course_1 = $this->factory->course->create();
 		$course_2 = $this->factory->course->create();

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -34,7 +34,7 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up after the test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		remove_filter( 'wp_redirect', [ $this, 'go_to' ] );
 	}


### PR DESCRIPTION
Based on #6288
Fixes #6287 #6284

### Changes proposed in this Pull Request

* Change preview users to be created for the current course only
* Multiple preview users are stored in the teacher's user meta (max one for each course) 
* Only switch to preview user when it's created for the current course

### Testing instructions

* Have multiple courses
* Open one, click 'Preview as Student'
* Confirm only the first course is using the preview user, not the other ones
* Also switch to a preview user for another course, ensure it's a different user

