### PR TITLE
Add/course list button editing

### DIFF
--- a/assets/blocks/course-actions-block/continue-course/index.js
+++ b/assets/blocks/course-actions-block/continue-course/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 
 /**
@@ -10,7 +9,6 @@ import { BlockControls } from '@wordpress/block-editor';
  */
 import { BlockStyles, createButtonBlockType } from '../../button';
 import CourseStatusToolbar from '../course-status-toolbar';
-import CourseStatusContext from '../course-status-context';
 
 /**
  * Continue Course block.
@@ -41,21 +39,12 @@ export default createButtonBlockType( {
 			BlockStyles.Link,
 		],
 	},
-	EditWrapper: ( { children } ) => {
-		const context = useContext( CourseStatusContext );
-
-		return (
-			<>
-				{ context?.courseStatus && (
-					<BlockControls>
-						<CourseStatusToolbar
-							courseStatus={ context.courseStatus }
-							setCourseStatus={ context.setCourseStatus }
-						/>
-					</BlockControls>
-				) }
-				{ children }
-			</>
-		);
-	},
+	EditWrapper: ( { children } ) => (
+		<>
+			<BlockControls>
+				<CourseStatusToolbar useCourseStatusContext={ true } />
+			</BlockControls>
+			{ children }
+		</>
+	),
 } );

--- a/assets/blocks/course-actions-block/continue-course/index.js
+++ b/assets/blocks/course-actions-block/continue-course/index.js
@@ -42,17 +42,15 @@ export default createButtonBlockType( {
 		],
 	},
 	EditWrapper: ( { children } ) => {
-		const { courseStatus, setCourseStatus } = useContext(
-			CourseStatusContext
-		);
+		const context = useContext( CourseStatusContext );
 
 		return (
 			<>
-				{ !! courseStatus && (
+				{ context?.courseStatus && (
 					<BlockControls>
 						<CourseStatusToolbar
-							courseStatus={ courseStatus }
-							setCourseStatus={ setCourseStatus }
+							courseStatus={ context.courseStatus }
+							setCourseStatus={ context.setCourseStatus }
 						/>
 					</BlockControls>
 				) }

--- a/assets/blocks/course-actions-block/continue-course/index.js
+++ b/assets/blocks/course-actions-block/continue-course/index.js
@@ -2,11 +2,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useContext } from '@wordpress/element';
+import { BlockControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { BlockStyles, createButtonBlockType } from '../../button';
+import CourseStatusToolbar from '../course-status-toolbar';
+import CourseStatusContext from '../course-status-context';
 
 /**
  * Continue Course block.
@@ -36,5 +40,24 @@ export default createButtonBlockType( {
 			BlockStyles.Outline,
 			BlockStyles.Link,
 		],
+	},
+	EditWrapper: ( { children } ) => {
+		const { courseStatus, setCourseStatus } = useContext(
+			CourseStatusContext
+		);
+
+		return (
+			<>
+				{ !! courseStatus && (
+					<BlockControls>
+						<CourseStatusToolbar
+							courseStatus={ courseStatus }
+							setCourseStatus={ setCourseStatus }
+						/>
+					</BlockControls>
+				) }
+				{ children }
+			</>
+		);
 	},
 } );

--- a/assets/blocks/course-actions-block/course-actions/block.json
+++ b/assets/blocks/course-actions-block/course-actions/block.json
@@ -15,13 +15,5 @@
 	"supports": {
 		"html": false
 	},
-    "attributes": {
-        "courseStatus": {
-            "type": "string"
-        }
-    },
-	"usesContext": [ "postType" ],
-    "providesContext": {
-        "sensei-lms/course-actions-course-status": "courseStatus"
-    }
+	"usesContext": [ "postType" ]
 }

--- a/assets/blocks/course-actions-block/course-actions/block.json
+++ b/assets/blocks/course-actions-block/course-actions/block.json
@@ -15,5 +15,13 @@
 	"supports": {
 		"html": false
 	},
-	"usesContext": [ "postType" ]
+    "attributes": {
+        "courseStatus": {
+            "type": "string"
+        }
+    },
+	"usesContext": [ "postType" ],
+    "providesContext": {
+        "sensei-lms/course-actions-course-status": "courseStatus"
+    }
 }

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,13 +29,19 @@ const innerBlocksTemplate = [
  * Edit course actions block component.
  *
  * @param {Object} props
- * @param {Object} props.className        Block className.
- * @param {Object} props.context          Block context.
- * @param {Object} props.context.postType Post type.
+ * @param {Object} props.className               Block className.
+ * @param {Object} props.context                 Block context.
+ * @param {Object} props.context.postType        Post type.
+ * @param {Object} props.attributes              Block attributes.
+ * @param {string} props.attributes.courseStatus The course status for the preview.
+ * @param {Object} props.setAttributes           Block setAttributes function.
  */
