### PR TITLE
Remove the "source" property from events data

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -92,13 +92,6 @@ class Sensei_Usage_Tracking_Data {
 		];
 
 		/**
-		 * Filter the event logging source.
-		 *
-		 * @param string The source (defaults to "unknown").
-		 */
-		$base_fields['source'] = apply_filters( 'sensei_event_logging_source', 'unknown' );
-
-		/**
 		 * Filter the fields that should be sent with every event that is logged.
 		 *
 		 * @param array $base_fields The default base fields.

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -24,9 +24,6 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		// Add filter for settings.
 		add_filter( 'sensei_settings_fields', array( $this, 'add_setting_field' ) );
 
-		// Init event logging source filters.
-		add_action( 'init', [ $this, 'init_event_logging_sources' ] );
-
 		// Log when Sensei is updated.
 		add_action( 'sensei_log_update', [ $this, 'log_update' ] );
 	}
@@ -39,10 +36,13 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * Initialize filters for event logging sources.
 	 *
 	 * @since 2.1.0
+	 * @deprecated $$next-version$$
 	 *
 	 * @access private
 	 */
 	public function init_event_logging_sources() {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		add_filter( 'sensei_event_logging_source', [ $this, 'detect_event_logging_source' ], 1 );
 		add_filter( 'template_redirect', [ $this, 'set_event_logging_source_frontend' ] );
 		add_filter( 'import_start', [ $this, 'set_event_logging_source_data_import' ] );
@@ -168,6 +168,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * Attempt to detect the source of the event logging request.
 	 *
 	 * @since 2.1.0
+	 * @deprecated $$next-version$$
 	 *
 	 * @access private
 	 *
@@ -175,6 +176,8 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * @return string         The detected source.
 	 */
 	public static function detect_event_logging_source( $source ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			return 'rest-api';
 		}
@@ -191,10 +194,13 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * Set the event logging source to `frontend`.
 	 *
 	 * @since 2.1.0
+	 * @deprecated $$next-version$$
 	 *
 	 * @access private
 	 */
 	public function set_event_logging_source_frontend() {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		add_filter(
 			'sensei_event_logging_source',
 			function( $fields ) {
@@ -207,10 +213,13 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * Set the event logging source to `data-import`.
 	 *
 	 * @since 2.1.0
+	 * @deprecated $$next-version$$
 	 *
 	 * @access private
 	 */
 	public function set_event_logging_source_data_import() {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		add_filter(
 			'sensei_event_logging_source',
 			function( $fields ) {


### PR DESCRIPTION
Fixes #6223

### Changes proposed in this Pull Request

* Removed the "source" property sent with all Tracks events because it's no longer needed.

### Testing instructions

* Enable usage tracking from Sensei LMS -> Settings -> Enable usage tracking.
* You can use the following code to trigger an event:
```php
add_action( 'template_redirect', function() {
	if ( Sensei()->usage_tracking->is_tracking_enabled() ) {
		sensei_log_event( 'test', [ 'type' => 'test' ] );
		exit( 'Event sent.' );
	} else {
		exit('Oops, tracking is disabled...');
	}
} );
```
* Open any page on the front end to execute the above code.
* After a few minutes, check [tracks](https://mc.a8c.com/tracks/live/?eventname=sensei_test&user=sensei.test&useragent=). Set the Event Name to `sensei_test` and the Username to your testing website domain. You may have to check the `Filter for only rejected events` to see the event as well.
* When you find your tracks entry, make sure the `source` property is missing.

Deprecated Code
* `Sensei_Usage_Tracking::init_event_logging_sources`
* `Sensei_Usage_Tracking::detect_event_logging_source`
* `Sensei_Usage_Tracking::set_event_logging_source_frontend`
* `Sensei_Usage_Tracking::set_event_logging_source_data_import`