### PR TITLE
Use incremental guest user count in guest display name

### DIFF
--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -220,14 +220,14 @@ class Sensei_Guest_User {
 	 * @return int
 	 */
 	private function create_guest_user() {
-		$user_count = get_user_count();
+		$user_count = Sensei_Utils::get_user_count_for_role( $this->guest_student_role ) + 1;
 		$user_name  = 'guest_user_' . wp_rand( 10000000, 99999999 ) . '_' . $user_count;
 		return wp_insert_user(
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,
 				'user_email'   => $user_name . '@senseiguest.senseiguest',
-				'display_name' => 'Guest Student ' . $user_count,
+				'display_name' => 'Guest Student ' . str_pad( $user_count, 3, '0', STR_PAD_LEFT ),
 				'role'         => $this->guest_student_role,
 			]
 		);

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2696,7 +2696,14 @@ class Sensei_Utils {
 	 * @return int    Count of users having the provided role.
 	 */
 	public static function get_user_count_for_role( $role ) {
-		return count( get_users( array( 'fields' => array( 'ID' ), 'role' => $role ) ) );
+		return count(
+			get_users(
+				[
+					'fields' => 'ID',
+					'role' => $role,
+				]
+			)
+		);
 	}
 }
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2700,7 +2700,7 @@ class Sensei_Utils {
 			get_users(
 				[
 					'fields' => 'ID',
-					'role' => $role,
+					'role'   => $role,
 				]
 			)
 		);

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2688,6 +2688,16 @@ class Sensei_Utils {
 	public static function is_atomic_platform(): bool {
 		return defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID && defined( 'ATOMIC_CLIENT_ID' ) && ATOMIC_CLIENT_ID;
 	}
+
+	/**
+	 * Get count of users for a provided role.
+	 *
+	 * @param  string $role Slug of the Role.
+	 * @return int    Count of users having the provided role.
+	 */
+	public static function get_user_count_for_role( $role ) {
+		return count( get_users( array( 'fields' => array( 'ID' ), 'role' => $role ) ) );
+	}
 }
 
 /**

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -61,6 +61,7 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 		$this->assertEquals( is_user_logged_in(), $open_access );
 		if ( $open_access ) {
 			$this->assertRegexp( '/^guest_user_.*$/', wp_get_current_user()->user_login );
+			$this->assertRegexp( '/^Guest Student 00.*$/', wp_get_current_user()->display_name );
 		}
 
 	}

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -306,4 +306,13 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 			'date'    => [ 8 * 24 * 60 * 60, null ],
 		];
 	}
+
+	public function testUserCountByRole_WhenCalled_ReturnsCorrectNumberOfStudents() {
+		$this->factory->user->create_many( 3 );
+		$this->factory->user->create_many( 2, array( 'role' => 'student' ) );
+
+		$result = Sensei_Utils::get_user_count_for_role( 'student' );
+
+		$this->assertEquals( 2, $result );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6291

### Changes proposed in this Pull Request

* Adds a util function to get user count for a specific role
* Uses that function to determine the number to append to the guest user display name
* Pads the number with 0 to the left up to 3 digits in case the number is smaller

### Testing instructions

- Create an open course
- Open the course in frontend when you are logged out, click on take course
- Now go to Users in wp_admin, make sure the newly created user has an incremental id appended that's equal to the number of total guest students, and if the number has less than 3 digits, it's appending 0 to the left