-const CourseActionsEdit = ( { className, context: { postType } } ) => {
-	const [ courseStatus, setCourseStatus ] = useState( null );
-
+const CourseActionsEdit = ( {
+	className,
+	context: { postType },
+	attributes: { courseStatus },
+	setAttributes,
+} ) => {
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
@@ -47,6 +52,10 @@ const CourseActionsEdit = ( { className, context: { postType } } ) => {
 			/>
 		);
 	}
+
+	const setCourseStatus = ( newCourseStatus ) => {
+		setAttributes( { courseStatus: newCourseStatus } );
+	};
 
 	return (
 		<>

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -9,6 +9,12 @@ import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
  */
 import InvalidUsageError from '../../../shared/components/invalid-usage';
 import CourseStatusToolbar from '../course-status-toolbar';
+import CourseStatusOptions from '../course-status-options';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
 
 const innerBlocksTemplate = [
 	[
@@ -56,6 +62,13 @@ const CourseActionsEdit = ( {
 	const setCourseStatus = ( newCourseStatus ) => {
 		setAttributes( { courseStatus: newCourseStatus } );
 	};
+
+	// Set the default course status.
+	if ( ! courseStatus ) {
+		setCourseStatus( CourseStatusOptions[ 0 ].value );
+	}
+
+	className = classnames( className, `is-status-${ courseStatus }` );
 
 	return (
 		<>

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -117,9 +117,6 @@ const CourseActionsEdit = ( {
 		);
 	}
 
-	// Set class name for course status.
-	className = classnames( className, `is-status-${ courseStatus }` );
-
 	return (
 		<CourseStatusContext.Provider
 			value={ {
@@ -127,7 +124,12 @@ const CourseActionsEdit = ( {
 				setCourseStatus: setCourseStatusAndSelectChildBlock,
 			} }
 		>
-			<div className={ className }>
+			<div
+				className={ classnames(
+					className,
+					`is-status-${ courseStatus }`
+				) }
+			>
 				<InnerBlocks
 					allowedBlocks={ [
 						'sensei-lms/button-take-course',

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -7,7 +7,7 @@ import {
 	BlockControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -106,6 +106,14 @@ const CourseActionsEdit = ( {
 		[ setCourseStatus, selectChildBlock ]
 	);
 
+	// Set up the value to provide in the context.
+	const contextValue = useMemo( () => {
+		return {
+			courseStatus,
+			setCourseStatus: setCourseStatusAndSelectChildBlock,
+		};
+	}, [ courseStatus, setCourseStatusAndSelectChildBlock ] );
+
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
@@ -118,12 +126,7 @@ const CourseActionsEdit = ( {
 	}
 
 	return (
-		<CourseStatusContext.Provider
-			value={ {
-				courseStatus,
-				setCourseStatus: setCourseStatusAndSelectChildBlock,
-			} }
-		>
+		<CourseStatusContext.Provider value={ contextValue }>
 			<div
 				className={ classnames(
 					className,

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -2,12 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import InvalidUsageError from '../../../shared/components/invalid-usage';
+import CourseStatusToolbar from '../course-status-toolbar';
 
 const innerBlocksTemplate = [
 	[
@@ -33,6 +35,8 @@ const innerBlocksTemplate = [
  * @param {Object} props.context.postType Post type.
  */
 const CourseActionsEdit = ( { className, context: { postType } } ) => {
+	const [ courseStatus, setCourseStatus ] = useState( null );
+
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
@@ -45,17 +49,25 @@ const CourseActionsEdit = ( { className, context: { postType } } ) => {
 	}
 
 	return (
-		<div className={ className }>
-			<InnerBlocks
-				allowedBlocks={ [
-					'sensei-lms/button-take-course',
-					'sensei-lms/button-continue-course',
-					'sensei-lms/button-view-results',
-				] }
-				template={ innerBlocksTemplate }
-				templateLock="all"
-			/>
-		</div>
+		<>
+			<div className={ className }>
+				<InnerBlocks
+					allowedBlocks={ [
+						'sensei-lms/button-take-course',
+						'sensei-lms/button-continue-course',
+						'sensei-lms/button-view-results',
+					] }
+					template={ innerBlocksTemplate }
+					templateLock="all"
+				/>
+			</div>
+			<BlockControls>
+				<CourseStatusToolbar
+					courseStatus={ courseStatus }
+					setCourseStatus={ setCourseStatus }
+				/>
+			</BlockControls>
+		</>
 	);
 };
 

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	BlockControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useCallback, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -41,21 +45,26 @@ const innerBlocksTemplate = [
  * @return {Function} Function to select a child block by block name.
  */
 const useSelectChildBlock = ( clientId ) => {
-	const select = useSelect( 'core/block-editor' );
-	const dispatch = useDispatch( 'core/block-editor' );
+	const childBlocks = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).getBlock( clientId ).innerBlocks;
+		},
+		[ clientId ]
+	);
+
+	const selectBlock = useDispatch( blockEditorStore ).selectBlock;
 
 	return useCallback(
 		( blockName ) => {
-			const childBlocks = select.getBlock( clientId ).innerBlocks;
-			const toSelect = childBlocks.find(
+			const blockToSelect = childBlocks.find(
 				( block ) => block.name === blockName
 			);
 
-			if ( toSelect ) {
-				dispatch.selectBlock( toSelect.clientId );
+			if ( blockToSelect ) {
+				selectBlock( blockToSelect.clientId );
 			}
 		},
-		[ clientId, select, dispatch ]
+		[ childBlocks, selectBlock ]
 	);
 };
 

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import { InnerBlocks, BlockControls } from '@wordpress/block-editor';
 import InvalidUsageError from '../../../shared/components/invalid-usage';
 import CourseStatusToolbar from '../course-status-toolbar';
 import CourseStatusOptions from '../course-status-options';
+import CourseStatusContext from '../course-status-context';
 
 /**
  * External dependencies
@@ -35,19 +37,15 @@ const innerBlocksTemplate = [
  * Edit course actions block component.
  *
  * @param {Object} props
- * @param {Object} props.className               Block className.
- * @param {Object} props.context                 Block context.
- * @param {Object} props.context.postType        Post type.
- * @param {Object} props.attributes              Block attributes.
- * @param {string} props.attributes.courseStatus The course status for the preview.
- * @param {Object} props.setAttributes           Block setAttributes function.
+ * @param {Object} props.className        Block className.
+ * @param {Object} props.context          Block context.
+ * @param {Object} props.context.postType Post type.
  */
-const CourseActionsEdit = ( {
-	className,
-	context: { postType },
-	attributes: { courseStatus },
-	setAttributes,
-} ) => {
+const CourseActionsEdit = ( { className, context: { postType } } ) => {
+	const [ courseStatus, setCourseStatus ] = useState(
+		CourseStatusOptions[ 0 ].value
+	);
+
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
@@ -59,19 +57,13 @@ const CourseActionsEdit = ( {
 		);
 	}
 
-	const setCourseStatus = ( newCourseStatus ) => {
-		setAttributes( { courseStatus: newCourseStatus } );
-	};
-
-	// Set the default course status.
-	if ( ! courseStatus ) {
-		setCourseStatus( CourseStatusOptions[ 0 ].value );
-	}
-
+	// Set class name for course status.
 	className = classnames( className, `is-status-${ courseStatus }` );
 
 	return (
-		<>
+		<CourseStatusContext.Provider
+			value={ { courseStatus, setCourseStatus } }
+		>
 			<div className={ className }>
 				<InnerBlocks
 					allowedBlocks={ [
@@ -89,7 +81,7 @@ const CourseActionsEdit = ( {
 					setCourseStatus={ setCourseStatus }
 				/>
 			</BlockControls>
-		</>
+		</CourseStatusContext.Provider>
 	);
 };
 

--- a/assets/blocks/course-actions-block/course-actions/course-actions-editor.scss
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-editor.scss
@@ -1,6 +1,19 @@
 .wp-block-sensei-lms-course-actions {
+	.wp-block-sensei-lms-button-take-course,
 	.wp-block-sensei-lms-button-continue-course,
 	.wp-block-sensei-lms-button-view-results {
 		display: none;
+	}
+
+	&.is-status-enrolled .wp-block-sensei-lms-button-take-course {
+		display: block;
+	}
+
+	&.is-status-in-progress .wp-block-sensei-lms-button-continue-course {
+		display: block;
+	}
+
+	&.is-status-completed .wp-block-sensei-lms-button-view-results {
+		display: block;
 	}
 }

--- a/assets/blocks/course-actions-block/course-actions/course-actions-editor.scss
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-editor.scss
@@ -5,7 +5,7 @@
 		display: none;
 	}
 
-	&.is-status-enrolled .wp-block-sensei-lms-button-take-course {
+	&.is-status-not-started .wp-block-sensei-lms-button-take-course {
 		display: block;
 	}
 

--- a/assets/blocks/course-actions-block/course-status-context.js
+++ b/assets/blocks/course-actions-block/course-status-context.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+/**
+ * A React context which contains the course status and a function to set it.
+ *
+ * It should contain the following properties:
+ *
+ * - courseStatus: The course status.
+ * - setCourseStatus: A function to set the course status.
+ */
+const CourseStatusContext = createContext();
+
+export default CourseStatusContext;

--- a/assets/blocks/course-actions-block/course-status-options.js
+++ b/assets/blocks/course-actions-block/course-status-options.js
@@ -5,16 +5,19 @@ import { __ } from '@wordpress/i18n';
 
 const CourseStatusOptions = [
 	{
-		label: __( 'Enrolled', 'sensei-lms' ),
-		value: 'enrolled',
+		label: __( 'Not Started', 'sensei-lms' ),
+		value: 'not-started',
+		showBlock: 'sensei-lms/button-take-course',
 	},
 	{
 		label: __( 'In Progress', 'sensei-lms' ),
 		value: 'in-progress',
+		showBlock: 'sensei-lms/button-continue-course',
 	},
 	{
 		label: __( 'Completed', 'sensei-lms' ),
 		value: 'completed',
+		showBlock: 'sensei-lms/button-view-results',
 	},
 ];
 

--- a/assets/blocks/course-actions-block/course-status-options.js
+++ b/assets/blocks/course-actions-block/course-status-options.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const CourseStatusOptions = [
+	{
+		label: __( 'Enrolled', 'sensei-lms' ),
+		value: 'enrolled',
+	},
+	{
+		label: __( 'In Progress', 'sensei-lms' ),
+		value: 'in-progress',
+	},
+	{
+		label: __( 'Completed', 'sensei-lms' ),
+		value: 'completed',
+	},
+];
+
+export default CourseStatusOptions;

--- a/assets/blocks/course-actions-block/course-status-toolbar.js
+++ b/assets/blocks/course-actions-block/course-status-toolbar.js
@@ -3,11 +3,13 @@
  */
 import { Toolbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import ToolbarDropdown from '../editor-components/toolbar-dropdown';
+import { useCallback } from 'react';
 
 const toolbarOptions = [
 	{
@@ -23,6 +25,32 @@ const toolbarOptions = [
 		value: 'completed',
 	},
 ];
+
+/**
+ * A hook for child blocks to set the parent Course Actions block's course status.
+ *
+ * @param {string} clientId The child block's client ID.
+ * @return {Function}       Callback function to set the course status.
+ */
+export const useSetCourseStatusOnCourseActionsBlock = ( clientId ) => {
+	const select = useSelect( 'core/block-editor' );
+	const dispatch = useDispatch( 'core/block-editor' );
+
+	return useCallback(
+		( status ) => {
+			const courseActionsBlockClientID = select.getBlockParentsByBlockName(
+				clientId,
+				'sensei-lms/course-actions',
+				true
+			)[ 0 ];
+
+			dispatch.updateBlockAttributes( courseActionsBlockClientID, {
+				courseStatus: status,
+			} );
+		},
+		[ clientId, select, dispatch ]
+	);
+};
 
 /**
  * Toolbar component for the Course State. It can be Enrolled (the default), In

--- a/assets/blocks/course-actions-block/course-status-toolbar.js
+++ b/assets/blocks/course-actions-block/course-status-toolbar.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { Toolbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ToolbarDropdown from '../editor-components/toolbar-dropdown';
+
+const toolbarOptions = [
+	{
+		label: __( 'Enrolled', 'sensei-lms' ),
+		value: 'enrolled',
+	},
+	{
+		label: __( 'In Progress', 'sensei-lms' ),
+		value: 'in-progress',
+	},
+	{
+		label: __( 'Completed', 'sensei-lms' ),
+		value: 'completed',
+	},
+];
+
+/**
+ * Toolbar component for the Course State. It can be Enrolled (the default), In
+ * Progress, or Completed.
+ *
+ * @param {Object}   props
+ * @param {string}   props.courseStatus    Course status.
+ * @param {Function} props.setCourseStatus Function to set the course status.
+ */
+const CourseStatusToolbar = ( { courseStatus, setCourseStatus } ) => {
+	if ( ! courseStatus ) {
+		courseStatus = toolbarOptions[ 0 ].value;
+	}
+
+	return (
+		<Toolbar>
+			<ToolbarDropdown
+				options={ toolbarOptions }
+				optionsLabel="Course Status"
+				value={ courseStatus }
+				onChange={ setCourseStatus }
+			/>
+		</Toolbar>
+	);
+};
+
+export default CourseStatusToolbar;

--- a/assets/blocks/course-actions-block/course-status-toolbar.js
+++ b/assets/blocks/course-actions-block/course-status-toolbar.js
@@ -2,40 +2,12 @@
  * WordPress dependencies
  */
 import { Toolbar } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import CourseStatusOptions from './course-status-options';
 import ToolbarDropdown from '../editor-components/toolbar-dropdown';
-import { useCallback } from 'react';
-
-/**
- * A hook for child blocks to set the parent Course Actions block's course status.
- *
- * @param {string} clientId The child block's client ID.
- * @return {Function}       Callback function to set the course status.
- */
-export const useSetCourseStatusOnCourseActionsBlock = ( clientId ) => {
-	const select = useSelect( 'core/block-editor' );
-	const dispatch = useDispatch( 'core/block-editor' );
-
-	return useCallback(
-		( status ) => {
-			const courseActionsBlockClientID = select.getBlockParentsByBlockName(
-				clientId,
-				'sensei-lms/course-actions',
-				true
-			)[ 0 ];
-
-			dispatch.updateBlockAttributes( courseActionsBlockClientID, {
-				courseStatus: status,
-			} );
-		},
-		[ clientId, select, dispatch ]
-	);
-};
 
 /**
  * Toolbar component for the Course State. It can be Enrolled (the default), In

--- a/assets/blocks/course-actions-block/course-status-toolbar.js
+++ b/assets/blocks/course-actions-block/course-status-toolbar.js
@@ -2,11 +2,13 @@
  * WordPress dependencies
  */
 import { Toolbar } from '@wordpress/components';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import CourseStatusOptions from './course-status-options';
+import CourseStatusContext from '../course-actions-block/course-status-context';
 import ToolbarDropdown from '../editor-components/toolbar-dropdown';
 
 /**
@@ -14,17 +16,37 @@ import ToolbarDropdown from '../editor-components/toolbar-dropdown';
  * Progress, or Completed.
  *
  * @param {Object}   props
- * @param {string}   props.courseStatus    Course status.
- * @param {Function} props.setCourseStatus Function to set the course status.
+ * @param {string}   props.courseStatus           Course status.
+ * @param {Function} props.setCourseStatus        Function to set the course status.
+ * @param {boolean}  props.useCourseStatusContext Whether to use the course status context instead of callbacks.
  */
-const CourseStatusToolbar = ( { courseStatus, setCourseStatus } ) => {
+const CourseStatusToolbar = ( {
+	courseStatus,
+	setCourseStatus,
+	useCourseStatusContext = false,
+} ) => {
+	const context = useContext( CourseStatusContext );
+
+	// Render nothing if we should use the context but it is not available.
+	if ( useCourseStatusContext && ! context?.courseStatus ) {
+		return null;
+	}
+
+	const courseStatusValue = useCourseStatusContext
+		? context.courseStatus
+		: courseStatus;
+
+	const setCourseStatusCallback = useCourseStatusContext
+		? context.setCourseStatus
+		: setCourseStatus;
+
 	return (
 		<Toolbar>
 			<ToolbarDropdown
 				options={ CourseStatusOptions }
 				optionsLabel="Course Status"
-				value={ courseStatus }
-				onChange={ setCourseStatus }
+				value={ courseStatusValue }
+				onChange={ setCourseStatusCallback }
 			/>
 		</Toolbar>
 	);

--- a/assets/blocks/course-actions-block/course-status-toolbar.js
+++ b/assets/blocks/course-actions-block/course-status-toolbar.js
@@ -2,29 +2,14 @@
  * WordPress dependencies
  */
 import { Toolbar } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import CourseStatusOptions from './course-status-options';
 import ToolbarDropdown from '../editor-components/toolbar-dropdown';
 import { useCallback } from 'react';
-
-const toolbarOptions = [
-	{
-		label: __( 'Enrolled', 'sensei-lms' ),
-		value: 'enrolled',
-	},
-	{
-		label: __( 'In Progress', 'sensei-lms' ),
-		value: 'in-progress',
-	},
-	{
-		label: __( 'Completed', 'sensei-lms' ),
-		value: 'completed',
-	},
-];
 
 /**
  * A hook for child blocks to set the parent Course Actions block's course status.
@@ -61,14 +46,10 @@ export const useSetCourseStatusOnCourseActionsBlock = ( clientId ) => {
  * @param {Function} props.setCourseStatus Function to set the course status.
  */
 const CourseStatusToolbar = ( { courseStatus, setCourseStatus } ) => {
-	if ( ! courseStatus ) {
-		courseStatus = toolbarOptions[ 0 ].value;
-	}
-
 	return (
 		<Toolbar>
 			<ToolbarDropdown
-				options={ toolbarOptions }
+				options={ CourseStatusOptions }
 				optionsLabel="Course Status"
 				value={ courseStatus }
 				onChange={ setCourseStatus }

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -46,17 +46,15 @@ export default createButtonBlockType( {
 		validPostTypes: [ 'course' ],
 	},
 	EditWrapper: ( { children } ) => {
-		const { courseStatus, setCourseStatus } = useContext(
-			CourseStatusContext
-		);
+		const context = useContext( CourseStatusContext );
 
 		return (
 			<>
-				{ !! courseStatus && (
+				{ context?.courseStatus && (
 					<BlockControls>
 						<CourseStatusToolbar
-							courseStatus={ courseStatus }
-							setCourseStatus={ setCourseStatus }
+							courseStatus={ context.courseStatus }
+							setCourseStatus={ context.setCourseStatus }
 						/>
 					</BlockControls>
 				) }

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -3,14 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
-import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { createButtonBlockType } from '../button';
 import CourseStatusToolbar from '../course-actions-block/course-status-toolbar';
-import CourseStatusContext from '../course-actions-block/course-status-context';
 
 /**
  * Take course button block.
@@ -45,21 +43,12 @@ export default createButtonBlockType( {
 		),
 		validPostTypes: [ 'course' ],
 	},
-	EditWrapper: ( { children } ) => {
-		const context = useContext( CourseStatusContext );
-
-		return (
-			<>
-				{ context?.courseStatus && (
-					<BlockControls>
-						<CourseStatusToolbar
-							courseStatus={ context.courseStatus }
-							setCourseStatus={ context.setCourseStatus }
-						/>
-					</BlockControls>
-				) }
-				{ children }
-			</>
-		);
-	},
+	EditWrapper: ( { children } ) => (
+		<>
+			<BlockControls>
+				<CourseStatusToolbar useCourseStatusContext={ true } />
+			</BlockControls>
+			{ children }
+		</>
+	),
 } );

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -2,11 +2,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { BlockControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { createButtonBlockType } from '../button';
+import CourseStatusToolbar, {
+	useSetCourseStatusOnCourseActionsBlock,
+} from '../course-actions-block/course-status-toolbar';
 
 /**
  * Take course button block.
@@ -33,6 +37,7 @@ export default createButtonBlockType( {
 				default: __( 'Take Course', 'sensei-lms' ),
 			},
 		},
+		usesContext: [ 'postType', 'sensei-lms/course-actions-course-status' ],
 	},
 	invalidUsage: {
 		message: __(
@@ -40,5 +45,31 @@ export default createButtonBlockType( {
 			'sensei-lms'
 		),
 		validPostTypes: [ 'course' ],
+	},
+	EditWrapper: ( { children, context, clientId } ) => {
+		const setCourseStatus = useSetCourseStatusOnCourseActionsBlock(
+			clientId
+		);
+
+		const hasCourseActionsCourseStatus =
+			'sensei-lms/course-actions-course-status' in context;
+
+		return (
+			<>
+				{ hasCourseActionsCourseStatus && (
+					<BlockControls>
+						<CourseStatusToolbar
+							courseStatus={
+								context[
+									'sensei-lms/course-actions-course-status'
+								]
+							}
+							setCourseStatus={ setCourseStatus }
+						/>
+					</BlockControls>
+				) }
+				{ children }
+			</>
+		);
 	},
 } );

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -3,14 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { createButtonBlockType } from '../button';
-import CourseStatusToolbar, {
-	useSetCourseStatusOnCourseActionsBlock,
-} from '../course-actions-block/course-status-toolbar';
+import CourseStatusToolbar from '../course-actions-block/course-status-toolbar';
+import CourseStatusContext from '../course-actions-block/course-status-context';
 
 /**
  * Take course button block.
@@ -37,7 +37,6 @@ export default createButtonBlockType( {
 				default: __( 'Take Course', 'sensei-lms' ),
 			},
 		},
-		usesContext: [ 'postType', 'sensei-lms/course-actions-course-status' ],
 	},
 	invalidUsage: {
 		message: __(
@@ -46,24 +45,17 @@ export default createButtonBlockType( {
 		),
 		validPostTypes: [ 'course' ],
 	},
-	EditWrapper: ( { children, context, clientId } ) => {
-		const setCourseStatus = useSetCourseStatusOnCourseActionsBlock(
-			clientId
+	EditWrapper: ( { children } ) => {
+		const { courseStatus, setCourseStatus } = useContext(
+			CourseStatusContext
 		);
-
-		const hasCourseActionsCourseStatus =
-			'sensei-lms/course-actions-course-status' in context;
 
 		return (
 			<>
-				{ hasCourseActionsCourseStatus && (
+				{ !! courseStatus && (
 					<BlockControls>
 						<CourseStatusToolbar
-							courseStatus={
-								context[
-									'sensei-lms/course-actions-course-status'
-								]
-							}
+							courseStatus={ courseStatus }
 							setCourseStatus={ setCourseStatus }
 						/>
 					</BlockControls>

--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -43,17 +43,15 @@ export default createButtonBlockType( {
 		validPostTypes: [ 'course' ],
 	},
 	EditWrapper: ( { children } ) => {
-		const { courseStatus, setCourseStatus } = useContext(
-			CourseStatusContext
-		);
+		const context = useContext( CourseStatusContext );
 
 		return (
 			<>
-				{ !! courseStatus && (
+				{ context?.courseStatus && (
 					<BlockControls>
 						<CourseStatusToolbar
-							courseStatus={ courseStatus }
-							setCourseStatus={ setCourseStatus }
+							courseStatus={ context.courseStatus }
+							setCourseStatus={ context.setCourseStatus }
 						/>
 					</BlockControls>
 				) }

--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 
 /**
@@ -10,7 +9,6 @@ import { BlockControls } from '@wordpress/block-editor';
  */
 import { BlockStyles, createButtonBlockType } from '../button';
 import CourseStatusToolbar from '../course-actions-block/course-status-toolbar';
-import CourseStatusContext from '../course-actions-block/course-status-context';
 
 /**
  * View results button block.
@@ -42,21 +40,12 @@ export default createButtonBlockType( {
 		),
 		validPostTypes: [ 'course' ],
 	},
-	EditWrapper: ( { children } ) => {
-		const context = useContext( CourseStatusContext );
-
-		return (
-			<>
-				{ context?.courseStatus && (
-					<BlockControls>
-						<CourseStatusToolbar
-							courseStatus={ context.courseStatus }
-							setCourseStatus={ context.setCourseStatus }
-						/>
-					</BlockControls>
-				) }
-				{ children }
-			</>
-		);
-	},
+	EditWrapper: ( { children } ) => (
+		<>
+			<BlockControls>
+				<CourseStatusToolbar useCourseStatusContext={ true } />
+			</BlockControls>
+			{ children }
+		</>
+	),
 } );

--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -2,11 +2,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useContext } from '@wordpress/element';
+import { BlockControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { BlockStyles, createButtonBlockType } from '../button';
+import CourseStatusToolbar from '../course-actions-block/course-status-toolbar';
+import CourseStatusContext from '../course-actions-block/course-status-context';
 
 /**
  * View results button block.
@@ -37,5 +41,24 @@ export default createButtonBlockType( {
 			'sensei-lms'
 		),
 		validPostTypes: [ 'course' ],
+	},
+	EditWrapper: ( { children } ) => {
+		const { courseStatus, setCourseStatus } = useContext(
+			CourseStatusContext
+		);
+
+		return (
+			<>
+				{ !! courseStatus && (
+					<BlockControls>
+						<CourseStatusToolbar
+							courseStatus={ courseStatus }
+							setCourseStatus={ setCourseStatus }
+						/>
+					</BlockControls>
+				) }
+				{ children }
+			</>
+		);
 	},
 } );


### PR DESCRIPTION
Fixes #6209

### Package for testing

(Commit 051e49d13): [sensei-lms.zip](https://github.com/Automattic/sensei/files/10270233/sensei-lms.zip)

### Changes proposed in this Pull Request

* Add a toolbar to Course Actions and its children to select the "status" of that course for the editor preview. Based on the status, the correct button block (Start Course, Continue, or Visit Results) will be shown in the editor so that it can be customized.
* As mentioned, the selector is added to both the parent block (Course Actions) and each child. Under the hood, the status is only set on the parent, but being able to change it from the child should be more discoverable for users.
* Available statuses are "Not Started", "In Progress", and "Completed".

### Testing instructions

* Ensure your site has a few courses. Bonus points if you have, for a given user, at least one that is not started, one that is in progress, and one that is completed.
* Create a new page and add the Course List block.
* Select the Start Course button. Ensure that you have a toolbar control for setting the course status.
* Change the status. Ensure that the new button appears, and it is selected so you can edit it right away.
* Select the parent block (Course Actions). Ensure that the toolbar works there too, but note that the parent block remains select upon changing the status.
* View the frontend and ensure that the displayed buttons there follow the actual course status, not the status set in the editor. Also ensure that any edits on any of the buttons appear in the frontend.
* View a Course in the block editor and ensure that the Take Course button works in that context, and does not include the Course Status toolbar control.

### Dev notes

I used a React Context instead of using the Block Editor context for this. I tried using the Block Editor context first, but it had a couple of side effects that I didn't like:

- The status had to be stored in an attribute and saved. I prefer for it to be transient, since it is only an editor control and doesn't affect the frontend.
- When changing the attributes of the block, it was changed in the query loop template, and this changed for all courses at once. I prefer to only change the status for the one course that is being interacted with. Note, however, that when the button text or styling is edited, it will change across the template.

Also note that the "Start Course" button is re-used in the Course block editor.