### PR TITLE
Skip welcome modal on the e2e test suite

### DIFF
--- a/tests/e2e-playwright/config/global-setup.ts
+++ b/tests/e2e-playwright/config/global-setup.ts
@@ -42,9 +42,6 @@ const setupDefaultUsers = async (): Promise< void > => {
 	const adminContext = await createAdminContext( adminPage );
 	const createdUsers = await createGlobalUsers( adminContext, GLOBAL_USERS );
 
-	// eslint-disable-next-line no-console
-	// console.log( { createdUsers } );
-
 	await Promise.all(
 		createdUsers.map( async ( user ) => {
 			const userPreference = await createUserPreference( browser, user );

--- a/tests/e2e-playwright/config/global-setup.ts
+++ b/tests/e2e-playwright/config/global-setup.ts
@@ -12,13 +12,11 @@ import {
 	configureSite,
 } from '@e2e/helpers/database';
 import { createUser, User } from '@e2e/helpers/api';
-import {
-	createAdminContext,
-} from '@e2e/helpers/context';
+import { createAdminContext } from '@e2e/helpers/context';
 import {
 	createUserPreference,
-	setDefaultPreferences
-} from "@e2e/helpers/preferences";
+	setDefaultPreferences,
+} from '@e2e/helpers/preferences';
 import { GLOBAL_USERS } from '@e2e/factories/users';
 
 export default async (): Promise< void > => {

--- a/tests/e2e-playwright/factories/users.ts
+++ b/tests/e2e-playwright/factories/users.ts
@@ -17,4 +17,10 @@ export const GLOBAL_USERS: User[] = [
 		email: 'student@student.com',
 		password: 'password',
 	},
+	{
+		username: 'editor',
+		email: 'editor@student.com',
+		password: 'password',
+		roles: [ 'editor' ],
+	},
 ];

--- a/tests/e2e-playwright/helpers/api/users.ts
+++ b/tests/e2e-playwright/helpers/api/users.ts
@@ -2,12 +2,14 @@ import { APIRequestContext } from '@playwright/test';
 import { createApiContext } from './index';
 
 export type UserResponse = {
+	id: number;
 	username: string;
 	name: string;
 	email: string;
 };
 
 export type User = {
+	id?: number;
 	username: string;
 	password?: string;
 	email?: string;

--- a/tests/e2e-playwright/helpers/preferences.ts
+++ b/tests/e2e-playwright/helpers/preferences.ts
@@ -1,0 +1,70 @@
+import { Browser } from '@playwright/test';
+import { User } from './api';
+import fs from 'fs/promises';
+import { login, getContextByRole } from './context';
+
+export type UserPreference = {
+	path: string;
+	key: string;
+	initialState: {
+		cookies: {
+			name: string;
+			value: string;
+			domain: string;
+			path: string;
+			expires: number;
+			httpOnly: boolean;
+			secure: boolean;
+			sameSite: 'Strict' | 'Lax' | 'None';
+		}[];
+		origins: {
+			origin: string;
+			localStorage: {
+				name: string;
+				value: string;
+			}[];
+		}[];
+	};
+};
+
+export const createUserPreference = async (
+	browser: Browser,
+	user: User
+): Promise< UserPreference > => {
+	const userPage = await login( await browser.newPage(), user );
+	const path = getContextByRole( user.username );
+	const initialState = await userPage.request.storageState( { path } );
+
+	return {
+		path,
+		key: `WP_PREFERENCES_USER_${ user.id }`,
+		initialState,
+	};
+};
+
+export const setDefaultPreferences = async (
+	userPreference: UserPreference
+): Promise< void > => {
+	const skipValues = {
+		'core/edit-post': { welcomeGuide: false },
+		'core/edit-page': { welcomeGuide: false },
+		'core/edit-site': { welcomeGuide: false },
+	};
+
+	const updated = {
+		...userPreference.initialState,
+		origins: [
+			{
+				origin: '/',
+				localStorage: [
+					{
+						name: userPreference.key,
+						value: JSON.stringify( skipValues ),
+					},
+				],
+			},
+		],
+	};
+
+	await fs.writeFile( userPreference.path, JSON.stringify( updated ) );
+};

--- a/tests/e2e-playwright/pages/admin/post-type/index.ts
+++ b/tests/e2e-playwright/pages/admin/post-type/index.ts
@@ -39,10 +39,7 @@ export default class PostType {
 		await this.page.goto(
 			`/wp-admin/post-new.php?post_type=${ this.postType }`
 		);
-		await this.page.waitForLoadState( 'networkidle' );
-		if ( ( await this.dialogCloseButton.count() ) > 0 ) {
-			return this.dialogCloseButton.click();
-		}
+
 		return null;
 	}
 

--- a/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
+++ b/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
@@ -7,12 +7,12 @@ import { test, expect } from '@playwright/test';
  */
 import { createCourse, createCourseCategory } from '@e2e/helpers/api';
 import PostType from '@e2e/pages/admin/post-type';
-import { adminRole } from '@e2e/helpers/context';
+import { editorRole } from '@e2e/helpers/context';
 
 const { describe, use, beforeAll } = test;
 
 describe( 'Courses List Block', () => {
-	use( adminRole() );
+	use( editorRole() );
 
 	const courses = [
 		{

--- a/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
+++ b/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
@@ -10,7 +10,7 @@ import { teacherRole } from '@e2e/helpers/context';
 
 const { describe, use } = test;
 
-describe( 'Create Courses', () => {
+describe.parallel( 'Create Courses', () => {
 	use( teacherRole() );
 
 	test( 'it has a Courses menu item in the main menu', async ( { page } ) => {
@@ -32,9 +32,6 @@ describe( 'Create Courses', () => {
 		coursesPage.goToPostTypeListingPage();
 
 		await coursesPage.createCourseButton.click();
-
-		// Close Welcome to the block editor dialog.
-		await coursesPage.dialogCloseButton.click();
 
 		// Fill in the course title and description.
 		const wizardModal = coursesPage.wizardModal;


### PR DESCRIPTION
Fixes #6302 

### Context
Currently, the Gutenberg editor displays a welcome modal the first time the user opens the editor,  this modal is breaking randomically our e2e tests because blocks the playwright to click on elements above the modal.  

The modal opening is controlled via a local storage key value:

``` javascript
WP_PREFERENCES_USER_${ user.id }:  { 
'core/edit-post': { welcomeGuide: false },
'core/edit-page': { welcomeGuide: false },
'core/edit-site': { welcomeGuide: false },
}
```

## Introduced change 
- Enable the e2e test suite to set default user preferences to disable the welcome modal to be opened. 


### Testing instructions
- Comment this [line](https://github.com/Automattic/sensei/blob/a74972201646528a2be4b2562643ff09c2ab27ac/tests/e2e-playwright/config/global-setup.ts#L48)

 ```
return setDefaultPreferences( userPreference );
```
- Run `npm run test:e2e:debug ./tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
- Check if the welcome modal is displayed like this:
<img width="1271" alt="Screenshot 2022-12-15 at 13 09 45" src="https://user-images.githubusercontent.com/38718/207911278-96300ef2-f0b7-43a4-8d64-6f221fbcaf88.png">
- Uncomment the line:
- Run the e2e test again
- Check if the test is passing.


