### PR TITLE
Ensure all strings in block pattern templates are translated and escaped

### DIFF
--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -76,15 +76,15 @@ class Sensei_Course_List_Block_Patterns {
 												<div class="wp-block-column" style="flex-basis:33.33%">
 													<!-- wp:sensei-lms/course-actions -->
 														<!-- wp:sensei-lms/button-take-course {"align":"right"} -->
-															<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link">Start Course</button></div>
+															<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link">' . esc_html__( 'Start Course', 'sensei-lms' ) . '</button></div>
 														<!-- /wp:sensei-lms/button-take-course -->
 
 														<!-- wp:sensei-lms/button-continue-course {"align":"right"} -->
-															<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Continue</a></div>
+															<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">' . esc_html__( 'Continue', 'sensei-lms' ) . '</a></div>
 														<!-- /wp:sensei-lms/button-continue-course -->
 
 														<!-- wp:sensei-lms/button-view-results {"align":"right","className":"is-style-default"} -->
-															<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Visit Results</a></div>
+															<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">' . esc_html__( 'Visit Results', 'sensei-lms' ) . '</a></div>
 														<!-- /wp:sensei-lms/button-view-results -->
 													<!-- /wp:sensei-lms/course-actions -->
 												</div>
@@ -134,19 +134,19 @@ class Sensei_Course_List_Block_Patterns {
 										<!-- wp:sensei-lms/course-actions {"lock":{"move": true}} -->
 											<!-- wp:sensei-lms/button-take-course {"align":"full"} -->
 												<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
-													<button class="wp-block-button__link">Start Course</button>
+													<button class="wp-block-button__link">' . esc_html__( 'Start Course', 'sensei-lms' ) . '</button>
 												</div>
 											<!-- /wp:sensei-lms/button-take-course -->
 
 											<!-- wp:sensei-lms/button-continue-course {"align":"full"} -->
 												<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
-													<a class="wp-block-button__link">Continue</a>
+													<a class="wp-block-button__link">' . esc_html__( 'Continue', 'sensei-lms' ) . '</a>
 												</div>
 											<!-- /wp:sensei-lms/button-continue-course -->
 
 											<!-- wp:sensei-lms/button-view-results {"align":"full","className":"is-style-default"} -->
 												<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
-													<a class="wp-block-button__link">Visit Results</a>
+													<a class="wp-block-button__link">' . esc_html__( 'Visit Results', 'sensei-lms' ) . '</a>
 												</div>
 											<!-- /wp:sensei-lms/button-view-results -->
 										<!-- /wp:sensei-lms/course-actions -->
@@ -166,11 +166,11 @@ class Sensei_Course_List_Block_Patterns {
 					'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"5rem","right":"20px","left":"20px","bottom":"100px"},"blockGap":"0px"},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","className":"sensei-course-theme-course-list-pattern","layout":{"type":"constrained","contentSize":""}} -->
 						<div class="wp-block-group alignfull sensei-course-theme-course-list-pattern has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:5rem;padding-right:20px;padding-bottom:100px;padding-left:20px"><!-- wp:group {"style":{"border":{"left":{"color":"var:preset|color|background","width":"1px"}},"spacing":{"padding":{"left":"20px"},"margin":{"bottom":"40px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 						<div class="wp-block-group" style="border-left-color:var(--wp--preset--color--background);border-left-width:1px;margin-bottom:40px;padding-left:20px"><!-- wp:heading {"level":2,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"},"spacing":{"padding":{"top":"0px"}}},"textColor":"background","className":"sensei-pattern-heading","fontSize":"medium"} -->
-						<h2 class="sensei-pattern-heading has-background-color has-text-color has-medium-font-size" style="padding-top:0px;line-height:1;text-transform:uppercase"><strong>' . __( 'Course list', 'sensei-lms' ) . '</strong></h2>
+						<h2 class="sensei-pattern-heading has-background-color has-text-color has-medium-font-size" style="padding-top:0px;line-height:1;text-transform:uppercase"><strong>' . esc_html__( 'Course list', 'sensei-lms' ) . '</strong></h2>
 						<!-- /wp:heading -->
 
 						<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"textColor":"background","className":"sensei-course-list-all-courses-link"} -->
-						<p class="sensei-course-list-all-courses-link has-background-color has-text-color has-link-color"><a href="' . Sensei_Course::get_courses_page_url() . '" target="_blank" rel="noreferrer noopener">' . __( 'Explore all courses', 'sensei-lms' ) . '</a></p>
+						<p class="sensei-course-list-all-courses-link has-background-color has-text-color has-link-color"><a href="' . Sensei_Course::get_courses_page_url() . '" target="_blank" rel="noreferrer noopener">' . esc_html__( 'Explore all courses', 'sensei-lms' ) . '</a></p>
 						<!-- /wp:paragraph --></div>
 						<!-- /wp:group -->
 
@@ -191,15 +191,15 @@ class Sensei_Course_List_Block_Patterns {
 
 						<!-- wp:sensei-lms/course-actions {"lock":{"move":false,"remove":false}} -->
 						<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":8,"backgroundColor":"background","textColor":"primary"} -->
-						<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . __( 'Start', 'sensei-lms' ) . '</button></div>
+						<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . esc_html__( 'Start', 'sensei-lms' ) . '</button></div>
 						<!-- /wp:sensei-lms/button-take-course -->
 
 						<!-- wp:sensei-lms/button-continue-course {"align":"full","borderRadius":8,"backgroundColor":"background","textColor":"primary"} -->
-						<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . __( 'Continue', 'sensei-lms' ) . '</a></div>
+						<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . esc_html__( 'Continue', 'sensei-lms' ) . '</a></div>
 						<!-- /wp:sensei-lms/button-continue-course -->
 
 						<!-- wp:sensei-lms/button-view-results {"align":"full","borderRadius":8,"className":"is-style-default","backgroundColor":"background","textColor":"primary"} -->
-						<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . __( 'Results', 'sensei-lms' ) . '</a></div>
+						<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . esc_html__( 'Results', 'sensei-lms' ) . '</a></div>
 						<!-- /wp:sensei-lms/button-view-results -->
 						<!-- /wp:sensei-lms/course-actions --></div>
 						<!-- /wp:group -->
@@ -214,11 +214,11 @@ class Sensei_Course_List_Block_Patterns {
 					'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"5rem","right":"20px","left":"20px","bottom":"100px"},"blockGap":"0px"},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","className":"sensei-course-theme-course-list-pattern","layout":{"type":"constrained","contentSize":""}} -->
 						<div class="wp-block-group alignfull sensei-course-theme-course-list-pattern has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:5rem;padding-right:20px;padding-bottom:100px;padding-left:20px"><!-- wp:group {"style":{"border":{"left":{"color":"var:preset|color|background","width":"1px"}},"spacing":{"padding":{"left":"20px"},"margin":{"bottom":"40px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 						<div class="wp-block-group" style="border-left-color:var(--wp--preset--color--background);border-left-width:1px;margin-bottom:40px;padding-left:20px"><!-- wp:heading {"level":2,"style":{"typography":{"textTransform":"uppercase","lineHeight":"1"},"spacing":{"padding":{"top":"0px"}}},"textColor":"background","className":"sensei-pattern-heading","fontSize":"medium"} -->
-						<h2 class="sensei-pattern-heading has-background-color has-text-color has-medium-font-size" style="padding-top:0px;line-height:1;text-transform:uppercase"><strong>' . __( 'Course list', 'sensei-lms' ) . '</strong></h2>
+						<h2 class="sensei-pattern-heading has-background-color has-text-color has-medium-font-size" style="padding-top:0px;line-height:1;text-transform:uppercase"><strong>' . esc_html__( 'Course list', 'sensei-lms' ) . '</strong></h2>
 						<!-- /wp:heading -->
 
 						<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"textColor":"background","className":"sensei-course-list-all-courses-link"} -->
-						<p class="sensei-course-list-all-courses-link has-background-color has-text-color has-link-color"><a href="' . Sensei_Course::get_courses_page_url() . '" target="_blank" rel="noreferrer noopener">' . __( 'Explore all courses', 'sensei-lms' ) . '</a></p>
+						<p class="sensei-course-list-all-courses-link has-background-color has-text-color has-link-color"><a href="' . Sensei_Course::get_courses_page_url() . '" target="_blank" rel="noreferrer noopener">' . esc_html__( 'Explore all courses', 'sensei-lms' ) . '</a></p>
 						<!-- /wp:paragraph --></div>
 						<!-- /wp:group -->
 
@@ -244,15 +244,15 @@ class Sensei_Course_List_Block_Patterns {
 						<!-- wp:column {"width":"15%"} -->
 						<div class="wp-block-column" style="flex-basis:15%"><!-- wp:sensei-lms/course-actions {"lock":{"move":false,"remove":false}} -->
 						<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":8,"buttonClassName":[],"backgroundColor":"background","textColor":"primary"} -->
-						<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . __( 'Start', 'sensei-lms' ) . '</button></div>
+						<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . esc_html__( 'Start', 'sensei-lms' ) . '</button></div>
 						<!-- /wp:sensei-lms/button-take-course -->
 
 						<!-- wp:sensei-lms/button-continue-course {"align":"full","borderRadius":8,"buttonClassName":[],"backgroundColor":"background","textColor":"primary"} -->
-						<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . __( 'Continue', 'sensei-lms' ) . '</a></div>
+						<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . esc_html__( 'Continue', 'sensei-lms' ) . '</a></div>
 						<!-- /wp:sensei-lms/button-continue-course -->
 
 						<!-- wp:sensei-lms/button-view-results {"align":"full","borderRadius":8,"buttonClassName":[],"className":"is-style-default","backgroundColor":"background","textColor":"primary"} -->
-						<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . __( 'Results', 'sensei-lms' ) . '</a></div>
+						<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link has-primary-color has-background-background-color has-text-color has-background" style="border-radius:8px">' . esc_html__( 'Results', 'sensei-lms' ) . '</a></div>
 						<!-- /wp:sensei-lms/button-view-results -->
 						<!-- /wp:sensei-lms/course-actions --></div>
 						<!-- /wp:column --></div>

--- a/lang/sensei-lms.pot
+++ b/lang/sensei-lms.pot
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Automattic
-# This file is distributed under the GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
+# This file is distributed under the same license as the Sensei LMS plugin.
 msgid ""
 msgstr ""
 "Project-Id-Version: Sensei LMS 4.9.1\n"
@@ -9,9 +9,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-12-09T10:31:25+00:00\n"
+"POT-Creation-Date: 2022-12-20T14:12:34+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0\n"
+"X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: sensei-lms\n"
 
 #. Plugin Name of the plugin
@@ -76,7 +76,7 @@ msgstr ""
 #: includes/class-sensei-course.php:3322
 #: includes/class-sensei-grading-main.php:254
 #: includes/class-sensei-grading-main.php:516
-#: includes/class-sensei-lesson.php:4466
+#: includes/class-sensei-lesson.php:4480
 #: assets/blocks/course-outline/status-preview/status-control/index.js:17
 #: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:40
 #: assets/dist/blocks/single-course.js:500
@@ -125,7 +125,7 @@ msgstr ""
 #: includes/class-sensei-course.php:979
 #: includes/class-sensei-lesson.php:389
 #: includes/class-sensei-lesson.php:479
-#: includes/class-sensei-lesson.php:1687
+#: includes/class-sensei-lesson.php:1701
 #: includes/class-sensei-modules.php:384
 #: includes/class-sensei-utils.php:2092
 #: assets/blocks/lesson-properties/constants.js:9
@@ -178,7 +178,6 @@ msgstr ""
 
 #. Translators: placeholder is the student's name.
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:125
-#: assets/admin/students/student-action-menu/index.js:38
 #: assets/admin/students/student-modal/index.js:41
 #: assets/dist/admin/students/student-action-menu/index.js:73
 #: assets/dist/admin/students/student-action-menu/index.js:271
@@ -188,7 +187,6 @@ msgstr ""
 
 #. Translators: placeholder is the student's name.
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:126
-#: assets/admin/students/student-action-menu/index.js:42
 #: assets/admin/students/student-modal/index.js:77
 #: assets/dist/admin/students/student-action-menu/index.js:75
 #: assets/dist/admin/students/student-action-menu/index.js:271
@@ -198,7 +196,6 @@ msgstr ""
 
 #. Translators: placeholder is the student's name.
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:127
-#: assets/admin/students/student-action-menu/index.js:46
 #: assets/admin/students/student-modal/index.js:114
 #: assets/dist/admin/students/student-action-menu/index.js:79
 #: assets/dist/admin/students/student-action-menu/index.js:271
@@ -348,7 +345,7 @@ msgstr ""
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:418
 #: includes/class-sensei-analysis-course-list-table.php:759
 #: includes/class-sensei-analysis-overview-list-table.php:923
-#: includes/class-sensei-lesson.php:1755
+#: includes/class-sensei-lesson.php:1769
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:354
 msgid "Filter"
 msgstr ""
@@ -467,8 +464,6 @@ msgstr ""
 #: includes/class-sensei-posttypes.php:795
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php:306
 #: assets/blocks/course-actions-block/continue-course/index.js:27
-#: assets/blocks/course-completed-actions/index.js:23
-#: assets/blocks/course-list-block/index.js:49
 #: assets/blocks/take-course-block/index.js:28
 #: assets/dist/blocks/global-blocks.js:200
 #: assets/dist/blocks/global-blocks.js:323
@@ -487,7 +482,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: includes/admin/class-sensei-learners-main.php:378
-#: includes/class-sensei-lesson.php:4701
+#: includes/class-sensei-lesson.php:4715
 #: includes/class-sensei-modules.php:1038
 #: includes/class-sensei-utils.php:1195
 #: assets/data-port/import/done/import-success-results.js:15
@@ -514,8 +509,6 @@ msgstr[1] ""
 #: includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php:52
 #: includes/shortcodes/class-sensei-shortcode-user-courses.php:570
 #: includes/template-functions.php:562
-#: assets/blocks/course-completed-actions/index.js:24
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:70
 #: assets/blocks/course-outline/status-preview/status-control/index.js:18
 #: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:44
 #: assets/data-port/import/done/done-page.js:91
@@ -538,18 +531,20 @@ msgid "No enrollment data was found."
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:417
-#: includes/class-sensei-lesson.php:4113
-#: includes/class-sensei-lesson.php:4140
-#: includes/class-sensei-lesson.php:4167
-#: includes/class-sensei-lesson.php:4186
+#: includes/admin/home/notices/class-sensei-home-notices.php:108
+#: includes/class-sensei-lesson.php:4127
+#: includes/class-sensei-lesson.php:4154
+#: includes/class-sensei-lesson.php:4181
+#: includes/class-sensei-lesson.php:4200
 msgid "Yes"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:417
-#: includes/class-sensei-lesson.php:4112
-#: includes/class-sensei-lesson.php:4139
-#: includes/class-sensei-lesson.php:4166
-#: includes/class-sensei-lesson.php:4185
+#: includes/admin/home/notices/class-sensei-home-notices.php:131
+#: includes/class-sensei-lesson.php:4126
+#: includes/class-sensei-lesson.php:4153
+#: includes/class-sensei-lesson.php:4180
+#: includes/class-sensei-lesson.php:4199
 msgid "No"
 msgstr ""
 
@@ -582,7 +577,6 @@ msgstr ""
 #: includes/class-sensei-grading.php:30
 #: includes/class-sensei-grading.php:71
 #: includes/class-sensei-grading.php:72
-#: assets/admin/students/student-action-menu/index.js:50
 #: assets/dist/admin/students/student-action-menu/index.js:271
 msgid "Grading"
 msgstr ""
@@ -602,7 +596,6 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:973
 #: includes/class-sensei-analysis-user-profile-list-table.php:316
-#: assets/admin/students/student-modal/course-list.js:37
 #: assets/dist/admin/students/student-action-menu/index.js:59
 #: assets/dist/admin/students/student-bulk-action-button/index.js:45
 msgid "No courses found."
@@ -649,7 +642,6 @@ msgstr ""
 #: includes/class-sensei-settings.php:162
 #: templates/course-results/lessons.php:39
 #: templates/single-course/modules.php:102
-#: assets/blocks/course-outline/module-block/module-edit.js:235
 #: assets/dist/blocks/single-course.js:381
 #: assets/dist/data-port/export.js:187
 #: assets/dist/data-port/import.js:625
@@ -724,8 +716,6 @@ msgstr ""
 #: includes/class-sensei-posttypes.php:1058
 #: includes/class-sensei-settings.php:157
 #: includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php:55
-#: assets/blocks/course-completed-actions/index.js:49
-#: assets/blocks/course-list-block/index.js:51
 #: assets/dist/blocks/global-blocks.js:323
 #: assets/dist/blocks/shared.js:239
 #: assets/dist/blocks/single-page.js:213
@@ -762,9 +752,6 @@ msgid "Congratulations on completing this course! 🥳"
 msgstr ""
 
 #: includes/admin/class-sensei-setup-wizard-pages.php:151
-#: assets/blocks/course-completed-actions/index.js:11
-#: assets/blocks/course-completed-actions/index.js:27
-#: assets/blocks/course-completed-actions/index.js:43
 #: assets/dist/blocks/single-page.js:213
 msgid "Find More Courses"
 msgstr ""
@@ -855,7 +842,7 @@ msgid "Pending"
 msgstr ""
 
 #: includes/admin/class-sensei-status.php:171
-#: includes/class-sensei-lesson.php:4462
+#: includes/class-sensei-lesson.php:4476
 #: includes/class-sensei-quiz.php:1850
 #: templates/single-quiz/pagination.php:125
 #: assets/blocks/lesson-actions/complete-lesson-block/index.js:24
@@ -937,33 +924,53 @@ msgstr ""
 msgid "Create a support ticket"
 msgstr ""
 
-#: includes/admin/home/notices/class-sensei-home-notices.php:171
+#: includes/admin/home/notices/class-sensei-home-notices.php:104
+msgid "Are you enjoying Sensei LMS?"
+msgstr ""
+
+#: includes/admin/home/notices/class-sensei-home-notices.php:154
+msgid "Let us know how we can improve your experience. We're always happy to help."
+msgstr ""
+
+#: includes/admin/home/notices/class-sensei-home-notices.php:156
+msgid "Share with us how can we help"
+msgstr ""
+
+#: includes/admin/home/notices/class-sensei-home-notices.php:172
+msgid "Great to hear! Would you be able to help us by leaving a review on WordPress.org?"
+msgstr ""
+
+#: includes/admin/home/notices/class-sensei-home-notices.php:174
+msgid "Write a review for us"
+msgstr ""
+
+#: includes/admin/home/notices/class-sensei-home-notices.php:301
 msgid "What's new"
 msgstr ""
 
 #. translators: First placeholder is the plugin name; second placeholder is the latest version.
-#: includes/admin/home/notices/class-sensei-home-notices.php:209
+#: includes/admin/home/notices/class-sensei-home-notices.php:339
 msgid "There is a new version of <strong>%1$s</strong> available (%2$s). Please activate the plugin license in order to proceed with the update process."
 msgstr ""
 
 #. translators: First placeholder is the plugin name and second placeholder is the latest version available.
-#: includes/admin/home/notices/class-sensei-home-notices.php:235
+#: includes/admin/home/notices/class-sensei-home-notices.php:365
 msgid "There is a new version of <strong>%1$s</strong> available (%2$s). Please activate the plugin in order to proceed with the update process."
 msgstr ""
 
-#: includes/admin/home/notices/class-sensei-home-notices.php:243
+#: includes/admin/home/notices/class-sensei-home-notices.php:373
 #: assets/course-theme/learning-mode-templates/template-actions.js:53
 #: assets/dist/course-theme/learning-mode-templates/index.js:30
 msgid "Activate"
 msgstr ""
 
 #. translators: First placeholder is the plugin name and second placeholder is the latest version available.
-#: includes/admin/home/notices/class-sensei-home-notices.php:266
+#: includes/admin/home/notices/class-sensei-home-notices.php:396
 msgid "There is a new version of <strong>%1$s</strong> available (%2$s). Please update to ensure you have the latest features and fixes."
 msgstr ""
 
-#: includes/admin/home/notices/class-sensei-home-notices.php:274
-#: includes/class-sensei-lesson.php:1585
+#: includes/admin/home/notices/class-sensei-home-notices.php:404
+#: includes/class-sensei-lesson.php:1599
 #: assets/dist/home/index.js:326
 #: assets/home/extension-actions.js:70
 msgid "Update"
@@ -1356,6 +1363,44 @@ msgstr ""
 msgid "Courses displayed in a list"
 msgstr ""
 
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:79
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:137
+#: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:15
+#: assets/blocks/course-actions-block/course-actions/index.js:22
+#: assets/dist/blocks/global-blocks.js:207
+#: assets/dist/blocks/global-blocks.js:230
+msgid "Start Course"
+msgstr ""
+
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:83
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:143
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:198
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:251
+#: includes/block-patterns/page/templates/landing-page-grid.php:72
+#: includes/block-patterns/page/templates/landing-page-list.php:82
+#: assets/blocks/course-actions-block/continue-course/index.js:26
+#: assets/blocks/course-actions-block/continue-course/index.js:31
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:25
+#: assets/data-port/export/export-select-content-page.js:59
+#: assets/data-port/import/upload/upload-page.js:72
+#: assets/dist/admin/editor-wizard/index.js:73
+#: assets/dist/admin/editor-wizard/index.js:107
+#: assets/dist/blocks/global-blocks.js:200
+#: assets/dist/blocks/single-lesson.js:329
+#: assets/dist/data-port/export.js:33
+#: assets/dist/data-port/import.js:532
+#: assets/dist/setup-wizard/index.js:271
+#: assets/setup-wizard/purpose/index.js:166
+msgid "Continue"
+msgstr ""
+
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:87
+#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:149
+#: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:22
+#: assets/dist/blocks/global-blocks.js:207
+msgid "Visit Results"
+msgstr ""
+
 #: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:104
 msgid "Courses displayed in a grid"
 msgstr ""
@@ -1387,28 +1432,6 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:198
-#: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:251
-#: includes/block-patterns/page/templates/landing-page-grid.php:72
-#: includes/block-patterns/page/templates/landing-page-list.php:82
-#: assets/admin/editor-wizard/steps/course-details-step.js:85
-#: assets/admin/editor-wizard/steps/lesson-details-step.js:72
-#: assets/blocks/course-actions-block/continue-course/index.js:26
-#: assets/blocks/course-actions-block/continue-course/index.js:31
-#: assets/blocks/lesson-actions/next-lesson-block/index.js:25
-#: assets/data-port/export/export-select-content-page.js:59
-#: assets/data-port/import/upload/upload-page.js:72
-#: assets/dist/admin/editor-wizard/index.js:73
-#: assets/dist/admin/editor-wizard/index.js:107
-#: assets/dist/blocks/global-blocks.js:200
-#: assets/dist/blocks/single-lesson.js:329
-#: assets/dist/data-port/export.js:33
-#: assets/dist/data-port/import.js:532
-#: assets/dist/setup-wizard/index.js:271
-#: assets/setup-wizard/purpose/index.js:166
-msgid "Continue"
-msgstr ""
-
 #: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:202
 #: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:255
 #: includes/block-patterns/page/templates/landing-page-grid.php:76
@@ -1417,7 +1440,6 @@ msgid "Results"
 msgstr ""
 
 #: includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php:212
-#: assets/blocks/course-list-block/index.js:44
 #: assets/dist/blocks/global-blocks.js:323
 #: assets/dist/blocks/shared.js:239
 msgid "Course List"
@@ -1763,7 +1785,6 @@ msgstr ""
 #: includes/block-patterns/lesson/templates/video-lesson.php:33
 #: includes/block-patterns/lesson/templates/zoom-meeting.php:68
 #: includes/class-sensei-frontend.php:912
-#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js:56
 #: assets/blocks/lesson-actions/reset-lesson-block/index.js:17
 #: assets/blocks/lesson-actions/reset-lesson-block/index.js:33
 #: assets/dist/blocks/single-lesson.js:251
@@ -1933,7 +1954,6 @@ msgstr ""
 #: includes/blocks/course-theme/class-course-navigation.php:256
 #: includes/class-sensei-frontend.php:1122
 #: includes/class-sensei-lesson.php:287
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:102
 #: assets/course-theme/learning-mode-templates/template-option/template-option-thumbnail.js:26
 #: assets/dist/blocks/single-course.js:333
 #: assets/dist/course-theme/learning-mode-templates/index.js:46
@@ -1945,7 +1965,6 @@ msgid "(Draft)"
 msgstr ""
 
 #: includes/blocks/class-sensei-course-outline-module-block.php:91
-#: assets/blocks/course-outline/module-block/module-edit.js:211
 #: assets/dist/blocks/single-course.js:381
 msgid "Toggle module content"
 msgstr ""
@@ -1962,7 +1981,6 @@ msgid "%1$d of %2$d lessons completed (%3$s)"
 msgstr ""
 
 #: includes/blocks/class-sensei-course-results-block.php:131
-#: assets/blocks/course-results-block/course-results-edit.js:138
 #: assets/dist/blocks/single-page.js:225
 msgid "Your Total Grade"
 msgstr ""
@@ -1978,8 +1996,6 @@ msgid "My Messages"
 msgstr ""
 
 #: includes/blocks/class-sensei-lesson-properties-block.php:71
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:46
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:91
 #: assets/dist/blocks/single-lesson.js:382
 #: assets/dist/course-theme/blocks/index.js:234
 msgid "Length"
@@ -1993,8 +2009,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: includes/blocks/class-sensei-lesson-properties-block.php:88
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:65
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:113
 #: assets/dist/blocks/single-lesson.js:382
 #: assets/dist/course-theme/blocks/index.js:234
 msgid "Difficulty"
@@ -2005,8 +2019,6 @@ msgstr ""
 #: includes/blocks/course-list/class-sensei-course-list-featured-filter.php:42
 #: includes/class-sensei-course.php:2820
 #: assets/blocks/course-list-block/featured-label/index.js:36
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:45
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:52
 #: assets/dist/blocks/global-blocks.js:304
 #: assets/dist/blocks/global-blocks.js:358
 #: assets/dist/blocks/shared.js:220
@@ -2014,8 +2026,7 @@ msgid "Featured"
 msgstr ""
 
 #: includes/blocks/course-list/class-sensei-course-list-categories-filter.php:45
-#: includes/class-sensei-lesson.php:1749
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:37
+#: includes/class-sensei-lesson.php:1763
 #: assets/dist/blocks/global-blocks.js:358
 msgid "All Categories"
 msgstr ""
@@ -2023,8 +2034,6 @@ msgstr ""
 #: includes/blocks/course-list/class-sensei-course-list-featured-filter.php:41
 #: includes/blocks/course-list/class-sensei-course-list-student-course-filter.php:41
 #: includes/class-sensei-course.php:215
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:48
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:62
 #: assets/blocks/learner-courses-block/learner-courses-edit.js:99
 #: assets/dist/blocks/global-blocks.js:358
 #: assets/dist/blocks/single-page.js:264
@@ -2033,8 +2042,6 @@ msgstr ""
 
 #: includes/blocks/course-list/class-sensei-course-list-student-course-filter.php:42
 #: includes/shortcodes/class-sensei-shortcode-user-courses.php:569
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:66
-#: assets/course-theme/learning-mode-templates/template-option/template-option-footer.js:40
 #: assets/dist/blocks/global-blocks.js:358
 #: assets/dist/course-theme/learning-mode-templates/index.js:38
 msgid "Active"
@@ -2108,7 +2115,7 @@ msgstr ""
 #: includes/blocks/course-theme/class-prev-next-lesson.php:97
 #: includes/class-sensei-course.php:1759
 #: includes/class-sensei-course.php:1871
-#: includes/class-sensei-lesson.php:1797
+#: includes/class-sensei-lesson.php:1811
 #: templates/single-quiz/pagination.php:98
 msgid "Previous"
 msgstr ""
@@ -2120,7 +2127,7 @@ msgstr ""
 #: includes/blocks/course-theme/class-prev-next-lesson.php:98
 #: includes/class-sensei-course.php:1774
 #: includes/class-sensei-course.php:1886
-#: includes/class-sensei-lesson.php:1797
+#: includes/class-sensei-lesson.php:1811
 #: templates/single-quiz/pagination.php:113
 #: assets/blocks/lesson-actions/next-lesson-block/index.js:24
 #: assets/course-theme/blocks/quiz-blocks/index.js:109
@@ -2293,9 +2300,8 @@ msgstr ""
 #: includes/class-sensei-analysis-lesson-list-table.php:53
 #: includes/class-sensei-grading-main.php:69
 #: includes/class-sensei-learner.php:157
-#: includes/class-sensei-lesson.php:1277
-#: includes/class-sensei-lesson.php:1286
-#: assets/blocks/quiz/question-block/settings/question-grade-settings.js:28
+#: includes/class-sensei-lesson.php:1291
+#: includes/class-sensei-lesson.php:1300
 #: assets/dist/blocks/quiz/index.js:682
 #: assets/dist/js/grading-general.js:68
 #: assets/js/grading-general.js:64
@@ -2627,8 +2633,8 @@ msgstr ""
 #. translators: Placeholder is the item title/name.
 #: includes/class-sensei-course.php:824
 #: includes/class-sensei-course.php:967
-#: includes/class-sensei-lesson.php:2790
-#: includes/class-sensei-lesson.php:2798
+#: includes/class-sensei-lesson.php:2804
+#: includes/class-sensei-lesson.php:2812
 #: includes/class-sensei-posttypes.php:847
 msgid "Edit %s"
 msgstr ""
@@ -2806,11 +2812,9 @@ msgstr ""
 
 #: includes/class-sensei-course.php:2815
 #: includes/class-sensei-grading-main.php:495
-#: includes/class-sensei-lesson.php:1738
-#: includes/class-sensei-lesson.php:2526
+#: includes/class-sensei-lesson.php:1752
+#: includes/class-sensei-lesson.php:2540
 #: includes/shortcodes/class-sensei-shortcode-user-courses.php:568
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:250
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:255
 #: assets/dist/blocks/quiz/index.js:855
 msgid "All"
 msgstr ""
@@ -2856,7 +2860,7 @@ msgstr ""
 
 #. translators: Placeholder is the item title.
 #: includes/class-sensei-course.php:3730
-#: includes/class-sensei-lesson.php:4779
+#: includes/class-sensei-lesson.php:4793
 #: includes/class-sensei-utils.php:1140
 #: includes/course-theme/class-sensei-course-theme-lesson.php:222
 msgid "You must first complete: %1$s"
@@ -3050,8 +3054,8 @@ msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:107
 #: includes/class-sensei-grading-user-quiz.php:377
-#: includes/class-sensei-lesson.php:1554
-#: includes/class-sensei-lesson.php:1696
+#: includes/class-sensei-lesson.php:1568
+#: includes/class-sensei-lesson.php:1710
 msgid "Grade:"
 msgstr ""
 
@@ -3098,49 +3102,43 @@ msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:152
 #: includes/class-sensei-grading-user-quiz.php:163
-#: includes/class-sensei-lesson.php:1498
+#: includes/class-sensei-lesson.php:1512
 #: includes/class-sensei-question.php:116
-#: assets/blocks/quiz/answer-blocks/index.js:39
 #: assets/dist/blocks/quiz/index.js:237
 msgid "Multiple Choice"
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:157
-#: includes/class-sensei-lesson.php:1498
+#: includes/class-sensei-lesson.php:1512
 #: includes/class-sensei-question.php:117
-#: assets/blocks/quiz/answer-blocks/index.js:84
 #: assets/dist/blocks/quiz/index.js:237
 msgid "True/False"
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:167
-#: includes/class-sensei-lesson.php:1498
+#: includes/class-sensei-lesson.php:1512
 #: includes/class-sensei-question.php:118
-#: assets/blocks/quiz/answer-blocks/index.js:95
 #: assets/dist/blocks/quiz/index.js:237
 msgid "Gap Fill"
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:193
-#: includes/class-sensei-lesson.php:1498
+#: includes/class-sensei-lesson.php:1512
 #: includes/class-sensei-question.php:120
-#: assets/blocks/quiz/answer-blocks/index.js:138
 #: assets/dist/blocks/quiz/index.js:237
 msgid "Multi Line"
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:197
-#: includes/class-sensei-lesson.php:1498
+#: includes/class-sensei-lesson.php:1512
 #: includes/class-sensei-question.php:119
-#: assets/blocks/quiz/answer-blocks/index.js:128
 #: assets/dist/blocks/quiz/index.js:237
 msgid "Single Line"
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:201
-#: includes/class-sensei-lesson.php:1498
+#: includes/class-sensei-lesson.php:1512
 #: includes/class-sensei-question.php:121
-#: assets/blocks/quiz/answer-blocks/index.js:148
 #: assets/dist/blocks/quiz/index.js:237
 msgid "File Upload"
 msgstr ""
@@ -3161,7 +3159,7 @@ msgid "Correct answer"
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:353
-#: includes/class-sensei-lesson.php:2298
+#: includes/class-sensei-lesson.php:2312
 #: assets/blocks/quiz/answer-feedback-block/answer-feedback-toggle.js:37
 #: assets/dist/blocks/quiz/index.js:349
 msgid "Answer Feedback"
@@ -3301,7 +3299,7 @@ msgid "Content Drip"
 msgstr ""
 
 #: includes/class-sensei-lesson.php:304
-#: includes/class-sensei-lesson.php:4053
+#: includes/class-sensei-lesson.php:4067
 msgid "Lesson Information"
 msgstr ""
 
@@ -3346,7 +3344,7 @@ msgid "Lesson Length in minutes"
 msgstr ""
 
 #: includes/class-sensei-lesson.php:387
-#: includes/class-sensei-lesson.php:4099
+#: includes/class-sensei-lesson.php:4113
 msgid "Lesson Complexity"
 msgstr ""
 
@@ -3373,126 +3371,123 @@ msgstr ""
 msgid "Allow this lesson to be viewed without login"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1220
+#: includes/class-sensei-lesson.php:1234
 msgid "Once you have saved your lesson you will be able to add questions."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1258
+#: includes/class-sensei-lesson.php:1272
 msgid "Please save your lesson in order to add questions to your quiz."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1276
-#: includes/class-sensei-lesson.php:1285
-#: includes/class-sensei-lesson.php:1763
-#: includes/class-sensei-lesson.php:1771
+#: includes/class-sensei-lesson.php:1290
+#: includes/class-sensei-lesson.php:1299
+#: includes/class-sensei-lesson.php:1777
+#: includes/class-sensei-lesson.php:1785
 #: includes/class-sensei-posttypes.php:810
 #: includes/class-sensei-question.php:212
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:146
 #: assets/dist/blocks/quiz/index.js:819
 msgid "Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1278
-#: includes/class-sensei-lesson.php:1287
-#: includes/class-sensei-lesson.php:1764
-#: includes/class-sensei-lesson.php:1772
-#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:45
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:147
+#: includes/class-sensei-lesson.php:1292
+#: includes/class-sensei-lesson.php:1301
+#: includes/class-sensei-lesson.php:1778
+#: includes/class-sensei-lesson.php:1786
 #: assets/dist/blocks/quiz/index.js:798
 #: assets/dist/blocks/quiz/index.js:819
 msgid "Type"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1279
-#: includes/class-sensei-lesson.php:1288
+#: includes/class-sensei-lesson.php:1293
+#: includes/class-sensei-lesson.php:1302
 msgid "Action"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1298
+#: includes/class-sensei-lesson.php:1312
 msgid "There are no Questions for this Quiz yet. Please add some below."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1448
-#: includes/class-sensei-lesson.php:1707
-#: includes/class-sensei-lesson.php:2637
+#: includes/class-sensei-lesson.php:1462
+#: includes/class-sensei-lesson.php:1721
+#: includes/class-sensei-lesson.php:2651
 msgid "Add file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1475
-#: includes/class-sensei-lesson.php:2638
+#: includes/class-sensei-lesson.php:1489
+#: includes/class-sensei-lesson.php:2652
 msgid "Change file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1502
+#: includes/class-sensei-lesson.php:1516
 msgid "Edit Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1502
+#: includes/class-sensei-lesson.php:1516
 msgid "Edit"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1502
-#: includes/class-sensei-lesson.php:1504
+#: includes/class-sensei-lesson.php:1516
+#: includes/class-sensei-lesson.php:1518
 msgid "Remove Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1502
-#: includes/class-sensei-lesson.php:1504
-#: includes/class-sensei-lesson.php:1521
+#: includes/class-sensei-lesson.php:1516
+#: includes/class-sensei-lesson.php:1518
+#: includes/class-sensei-lesson.php:1535
 msgid "Remove"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1504
+#: includes/class-sensei-lesson.php:1518
 msgid "You are not the question owner, so you cannot edit it."
 msgstr ""
 
 #. translators: Placeholder is the question category name.
-#: includes/class-sensei-lesson.php:1515
+#: includes/class-sensei-lesson.php:1529
 msgid "Selected from '%1$s' "
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1521
+#: includes/class-sensei-lesson.php:1535
 msgid "Remove Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1542
-#: includes/class-sensei-lesson.php:1665
+#: includes/class-sensei-lesson.php:1556
+#: includes/class-sensei-lesson.php:1679
 msgid "Question:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1548
-#: includes/class-sensei-lesson.php:1670
+#: includes/class-sensei-lesson.php:1562
+#: includes/class-sensei-lesson.php:1684
 msgid "Description:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1561
-#: includes/class-sensei-lesson.php:1701
+#: includes/class-sensei-lesson.php:1575
+#: includes/class-sensei-lesson.php:1715
 #: assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js:20
 #: assets/dist/blocks/quiz/index.js:700
 msgid "Random Order"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1567
-#: includes/class-sensei-lesson.php:1706
+#: includes/class-sensei-lesson.php:1581
+#: includes/class-sensei-lesson.php:1720
 msgid "Media:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1568
-#: includes/class-sensei-lesson.php:1707
+#: includes/class-sensei-lesson.php:1582
+#: includes/class-sensei-lesson.php:1721
 msgid "Add file to question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1568
-#: includes/class-sensei-lesson.php:1707
+#: includes/class-sensei-lesson.php:1582
+#: includes/class-sensei-lesson.php:1721
 msgid "Add to question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1569
-#: includes/class-sensei-lesson.php:1708
+#: includes/class-sensei-lesson.php:1583
+#: includes/class-sensei-lesson.php:1722
 msgid "Delete file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1584
+#: includes/class-sensei-lesson.php:1598
 #: assets/blocks/editor-components/confirm-dialog/confirm-dialog.js:29
 #: assets/course-theme/learning-mode-templates/template-preview.js:41
 #: assets/data-port/export/export-progress-page.js:57
@@ -3501,69 +3496,66 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1585
+#: includes/class-sensei-lesson.php:1599
 msgid "Update Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1646
+#: includes/class-sensei-lesson.php:1660
 #: includes/class-sensei-question.php:103
 #: assets/blocks/quiz/quiz-block/quiz-appender.js:51
 #: assets/dist/blocks/quiz/index.js:828
 msgid "New Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1647
+#: includes/class-sensei-lesson.php:1661
 msgid "Existing Questions"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1649
+#: includes/class-sensei-lesson.php:1663
 msgid "Category Questions"
 msgstr ""
 
 #. translators: Placeholders are an opening and closing <a> tag linking to the question bank.
-#: includes/class-sensei-lesson.php:1658
+#: includes/class-sensei-lesson.php:1672
 msgid "Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1675
+#: includes/class-sensei-lesson.php:1689
 msgid "Question Type:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1685
+#: includes/class-sensei-lesson.php:1699
 msgid "Question Category:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1723
+#: includes/class-sensei-lesson.php:1737
 msgid "Add Question"
 msgstr ""
 
 #. translators: Placeholders are an opening and closing <a> tag linking to the question bank.
-#: includes/class-sensei-lesson.php:1734
+#: includes/class-sensei-lesson.php:1748
 msgid "Add an existing question to this quiz from the %1$squestion bank%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1739
+#: includes/class-sensei-lesson.php:1753
 msgid "Unused"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1740
+#: includes/class-sensei-lesson.php:1754
 msgid "Used"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1743
+#: includes/class-sensei-lesson.php:1757
 msgid "All Types"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1754
+#: includes/class-sensei-lesson.php:1768
 msgid "Search"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1765
-#: includes/class-sensei-lesson.php:1773
+#: includes/class-sensei-lesson.php:1779
+#: includes/class-sensei-lesson.php:1787
 #: assets/blocks/learner-courses-block/learner-courses-settings.js:40
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:112
-#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:56
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:148
 #: assets/dist/blocks/quiz/index.js:387
 #: assets/dist/blocks/quiz/index.js:798
 #: assets/dist/blocks/quiz/index.js:819
@@ -3571,50 +3563,50 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1801
+#: includes/class-sensei-lesson.php:1815
 msgid "Add Selected Question(s)"
 msgstr ""
 
 #. translators: Placeholders are an opening and closing <a> tag linking to the question categories page.
-#: includes/class-sensei-lesson.php:1810
+#: includes/class-sensei-lesson.php:1824
 msgid "Add any number of questions from a specified category. Edit your question categories %1$shere%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1813
+#: includes/class-sensei-lesson.php:1827
 msgid "Select a Question Category"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1819
+#: includes/class-sensei-lesson.php:1833
 msgid "Number of questions:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1821
+#: includes/class-sensei-lesson.php:1835
 msgid "Add Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2034
+#: includes/class-sensei-lesson.php:2048
 msgid "There are no questions matching your search."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2089
-#: includes/class-sensei-lesson.php:2635
+#: includes/class-sensei-lesson.php:2103
+#: includes/class-sensei-lesson.php:2649
 msgid "Right:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2111
-#: includes/class-sensei-lesson.php:2636
+#: includes/class-sensei-lesson.php:2125
+#: includes/class-sensei-lesson.php:2650
 msgid "Wrong:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2139
+#: includes/class-sensei-lesson.php:2153
 msgid "Add right answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2140
+#: includes/class-sensei-lesson.php:2154
 msgid "Add wrong answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2155
+#: includes/class-sensei-lesson.php:2169
 #: includes/class-sensei-question.php:1483
 #: templates/single-quiz/question-type-boolean.php:82
 #: assets/blocks/quiz/answer-blocks/true-false.js:27
@@ -3624,7 +3616,7 @@ msgstr ""
 msgid "True"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2156
+#: includes/class-sensei-lesson.php:2170
 #: includes/class-sensei-question.php:1485
 #: templates/single-quiz/question-type-boolean.php:86
 #: assets/blocks/quiz/answer-blocks/true-false.js:28
@@ -3634,198 +3626,198 @@ msgstr ""
 msgid "False"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2178
+#: includes/class-sensei-lesson.php:2192
 msgid "Text before the gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2180
+#: includes/class-sensei-lesson.php:2194
 msgid "Gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2182
+#: includes/class-sensei-lesson.php:2196
 msgid "Text after the gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2184
+#: includes/class-sensei-lesson.php:2198
 msgid "Preview:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2196
-#: includes/class-sensei-lesson.php:2209
-#: includes/class-sensei-lesson.php:2233
+#: includes/class-sensei-lesson.php:2210
+#: includes/class-sensei-lesson.php:2223
+#: includes/class-sensei-lesson.php:2247
 msgid "Grading Notes:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2198
-#: includes/class-sensei-lesson.php:2211
-#: includes/class-sensei-lesson.php:2235
+#: includes/class-sensei-lesson.php:2212
+#: includes/class-sensei-lesson.php:2225
+#: includes/class-sensei-lesson.php:2249
 #: assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js:23
 #: assets/dist/blocks/quiz/index.js:691
 msgid "Displayed to the teacher when grading the question."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2228
+#: includes/class-sensei-lesson.php:2242
 msgid "Upload notes:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2230
+#: includes/class-sensei-lesson.php:2244
 msgid "Displayed to the student to describe what to upload."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2297
+#: includes/class-sensei-lesson.php:2311
 msgid "This feedback will be automatically displayed to the student once they have completed the quiz."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2412
+#: includes/class-sensei-lesson.php:2426
 msgid "There is no quiz for this lesson yet - please add one in the 'Quiz Questions' box."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2503
+#: includes/class-sensei-lesson.php:2517
 msgid "Pass required to complete lesson"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2504
+#: includes/class-sensei-lesson.php:2518
 msgid "The passmark must be achieved before the lesson is complete."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2511
+#: includes/class-sensei-lesson.php:2525
 msgid "Quiz passmark percentage"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2522
-#: includes/class-sensei-lesson.php:4159
+#: includes/class-sensei-lesson.php:2536
+#: includes/class-sensei-lesson.php:4173
 msgid "Number of questions to show"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2523
+#: includes/class-sensei-lesson.php:2537
 msgid "Show a random selection of questions from this quiz each time a student views it."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2532
-#: includes/class-sensei-lesson.php:4178
+#: includes/class-sensei-lesson.php:2546
+#: includes/class-sensei-lesson.php:4192
 msgid "Randomise question order"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2540
-#: includes/class-sensei-lesson.php:4197
+#: includes/class-sensei-lesson.php:2554
+#: includes/class-sensei-lesson.php:4211
 msgid "Grade quiz automatically"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2541
+#: includes/class-sensei-lesson.php:2555
 msgid "Grades quiz and displays answer explanation immediately after completion. Only applicable if quiz is limited to Multiple Choice, True/False and Gap Fill questions. Questions that have a grade of zero are skipped during autograding."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2548
+#: includes/class-sensei-lesson.php:2562
 msgid "Allow user to retake the quiz"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2549
+#: includes/class-sensei-lesson.php:2563
 msgid "Enables the quiz reset button."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2639
+#: includes/class-sensei-lesson.php:2653
 msgid "Are you sure you want to remove this question?"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2640
+#: includes/class-sensei-lesson.php:2654
 msgid "Are you sure you want to remove these questions?"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2641
+#: includes/class-sensei-lesson.php:2655
 msgid "You have selected more questions than this category contains - please reduce the number of questions that you are adding."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2746
+#: includes/class-sensei-lesson.php:2760
 msgctxt "column name"
 msgid "Lesson Title"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2747
+#: includes/class-sensei-lesson.php:2761
 msgctxt "column name"
 msgid "Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2748
+#: includes/class-sensei-lesson.php:2762
 msgctxt "column name"
 msgid "Pre-requisite Lesson"
 msgstr ""
 
 #. translators: Placeholders are the question number and the question category name.
-#: includes/class-sensei-lesson.php:2920
+#: includes/class-sensei-lesson.php:2934
 #: includes/rest-api/class-sensei-rest-api-question-helpers-trait.php:109
 msgid "%1$s Question(s) from %2$s"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3460
+#: includes/class-sensei-lesson.php:3474
 #: assets/blocks/lesson-properties/constants.js:13
 #: assets/dist/blocks/single-lesson.js:360
 #: assets/dist/course-theme/blocks/index.js:212
 msgid "Easy"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3461
+#: includes/class-sensei-lesson.php:3475
 #: assets/blocks/lesson-properties/constants.js:17
 #: assets/dist/blocks/single-lesson.js:360
 #: assets/dist/course-theme/blocks/index.js:212
 msgid "Standard"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3462
+#: includes/class-sensei-lesson.php:3476
 #: assets/blocks/lesson-properties/constants.js:21
 #: assets/dist/blocks/single-lesson.js:360
 #: assets/dist/course-theme/blocks/index.js:212
 msgid "Hard"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4061
+#: includes/class-sensei-lesson.php:4075
 msgid "No Change"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4083
+#: includes/class-sensei-lesson.php:4097
 msgid "Lesson Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4103
+#: includes/class-sensei-lesson.php:4117
 msgid "Quiz Settings"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4124
+#: includes/class-sensei-lesson.php:4138
 msgid "Pass required"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4132
+#: includes/class-sensei-lesson.php:4146
 msgid "Pass Percentage"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4151
+#: includes/class-sensei-lesson.php:4165
 msgid "Enable quiz reset button"
 msgstr ""
 
 #. translators: Placeholder is the lesson title.
-#: includes/class-sensei-lesson.php:4422
+#: includes/class-sensei-lesson.php:4436
 #: templates/course-results/lessons.php:91
 #: templates/course-results/lessons.php:148
 msgid "Start %s"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4445
+#: includes/class-sensei-lesson.php:4459
 msgid "Length:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4445
+#: includes/class-sensei-lesson.php:4459
 msgid "minutes"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4451
+#: includes/class-sensei-lesson.php:4465
 msgid "Author:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4456
+#: includes/class-sensei-lesson.php:4470
 msgid "Complexity:"
 msgstr ""
 
 #. translators: Placeholders are an opening and closing <a> tag linking to the course permalink.
-#: includes/class-sensei-lesson.php:4700
+#: includes/class-sensei-lesson.php:4714
 #: includes/class-sensei-modules.php:1037
 #: includes/class-sensei-utils.php:1085
 #: includes/class-sensei-utils.php:1194
@@ -3833,21 +3825,21 @@ msgid "Sign Up"
 msgstr ""
 
 #. translators: The placeholder %1$s is a link to the Course.
-#: includes/class-sensei-lesson.php:4705
+#: includes/class-sensei-lesson.php:4719
 msgid "Please sign up for the %1$s before starting the lesson."
 msgstr ""
 
 #. translators: Placeholder is the link to the prerequisite lesson.
-#: includes/class-sensei-lesson.php:4784
+#: includes/class-sensei-lesson.php:4798
 msgid "You must first complete %1$s before viewing this Lesson"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4803
+#: includes/class-sensei-lesson.php:4817
 msgid "Lessons Archive"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4900
-#: includes/class-sensei-lesson.php:4902
+#: includes/class-sensei-lesson.php:4914
+#: includes/class-sensei-lesson.php:4916
 msgid "View the Lesson Quiz"
 msgstr ""
 
@@ -4342,7 +4334,6 @@ msgid "New Question Category Name"
 msgstr ""
 
 #: includes/class-sensei-posttypes.php:713
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:34
 #: assets/dist/blocks/global-blocks.js:358
 msgid "Categories"
 msgstr ""
@@ -4920,13 +4911,11 @@ msgstr ""
 
 #: includes/class-sensei-settings.php:470
 #: assets/dist/js/admin/course-edit.js:140
-#: assets/js/admin/course-theme/course-theme-sidebar.js:33
 msgid "Learning Mode"
 msgstr ""
 
 #: includes/class-sensei-settings.php:471
 #: assets/dist/js/admin/course-edit.js:140
-#: assets/js/admin/course-theme/course-theme-sidebar.js:49
 msgid "Show an immersive and distraction-free view for lessons and quizzes."
 msgstr ""
 
@@ -5924,7 +5913,6 @@ msgid "Module title"
 msgstr ""
 
 #: includes/rest-api/class-sensei-rest-api-course-structure-controller.php:287
-#: assets/blocks/course-outline/module-block/module-edit.js:226
 #: assets/dist/blocks/single-course.js:381
 msgid "Module description"
 msgstr ""
@@ -6476,43 +6464,6 @@ msgstr ""
 msgid "More Lessons"
 msgstr ""
 
-#: assets/admin/editor-wizard/patterns-list.js:78
-#: assets/dist/admin/editor-wizard/index.js:64
-msgid "Sensei block patterns"
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/course-details-step.js:42
-#: assets/dist/admin/editor-wizard/index.js:72
-msgid "Create your course"
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/course-details-step.js:45
-#: assets/dist/admin/editor-wizard/index.js:72
-msgid "Keep your Course Title short as it will get displayed in different places around your website. You can easily change both later."
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/course-details-step.js:53
-#: assets/blocks/course-results-block/course-results-edit.js:145
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:140
-#: assets/course-theme/blocks/lesson-blocks/index.js:45
-#: assets/course-theme/blocks/lesson-blocks/index.js:54
-#: assets/dist/admin/editor-wizard/index.js:72
-#: assets/dist/blocks/single-page.js:225
-#: assets/dist/blocks/single-page.js:267
-#: assets/dist/course-theme/blocks/index.js:255
-msgid "Course Title"
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/course-details-step.js:60
-#: assets/dist/admin/editor-wizard/index.js:72
-msgid "Course Description"
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/course-details-step.js:71
-#: assets/dist/admin/editor-wizard/index.js:72
-msgid "Illustration of course sample with some placeholders."
-msgstr ""
-
 #: assets/admin/editor-wizard/steps/course-patterns-step.js:38
 #: assets/dist/admin/editor-wizard/index.js:81
 msgid "Course Layout"
@@ -6584,28 +6535,6 @@ msgstr ""
 msgid "Continue with Sensei Free"
 msgstr ""
 
-#: assets/admin/editor-wizard/steps/lesson-details-step.js:32
-#: assets/dist/admin/editor-wizard/index.js:100
-msgid "Create your lesson"
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/lesson-details-step.js:35
-#: assets/dist/admin/editor-wizard/index.js:100
-msgid "It is best to keep your Lesson Title short because it will show in your course outline and navigation. You can easily change both later."
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/lesson-details-step.js:43
-#: assets/course-theme/blocks/lesson-blocks/index.js:215
-#: assets/dist/admin/editor-wizard/index.js:100
-#: assets/dist/course-theme/blocks/index.js:255
-msgid "Lesson Title"
-msgstr ""
-
-#: assets/admin/editor-wizard/steps/lesson-details-step.js:54
-#: assets/dist/admin/editor-wizard/index.js:100
-msgid "Illustration of lesson sample with some placeholders."
-msgstr ""
-
 #: assets/admin/editor-wizard/steps/lesson-patterns-step.js:32
 #: assets/dist/admin/editor-wizard/index.js:122
 msgid "Lesson Type"
@@ -6635,26 +6564,6 @@ msgstr ""
 #: assets/admin/editor-wizard/wizard.js:52
 #: assets/dist/admin/editor-wizard/index.js:156
 msgid "Step %1$d of %2$d"
-msgstr ""
-
-#: assets/admin/exit-survey/form.js:63
-#: assets/dist/admin/exit-survey/index.js:17
-msgid "Quick Feedback"
-msgstr ""
-
-#: assets/admin/exit-survey/form.js:65
-#: assets/dist/admin/exit-survey/index.js:17
-msgid "If you have a moment, please let us know why you are deactivating so that we can work to improve our product."
-msgstr ""
-
-#: assets/admin/exit-survey/form.js:80
-#: assets/dist/admin/exit-survey/index.js:17
-msgid "Submit Feedback"
-msgstr ""
-
-#: assets/admin/exit-survey/form.js:87
-#: assets/dist/admin/exit-survey/index.js:17
-msgid "Skip Feedback"
 msgstr ""
 
 #: assets/admin/exit-survey/reasons.js:12
@@ -6702,20 +6611,9 @@ msgstr ""
 msgid "Why are you deactivating?"
 msgstr ""
 
-#: assets/admin/students/student-action-menu/index.js:78
-#: assets/dist/admin/students/student-action-menu/index.js:271
-msgid "Select an action"
-msgstr ""
-
 #: assets/admin/students/student-bulk-action-button/index.js:103
 #: assets/dist/admin/students/student-bulk-action-button/index.js:257
 msgid "Select Action"
-msgstr ""
-
-#: assets/admin/students/student-modal/course-list.js:135
-#: assets/dist/admin/students/student-action-menu/index.js:61
-#: assets/dist/admin/students/student-bulk-action-button/index.js:47
-msgid "Your Courses"
 msgstr ""
 
 #. Translators: placeholder is the number of selected students.
@@ -6780,95 +6678,6 @@ msgstr ""
 msgid "Add text…"
 msgstr ""
 
-#: assets/blocks/button/button-settings.js:24
-#: assets/blocks/course-outline/module-block/module-settings.js:25
-#: assets/dist/blocks/global-blocks.js:160
-#: assets/dist/blocks/shared.js:126
-#: assets/dist/blocks/single-course.js:390
-#: assets/dist/blocks/single-lesson.js:126
-#: assets/dist/blocks/single-page.js:178
-msgid "Border settings"
-msgstr ""
-
-#: assets/blocks/button/button-settings.js:28
-#: assets/dist/blocks/global-blocks.js:160
-#: assets/dist/blocks/global-blocks.js:629
-#: assets/dist/blocks/shared.js:126
-#: assets/dist/blocks/single-lesson.js:126
-#: assets/dist/blocks/single-page.js:178
-#: assets/dist/blocks/single-page.js:346
-#: assets/shared/blocks/progress-bar/progress-bar-settings.js:39
-msgid "Border radius"
-msgstr ""
-
-#: assets/blocks/button/button-settings.js:55
-#: assets/dist/blocks/global-blocks.js:162
-#: assets/dist/blocks/shared.js:128
-#: assets/dist/blocks/single-lesson.js:128
-#: assets/dist/blocks/single-page.js:180
-msgid "Change button alignment"
-msgstr ""
-
-#: assets/blocks/button/color-hooks.js:43
-#: assets/blocks/course-categories-block/course-categories-edit.js:131
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:123
-#: assets/dist/blocks/global-blocks.js:168
-#: assets/dist/blocks/global-blocks.js:252
-#: assets/dist/blocks/shared.js:134
-#: assets/dist/blocks/single-course.js:328
-#: assets/dist/blocks/single-lesson.js:134
-#: assets/dist/blocks/single-page.js:186
-msgid "Background color"
-msgstr ""
-
-#: assets/blocks/button/color-hooks.js:47
-#: assets/blocks/course-categories-block/course-categories-edit.js:127
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:127
-#: assets/blocks/course-outline/module-block/module-edit.js:254
-#: assets/blocks/course-progress-block/course-progress-edit.js:131
-#: assets/dist/blocks/global-blocks.js:168
-#: assets/dist/blocks/global-blocks.js:252
-#: assets/dist/blocks/global-blocks.js:546
-#: assets/dist/blocks/shared.js:134
-#: assets/dist/blocks/single-course.js:328
-#: assets/dist/blocks/single-course.js:370
-#: assets/dist/blocks/single-lesson.js:134
-#: assets/dist/blocks/single-page.js:186
-msgid "Text color"
-msgstr ""
-
-#: assets/blocks/button/index.js:29
-#: assets/dist/blocks/global-blocks.js:187
-#: assets/dist/blocks/shared.js:153
-#: assets/dist/blocks/single-lesson.js:153
-#: assets/dist/blocks/single-page.js:205
-msgid "Fill"
-msgstr ""
-
-#: assets/blocks/button/index.js:33
-#: assets/dist/blocks/global-blocks.js:187
-#: assets/dist/blocks/shared.js:153
-#: assets/dist/blocks/single-lesson.js:153
-#: assets/dist/blocks/single-page.js:205
-msgid "Outline"
-msgstr ""
-
-#: assets/blocks/button/index.js:37
-#: assets/dist/blocks/global-blocks.js:187
-#: assets/dist/blocks/shared.js:153
-#: assets/dist/blocks/single-lesson.js:153
-#: assets/dist/blocks/single-page.js:205
-msgid "Link"
-msgstr ""
-
-#: assets/blocks/button/index.js:145
-#: assets/dist/blocks/global-blocks.js:187
-#: assets/dist/blocks/shared.js:153
-#: assets/dist/blocks/single-lesson.js:153
-#: assets/dist/blocks/single-page.js:205
-msgid "This block can only be used inside the Course List block."
-msgstr ""
-
 #: assets/blocks/conditional-content-block/conditional-content-settings.js:89
 #: assets/dist/blocks/shared.js:183
 msgid "Visible when"
@@ -6907,26 +6716,9 @@ msgstr ""
 msgid "Button"
 msgstr ""
 
-#: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:15
-#: assets/blocks/course-actions-block/course-actions/index.js:22
-#: assets/dist/blocks/global-blocks.js:207
-#: assets/dist/blocks/global-blocks.js:230
-msgid "Start Course"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:22
-#: assets/dist/blocks/global-blocks.js:207
-msgid "Visit Results"
-msgstr ""
-
 #: assets/blocks/course-actions-block/course-actions/course-actions-edit.js:39
 #: assets/dist/blocks/global-blocks.js:209
 msgid "The Course Actions block can only be used inside the Course List block."
-msgstr ""
-
-#: assets/blocks/course-categories-block/course-categories-edit.js:98
-#: assets/dist/blocks/global-blocks.js:259
-msgid "The Course Categories block can only be used inside the Course List block."
 msgstr ""
 
 #: assets/blocks/course-categories-block/index.js:23
@@ -6937,76 +6729,6 @@ msgstr ""
 #: assets/blocks/course-categories-block/index.js:27
 #: assets/dist/blocks/global-blocks.js:287
 msgid "Movies"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:16
-#: assets/dist/blocks/single-page.js:213
-msgid "Course Completed Actions"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:17
-#: assets/dist/blocks/single-page.js:213
-msgid "Prompt students to take action after completing a course."
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:25
-#: assets/dist/blocks/single-page.js:213
-msgid "Actions"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:26
-#: assets/dist/blocks/single-page.js:213
-msgid "Buttons"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:28
-#: assets/dist/blocks/single-page.js:213
-msgid "View Certificate"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:44
-#: assets/dist/blocks/single-page.js:213
-msgid "Prompt students to find more courses."
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:50
-#: assets/dist/blocks/single-page.js:213
-msgid "Archive"
-msgstr ""
-
-#: assets/blocks/course-list-block/hooks.js:88
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:60
-#: assets/dist/blocks/global-blocks.js:311
-#: assets/dist/blocks/shared.js:227
-#: assets/dist/blocks/single-page.js:276
-msgid "Grid view"
-msgstr ""
-
-#: assets/blocks/course-list-block/index.js:45
-#: assets/dist/blocks/global-blocks.js:323
-#: assets/dist/blocks/shared.js:239
-msgid "Show a list of courses."
-msgstr ""
-
-#: assets/blocks/course-list-block/index.js:50
-#: assets/dist/blocks/global-blocks.js:323
-#: assets/dist/blocks/shared.js:239
-msgid "List"
-msgstr ""
-
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:59
-#: assets/dist/blocks/global-blocks.js:358
-msgid "Student Courses"
-msgstr ""
-
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:118
-#: assets/dist/blocks/global-blocks.js:358
-msgid "The Course List Filter block can only be used inside the Course List block."
-msgstr ""
-
-#: assets/blocks/course-list-filter-block/course-list-filter-edit.js:129
-#: assets/dist/blocks/global-blocks.js:358
-msgid "Filter Type"
 msgstr ""
 
 #. translators: Error message.
@@ -7028,21 +6750,6 @@ msgstr ""
 #: assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js:67
 #: assets/dist/blocks/single-course.js:317
 msgid "Save to edit lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:60
-#: assets/dist/blocks/single-course.js:333
-msgid "Unsaved"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:62
-#: assets/dist/blocks/single-course.js:333
-msgid "Draft"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:92
-#: assets/dist/blocks/single-course.js:333
-msgid "Add Lesson"
 msgstr ""
 
 #: assets/blocks/course-outline/lesson-block/lesson-settings.js:45
@@ -7080,19 +6787,13 @@ msgstr ""
 msgid "Minimal"
 msgstr ""
 
-#: assets/blocks/course-outline/module-block/module-edit.js:185
-#: assets/dist/blocks/single-course.js:381
-msgid "Module name"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-edit.js:252
-#: assets/dist/blocks/single-course.js:370
-msgid "Main color"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-edit.js:257
-#: assets/dist/blocks/single-course.js:370
-msgid "Border color"
+#: assets/blocks/course-outline/module-block/module-settings.js:25
+#: assets/dist/blocks/global-blocks.js:160
+#: assets/dist/blocks/shared.js:126
+#: assets/dist/blocks/single-course.js:390
+#: assets/dist/blocks/single-lesson.js:126
+#: assets/dist/blocks/single-page.js:178
+msgid "Border settings"
 msgstr ""
 
 #: assets/blocks/course-outline/module-block/module-settings.js:31
@@ -7185,72 +6886,6 @@ msgstr ""
 msgid "The Course Overview block can only be used inside the Course List block."
 msgstr ""
 
-#: assets/blocks/course-progress-block/course-progress-edit.js:85
-#: assets/dist/blocks/global-blocks.js:546
-msgid "The Course Progress block can only be used inside the Course List block."
-msgstr ""
-
-#: assets/blocks/course-progress-block/course-progress-edit.js:102
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:168
-#: assets/dist/blocks/global-blocks.js:546
-#: assets/dist/blocks/single-page.js:267
-msgid "lessons"
-msgstr ""
-
-#: assets/blocks/course-progress-block/course-progress-edit.js:123
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:297
-#: assets/dist/blocks/global-blocks.js:546
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Progress bar color"
-msgstr ""
-
-#: assets/blocks/course-progress-block/course-progress-edit.js:127
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:306
-#: assets/dist/blocks/global-blocks.js:546
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Progress bar background color"
-msgstr ""
-
-#. translators: Mock lesson number.
-#: assets/blocks/course-results-block/course-results-edit.js:36
-#: assets/dist/blocks/single-page.js:223
-msgid "Lesson %s"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:148
-#: assets/course-theme/blocks/course-navigation/index.js:31
-#: assets/dist/blocks/single-page.js:225
-#: assets/dist/course-theme/blocks/index.js:241
-msgid "Module A"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:154
-#: assets/course-theme/blocks/course-navigation/index.js:55
-#: assets/dist/blocks/single-page.js:225
-#: assets/dist/course-theme/blocks/index.js:241
-msgid "Module B"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:160
-#: assets/dist/blocks/single-page.js:225
-msgid "Module C"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:175
-#: assets/dist/blocks/single-page.js:225
-msgid "Module color"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:179
-#: assets/dist/blocks/single-page.js:225
-msgid "Module text color"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:183
-#: assets/dist/blocks/single-page.js:225
-msgid "Module border color"
-msgstr ""
-
 #: assets/blocks/editor-components/confirm-dialog/confirm-dialog.js:30
 msgid "OK"
 msgstr ""
@@ -7261,6 +6896,16 @@ msgstr ""
 msgid "Characters: %1$d/%2$d"
 msgstr ""
 
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:140
+#: assets/course-theme/blocks/lesson-blocks/index.js:45
+#: assets/course-theme/blocks/lesson-blocks/index.js:54
+#: assets/dist/admin/editor-wizard/index.js:72
+#: assets/dist/blocks/single-page.js:225
+#: assets/dist/blocks/single-page.js:267
+#: assets/dist/course-theme/blocks/index.js:255
+msgid "Course Title"
+msgstr ""
+
 #: assets/blocks/learner-courses-block/learner-courses-edit.js:146
 #: assets/dist/blocks/single-page.js:267
 msgid "Category Name"
@@ -7269,6 +6914,12 @@ msgstr ""
 #: assets/blocks/learner-courses-block/learner-courses-edit.js:152
 #: assets/dist/blocks/single-page.js:267
 msgid "This is a preview of the course description…"
+msgstr ""
+
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:168
+#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/single-page.js:267
+msgid "lessons"
 msgstr ""
 
 #: assets/blocks/learner-courses-block/learner-courses-settings.js:36
@@ -7291,6 +6942,13 @@ msgstr ""
 #: assets/blocks/learner-courses-block/learner-courses-settings.js:55
 #: assets/dist/blocks/single-page.js:276
 msgid "List view"
+msgstr ""
+
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:60
+#: assets/dist/blocks/global-blocks.js:311
+#: assets/dist/blocks/shared.js:227
+#: assets/dist/blocks/single-page.js:276
+msgid "Grid view"
 msgstr ""
 
 #: assets/blocks/learner-courses-block/learner-courses-settings.js:68
@@ -7319,7 +6977,6 @@ msgid "Layout"
 msgstr ""
 
 #: assets/blocks/learner-courses-block/learner-courses-settings.js:138
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:275
 #: assets/dist/blocks/global-blocks.js:649
 #: assets/dist/blocks/quiz/index.js:855
 #: assets/dist/blocks/shared.js:309
@@ -7327,7 +6984,6 @@ msgstr ""
 #: assets/dist/blocks/single-lesson.js:417
 #: assets/dist/blocks/single-page.js:276
 #: assets/dist/blocks/single-page.js:366
-#: assets/shared/blocks/settings.js:82
 msgid "Color settings"
 msgstr ""
 
@@ -7401,125 +7057,17 @@ msgstr ""
 msgid "Enable a student to view the quiz."
 msgstr ""
 
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:43
-#: assets/dist/blocks/single-lesson.js:382
-#: assets/dist/course-theme/blocks/index.js:234
-msgid "Properties"
-msgstr ""
-
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:56
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:95
-#: assets/dist/blocks/single-lesson.js:382
-#: assets/dist/course-theme/blocks/index.js:234
-msgid "minute"
-msgid_plural "minutes"
-msgstr[0] ""
-msgstr[1] ""
-
 #: assets/blocks/quiz/answer-blocks/file-upload.js:13
 #: assets/dist/blocks/quiz/index.js:204
 msgid "Browse…"
 msgstr ""
 
-#: assets/blocks/quiz/answer-blocks/gap-fill.js:41
-#: assets/dist/blocks/quiz/index.js:211
-msgid "Text before the gap"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/gap-fill.js:64
-#: assets/dist/blocks/quiz/index.js:211
-msgid "Add right answers. Separate with commas or the Enter key."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/gap-fill.js:74
-#: assets/dist/blocks/quiz/index.js:211
-msgid "Text after the gap"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:40
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Select from a list of options."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:61
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Add at least one right and one wrong answer."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:65
-#: assets/blocks/quiz/answer-blocks/index.js:112
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Add a right answer to this question."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:69
-#: assets/dist/blocks/quiz/index.js:237
-msgid "The value of the right answer can not be blank space."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:73
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Add a wrong answer to this question. Value can not be blank space."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:77
-#: assets/dist/blocks/quiz/index.js:237
-msgid "The value of the wrong answer can not be blank space."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:85
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Select whether a statement is true or false."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:96
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Fill in the blank."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:113
-#: assets/dist/blocks/quiz/index.js:237
-msgid "The value of a right answer can not be blank space."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:117
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Add text before or after the gap. Value can not be blank space."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:121
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Value of the text before or after the gap can not be blank space."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:129
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Short answer to an open-ended question."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:139
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Long answer to an open-ended question."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:149
-#: assets/dist/blocks/quiz/index.js:237
-msgid "Upload a file or document."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:54
-#: assets/dist/blocks/quiz/index.js:270
-msgid "Add Answer"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:69
 #: assets/blocks/quiz/answer-blocks/true-false.js:53
 #: assets/dist/blocks/quiz/index.js:270
 #: assets/dist/blocks/quiz/index.js:332
 msgid "Right"
 msgstr ""
 
-#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:70
 #: assets/blocks/quiz/answer-blocks/true-false.js:55
 #: assets/dist/blocks/quiz/index.js:270
 #: assets/dist/blocks/quiz/index.js:332
@@ -7561,52 +7109,6 @@ msgstr ""
 msgid "Display incorrect answer feedback."
 msgstr ""
 
-#: assets/blocks/quiz/category-question-block/category-question-edit.js:75
-#: assets/dist/blocks/quiz/index.js:377
-msgid "Category Question"
-msgstr ""
-
-#. translators: placeholder is number of questions to show from category.
-#: assets/blocks/quiz/category-question-block/category-question-edit.js:82
-#: assets/dist/blocks/quiz/index.js:378
-msgid "%d question"
-msgid_plural "%d questions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:101
-#: assets/dist/blocks/quiz/index.js:387
-msgid "Category Question Settings"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:106
-#: assets/dist/blocks/quiz/index.js:387
-msgid "No question categories exist."
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:134
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:53
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:241
-#: assets/dist/blocks/quiz/index.js:387
-#: assets/dist/blocks/quiz/index.js:777
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Number of Questions"
-msgstr ""
-
-#. translators: The underlying error message.
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:149
-#: assets/dist/blocks/quiz/index.js:388
-msgid "An error occurred while retrieving questions: %s"
-msgstr ""
-
-#. translators: Placeholder is number of questions in category.
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:166
-#: assets/dist/blocks/quiz/index.js:389
-msgid "The selected category has %d question."
-msgid_plural "The selected category has %d questions."
-msgstr[0] ""
-msgstr[1] ""
-
 #: assets/blocks/quiz/category-question-block/index.js:24
 #: assets/dist/blocks/quiz/index.js:418
 msgid "Example Category"
@@ -7633,67 +7135,14 @@ msgstr ""
 msgid "Add a title to this question."
 msgstr ""
 
-#: assets/blocks/quiz/question-block/question-block-helpers.js:20
-#: assets/dist/blocks/quiz/index.js:562
-msgid "Any updates made to this question will also update it in any other quiz that includes it."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-block-helpers.js:25
-#: assets/dist/blocks/quiz/index.js:562
-msgid "Shared Question"
-msgstr ""
-
 #: assets/blocks/quiz/question-block/question-settings.js:34
 #: assets/dist/blocks/quiz/index.js:628
 msgid "Question settings"
 msgstr ""
 
-#: assets/blocks/quiz/question-block/question-type-toolbar.js:26
-#: assets/blocks/quiz/question-block/question-type-toolbar.js:30
-#: assets/dist/blocks/quiz/index.js:635
-msgid "Question Type"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-view.js:56
-#: assets/dist/blocks/quiz/index.js:661
-msgid "Locked"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-view.js:62
-#: assets/dist/blocks/quiz/index.js:661
-msgid "Question Details"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-view.js:66
-#: assets/dist/blocks/quiz/index.js:661
-msgid "You are not allowed to edit this question."
-msgstr ""
-
 #: assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js:20
 #: assets/dist/blocks/quiz/index.js:691
 msgid "Grading Notes"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:51
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:34
-#: assets/dist/blocks/quiz/index.js:709
-#: assets/dist/blocks/quiz/index.js:871
-msgid "View issues"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:58
-#: assets/dist/blocks/quiz/index.js:709
-msgid "This question is incomplete."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:66
-#: assets/dist/blocks/quiz/index.js:709
-msgid "Validation"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:72
-#: assets/dist/blocks/quiz/index.js:709
-msgid "Incomplete questions added to a quiz won't be displayed to the student."
 msgstr ""
 
 #: assets/blocks/quiz/question-description-block/question-description.js:30
@@ -7709,6 +7158,13 @@ msgstr ""
 #: assets/blocks/quiz/quiz-block/pagination-settings.js:29
 #: assets/dist/blocks/quiz/index.js:777
 msgid "Multi-page"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:53
+#: assets/dist/blocks/quiz/index.js:387
+#: assets/dist/blocks/quiz/index.js:777
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Number of Questions"
 msgstr ""
 
 #: assets/blocks/quiz/quiz-block/pagination-settings.js:57
@@ -7777,24 +7233,9 @@ msgstr ""
 msgid "Clear Selected"
 msgstr ""
 
-#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:86
-#: assets/dist/blocks/quiz/index.js:798
-msgid "Search questions"
-msgstr ""
-
 #: assets/blocks/quiz/quiz-block/questions-modal/index.js:54
 #: assets/dist/blocks/quiz/index.js:807
 msgid "Unable to add the selected question(s). Please make sure you are still logged in and try again."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:138
-#: assets/dist/blocks/quiz/index.js:819
-msgid "Toggle all visible questions selection."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:156
-#: assets/dist/blocks/quiz/index.js:819
-msgid "No questions found."
 msgstr ""
 
 #: assets/blocks/quiz/quiz-block/quiz-appender.js:57
@@ -7812,94 +7253,6 @@ msgstr ""
 msgid "Add new or existing question(s)"
 msgstr ""
 
-#: assets/blocks/quiz/quiz-block/quiz-edit.js:74
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:114
-#: assets/dist/blocks/quiz/index.js:837
-#: assets/dist/blocks/quiz/index.js:874
-msgid "Lesson Quiz"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-progress-bar-edit.js:47
-#: assets/dist/blocks/quiz/index.js:846
-msgid "questions"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:122
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:127
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Quiz settings"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:134
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Pass Required"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:141
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Passing Grade (%)"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:159
-#: assets/dist/blocks/quiz/index.js:855
-msgid "What students see when reviewing their quiz after grading."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:165
-#: assets/dist/blocks/quiz/index.js:855
-msgid "If student does not pass quiz"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:176
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Indicate which questions are incorrect."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:186
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Show correct answers."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:196
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Show “Answer Feedback” text."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:210
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Auto Grade"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:211
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Automatically grade Multiple Choice, True/False and Gap Fill questions that have a non-zero point value."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:221
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Allow Retakes"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:230
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Random Question Order"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:245
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Display a random selection of questions."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:281
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Button text color"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:288
-#: assets/dist/blocks/quiz/index.js:855
-msgid "Button background color"
-msgstr ""
-
 #: assets/blocks/quiz/quiz-block/quiz-timer-promo.js:15
 #: assets/dist/blocks/quiz/index.js:864
 msgid "Quiz Timer"
@@ -7908,31 +7261,6 @@ msgstr ""
 #: assets/blocks/quiz/quiz-block/quiz-timer-promo.js:16
 #: assets/dist/blocks/quiz/index.js:864
 msgid "The quiz timer enables you to control how much time a student has to complete the quiz."
-msgstr ""
-
-#. Translators: placeholder is the numer of incomplete questions.
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:42
-#: assets/dist/blocks/quiz/index.js:872
-msgid "There is %d incomplete question in this lesson's quiz."
-msgid_plural "There are %d incomplete questions in this lesson's quiz."
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:120
-#: assets/dist/blocks/quiz/index.js:874
-msgid "Incomplete questions won't be displayed to the student when taking the quiz."
-msgstr ""
-
-#. translators: Error message.
-#: assets/blocks/quiz/quiz-store.js:166
-#: assets/dist/blocks/quiz/index.js:946
-msgid "Quiz settings and questions could not be loaded. %s"
-msgstr ""
-
-#. translators: Error message.
-#: assets/blocks/quiz/quiz-store.js:185
-#: assets/dist/blocks/quiz/index.js:954
-msgid "Quiz settings and questions could not be updated. %s"
 msgstr ""
 
 #: assets/blocks/take-course-block/index.js:17
@@ -7975,6 +7303,12 @@ msgstr ""
 msgid "The View Results block can only be used inside the Course List block."
 msgstr ""
 
+#: assets/course-theme/blocks/course-navigation/index.js:31
+#: assets/dist/blocks/single-page.js:225
+#: assets/dist/course-theme/blocks/index.js:241
+msgid "Module A"
+msgstr ""
+
 #: assets/course-theme/blocks/course-navigation/index.js:43
 #: assets/dist/course-theme/blocks/index.js:241
 msgid "Third Lesson"
@@ -7983,6 +7317,12 @@ msgstr ""
 #: assets/course-theme/blocks/course-navigation/index.js:48
 #: assets/dist/course-theme/blocks/index.js:241
 msgid "Fourth Lesson"
+msgstr ""
+
+#: assets/course-theme/blocks/course-navigation/index.js:55
+#: assets/dist/blocks/single-page.js:225
+#: assets/dist/course-theme/blocks/index.js:241
+msgid "Module B"
 msgstr ""
 
 #: assets/course-theme/blocks/course-navigation/index.js:58
@@ -8115,6 +7455,12 @@ msgstr ""
 msgid "Display title of the current lesson or quiz."
 msgstr ""
 
+#: assets/course-theme/blocks/lesson-blocks/index.js:215
+#: assets/dist/admin/editor-wizard/index.js:100
+#: assets/dist/course-theme/blocks/index.js:255
+msgid "Lesson Title"
+msgstr ""
+
 #: assets/course-theme/blocks/lesson-blocks/index.js:221
 #: assets/dist/course-theme/blocks/index.js:255
 msgid "Course Content"
@@ -8220,11 +7566,6 @@ msgstr ""
 msgid "Automatically fill space between blocks."
 msgstr ""
 
-#: assets/course-theme/blocks/ui/ui-block.js:86
-#: assets/dist/course-theme/blocks/index.js:331
-msgid "Interface Element"
-msgstr ""
-
 #: assets/course-theme/blocks/ui/ui-block.variations.js:57
 #: assets/dist/course-theme/blocks/index.js:339
 msgid "Fixed Header"
@@ -8285,11 +7626,6 @@ msgstr ""
 msgid "Navigation area below the content."
 msgstr ""
 
-#: assets/course-theme/complete-lesson-button.js:79
-#: assets/dist/course-theme/learning-mode.js:305
-msgid "Lesson complete"
-msgstr ""
-
 #. translators: The %1$s is the name of the Learning Mode template.
 #: assets/course-theme/learning-mode-templates/template-preview.js:27
 #: assets/dist/course-theme/learning-mode-templates/index.js:70
@@ -8315,7 +7651,6 @@ msgstr ""
 #: assets/dist/data-port/import.js:809
 #: assets/dist/home/index.js:381
 #: assets/dist/setup-wizard/index.js:626
-#: assets/home/main.js:58
 #: assets/setup-wizard/index.js:72
 msgid "An error has occurred while fetching the data. Please try again later!"
 msgstr ""
@@ -8324,7 +7659,6 @@ msgstr ""
 #: assets/dist/data-port/import.js:809
 #: assets/dist/home/index.js:381
 #: assets/dist/setup-wizard/index.js:626
-#: assets/home/main.js:63
 #: assets/setup-wizard/index.js:77
 msgid "Error details:"
 msgstr ""
@@ -8357,7 +7691,6 @@ msgstr ""
 #: assets/data-port/import/done/done-page.js:81
 #: assets/dist/data-port/import.js:393
 #: assets/dist/setup-wizard/index.js:232
-#: assets/setup-wizard/features/use-actions-navigator.js:76
 msgid "Retry"
 msgstr ""
 
@@ -8461,6 +7794,38 @@ msgstr ""
 msgid "Choose one or more CSV files to upload from your computer."
 msgstr ""
 
+#: assets/dist/admin/editor-wizard/index.js:64
+msgid "Sensei block patterns"
+msgstr ""
+
+#: assets/dist/admin/editor-wizard/index.js:72
+msgid "Create your course"
+msgstr ""
+
+#: assets/dist/admin/editor-wizard/index.js:72
+msgid "Keep your Course Title short as it will get displayed in different places around your website. You can easily change both later."
+msgstr ""
+
+#: assets/dist/admin/editor-wizard/index.js:72
+msgid "Course Description"
+msgstr ""
+
+#: assets/dist/admin/editor-wizard/index.js:72
+msgid "Illustration of course sample with some placeholders."
+msgstr ""
+
+#: assets/dist/admin/editor-wizard/index.js:100
+msgid "Create your lesson"
+msgstr ""
+
+#: assets/dist/admin/editor-wizard/index.js:100
+msgid "It is best to keep your Lesson Title short because it will show in your course outline and navigation. You can easily change both later."
+msgstr ""
+
+#: assets/dist/admin/editor-wizard/index.js:100
+msgid "Illustration of lesson sample with some placeholders."
+msgstr ""
+
 #: assets/dist/admin/editor-wizard/index.js:206
 #: assets/dist/home/index.js:249
 #: assets/extensions/store.js:139
@@ -8487,6 +7852,136 @@ msgstr ""
 msgid "There was an error while installing the plugin: %1$s"
 msgstr ""
 
+#: assets/dist/admin/exit-survey/index.js:17
+msgid "Quick Feedback"
+msgstr ""
+
+#: assets/dist/admin/exit-survey/index.js:17
+msgid "If you have a moment, please let us know why you are deactivating so that we can work to improve our product."
+msgstr ""
+
+#: assets/dist/admin/exit-survey/index.js:17
+msgid "Submit Feedback"
+msgstr ""
+
+#: assets/dist/admin/exit-survey/index.js:17
+msgid "Skip Feedback"
+msgstr ""
+
+#: assets/dist/admin/students/student-action-menu/index.js:61
+#: assets/dist/admin/students/student-bulk-action-button/index.js:47
+msgid "Your Courses"
+msgstr ""
+
+#: assets/dist/admin/students/student-action-menu/index.js:271
+msgid "Select an action"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:160
+#: assets/dist/blocks/global-blocks.js:629
+#: assets/dist/blocks/shared.js:126
+#: assets/dist/blocks/single-lesson.js:126
+#: assets/dist/blocks/single-page.js:178
+#: assets/dist/blocks/single-page.js:346
+#: assets/shared/blocks/progress-bar/progress-bar-settings.js:39
+msgid "Border radius"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:162
+#: assets/dist/blocks/shared.js:128
+#: assets/dist/blocks/single-lesson.js:128
+#: assets/dist/blocks/single-page.js:180
+msgid "Change button alignment"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:168
+#: assets/dist/blocks/global-blocks.js:252
+#: assets/dist/blocks/shared.js:134
+#: assets/dist/blocks/single-course.js:328
+#: assets/dist/blocks/single-lesson.js:134
+#: assets/dist/blocks/single-page.js:186
+msgid "Background color"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:168
+#: assets/dist/blocks/global-blocks.js:252
+#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/shared.js:134
+#: assets/dist/blocks/single-course.js:328
+#: assets/dist/blocks/single-course.js:370
+#: assets/dist/blocks/single-lesson.js:134
+#: assets/dist/blocks/single-page.js:186
+msgid "Text color"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:187
+#: assets/dist/blocks/shared.js:153
+#: assets/dist/blocks/single-lesson.js:153
+#: assets/dist/blocks/single-page.js:205
+msgid "Fill"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:187
+#: assets/dist/blocks/shared.js:153
+#: assets/dist/blocks/single-lesson.js:153
+#: assets/dist/blocks/single-page.js:205
+msgid "Outline"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:187
+#: assets/dist/blocks/shared.js:153
+#: assets/dist/blocks/single-lesson.js:153
+#: assets/dist/blocks/single-page.js:205
+msgid "Link"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:187
+#: assets/dist/blocks/shared.js:153
+#: assets/dist/blocks/single-lesson.js:153
+#: assets/dist/blocks/single-page.js:205
+msgid "This block can only be used inside the Course List block."
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:259
+msgid "The Course Categories block can only be used inside the Course List block."
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:323
+#: assets/dist/blocks/shared.js:239
+msgid "Show a list of courses."
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:323
+#: assets/dist/blocks/shared.js:239
+msgid "List"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:358
+msgid "Student Courses"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:358
+msgid "The Course List Filter block can only be used inside the Course List block."
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:358
+msgid "Filter Type"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Progress bar color"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:546
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Progress bar background color"
+msgstr ""
+
+#: assets/dist/blocks/global-blocks.js:546
+msgid "The Course Progress block can only be used inside the Course List block."
+msgstr ""
+
 #: assets/dist/blocks/global-blocks.js:629
 #: assets/dist/blocks/single-page.js:346
 #: assets/shared/blocks/progress-bar/progress-bar-settings.js:33
@@ -8497,8 +7992,118 @@ msgstr ""
 #: assets/dist/blocks/global-blocks.js:639
 #: assets/dist/blocks/quiz/index.js:1056
 #: assets/dist/blocks/single-page.js:356
-#: assets/shared/blocks/progress-bar/progress-bar.js:60
 msgid "%1$d of %2$d %3$s completed"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:211
+msgid "Text before the gap"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:211
+msgid "Add right answers. Separate with commas or the Enter key."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:211
+msgid "Text after the gap"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Select from a list of options."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Add at least one right and one wrong answer."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Add a right answer to this question."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "The value of the right answer can not be blank space."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Add a wrong answer to this question. Value can not be blank space."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "The value of the wrong answer can not be blank space."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Select whether a statement is true or false."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Fill in the blank."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "The value of a right answer can not be blank space."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Add text before or after the gap. Value can not be blank space."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Value of the text before or after the gap can not be blank space."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Short answer to an open-ended question."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Long answer to an open-ended question."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:237
+msgid "Upload a file or document."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:270
+msgid "Add Answer"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:377
+msgid "Category Question"
+msgstr ""
+
+#. translators: placeholder is number of questions to show from category.
+#: assets/dist/blocks/quiz/index.js:378
+msgid "%d question"
+msgid_plural "%d questions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/blocks/quiz/index.js:387
+msgid "Category Question Settings"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:387
+msgid "No question categories exist."
+msgstr ""
+
+#. translators: The underlying error message.
+#: assets/dist/blocks/quiz/index.js:388
+msgid "An error occurred while retrieving questions: %s"
+msgstr ""
+
+#. translators: Placeholder is number of questions in category.
+#: assets/dist/blocks/quiz/index.js:389
+msgid "The selected category has %d question."
+msgid_plural "The selected category has %d questions."
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/blocks/quiz/index.js:562
+msgid "Any updates made to this question will also update it in any other quiz that includes it."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:562
+msgid "Shared Question"
 msgstr ""
 
 #. Translators: placeholder is the grade for the questions.
@@ -8510,6 +8115,234 @@ msgstr[1] ""
 
 #: assets/dist/blocks/quiz/index.js:603
 msgid "Question Title"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:635
+msgid "Question Type"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:661
+msgid "Locked"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:661
+msgid "Question Details"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:661
+msgid "You are not allowed to edit this question."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:709
+#: assets/dist/blocks/quiz/index.js:871
+msgid "View issues"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:709
+msgid "This question is incomplete."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:709
+msgid "Validation"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:709
+msgid "Incomplete questions added to a quiz won't be displayed to the student."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:798
+msgid "Search questions"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:819
+msgid "Toggle all visible questions selection."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:819
+msgid "No questions found."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:837
+#: assets/dist/blocks/quiz/index.js:874
+msgid "Lesson Quiz"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:846
+msgid "questions"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Quiz settings"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Pass Required"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Passing Grade (%)"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "What students see when reviewing their quiz after grading."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "If student does not pass quiz"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Indicate which questions are incorrect."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Show correct answers."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Show “Answer Feedback” text."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Auto Grade"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Automatically grade Multiple Choice, True/False and Gap Fill questions that have a non-zero point value."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Allow Retakes"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Random Question Order"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Display a random selection of questions."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Button text color"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:855
+msgid "Button background color"
+msgstr ""
+
+#. Translators: placeholder is the numer of incomplete questions.
+#: assets/dist/blocks/quiz/index.js:872
+msgid "There is %d incomplete question in this lesson's quiz."
+msgid_plural "There are %d incomplete questions in this lesson's quiz."
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/blocks/quiz/index.js:874
+msgid "Incomplete questions won't be displayed to the student when taking the quiz."
+msgstr ""
+
+#. translators: Error message.
+#: assets/dist/blocks/quiz/index.js:946
+msgid "Quiz settings and questions could not be loaded. %s"
+msgstr ""
+
+#. translators: Error message.
+#: assets/dist/blocks/quiz/index.js:954
+msgid "Quiz settings and questions could not be updated. %s"
+msgstr ""
+
+#: assets/dist/blocks/single-course.js:333
+msgid "Unsaved"
+msgstr ""
+
+#: assets/dist/blocks/single-course.js:333
+msgid "Draft"
+msgstr ""
+
+#: assets/dist/blocks/single-course.js:333
+msgid "Add Lesson"
+msgstr ""
+
+#: assets/dist/blocks/single-course.js:370
+msgid "Main color"
+msgstr ""
+
+#: assets/dist/blocks/single-course.js:370
+msgid "Border color"
+msgstr ""
+
+#: assets/dist/blocks/single-course.js:381
+msgid "Module name"
+msgstr ""
+
+#: assets/dist/blocks/single-lesson.js:382
+#: assets/dist/course-theme/blocks/index.js:234
+msgid "Properties"
+msgstr ""
+
+#: assets/dist/blocks/single-lesson.js:382
+#: assets/dist/course-theme/blocks/index.js:234
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/blocks/single-page.js:213
+msgid "Course Completed Actions"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:213
+msgid "Prompt students to take action after completing a course."
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:213
+msgid "Actions"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:213
+msgid "Buttons"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:213
+msgid "View Certificate"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:213
+msgid "Prompt students to find more courses."
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:213
+msgid "Archive"
+msgstr ""
+
+#. translators: Mock lesson number.
+#: assets/dist/blocks/single-page.js:223
+msgid "Lesson %s"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:225
+msgid "Module color"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:225
+msgid "Module text color"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:225
+msgid "Module border color"
+msgstr ""
+
+#: assets/dist/blocks/single-page.js:225
+msgid "Module C"
+msgstr ""
+
+#: assets/dist/course-theme/blocks/index.js:331
+msgid "Interface Element"
+msgstr ""
+
+#: assets/dist/course-theme/learning-mode.js:305
+msgid "Lesson complete"
 msgstr ""
 
 #: assets/dist/data-port/export.js:17
@@ -8529,7 +8362,6 @@ msgid "Warning"
 msgstr ""
 
 #: assets/dist/home/index.js:309
-#: assets/home/card.js:53
 msgid "New version"
 msgstr ""
 
@@ -8603,7 +8435,6 @@ msgid "See more"
 msgstr ""
 
 #: assets/dist/home/index.js:442
-#: assets/home/sections/quick-links.js:105
 msgid "Quick Links"
 msgstr ""
 
@@ -8735,13 +8566,11 @@ msgstr ""
 
 #: assets/dist/js/admin/course-edit.js:36
 #: assets/dist/js/admin/lesson-edit.js:16
-#: assets/js/admin/blocks-toggling-control.js:129
 msgid "It looks like this course page doesn't have any Sensei blocks. This means that content will be handled by custom templates."
 msgstr ""
 
 #: assets/dist/js/admin/course-edit.js:36
 #: assets/dist/js/admin/lesson-edit.js:16
-#: assets/js/admin/blocks-toggling-control.js:138
 msgid "Learn more"
 msgstr ""
 
@@ -8806,17 +8635,14 @@ msgid "Create a product"
 msgstr ""
 
 #: assets/dist/js/admin/course-edit.js:140
-#: assets/js/admin/course-theme/course-theme-sidebar.js:39
 msgid "Learning Mode is enabled globally."
 msgstr ""
 
 #: assets/dist/js/admin/course-edit.js:140
-#: assets/js/admin/course-theme/course-theme-sidebar.js:48
 msgid "Enable Learning Mode"
 msgstr ""
 
 #: assets/dist/js/admin/course-edit.js:140
-#: assets/js/admin/course-theme/course-theme-sidebar.js:60
 msgid "Change Template"
 msgstr ""
 
@@ -8876,7 +8702,6 @@ msgid "Go to Sensei Home"
 msgstr ""
 
 #: assets/dist/setup-wizard/index.js:232
-#: assets/setup-wizard/features/use-actions-navigator.js:80
 msgid "Skip"
 msgstr ""
 
@@ -9000,455 +8825,4 @@ msgstr ""
 #: assets/dist/setup-wizard/index.js:307
 #: assets/setup-wizard/welcome/index.js:80
 msgid "Skip onboarding"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block title"
-msgid "Conditional Content"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block description"
-msgid "Content inside this block will be shown to the selected subgroup of users."
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block keyword"
-msgid "enrolled"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block keyword"
-msgid "content"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block keyword"
-msgid "locked"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block keyword"
-msgid "private"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block keyword"
-msgid "completed"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block keyword"
-msgid "not enrolled"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block keyword"
-msgid "restrict"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/block.json
-msgctxt "block keyword"
-msgid "access"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-msgctxt "block title"
-msgid "Course Actions"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-msgctxt "block description"
-msgid "Enable a student to perform specific actions for a course."
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-#: assets/blocks/course-categories-block/block.json
-#: assets/blocks/course-list-filter-block/block.json
-#: assets/blocks/course-outline/lesson-block/block.json
-#: assets/blocks/course-outline/outline-block/block.json
-#: assets/blocks/course-progress-block/block.json
-#: assets/blocks/course-results-block/block.json
-msgctxt "block keyword"
-msgid "course"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block keyword"
-msgid "actions"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block keyword"
-msgid "buttons"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-msgctxt "block keyword"
-msgid "start course"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-msgctxt "block keyword"
-msgid "continue"
-msgstr ""
-
-#: assets/blocks/course-actions-block/course-actions/block.json
-msgctxt "block keyword"
-msgid "visit results"
-msgstr ""
-
-#: assets/blocks/course-categories-block/block.json
-msgctxt "block title"
-msgid "Course Categories"
-msgstr ""
-
-#: assets/blocks/course-categories-block/block.json
-msgctxt "block description"
-msgid "Show the course categories"
-msgstr ""
-
-#: assets/blocks/course-categories-block/block.json
-#: assets/blocks/course-list-filter-block/block.json
-#: assets/blocks/course-outline/module-block/block.json
-#: assets/blocks/course-outline/outline-block/block.json
-#: assets/blocks/course-results-block/block.json
-msgctxt "block keyword"
-msgid "lessons"
-msgstr ""
-
-#: assets/blocks/course-categories-block/block.json
-#: assets/blocks/course-list-filter-block/block.json
-msgctxt "block keyword"
-msgid "categories"
-msgstr ""
-
-#: assets/blocks/course-list-filter-block/block.json
-msgctxt "block title"
-msgid "Course List Filter"
-msgstr ""
-
-#: assets/blocks/course-list-filter-block/block.json
-msgctxt "block description"
-msgid "Filter courses in Course List block"
-msgstr ""
-
-#: assets/blocks/course-list-filter-block/block.json
-msgctxt "block keyword"
-msgid "featured"
-msgstr ""
-
-#: assets/blocks/course-list-filter-block/block.json
-msgctxt "block keyword"
-msgid "filter"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/block.json
-msgctxt "block title"
-msgid "Lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/block.json
-msgctxt "block description"
-msgid "Where your course content lives."
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/block.json
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block keyword"
-msgid "lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/block.json
-msgctxt "block title"
-msgid "Module"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/block.json
-msgctxt "block description"
-msgid "Group related lessons together."
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/block.json
-msgctxt "block keyword"
-msgid "module"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/block.json
-msgctxt "block keyword"
-msgid "course module"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/block.json
-msgctxt "block keyword"
-msgid "group"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/block.json
-msgctxt "block title"
-msgid "Course Outline"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/block.json
-msgctxt "block description"
-msgid "Manage your Sensei LMS course outline."
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/block.json
-#: assets/blocks/course-results-block/block.json
-msgctxt "block keyword"
-msgid "modules"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/block.json
-msgctxt "block keyword"
-msgid "outline"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/block.json
-msgctxt "block keyword"
-msgid "structure"
-msgstr ""
-
-#: assets/blocks/course-overview-block/block.json
-msgctxt "block title"
-msgid "Course Overview"
-msgstr ""
-
-#: assets/blocks/course-overview-block/block.json
-msgctxt "block description"
-msgid "Displays a link to the course."
-msgstr ""
-
-#: assets/blocks/course-progress-block/block.json
-msgctxt "block title"
-msgid "Course Progress"
-msgstr ""
-
-#: assets/blocks/course-progress-block/block.json
-msgctxt "block description"
-msgid "Display the user's progress in the course. This block is only displayed if the user is enrolled."
-msgstr ""
-
-#: assets/blocks/course-progress-block/block.json
-msgctxt "block keyword"
-msgid "progress"
-msgstr ""
-
-#: assets/blocks/course-progress-block/block.json
-msgctxt "block keyword"
-msgid "bar"
-msgstr ""
-
-#: assets/blocks/course-results-block/block.json
-msgctxt "block title"
-msgid "Course Results"
-msgstr ""
-
-#: assets/blocks/course-results-block/block.json
-msgctxt "block description"
-msgid "Show course results to students on the course completion page."
-msgstr ""
-
-#: assets/blocks/course-results-block/block.json
-msgctxt "block keyword"
-msgid "results"
-msgstr ""
-
-#: assets/blocks/course-results-block/block.json
-msgctxt "block keyword"
-msgid "completion"
-msgstr ""
-
-#: assets/blocks/featured-video/block.json
-msgctxt "block title"
-msgid "Featured Video"
-msgstr ""
-
-#: assets/blocks/featured-video/block.json
-msgctxt "block description"
-msgid "Add a featured video to your lesson to highlight the video and make use of our video templates."
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block title"
-msgid "Student Courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block description"
-msgid "Manage what students see on their dashboard. This block is only displayed to logged in students."
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block keyword"
-msgid "student courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block keyword"
-msgid "my courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block keyword"
-msgid "dashboard"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block keyword"
-msgid "courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block keyword"
-msgid "learner"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/block.json
-msgctxt "block keyword"
-msgid "student"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block title"
-msgid "Lesson Actions"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block description"
-msgid "Enable a student to perform specific actions for a lesson."
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block keyword"
-msgid "complete"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block keyword"
-msgid "next"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/block.json
-msgctxt "block keyword"
-msgid "reset"
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block title"
-msgid "Lesson Properties"
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block description"
-msgid "Add lesson properties such as length and difficulty."
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block keyword"
-msgid "metadata"
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block keyword"
-msgid "length"
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block keyword"
-msgid "complexity"
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block keyword"
-msgid "difficulty"
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block keyword"
-msgid "lesson information"
-msgstr ""
-
-#: assets/blocks/lesson-properties/block.json
-msgctxt "block keyword"
-msgid "lesson properties"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/block.json
-msgctxt "block title"
-msgid "Category Question"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/block.json
-msgctxt "block description"
-msgid "Pull questions from a question category."
-msgstr ""
-
-#: assets/blocks/quiz/question-answers-block/block.json
-msgctxt "block title"
-msgid "Answers"
-msgstr ""
-
-#: assets/blocks/quiz/question-answers-block/block.json
-msgctxt "block description"
-msgid "Question Answers."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/block.json
-msgctxt "block title"
-msgid "Question"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/block.json
-msgctxt "block description"
-msgid "The building block of all quizzes."
-msgstr ""
-
-#: assets/blocks/quiz/question-description-block/block.json
-msgctxt "block title"
-msgid "Description"
-msgstr ""
-
-#: assets/blocks/quiz/question-description-block/block.json
-msgctxt "block description"
-msgid "Question Description."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/block.json
-msgctxt "block title"
-msgid "Quiz"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/block.json
-msgctxt "block description"
-msgid "Evaluate progress and strengthen understanding of course concepts."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/block.json
-msgctxt "block keyword"
-msgid "exam"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/block.json
-msgctxt "block keyword"
-msgid "questions"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/block.json
-msgctxt "block keyword"
-msgid "test"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/block.json
-msgctxt "block keyword"
-msgid "assessment"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/block.json
-msgctxt "block keyword"
-msgid "evaluation"
 msgstr ""


### PR DESCRIPTION
Fixes #6321 

### Changes proposed in this Pull Request

Set up translations in the Course List block pattern template.

### Testing instructions

1. Set your site's language to Spanish (note that you may need to save Permalinks to flush the cache and get the frontend paths working).
2. Download the latest translations on the Dashboard > Updates page (Escritorio > Actualizaciones)
3. Create three courses. Add two lessons to each.
4. On one course, complete one lesson.
5. On another course, complete all lessons.
6. Do not start the last course.
7. Install Loco Translate. Open the translation file for Sensei LMS in the language you've chosen.
8. Add translations for "Start Course", "Continue", and "Visit Results" and save. This will ensure the `.po`/`.mo` and `.json` files are generated.
9. Create a new page and add the Course List block (Lista del curso).
10. Ensure that in the editor, the buttons are translated (Empezar el curso)
11. Publish the page and view the frontend. You should see all three button statuses, and they should all be translated: Empezar el curso, Continuar, Visitar resultados.
