### PR TITLE
Add  `Sensei_Data_Port_Utilities::get_demo_course_id()` helper method

### DIFF
--- a/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
+++ b/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
@@ -56,24 +56,12 @@ class Sensei_Home_Quick_Links_Provider {
 	 * @return array The magical link to create a demo course or the link to edit the demo course.
 	 */
 	private function create_demo_link() {
-		global $wpdb;
-		$cache_key   = 'home/metadata/demo-course';
-		$cache_group = 'sensei/temporary';
-		$result      = wp_cache_get( $cache_key, $cache_group );
-		if ( false === $result ) {
-			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
-			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name LIKE %s ORDER BY post_status='published' DESC, ID ASC LIMIT 1", "{$prefix}%" ) );
-			if ( null === $post_id ) {
-				$result = null;
-			} else {
-				$result = $post_id;
-				wp_cache_set( $cache_key, $result, $cache_group, 60 );
-			}
+		$demo_course_id = Sensei_Data_Port_Utilities::get_demo_course_id();
+
+		if ( $demo_course_id ) {
+			return $this->create_item( __( 'Edit demo course', 'sensei-lms' ), get_edit_post_link( $demo_course_id, '&' ) );
 		}
-		if ( null !== $result ) {
-			return $this->create_item( __( 'Edit demo course', 'sensei-lms' ), get_edit_post_link( $result, '&' ) );
-		}
+
 		return $this->create_item( __( 'Install a demo course', 'sensei-lms' ), self::ACTION_INSTALL_DEMO_COURSE );
 	}
 

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -539,6 +539,8 @@ class Sensei_Data_Port_Utilities {
 	/**
 	 * Get the ID of the imported demo course.
 	 *
+	 * @internal
+	 *
 	 * @since $$next-version$$
 	 *
 	 * @return int|null

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -429,7 +429,7 @@ class Sensei_Data_Port_Utilities {
 	 * Serialize a list of terms into comma-separated list.
 	 * Adds quotes if name contains commas.
 	 *
-	 * @param WP_Term[] $terms
+	 * @param WP_Term[] $terms The terms array.
 	 *
 	 * @return string
 	 */
@@ -441,7 +441,7 @@ class Sensei_Data_Port_Utilities {
 	/**
 	 * Return term name and hierarchy representation, in the format of 'Parent > Child'.
 	 *
-	 * @param WP_Term $term
+	 * @param WP_Term $term The term object.
 	 *
 	 * @return string
 	 */
@@ -462,7 +462,7 @@ class Sensei_Data_Port_Utilities {
 	 *
 	 * @deprecated 3.5.2
 	 *
-	 * @param string[] $values
+	 * @param string[] $values The values array.
 	 *
 	 * @return string
 	 */
@@ -478,7 +478,7 @@ class Sensei_Data_Port_Utilities {
 	 * Wrap value in quotes if it contains a comma.
 	 * Escape quotes if wrapped.
 	 *
-	 * @param string $value
+	 * @param string $value The value.
 	 *
 	 * @return string
 	 */

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -535,4 +535,29 @@ class Sensei_Data_Port_Utilities {
 
 		return $module;
 	}
+
+	/**
+	 * Get the ID of the imported demo course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int|null
+	 */
+	public static function get_demo_course_id(): ?int {
+		$query = new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'post_type'      => 'course',
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'name'           => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG,
+			]
+		);
+
+		if ( ! $query->found_posts ) {
+			return null;
+		}
+
+		return $query->get_posts()[0];
+	}
 }

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -16,6 +16,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$this->factory->tearDown();
+	}
 
 	public function testUserIsCreatedIfDoesNotExist() {
 		$user_id = Sensei_Data_Port_Utilities::create_user( 'testuser', 'testemail@test.com' )->ID;
@@ -486,5 +497,24 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 		$serialized = Sensei_Data_Port_Utilities::serialize_id_field( $ids );
 
 		$this->assertEquals( $expected, $serialized );
+	}
+
+	public function testGetDemoCourseId_WhenHasDemoCourse_ReturnsCourseId() {
+		/* Arrange. */
+		$this->factory->course->create( [ 'post_name' => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG ] );
+
+		/* Act. */
+		$demo_course_id = Sensei_Data_Port_Utilities::get_demo_course_id();
+
+		/* Assert. */
+		$this->assertNotNull( $demo_course_id );
+	}
+
+	public function testGetDemoCourseId_WhenNoDemoCourse_ReturnsNull() {
+		/* Act. */
+		$demo_course_id = Sensei_Data_Port_Utilities::get_demo_course_id();
+
+		/* Assert. */
+		$this->assertNull( $demo_course_id );
 	}
 }


### PR DESCRIPTION
Needed for #6316
Context https://github.com/Automattic/sensei-pro/pull/1993#discussion_r1053430269

### Changes proposed in this Pull Request

* Adds a helper method that gets the demo course ID. We need this method to help us exclude the demo course from log events. It will be used in both Sensei and Sensei Pro.
* Refactor `Sensei_Home_Quick_Links_Provider::create_demo_link` to use the new `get_demo_course_id` method.

I've decided to include this method in `Sensei_Data_Port_Utilities` because it's closer to its origin domain. Let me know if you have a better idea of where to put it.

### Testing instructions

* Make sure the code makes sense and the tests are passing.
