### PR TITLE
Fix editor wizard header style

### DIFF
--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -37,7 +37,7 @@
 .sensei-editor-wizard-modal {
 	color: #1e1e1e;
 
-	@media ( min-width: 600px ) { // Media query needed for WP 5.8 compatibility.
+	@media ( min-width: 600px ) {
 		width: 800px;
 		height: 670px;
 	}
@@ -53,19 +53,10 @@
 
 	.components-modal__header {
 		border-bottom: none;
-		padding: 0;
-		position: sticky;
-		top: 0;
-		margin: 0 0 -60px;
+		padding: 0 18px;
 
-		// WP 5.8 fixes.
-		width: 100%;
-		background: transparent;
-
-		.components-button {
-			align-self: flex-start;
-			margin: 8px 8px 0 0;
-			position: static;
+		@media ( min-width: 600px ) {
+			padding: 0 30px;
 		}
 	}
 

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -175,6 +175,7 @@
 .sensei-editor-wizard-step {
 	&__title,
 	&__sticky-title {
+		padding-right: 30px; // Keep out of the close space.
 		line-height: 1.1;
 		color: inherit;
 	}


### PR DESCRIPTION
Fixes #6206

### Changes proposed in this Pull Request

* It fixes a problem with the header of the editor wizard modal.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Setup envs for WP 5.9, 6.0 and 6.1.
* Create a new course and a new lesson.
* Check that the styles of the wizard modal work properly in different resolutions.
* Navigate through all the steps and use the scroll in different resolutions too to make sure it works properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="988" alt="Screenshot 2022-12-26 at 11 27 58" src="https://user-images.githubusercontent.com/876340/209558782-39b3612f-5e50-4000-9586-39f406d0e2ef.png">

This screenshot is the modal in WP 6.1. Notice that in WP 5.9 and 6.0 the close button is a bit smaller. Since it's not something critical, just a bit different, I preferred to not set any extra style to this to avoid more conflicts.