### PR TITLE
Allow preview users to take unpublished course

### DIFF
--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -109,7 +109,7 @@ class Sensei_Course_Outline_Block {
 	/**
 	 * Extract attributes from module block.
 	 *
-	 * @param array $attributes
+	 * @param array $attributes Block attributes.
 	 *
 	 * @access private
 	 * @return string
@@ -125,7 +125,7 @@ class Sensei_Course_Outline_Block {
 	/**
 	 * Extract attributes from module block.
 	 *
-	 * @param array $attributes
+	 * @param array $attributes Block attributes.
 	 *
 	 * @access private
 	 * @return string
@@ -166,7 +166,7 @@ class Sensei_Course_Outline_Block {
 
 		$context    = 'view';
 		$attributes = $this->block_attributes['course'];
-		$is_preview = is_preview() && $this->can_current_user_edit_course( $post->ID );
+		$is_preview = is_preview() && Sensei_Course::can_current_user_edit_course( $post->ID );
 
 		if ( $is_preview ) {
 			$context = 'edit';
@@ -214,17 +214,6 @@ class Sensei_Course_Outline_Block {
 			}
 		}
 		return false;
-	}
-
-	/**
-	 * Check user permission for editing a course.
-	 *
-	 * @param int $course_id Course post ID.
-	 *
-	 * @return bool Whether the user can edit the course.
-	 */
-	private function can_current_user_edit_course( $course_id ) {
-		return current_user_can( get_post_type_object( 'course' )->cap->edit_post, $course_id );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -152,6 +152,17 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Check user permission for editing a course.
+	 *
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return bool Whether the user can edit the course.
+	 */
+	public static function can_current_user_edit_course( $course_id ) {
+		return current_user_can( get_post_type_object( 'course' )->cap->edit_post, $course_id );
+	}
+
+	/**
 	 * Highlight the menu item for the course pages.
 	 *
 	 * @deprecated 4.8.0

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -104,7 +104,6 @@ class Sensei_Preview_User {
 
 		$preview_user_id = $this->create_preview_user( $course_id );
 		$this->set_preview_user( $preview_user_id );
-		Sensei()->frontend->manually_enrol_learner( $preview_user_id, $course_id );
 
 		wp_safe_redirect( remove_query_arg( self::SWITCH_ON_ACTION ) );
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -188,8 +188,13 @@ function sensei_get_modules_and_lessons( $course_id ) {
  * @return array Other lessons not part of a module
  */
 function sensei_get_other_lessons( $course_id, $lesson_ids ) {
+
+	global $wp_query;
+	$course_lessons_post_status = isset( $wp_query ) && $wp_query->is_preview() ? 'all' : 'publish';
+
 	$args = array(
 		'post_type'        => 'lesson',
+		'post_status'      => $course_lessons_post_status,
 		'posts_per_page'   => -1,
 		'suppress_filters' => 0,
 		'meta_key'         => '_order_' . $course_id,


### PR DESCRIPTION
Fixes #6282

### Changes proposed in this Pull Request

* Treat the preview user as enrolled
* Add permission caps via a filter so they can see draft post content
* Hide some notices about draft courses
* Tweak some queries so they work in preview context
* Also add filter to make sure draft lessons are listed/counted
* Add permission check on who can switch to a preview user

### Testing instructions

* Create a new course or switch an existing one to draft, including its lessons. Add some content to the lessons.
* Open it on the frontend (eg via the Preview link in the editor)
* Click 'Preview as Student'
* Make sure course and lesson content is visible as a preview user
* Make sure complete lesson works, course can be completed
* Check that course outline, progress bar, next/preview lesson links are showing up correctly
* Check with and without learning mode
--
* Add a quiz to a lesson
* Also take this as a preview student
* Open the grading screen in admin and grade the preview user's quiz submission
* Make sure this all works as expected, as with a real student
* **Note:** there is some issue with the View Quiz block button, it redirects to the homepage, even for the teacher. So this only works in Learning Mode, or by opening the quiz page directly (`/?post_type=quiz&p= { lesson_id + 1 }`)
