### PR TITLE
Stop guest users and guest role from appearing

### DIFF
--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -23,14 +23,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Guest_User {
 
 	/**
-	 * Keeps a reference to the Guest Student role object
+	 * Name of the Role for Guest Users.
 	 *
-	 * @access protected
 	 * @since $$next-version$$
 	 *
 	 * @var string
 	 */
-	protected $guest_student_role = 'guest_student';
+	const ROLE = 'guest_student';
+
+	/**
+	 * Guest user login name prefix.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const LOGIN_PREFIX = 'sensei_guest_';
 
 	/**
 	 * List of actions to create a guest user for if the course is open access.
@@ -185,7 +193,7 @@ class Sensei_Guest_User {
 	 *  @param array $views List of tabs.
 	 */
 	public static function filter_out_guest_user_tab_from_users_list( $views ) {
-		unset( $views['guest_student'] );
+		unset( $views[ self::ROLE ] );
 		return $views;
 	}
 
@@ -198,7 +206,7 @@ class Sensei_Guest_User {
 	 *  @param array $roles List of roles.
 	 */
 	public static function filter_out_guest_student_role( $roles ) {
-		unset( $roles['guest_student'] );
+		unset( $roles[ self::ROLE ] );
 		return $roles;
 	}
 
@@ -215,7 +223,7 @@ class Sensei_Guest_User {
 
 		$query->query_where = str_replace(
 			'WHERE 1=1',
-			"WHERE 1=1 AND {$wpdb->users}.user_login NOT LIKE 'sensei_guest_%'",
+			"WHERE 1=1 AND {$wpdb->users}.user_login NOT LIKE '" . self::LOGIN_PREFIX . "%'",
 			$query->query_where
 		);
 	}
@@ -255,7 +263,7 @@ class Sensei_Guest_User {
 	 */
 	private function is_current_user_guest() {
 		$user = wp_get_current_user();
-		return in_array( $this->guest_student_role, (array) $user->roles, true );
+		return in_array( self::ROLE, (array) $user->roles, true );
 	}
 	/**
 	 * Recreate nonce after logging in user invalidates existing one.
@@ -276,15 +284,15 @@ class Sensei_Guest_User {
 	 * @return int
 	 */
 	private function create_guest_user() {
-		$user_count = Sensei_Utils::get_user_count_for_role( $this->guest_student_role ) + 1;
-		$user_name  = 'sensei_guest_' . wp_rand( 10000000, 99999999 ) . '_' . $user_count;
+		$user_count = Sensei_Utils::get_user_count_for_role( self::ROLE ) + 1;
+		$user_name  = self::LOGIN_PREFIX . wp_rand( 10000000, 99999999 ) . '_' . $user_count;
 		return wp_insert_user(
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,
 				'user_email'   => $user_name . '@senseiguest.senseiguest',
 				'display_name' => 'Guest Student ' . str_pad( $user_count, 3, '0', STR_PAD_LEFT ),
-				'role'         => $this->guest_student_role,
+				'role'         => self::ROLE,
 			]
 		);
 	}
@@ -326,12 +334,12 @@ class Sensei_Guest_User {
 	 */
 	private function create_guest_student_role_if_not_exists() {
 		// Check if the Guest Student role exists.
-		$guest_role = get_role( $this->guest_student_role );
+		$guest_role = get_role( self::ROLE );
 
 		// If Guest Student is not a valid WordPress role create it.
 		if ( ! is_a( $guest_role, 'WP_Role' ) ) {
 			// Create the role.
-			add_role( $this->guest_student_role, __( 'Guest Student', 'sensei-lms' ) );
+			add_role( self::ROLE, __( 'Guest Student', 'sensei-lms' ) );
 		}
 	}
 

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -170,9 +170,23 @@ class Sensei_Guest_User {
 	 * @since $$next-version$$
 	 */
 	public static function init_guest_user_admin() {
-		add_filter( 'editable_roles', [ static::class, 'remove_guest_student_role' ], 11 );
+		add_filter( 'editable_roles', [ static::class, 'filter_out_guest_student_role' ], 11 );
+		add_filter( 'views_users', [ static::class, 'filter_out_guest_user_tab_from_users_list' ] );
 
 		add_action( 'pre_user_query', [ static::class, 'filter_out_guest_users' ], 11 );
+	}
+
+	/**
+	 * Filter out Guest Student role tab from Users page in Settings.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 *
+	 *  @param array $views List of tabs.
+	 */
+	public static function filter_out_guest_user_tab_from_users_list( $views ) {
+		unset( $views['guest_student'] );
+		return $views;
 	}
 
 	/**
@@ -183,7 +197,7 @@ class Sensei_Guest_User {
 	 *
 	 *  @param array $roles List of roles.
 	 */
-	public static function remove_guest_student_role( $roles ) {
+	public static function filter_out_guest_student_role( $roles ) {
 		unset( $roles['guest_student'] );
 		return $roles;
 	}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -525,6 +525,8 @@ class Sensei_Main {
 			new Sensei_Exit_Survey();
 
 			Sensei_No_Users_Table_Relationship::instance()->init();
+
+			Sensei_Guest_User::init_guest_user_admin();
 		} else {
 
 			// Load Frontend Class

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -114,7 +114,13 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 		];
 		$result1   = ( new WP_User_Query( $user_args ) )->get_results();
 
-		$this->factory->user->create_many( 2, [ 'role' => 'guest_student' ] );
+		$this->factory->user->create_many(
+			2,
+			[
+				'user_login' => 'sensei_guest_user',
+				'role'       => 'guest_student',
+			],
+		);
 		Sensei_Guest_User::init_guest_user_admin();
 
 		/* Act */

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -91,4 +91,37 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	}
 
+	public function testRolesList_WhenFetched_DoesNotContainGuestStudentRole() {
+		/* Arrange */
+		$this->factory->user->create( [ 'role' => 'guest_student' ] );
+
+		$all_roles = get_editable_roles();
+
+		Sensei_Guest_User::init_guest_user_admin();
+
+		/* Act */
+		$all_roles_except_guest = get_editable_roles();
+
+		/* Assert */
+		$this->assertArrayHasKey( 'guest_student', $all_roles );
+		$this->assertArrayNotHasKey( 'guest_student', $all_roles_except_guest );
+	}
+
+	public function testUserList_WhenFetched_DoesNotContainGuestUsers() {
+		/* Arrange */
+		$user_args = [
+			'fields' => 'ID',
+		];
+		$result1   = ( new WP_User_Query( $user_args ) )->get_results();
+
+		$this->factory->user->create_many( 2, [ 'role' => 'guest_student' ] );
+		Sensei_Guest_User::init_guest_user_admin();
+
+		/* Act */
+		$result2 = ( new WP_User_Query( $user_args ) )->get_results();
+
+		/* Assert */
+		$this->assertEquals( count( $result1 ), count( $result2 ) );
+	}
+
 }

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -93,7 +93,7 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testRolesList_WhenFetched_DoesNotContainGuestStudentRole() {
 		/* Arrange */
-		$this->factory->user->create( [ 'role' => 'guest_student' ] );
+		$this->factory->user->create( [ 'role' => Sensei_Guest_User::ROLE ] );
 
 		$all_roles = get_editable_roles();
 
@@ -103,8 +103,8 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 		$all_roles_except_guest = get_editable_roles();
 
 		/* Assert */
-		$this->assertArrayHasKey( 'guest_student', $all_roles );
-		$this->assertArrayNotHasKey( 'guest_student', $all_roles_except_guest );
+		$this->assertArrayHasKey( Sensei_Guest_User::ROLE, $all_roles );
+		$this->assertArrayNotHasKey( Sensei_Guest_User::ROLE, $all_roles_except_guest );
 	}
 
 	public function testUserList_WhenFetched_DoesNotContainGuestUsers() {
@@ -117,8 +117,8 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 		$this->factory->user->create_many(
 			2,
 			[
-				'user_login' => 'sensei_guest_user',
-				'role'       => 'guest_student',
+				'user_login' => Sensei_Guest_User::LOGIN_PREFIX . 'user',
+				'role'       => Sensei_Guest_User::ROLE,
 			]
 		);
 		Sensei_Guest_User::init_guest_user_admin();

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -119,7 +119,7 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 			[
 				'user_login' => 'sensei_guest_user',
 				'role'       => 'guest_student',
-			],
+			]
 		);
 		Sensei_Guest_User::init_guest_user_admin();
 

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -60,7 +60,7 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( is_user_logged_in(), $open_access );
 		if ( $open_access ) {
-			$this->assertRegexp( '/^guest_user_.*$/', wp_get_current_user()->user_login );
+			$this->assertRegexp( '/^sensei_guest_.*$/', wp_get_current_user()->user_login );
 			$this->assertRegexp( '/^Guest Student 00.*$/', wp_get_current_user()->display_name );
 		}
 


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/6245

### Changes proposed in this Pull Request

- Filtered out Guest Student role from Role selection dropdown in settings
- Filtered out Guest Students from user list

### Testing instructions

- Create a Course, mark it as Open Access, publish it
- Take the course as a logged out user
- Now go to wp-admin->All Users. Select a user. In the role dropdown, make sure you don't see "Guest Student" role
- Now go to wp-admin->General->**New User Default Role**, make sure this dropdown also does not have the role
- Now go to All Users again, make sure you don't see any user with Guest Student Role