### PR TITLE
Upgrade playwright version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@babel/runtime": "7.17.9",
         "@es-joy/jsdoccomment": "0.8.0",
         "@lifeomic/attempt": "3.0.3",
-        "@playwright/test": "1.25.0",
+        "@playwright/test": "1.28.0",
         "@svgr/webpack": "6.1.2",
         "@testing-library/dom": "7.30.3",
         "@testing-library/jest-dom": "5.11.10",
@@ -6409,13 +6409,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.0.tgz",
-      "integrity": "sha512-j4EZhTTQI3dBeWblE21EV//swwmBtOpIrLdOIJIRv4uqsLdHgBg1z+JtTg+AeC5o2bAXIE26kDNW5A0TimG8Bg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
+      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.25.0"
+        "playwright-core": "1.28.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -32076,9 +32076,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.0.tgz",
-      "integrity": "sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
+      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -44038,13 +44038,13 @@
       }
     },
     "@playwright/test": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.0.tgz",
-      "integrity": "sha512-j4EZhTTQI3dBeWblE21EV//swwmBtOpIrLdOIJIRv4uqsLdHgBg1z+JtTg+AeC5o2bAXIE26kDNW5A0TimG8Bg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
+      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.25.0"
+        "playwright-core": "1.28.0"
       }
     },
     "@polka/url": {
@@ -62462,9 +62462,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.0.tgz",
-      "integrity": "sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
+      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
       "dev": true
     },
     "please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/runtime": "7.17.9",
     "@es-joy/jsdoccomment": "0.8.0",
     "@lifeomic/attempt": "3.0.3",
-    "@playwright/test": "1.25.0",
+    "@playwright/test": "1.28.0",
     "@svgr/webpack": "6.1.2",
     "@testing-library/dom": "7.30.3",
     "@testing-library/jest-dom": "5.11.10",


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Upgrade playwright from 1.25 -> 1.28

### Testing instructions
- Run `npm install` 
- Run  `npx playwright install` --> I think the npm install will warn about 
- Run all e2e tests in your local env;
- Check if the pipeline is green
