### PR TITLE
Add filters for course actions buttons

### DIFF
--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -44,15 +45,25 @@ const CourseActionsEdit = ( { className, context: { postType } } ) => {
 		);
 	}
 
+	const allowed = applyFilters(
+		'sensei-lms.Course.courseActionsAllowedBlocks',
+		[
+			'sensei-lms/button-take-course',
+			'sensei-lms/button-continue-course',
+			'sensei-lms/button-view-results',
+		]
+	);
+
+	const template = applyFilters(
+		'sensei-lms.Course.courseActionsTemplate',
+		innerBlocksTemplate
+	);
+
 	return (
 		<div className={ className }>
 			<InnerBlocks
-				allowedBlocks={ [
-					'sensei-lms/button-take-course',
-					'sensei-lms/button-continue-course',
-					'sensei-lms/button-view-results',
-				] }
-				template={ innerBlocksTemplate }
+				allowedBlocks={ allowed }
+				template={ template }
 				templateLock="all"
 			/>
 		</div>

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -45,35 +44,15 @@ const CourseActionsEdit = ( { className, context: { postType } } ) => {
 		);
 	}
 
-	/**
-	 * Filter the allowed blocks for the course actions block.
-	 *
-	 * @param {string[]} allowedBlocks Allowed blocks.
-	 */
-	const allowed = applyFilters(
-		'sensei-lms.Course.courseActionsAllowedBlocks',
-		[
-			'sensei-lms/button-take-course',
-			'sensei-lms/button-continue-course',
-			'sensei-lms/button-view-results',
-		]
-	);
-
-	/**
-	 * Filter the template for the course actions block.
-	 *
-	 * @param {Array} template Template.
-	 */
-	const template = applyFilters(
-		'sensei-lms.Course.courseActionsTemplate',
-		innerBlocksTemplate
-	);
-
 	return (
 		<div className={ className }>
 			<InnerBlocks
-				allowedBlocks={ allowed }
-				template={ template }
+				allowedBlocks={ [
+					'sensei-lms/button-take-course',
+					'sensei-lms/button-continue-course',
+					'sensei-lms/button-view-results',
+				] }
+				template={ innerBlocksTemplate }
 				templateLock="all"
 			/>
 		</div>

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -45,6 +45,11 @@ const CourseActionsEdit = ( { className, context: { postType } } ) => {
 		);
 	}
 
+	/**
+	 * Filter the allowed blocks for the course actions block.
+	 *
+	 * @param {string[]} allowedBlocks Allowed blocks.
+	 */
 	const allowed = applyFilters(
 		'sensei-lms.Course.courseActionsAllowedBlocks',
 		[
@@ -54,6 +59,11 @@ const CourseActionsEdit = ( { className, context: { postType } } ) => {
 		]
 	);
 
+	/**
+	 * Filter the template for the course actions block.
+	 *
+	 * @param {Array} template Template.
+	 */
 	const template = applyFilters(
 		'sensei-lms.Course.courseActionsTemplate',
 		innerBlocksTemplate

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -123,16 +123,6 @@ $block: '.wp-block-sensei-lms-course-list';
 			}
 		}
 	}
-
-	@media ( min-width: 782px ) {
-		&--is-list-view {
-			.wp-block-sensei-lms-button-take-course,
-			.wp-block-sensei-lms-button-continue-course,
-			.wp-block-sensei-lms-button-view-results {
-				text-align: right;
-			}
-		}
-	}
 }
 
 /* Divi overrides */

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -124,6 +124,11 @@ $block: '.wp-block-sensei-lms-course-list';
 		}
 	}
 
+	&--is-list-view .sensei-cta .wp-block-button__link {
+		display: block;
+		float: right;
+	}
+
 	@media ( min-width: 782px ) {
 		&--is-list-view {
 			.wp-block-sensei-lms-button-take-course,

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -123,6 +123,16 @@ $block: '.wp-block-sensei-lms-course-list';
 			}
 		}
 	}
