### PR TITLE
Add scheduled cleaner for inactive guest user

### DIFF
--- a/includes/class-sensei-guest-user-cleaner.php
+++ b/includes/class-sensei-guest-user-cleaner.php
@@ -87,8 +87,8 @@ class Sensei_Guest_User_Cleaner {
 			$course_ids = Sensei_Learner::instance()->get_enrolled_courses_query(
 				$user_id,
 				[
-					'posts_per_page'   => -1,
-					'fields' => 'ids',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
 				]
 			)->posts;
 
@@ -121,9 +121,9 @@ class Sensei_Guest_User_Cleaner {
 			'status'     => 'any',
 			'date_query' => [
 				[
-					'after' => '1 week ago'
-				]
-			]
+					'after' => '1 week ago',
+				],
+			],
 		];
 
 		$last_week_activities = Sensei_Utils::sensei_check_for_activity( $activity_args, true );

--- a/includes/class-sensei-guest-user-cleaner.php
+++ b/includes/class-sensei-guest-user-cleaner.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Guest User Cleaner
+ *
+ * Handles cleaning of guest users who are not active.
+ *
+ * @package sensei-lms
+ *
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei Guest User Cleaner Class.
+ *
+ * @author Automattic
+ *
+ * @since $$next-version$$
+ * @package Core
+ */
+class Sensei_Guest_User_Cleaner {
+
+	/**
+	 * Instance of singleton.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Fetches an instance of the class.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Sensei_Guest_User_Cleaner constructor. Private so it can only be initialized internally.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Sensei_Guest_User_Cleaner constructor.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function init() {
+		add_action( 'init', [ $this, 'maybe_schedule_cron_jobs' ], 101 );
+		add_action( 'sensei_remove_inactive_guest_users', [ $this, 'clean_inactive_guest_users' ] );
+	}
+
+
+	/**
+	 * Attaches guest user cleaning job to cron.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 */
+	public function maybe_schedule_cron_jobs() {
+		if ( ! wp_next_scheduled( 'sensei_remove_inactive_guest_users' ) ) {
+			wp_schedule_event( time(), 'daily', 'sensei_remove_inactive_guest_users' );
+		}
+	}
+
+	/**
+	 * Remove guest users who have not been active within last week.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 */
+	public function clean_inactive_guest_users() {
+		$user_ids_to_be_deleted = $this->get_inactive_users();
+
+		foreach ( $user_ids_to_be_deleted as $user_id ) {
+			$course_ids = Sensei_Learner::instance()->get_enrolled_courses_query(
+				$user_id,
+				[
+					'posts_per_page'   => -1,
+					'fields' => 'ids',
+				]
+			)->posts;
+
+			foreach ( $course_ids as $course_id ) {
+				Sensei_Utils::sensei_remove_user_from_course( $course_id, $user_id );
+			}
+
+			$this->delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Get a list of guest users who have not been active within last week.
+	 *
+	 * @access private
+	 *
+	 * @return array List of user IDs.
+	 */
+	private function get_inactive_users() {
+		$guest_user_ids = get_users(
+			[
+				'fields' => 'ID',
+				'role'   => 'guest_student',
+			]
+		);
+
+		$activity_args = [
+			'user_id'    => $guest_user_ids,
+			'type_in'    => [ 'sensei_lesson_status', 'sensei_course_status' ],
+			'status'     => 'any',
+			'date_query' => [
+				[
+					'after' => '1 week ago'
+				]
+			]
+		];
+
+		$last_week_activities = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+
+		if ( $last_week_activities && is_a( $last_week_activities, 'WP_Comment' ) ) {
+			$last_week_activities = [ $last_week_activities ];
+		} elseif ( ! is_array( $last_week_activities ) ) {
+			$last_week_activities = [];
+		}
+
+		return array_values( array_diff( $guest_user_ids, array_column( $last_week_activities, 'user_id' ) ) );
+	}
+
+	/**
+	 * Delete a user for both single and multisite.
+	 *
+	 * @access private
+	 *
+	 * @param int $user_id ID of the user to be removed.
+	 */
+	private function delete_user( $user_id ) {
+		if ( is_multisite() ) {
+			if ( ! function_exists( 'wpmu_delete_user' ) ) {
+				require_once ABSPATH . '/wp-admin/includes/ms.php';
+			}
+			wpmu_delete_user( $user_id );
+		} else {
+			if ( ! function_exists( 'wp_delete_user' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/user.php';
+			}
+			wp_delete_user( $user_id );
+		}
+	}
+}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -562,6 +562,9 @@ class Sensei_Main {
 		$this->quiz_submission_repository = ( new Submission_Repository_Factory() )->create();
 		$this->quiz_answer_repository     = ( new Answer_Repository_Factory() )->create();
 		$this->quiz_grade_repository      = ( new Grade_Repository_Factory() )->create();
+
+		// Cron for periodically cleaning guest user related data.
+		Sensei_Guest_User_Cleaner::instance()->init();
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-guest-user-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-guest-user-cleaner.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * File with class for testing Sensei Guest User Cleaner.
+ *
+ * @package sensei-tests
+ */
+
+/**
+ * Class for testing Sensei_Guest_User_Cleaner class.
+ *
+ * @group Guest User
+ */
+class Sensei_Guest_User_Cleaner_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Factory object.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	private function setup_course() {
+		$course_data = $this->factory->get_course_with_lessons();
+		$course_id   = $course_data['course_id'];
+		update_post_meta( $course_id, 'open_access', true );
+
+		global $post, $wp_query;
+		$post                  = get_post( $course_id );
+		$wp_query->post        = $post;
+		$wp_query->is_singular   = true;
+		$wp_query->in_the_loop = false;
+		echo is_singular( 'course' );
+		return $course_data;
+	}
+
+	public function testIfAGuestUserIsInactive_WhenCronEventIsFired_OnlyTheInactiveUserGetsRemoved() {
+
+		/* Arrange */
+		[ 'course_id' => $course_id ] = $this->setup_course();
+
+		$_POST['course_start']                           = 1;
+		$_POST[ 'woothemes_sensei_start_course_noonce' ] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
+		do_action( 'wp' );
+		$this->logout();
+
+		$_POST['course_start']                           = 1;
+		$_POST[ 'woothemes_sensei_start_course_noonce' ] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
+		do_action( 'wp' );
+
+		$user_count_before = Sensei_Utils::get_user_count_for_role( 'guest_student' );
+
+		$comment_id = Sensei_Utils::update_course_status( get_current_user_id(), $course_id, 'complete' );
+		update_comment_meta( $comment_id, 'start', '2022-01-01 00:00:01' );
+
+		$activity_args = [
+			'user_id' => get_current_user_id(),
+			'type_in' => [ 'sensei_lesson_status', 'sensei_course_status' ],
+			'status'  => 'any',
+			'fields'  => 'ids'
+		];
+
+		$activity = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+
+		wp_update_comment(
+			[
+				'comment_ID'   => $activity,
+				'comment_date' => '2022-01-02 00:00:01',
+			]
+		);
+
+
+		/* Act */
+		do_action( 'sensei_remove_inactive_guest_users' );
+
+		/* Assert */
+		$user_count_later = Sensei_Utils::get_user_count_for_role( 'guest_student' );
+
+		$this->assertEquals( 2, $user_count_before );
+		$this->assertEquals( 1, $user_count_later );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-guest-user-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-guest-user-cleaner.php
@@ -30,16 +30,17 @@ class Sensei_Guest_User_Cleaner_Test extends WP_UnitTestCase {
 	}
 
 	private function setup_course() {
+		global $post, $wp_query;
+
 		$course_data = $this->factory->get_course_with_lessons();
 		$course_id   = $course_data['course_id'];
 		update_post_meta( $course_id, 'open_access', true );
 
-		global $post, $wp_query;
 		$post                  = get_post( $course_id );
 		$wp_query->post        = $post;
-		$wp_query->is_singular   = true;
+		$wp_query->is_singular = true;
 		$wp_query->in_the_loop = false;
-		echo is_singular( 'course' );
+
 		return $course_data;
 	}
 
@@ -48,13 +49,13 @@ class Sensei_Guest_User_Cleaner_Test extends WP_UnitTestCase {
 		/* Arrange */
 		[ 'course_id' => $course_id ] = $this->setup_course();
 
-		$_POST['course_start']                           = 1;
-		$_POST[ 'woothemes_sensei_start_course_noonce' ] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
+		$_POST['course_start']                         = 1;
+		$_POST['woothemes_sensei_start_course_noonce'] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
 		do_action( 'wp' );
 		$this->logout();
 
-		$_POST['course_start']                           = 1;
-		$_POST[ 'woothemes_sensei_start_course_noonce' ] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
+		$_POST['course_start']                         = 1;
+		$_POST['woothemes_sensei_start_course_noonce'] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
 		do_action( 'wp' );
 
 		$user_count_before = Sensei_Utils::get_user_count_for_role( 'guest_student' );
@@ -66,7 +67,7 @@ class Sensei_Guest_User_Cleaner_Test extends WP_UnitTestCase {
 			'user_id' => get_current_user_id(),
 			'type_in' => [ 'sensei_lesson_status', 'sensei_course_status' ],
 			'status'  => 'any',
-			'fields'  => 'ids'
+			'fields'  => 'ids',
 		];
 
 		$activity = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
@@ -77,7 +78,6 @@ class Sensei_Guest_User_Cleaner_Test extends WP_UnitTestCase {
 				'comment_date' => '2022-01-02 00:00:01',
 			]
 		);
-
 
 		/* Act */
 		do_action( 'sensei_remove_inactive_guest_users' );


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/6243

### Changes proposed in this Pull Request

* Added cleaner to daily run and clean guest users who have not been active in a week

### Testing instructions

- Create an Open Access course with lessons, publish it
- Set your time to more than a week back
- Open the course in an incognito window, take the course, complete some lessons, close the incognito window
- Take note of the new user that was created
- Now fix your time to actual value. Open a new incognito window, take course, complete lessons, close window.
- Take note of the new user that was created
- Now install the plugin **Wp Control**
- Go To tools -> Cron events; find event sensei_remove_inactive_guest_users, click on Run Now
- Make sure the first user got removed and the second user is still there
- If you face any issues setting your time back, go to db and change wp_comments of the first users to have a date more than a week old
