### PR TITLE
Fix conflict by disabling Yoast initialization on Divi preview

### DIFF
--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -8,3 +8,4 @@
 // Require compatibility files.
 require_once dirname( __FILE__ ) . '/jetpack.php';
 require_once dirname( __FILE__ ) . '/woocommerce.php';
+require_once dirname( __FILE__ ) . '/divi.php';

--- a/includes/3rd-party/divi.php
+++ b/includes/3rd-party/divi.php
@@ -10,14 +10,11 @@
  * It avoids an existing conflict that prevents the preview from loading.
  */
 function sensei_fix_divi_yoast_conflict() {
-	if ( isset( $_GET['et_block_layout_preview'] ) && '1' === $_GET['et_block_layout_preview'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$admin_url        = get_admin_url();
-		$admin_url_length = strlen( $admin_url );
-
-		// Check if the request is coming from the admin.
-		if ( isset( $_SERVER['HTTP_REFERER'] ) && substr( esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, $admin_url_length ) === $admin_url ) {
-			remove_action( 'plugins_loaded', 'wpseo_init', 14 );
-		}
+	if (
+		isset( $_GET['et_block_layout_preview'] ) && '1' === $_GET['et_block_layout_preview'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		&& current_user_can( 'edit_post', get_the_id() )
+	) {
+		remove_all_actions( 'wpseo_head' );
 	}
 }
-add_action( 'plugins_loaded', 'sensei_fix_divi_yoast_conflict', 13 );
+add_action( 'wp', 'sensei_fix_divi_yoast_conflict', 13 );

--- a/includes/3rd-party/divi.php
+++ b/includes/3rd-party/divi.php
@@ -11,7 +11,13 @@
  */
 function sensei_fix_divi_yoast_conflict() {
 	if ( isset( $_GET['et_block_layout_preview'] ) && '1' === $_GET['et_block_layout_preview'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		remove_action( 'plugins_loaded', 'wpseo_init', 14 );
+		$admin_url        = get_admin_url();
+		$admin_url_length = strlen( $admin_url );
+
+		// Check if the request is coming from the admin.
+		if ( isset( $_SERVER['HTTP_REFERER'] ) && substr( esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, $admin_url_length ) === $admin_url ) {
+			remove_action( 'plugins_loaded', 'wpseo_init', 14 );
+		}
 	}
 }
 add_action( 'plugins_loaded', 'sensei_fix_divi_yoast_conflict', 13 );

--- a/includes/3rd-party/divi.php
+++ b/includes/3rd-party/divi.php
@@ -12,9 +12,13 @@
 function sensei_fix_divi_yoast_conflict() {
 	if (
 		isset( $_GET['et_block_layout_preview'] ) && '1' === $_GET['et_block_layout_preview'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		&& 'lesson' === get_post_type()
 		&& current_user_can( 'edit_post', get_the_id() )
 	) {
-		remove_all_actions( 'wpseo_head' );
+		$course_id = Sensei_Utils::get_current_course();
+		if ( Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {
+			remove_all_actions( 'wpseo_head' );
+		}
 	}
 }
 add_action( 'wp', 'sensei_fix_divi_yoast_conflict', 13 );

--- a/includes/3rd-party/divi.php
+++ b/includes/3rd-party/divi.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Adds additional compatibility with Divi.
+ *
+ * @package 3rd-Party
+ */
+
+/**
+ * It disables Yoast initialization when running the Divi preview in the editor.
+ * It avoids an existing conflict that prevents the preview from loading.
+ */
+function sensei_fix_divi_yoast_conflict() {
+	if ( isset( $_GET['et_block_layout_preview'] ) && '1' === $_GET['et_block_layout_preview'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		remove_action( 'plugins_loaded', 'wpseo_init', 14 );
+	}
+}
+add_action( 'plugins_loaded', 'sensei_fix_divi_yoast_conflict', 13 );


### PR DESCRIPTION
Fixes temporarily #6112

### Changes proposed in this Pull Request

* In order to fix the conflict between Learning Mode + Divi + Yoast, this PR disables the Yoast initialization when it's running the Divi preview in the editor.
* It's important to mention that I didn't find the root cause of the issue yet, but since this solution is probably safe I decided to stop investing much more time in that. I don't think a user would want to optimize the SEO in the Divi preview in the editor - unless there's any other implication that I didn't realize.

### My findings from the investigation

* `\add_action( 'wpseo_head', [ $this, 'present_head' ], -9999 );` in Yoast will make it call the `get_the_excerpt` (`Post_Helper::get_the_excerpt`). If we don't call the `get_the_excerpt` there, the problem doesn't happen.
* There's also a method in Divi that I suspect a little, but I couldn't figure out too much from that. The method is `ET_Builder_Element::reset_element_indexes`. It seems it tries to fix something related to `the_content` recursions. And my suspicious is that it has something related to the problem because with the Learning Mode we make some nested `the_content` calls in `Sensei\Blocks\Course_Theme\Course_Content::render_content`.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* See the [issue details](https://github.com/Automattic/sensei/issues/6112), and make sure you can reproduce it using the `trunk`.
* Check that running the code from this branch the problem doesn't happen anymore.