### PR TITLE
Update Sensei logo

### DIFF
--- a/assets/blocks/register-sensei-blocks.js
+++ b/assets/blocks/register-sensei-blocks.js
@@ -11,7 +11,7 @@ import { registerBlockType, updateCategory } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import SenseiIcon from '../icons/sensei.svg';
+import LogoTreeIcon from '../icons/logo-tree.svg';
 
 /**
  * Register Sensei blocks.
@@ -21,7 +21,7 @@ import SenseiIcon from '../icons/sensei.svg';
  */
 const registerSenseiBlocks = ( blocks ) => {
 	updateCategory( 'sensei-lms', {
-		icon: <SenseiIcon width="20" height="20" />,
+		icon: <LogoTreeIcon width="20" height="20" />,
 	} );
 
 	blocks.forEach( ( block ) => {

--- a/assets/course-theme/blocks/course-navigation/index.js
+++ b/assets/course-theme/blocks/course-navigation/index.js
@@ -13,7 +13,7 @@ import CheckCircleIcon from '../../../icons/check-filled-circle.svg';
 import LockIcon from '../../../icons/lock.svg';
 import EyeIcon from '../../../icons/eye.svg';
 import meta from './course-navigation.block.json';
-import SenseiIcon from '../../../icons/sensei.svg';
+import LogoTreeIcon from '../../../icons/logo-tree.svg';
 import { useBlockProps } from '@wordpress/block-editor';
 
 const ICONS = {
@@ -134,7 +134,7 @@ const Lesson = ( { title, quiz, status } ) => {
 export default {
 	...meta,
 	icon: {
-		src: <SenseiIcon width="20" height="20" />,
+		src: <LogoTreeIcon width="20" height="20" />,
 		foreground: '#43AF99',
 	},
 	attributes: {},

--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -11,7 +11,7 @@ import ChevronLeft from '../../../icons/chevron-left.svg';
 import ChevronRight from '../../../icons/chevron-right.svg';
 import DoubleChevronRight from '../../../icons/double-chevron-right.svg';
 import MenuIcon from '../../../icons/menu.svg';
-import SenseiIcon from '../../../icons/sensei.svg';
+import LogoTreeIcon from '../../../icons/logo-tree.svg';
 import lessonPropertiesBlock from '../../../blocks/lesson-properties';
 import courseContentMeta from './course-content.block.json';
 import courseThemeCourseProgressBarMeta from './course-theme-course-progress-bar.block.json';
@@ -33,7 +33,7 @@ const meta = {
 	category: 'theme',
 	attributes: {},
 	icon: {
-		src: <SenseiIcon width="20" height="20" />,
+		src: <LogoTreeIcon width="20" height="20" />,
 		foreground: '#43AF99',
 	},
 };

--- a/assets/course-theme/blocks/quiz-blocks/index.js
+++ b/assets/course-theme/blocks/quiz-blocks/index.js
@@ -7,7 +7,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import SenseiIcon from '../../../icons/sensei.svg';
+import LogoTreeIcon from '../../../icons/logo-tree.svg';
 import quizActionsMeta from './quiz-actions.block.json';
 import quizBackToLessonMeta from './quiz-back-to-lesson.block.json';
 import quizProgressMeta from './quiz-progress.block.json';
@@ -15,7 +15,7 @@ import quizProgressMeta from './quiz-progress.block.json';
 const meta = {
 	attributes: {},
 	icon: {
-		src: <SenseiIcon width="20" height="20" />,
+		src: <LogoTreeIcon width="20" height="20" />,
 		foreground: '#43AF99',
 	},
 };


### PR DESCRIPTION
Fixes #6015

### Changes proposed in this Pull Request

* It updates the Sensei logos to the tree icon. Notice that the issue mentions the icon being used in WP Admin menu (without the circle). We had a logo in the code with the circle, already being used in other places, so I used this one. In summary, we use it without the circle in the menu, and with the circle in the other places.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Navigate to the Course editor.
* Click on "+" to add a new block, and make sure the Sensei LMS category is displayed with the tree logo.
* Edit the lesson and the quiz template. Make sure the template blocks have the tree icon.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="348" alt="Screenshot 2022-12-26 at 18 33 34" src="https://user-images.githubusercontent.com/876340/209584708-82bc968f-a876-4e39-8b94-c118d479a2d0.png">

<img width="1235" alt="Screenshot 2022-12-26 at 18 36 02" src="https://user-images.githubusercontent.com/876340/209584701-d28e7d38-b976-44fc-9580-a4e2567d9132.png">

