### PR TITLE
Add support to the  "Preview in new tab" editor feature

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,6 @@
 name: E2E
 on:
     pull_request:
-        branches:
-            - feature/*
     workflow_call:
 env:
     CI: true

--- a/tests/e2e-playwright/pages/admin/post-type/index.ts
+++ b/tests/e2e-playwright/pages/admin/post-type/index.ts
@@ -55,12 +55,6 @@ export default class PostType {
 		return new QueryLoop( this.queryLoopPatternSelection, this.page );
 	}
 
-	async getPreviewURL(): Promise< string > {
-		const params = new URL( await this.page.url() ).searchParams;
-
-		return `/?page_id=${ params.get( 'post' ) }`;
-	}
-
 	async goToPreview(): Promise< Page > {
 		await this.page.locator( 'button:has-text("Preview")' ).first().click();
 
@@ -70,6 +64,14 @@ export default class PostType {
 		] );
 		await previewPage.waitForLoadState();
 		return previewPage;
+	}
+
+	async viewPage(): Promise< Page > {
+		await this.page
+			.locator( '[aria-label="Editor publish"]' )
+			.locator( 'text=View Page' )
+			.click();
+		return this.page;
 	}
 
 	async publish(): Promise< void > {

--- a/tests/e2e-playwright/pages/admin/post-type/index.ts
+++ b/tests/e2e-playwright/pages/admin/post-type/index.ts
@@ -61,26 +61,45 @@ export default class PostType {
 		return `/?page_id=${ params.get( 'post' ) }`;
 	}
 
-	async publish(): Promise< Response > {
+	async goToPreview(): Promise< Page > {
+		await this.page.locator( 'button:has-text("Preview")' ).first().click();
+
+		const [ previewPage ] = await Promise.all( [
+			this.page.waitForEvent( 'popup' ),
+			this.page.locator( 'text=Preview in new tab' ).click(),
+		] );
+		await previewPage.waitForLoadState();
+		return previewPage;
+	}
+
+	async publish(): Promise< void > {
 		await this.page
 			.locator( '[aria-label="Editor top bar"] >> text=Publish' )
 			.click();
-		await this.page
+
+		return this.page
 			.locator( '[aria-label="Editor publish"] >> text=Publish' )
 			.first()
 			.click();
+	}
 
-		return this.page.waitForNavigation( { url: '**/post.php?post=**' } );
+	async submitForPreview(): Promise< void > {
+		await this.page
+			.locator( '[aria-label="Editor top bar"] >> text=Publish' )
+			.click();
+
+		return this.page
+			.locator(
+				'[aria-label="Editor publish"] >> text=Submit For Review'
+			)
+			.first()
+			.click();
 	}
 
 	async goToPostTypeListingPage(): Promise< Response > {
 		return this.page.goto(
 			`/wp-admin/edit.php?post_type=${ this.postType }`
 		);
-	}
-
-	async gotToPreviewPage(): Promise< Response > {
-		return this.page.goto( await this.getPreviewURL() );
 	}
 }
 

--- a/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
+++ b/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
@@ -56,17 +56,17 @@ describe( 'Courses List Block', () => {
 		await courseList.choosePattern( 'Courses displayed in a grid' );
 
 		await postTypePage.publish();
-		const preview = await postTypePage.goToPreview();
+		const published = await postTypePage.viewPage();
 
 		for ( const course of courses ) {
 			await expect(
-				preview.locator( `role=heading[name=${ course.title }]` )
+				published.locator( `role=heading[name=${ course.title }]` )
 			).toBeVisible();
 			await expect(
-				preview.locator( `text='${ course.excerpt }'` )
+				published.locator( `text='${ course.excerpt }'` )
 			).toBeVisible();
 			await expect(
-				preview.locator( `role=link[name='${ course.category }']` )
+				published.locator( `role=link[name='${ course.category }']` )
 			).toBeVisible();
 		}
 

--- a/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
+++ b/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
@@ -56,17 +56,17 @@ describe( 'Courses List Block', () => {
 		await courseList.choosePattern( 'Courses displayed in a grid' );
 
 		await postTypePage.publish();
-		await postTypePage.gotToPreviewPage();
+		const preview = await postTypePage.goToPreview();
 
 		for ( const course of courses ) {
 			await expect(
-				page.locator( `role=heading[name=${ course.title }]` )
+				preview.locator( `role=heading[name=${ course.title }]` )
 			).toBeVisible();
 			await expect(
-				page.locator( `text='${ course.excerpt }'` )
+				preview.locator( `text='${ course.excerpt }'` )
 			).toBeVisible();
 			await expect(
-				page.locator( `role=link[name='${ course.category }']` )
+				preview.locator( `role=link[name='${ course.category }']` )
 			).toBeVisible();
 		}
 

--- a/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
+++ b/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
@@ -50,21 +50,19 @@ describe.parallel( 'Create Courses', () => {
 			'Lesson 1 in Module 1'
 		);
 
-		// Publish the course (publish method doesn't work as there is no redirect at this point).
-		await coursesPage.publishButton.click();
-		await coursesPage.confirmPublishButton.click();
+		await coursesPage.submitForPreview();
 
-		await coursesPage.viewPreviewLink.click();
+		const previewPage = await coursesPage.goToPreview();
 
 		await expect(
-			page.locator( 'h1:has-text("Test Create Course")' )
+			previewPage.locator( 'h1:has-text("Test Create Course")' )
 		).toBeVisible();
-		await expect( page.locator( 'text="Module 1"' ) ).toBeVisible();
+		await expect( previewPage.locator( 'text="Module 1"' ) ).toBeVisible();
 		await expect(
-			page.locator( 'text="Lesson 1 in Module 1"' )
+			previewPage.locator( 'text="Lesson 1 in Module 1"' )
 		).toBeVisible();
 		await expect(
-			page.locator( 'button:has-text("Take Course")' )
+			previewPage.locator( 'button:has-text("Take Course")' )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Fixes #6308 

### Changes proposed in this Pull Request
* Add a method to go to the preview page in a new method
* Enable the CI to run on every PR.
* Add `submitForPreview` method() to publish post that requires approval
* Add `viewPage`  to see published pages

### Testing instructions
- Run `npm run test:e2e:debug  /tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts` 
- Check if the preview was opened in a new tab
- Check if the update spec files are passing.

