### PR TITLE
Run e2e tests using the course theme

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,5 @@
 {
 	"core": null,
-	"plugins": [ "." ]
+	"plugins": [ "." ],
+	"themes": ["Automattic/course#trunk"]
 }

--- a/tests/e2e-playwright/helpers/database.ts
+++ b/tests/e2e-playwright/helpers/database.ts
@@ -23,7 +23,11 @@ export const cleanAll = (): Buffer => {
  * - Set permalink structure.
  */
 export const configureSite = (): void => {
-	[ `wp rewrite structure /%postname%/`, `wp rewrite flush` ].forEach( cli );
+	[
+		`wp rewrite structure /%postname%/`,
+		`wp rewrite flush`,
+		`wp theme activate course`,
+	].forEach( cli );
 };
 
 /**


### PR DESCRIPTION
Fixes #6317

### Changes proposed in this Pull Request

* Run the e2e tests using the new course theme.

 

### Testing instructions
* Run `npm run wp-env start` to reload the docker env.
* Run. `npm run test:e2e:debug`  to see the magic happening