### PR TITLE
Log when reports are run

### DIFF
--- a/tests/unit-tests/test-class-sensei-analysis.php
+++ b/tests/unit-tests/test-class-sensei-analysis.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\MockObject\MockObject;
+
 /**
  * Sensei Analysis Unit Tests
  *
@@ -9,6 +11,23 @@ class Sensei_Analysis_Test extends WP_UnitTestCase {
 	use Sensei_Test_Login_Helpers;
 
 	private static $initial_hook_suffix;
+
+	/**
+	 * Setup method.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Sensei_Test_Events::reset();
+
+		// Disable `wp_die`.
+		add_filter(
+			'wp_die_handler',
+			function() {
+				return '__return_false';
+			}
+		);
+	}
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -76,5 +95,182 @@ class Sensei_Analysis_Test extends WP_UnitTestCase {
 		/* Assert */
 		$expected = '<h1><a href="http://example.org/wp-admin/admin.php?page=sensei_reports">Reports</a>&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="http://example.org/wp-admin/admin.php?page=sensei_reports&#038;user_id=1">admin</a></span></h1>';
 		$this->assertEquals( $expected, $actual );
+	}
+
+	public function testAnalysisPage_WhenNoView_LogsUsersEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'users', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenUsersView_LogsUsersEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'view' => 'students',
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'users', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenCoursesView_LogsCoursesEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'view' => 'courses',
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'courses', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenLessonsViewWithNoCourseSelected_DoesntLogEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'view' => 'lessons',
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertEmpty( $events );
+	}
+
+	public function testAnalysisPage_WhenLessonsViewWithCourseSelected_LogsLessonsEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'view'          => 'lessons',
+			'course_filter' => 1,
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'lessons', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenCourseLessonUsersView_LogsCourseLessonUsersEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'lesson_id' => 1,
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'course-lesson-users', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenCourseUsersView_LogsCourseUsersEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'view'      => 'user',
+			'course_id' => 1,
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'course-users', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenUserCourseLessonsView_LogsUserCourseLessonsEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'course_id' => 1,
+			'user_id'   => 1,
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'user-course-lessons', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenCourseLessonsView_LogsCourseLessonsEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'course_id' => 1,
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'course-lessons', $events[0]['url_args']['view'] );
+	}
+
+	public function testAnalysisPage_WhenUserCoursesView_LogsUserCoursesEvent() {
+		/* Arrange */
+		$analysis_mock = $this->createMockWithExcludedMethod( Sensei_Analysis::class, 'analysis_page' );
+
+		$_GET = [
+			'user_id' => 1,
+		];
+
+		/* Act */
+		$analysis_mock->analysis_page();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_analysis_view' );
+
+		/* Assert */
+		$this->assertSame( 'user-courses', $events[0]['url_args']['view'] );
+	}
+
+	/**
+	 * Returns a partial mock object for the specified class
+	 * with all of its methods mocked but one.
+	 *
+	 * @param string $class_name The class to mock.
+	 * @param string $method The method to skip.
+	 *
+	 * @return MockObject
+	 */
+	private function createMockWithExcludedMethod( string $class_name, string $method ): MockObject {
+		$class_methods = get_class_methods( $class_name );
+
+		return $this->createPartialMock(
+			$class_name,
+			array_diff( $class_methods, [ $method ] )
+		);
 	}
 }


### PR DESCRIPTION
Fixes #6255

### Changes proposed in this Pull Request

* Send event logs when a user runs any report.

### Testing instructions

* Go to Sensei -> Reports.
* Try each case below, and ensure that an event is logged with the correct properties.

---

* Reports (Students)
  * view: users
* Reports (Courses):
  * view: courses
* Reports (Lessons -> Select a course):
  * view: lessons - Triggered only if a course is selected. No event sent otherwise.
* Reports > Username:
  * view: user-courses
* Reports > Username > Username > Course Name:
  * view: user-course-lessons
* Reports > Course Name (Lessons):
  * view: course-lessons
* Reports > Course Name (Learners):
  * view: course-users
* Reports > Course Name > Lesson Name:
  * view: ~~lesson-learners~~ course-lesson-users - The view value is corrected to make it consistent with the [report download event](https://github.com/Automattic/sensei/blob/7138226ee94a86b8683b2564af01efff0167de47/includes/class-sensei-analysis.php#L758).