+
+	@media ( min-width: 782px ) {
+		&--is-list-view {
+			.wp-block-sensei-lms-button-take-course,
+			.wp-block-sensei-lms-button-continue-course,
+			.wp-block-sensei-lms-button-view-results {
+				text-align: right;
+			}
+		}
+	}
 }
 
 /* Divi overrides */

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -128,6 +128,7 @@ class Sensei_Course_List_Block_Patterns {
 										<!-- wp:post-excerpt {"textAlign":"left","lock":{"move": true}} /-->
 
 										<!-- wp:sensei-lms/course-overview /-->
+										<!-- wp:sensei-certificates/view-certificate-link /-->
 
 										<!-- wp:sensei-lms/course-progress {"lock":{"move": true}} /-->
 

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -75,16 +75,16 @@ class Sensei_Course_List_Block_Patterns {
 											<!-- wp:column {"width":"33.33%"} -->
 												<div class="wp-block-column" style="flex-basis:33.33%">
 													<!-- wp:sensei-lms/course-actions -->
-														<!-- wp:sensei-lms/button-take-course {"align":"right"} -->
-															<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link">Start Course</button></div>
+														<!-- wp:sensei-lms/button-take-course {"align":"full"} -->
+															<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link">Start Course</button></div>
 														<!-- /wp:sensei-lms/button-take-course -->
 
-														<!-- wp:sensei-lms/button-continue-course {"align":"right"} -->
-															<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Continue</a></div>
+														<!-- wp:sensei-lms/button-continue-course {"align":"full"} -->
+															<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link">Continue</a></div>
 														<!-- /wp:sensei-lms/button-continue-course -->
 
-														<!-- wp:sensei-lms/button-view-results {"align":"right","className":"is-style-default"} -->
-															<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Visit Results</a></div>
+														<!-- wp:sensei-lms/button-view-results {"align":"full","className":"is-style-default"} -->
+															<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link">Visit Results</a></div>
 														<!-- /wp:sensei-lms/button-view-results -->
 													<!-- /wp:sensei-lms/course-actions -->
 												</div>

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -33,6 +33,25 @@ class Sensei_Course_List_Block_Patterns {
 				<!-- wp:query-pagination-next {"fontSize":"small"} /-->
 			<!-- /wp:query-pagination -->';
 
+		// Get extra links for Course List patterns.
+		$patterns_with_extra_links = [ 'course-list', 'course-grid' ];
+		$course_list_extra_links   = [];
+		foreach ( $patterns_with_extra_links as $pattern ) {
+
+			/**
+			 * Filter to add extra links to a Course List pattern. The added
+			 * links must be a valid rendered block.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param array  $course_list_extra_links The extra links.
+			 * @param string $pattern                 The pattern name.
+			 *
+			 * @return array The extra links.
+			 */
+			$course_list_extra_links[ $pattern ] = apply_filters( 'sensei_course_list_block_patterns_extra_links', [], $pattern );
+		}
+
 		$patterns = [
 			'course-list'                 =>
 			[
@@ -67,6 +86,8 @@ class Sensei_Course_List_Block_Patterns {
 													<!-- wp:post-excerpt {"textAlign":"left"} /-->
 
 													<!-- wp:sensei-lms/course-overview /-->
+
+													' . implode( "\n", $course_list_extra_links['course-list'] ) . '
 
 													<!-- wp:sensei-lms/course-progress /-->
 												</div>
@@ -128,6 +149,8 @@ class Sensei_Course_List_Block_Patterns {
 										<!-- wp:post-excerpt {"textAlign":"left","lock":{"move": true}} /-->
 
 										<!-- wp:sensei-lms/course-overview /-->
+
+										' . implode( "\n", $course_list_extra_links['course-list'] ) . '
 
 										<!-- wp:sensei-lms/course-progress {"lock":{"move": true}} /-->
 
@@ -262,15 +285,6 @@ class Sensei_Course_List_Block_Patterns {
 						<!-- /wp:group -->',
 				],
 		];
-
-		/**
-		 * Filter the Sensei Course List block patterns.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param array $patterns The patterns.
-		 */
-		$patterns = apply_filters( 'sensei_course_list_block_patterns', $patterns );
 
 		foreach ( $patterns as $key => $pattern ) {
 			register_block_pattern(

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -75,16 +75,16 @@ class Sensei_Course_List_Block_Patterns {
 											<!-- wp:column {"width":"33.33%"} -->
 												<div class="wp-block-column" style="flex-basis:33.33%">
 													<!-- wp:sensei-lms/course-actions -->
-														<!-- wp:sensei-lms/button-take-course {"align":"full"} -->
-															<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link">Start Course</button></div>
+														<!-- wp:sensei-lms/button-take-course {"align":"right"} -->
+															<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link">Start Course</button></div>
 														<!-- /wp:sensei-lms/button-take-course -->
 
-														<!-- wp:sensei-lms/button-continue-course {"align":"full"} -->
-															<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link">Continue</a></div>
+														<!-- wp:sensei-lms/button-continue-course {"align":"right"} -->
+															<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Continue</a></div>
 														<!-- /wp:sensei-lms/button-continue-course -->
 
-														<!-- wp:sensei-lms/button-view-results {"align":"full","className":"is-style-default"} -->
-															<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link">Visit Results</a></div>
+														<!-- wp:sensei-lms/button-view-results {"align":"right","className":"is-style-default"} -->
+															<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Visit Results</a></div>
 														<!-- /wp:sensei-lms/button-view-results -->
 													<!-- /wp:sensei-lms/course-actions -->
 												</div>
@@ -128,7 +128,6 @@ class Sensei_Course_List_Block_Patterns {
 										<!-- wp:post-excerpt {"textAlign":"left","lock":{"move": true}} /-->
 
 										<!-- wp:sensei-lms/course-overview /-->
-										<!-- wp:sensei-certificates/view-certificate-link /-->
 
 										<!-- wp:sensei-lms/course-progress {"lock":{"move": true}} /-->
 

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -150,7 +150,7 @@ class Sensei_Course_List_Block_Patterns {
 
 										<!-- wp:sensei-lms/course-overview /-->
 
-										' . implode( "\n", $course_list_extra_links['course-list'] ) . '
+										' . implode( "\n", $course_list_extra_links['course-grid'] ) . '
 
 										<!-- wp:sensei-lms/course-progress {"lock":{"move": true}} /-->
 

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -44,10 +44,10 @@ class Sensei_Course_List_Block_Patterns {
 			 *
 			 * @since $$next-version$$
 			 *
-			 * @param array  $course_list_extra_links The extra links.
-			 * @param string $pattern                 The pattern name.
+			 * @param {array}  $course_list_extra_links The extra links.
+			 * @param {string} $pattern                 The pattern name.
 			 *
-			 * @return array The extra links.
+			 * @return {array} The extra links.
 			 */
 			$course_list_extra_links[ $pattern ] = apply_filters( 'sensei_course_list_block_patterns_extra_links', [], $pattern );
 		}

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -263,6 +263,15 @@ class Sensei_Course_List_Block_Patterns {
 				],
 		];
 
+		/**
+		 * Filter the Sensei Course List block patterns.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $patterns The patterns.
+		 */
+		$patterns = apply_filters( 'sensei_course_list_block_patterns', $patterns );
+
 		foreach ( $patterns as $key => $pattern ) {
 			register_block_pattern(
 				$key,


### PR DESCRIPTION
Part of #6292

Please see https://github.com/woocommerce/sensei-certificates/pull/327 for more details about this PR.

### Changes proposed in this Pull Request

- Add a filter so that extensions can change the Course List patterns.

<!--
* Add filters so that extensions can change the buttons in the Course List patterns.
* Make all buttons aligned `full` in the Course List patterns.
-->

### Testing instructions

Refer to https://github.com/woocommerce/sensei-certificates/pull/327

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

<!--
#### JS

* `sensei-lms.Course.courseActionsAllowedBlocks` - filters the `allowedBlocks` list for the Course Actions block's `InnerBlocks`.
* `sensei-lms.Course.courseActionsTemplate` - filters the `template` list for the Course Actions block's `InnerBlocks`.

#### PHP
-->

* `sensei_course_list_block_patterns_extra_links` - filter to add extra links into the templates for the Course List block.