### PR TITLE
Add tooling to keep frontend bundle sizes in check 

### DIFF
--- a/.github/workflows/close-issue-on-merge.yml
+++ b/.github/workflows/close-issue-on-merge.yml
@@ -9,6 +9,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Closes issues related to a merged pull request.
-              uses: docker://ghcr.io/fjorgemota/gha-mjolnir
+              uses: docker://ghcr.io/Automattic/gha-mjolnir
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -103,6 +103,10 @@ jobs:
                   name: combined-assets
                   path: ${{ github.workspace }}/dist-trunk
                   if_no_artifact_found: ignore
+            - name: Current directory
+              run: pwd
+            - name: List dist
+              run: ls assets/dist
             - name: Analyze dependencies and publish report
               uses: fjorgemota/github-action-wordpress-dependencies-report@v0
               with:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -101,7 +101,7 @@ jobs:
                   workflow_conclusion: completed
                   branch: trunk
                   name: combined-assets
-                  path: ./dist-trunk
+                  path: ${{ github.workspace }}/dist-trunk
                   if_no_artifact_found: ignore
             - name: Analyze dependencies and publish report
               uses: fjorgemota/github-action-wordpress-dependencies-report@v0

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -107,7 +107,7 @@ jobs:
               uses: fjorgemota/github-action-wordpress-dependencies-report@v0
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  old-assets-folder: ./dist-trunk
+                  old-assets-folder: ${{ github.workspace }}/dist-trunk
                   old-assets-branch: trunk
-                  new-assets-folder: ./assets/dist
+                  new-assets-folder: ${{ github.workspace }}/assets/dist
                   

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -104,9 +104,7 @@ jobs:
                   path: ${{ github.workspace }}/dist-trunk
                   if_no_artifact_found: ignore
             - name: Current directory
-              run: pwd
-            - name: List dist
-              run: ls assets/dist
+              run: ls -lah ${{ github.workspace }}/assets/dist
             - name: Analyze dependencies and publish report
               uses: fjorgemota/github-action-wordpress-dependencies-report@v0
               with:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -94,7 +94,7 @@ jobs:
             - name: Build Combined Assets
               run: npm run build:combine-assets
             - name: Download assets (trunk)
-              uses: fjorgemota/action-download-artifact@v2
+              uses: fjorgemota/github-action-download-artifact@v2
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   workflow: trunk.yml

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -103,8 +103,6 @@ jobs:
                   name: combined-assets
                   path: ${{ github.workspace }}/dist-trunk
                   if_no_artifact_found: ignore
-            - name: Current directory
-              run: ls -lah ${{ github.workspace }}/assets/dist
             - name: Analyze dependencies and publish report
               uses: fjorgemota/github-action-wordpress-dependencies-report@v0
               with:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -94,7 +94,7 @@ jobs:
             - name: Build Combined Assets
               run: npm run build:combine-assets
             - name: Download assets (trunk)
-              uses: fjorgemota/github-action-download-artifact@v2
+              uses: Automattic/github-action-download-artifact@v2
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   workflow: trunk.yml
@@ -104,7 +104,7 @@ jobs:
                   path: ${{ github.workspace }}/dist-trunk
                   if_no_artifact_found: ignore
             - name: Analyze dependencies and publish report
-              uses: fjorgemota/github-action-wordpress-dependencies-report@v0
+              uses: Automattic/github-action-wordpress-dependencies-report@v0
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   old-assets-folder: ${{ github.workspace }}/dist-trunk

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -71,3 +71,43 @@ jobs:
               run: npm ci
             - name: Test JS
               run: npm run test-js
+
+    dependencies-report:
+        name: WordPress Dependencies Report
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Get npm cache directory
+              id: npm-cache
+              run: |
+                  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+            - uses: actions/cache@v3
+              with:
+                  path: ${{ steps.npm-cache.outputs.dir }}
+                  key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+            - name: Updates the npm version
+              run: npm install -g npm@^8
+            - name: Install JS dependencies
+              run: npm ci
+            - name: Build Combined Assets
+              run: npm run build:combine-assets
+            - name: Download assets (trunk)
+              uses: fjorgemota/action-download-artifact@v2
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  workflow: trunk.yml
+                  workflow_conclusion: completed
+                  branch: trunk
+                  name: combined-assets
+                  path: ./dist-trunk
+                  if_no_artifact_found: ignore
+            - name: Analyze dependencies and publish report
+              uses: fjorgemota/github-action-wordpress-dependencies-report@v0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  old-assets-folder: ./dist-trunk
+                  old-assets-branch: trunk
+                  new-assets-folder: ./assets/dist
+                  

--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/checkout@v3
             - name: Publish commit status with the link to download the plugin
               id: plugin_artifact
-              uses: fjorgemota/github-action-report-artifact@v0
+              uses: Automattic/github-action-report-artifact@v0
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   artifact-name: sensei-lms-${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -16,3 +16,31 @@ jobs:
     build:
         needs: [ unit-js, unit-php, e2e ]
         uses: ./.github/workflows/build.yml
+        
+    wordpress-report-build:
+        needs: [unit-js, unit-php, e2e]
+        runs-on: ubuntu-latest
+        name: WordPress Dependencies Report
+        steps:
+            - uses: actions/checkout@v3
+            - name: Get npm cache directory
+              id: npm-cache
+              run: |
+                  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+            - uses: actions/cache@v3
+              with:
+                  path: ${{ steps.npm-cache.outputs.dir }}
+                  key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+            - name: Updates the npm version
+              run: npm install -g npm@^8
+            - name: Install JS dependencies
+              run: npm ci
+            - name: Build Combined Assets
+              run: npm run build:combine-assets
+            - name: Upload Artifact
+              uses: actions/upload-artifact@v2
+              with:
+                  name: combined-assets
+                  path: ./assets/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@types/node": "18.11.9",
         "@types/testing-library__jest-dom": "5.14.5",
         "@wordpress/babel-preset-default": "wp-5.9",
+        "@wordpress/dependency-extraction-webpack-plugin": "3.5.0",
         "@wordpress/e2e-test-utils": "wp-5.9",
         "@wordpress/env": "wp-6.0",
         "@wordpress/eslint-plugin": "wp-5.9",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   "scripts": {
     "build": "npm run build:assets && npm run archive",
     "build:assets": "rm -rf ./assets/dist && cross-env NODE_ENV=production npx calypso-build",
+    "build:combine-assets": "cross-env COMBINE_ASSETS=true npm run build:assets",
     "build:analyzer": "npm run --silent build:assets -- --json > node_modules/.cache/sensei-lms/build-stats.json && npx webpack-bundle-analyzer node_modules/.cache/sensei-lms/build-stats.json assets/dist",
     "build:docs": "rm -rf hookdocs/ && jsdoc -c hookdoc-conf.json",
     "build:vendor": "cp ./node_modules/select2/dist/css/select2.min.css ./node_modules/select2/dist/js/select2.full.js ./node_modules/select2/dist/js/select2.full.min.js ./assets/vendor/select2",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "lint-pkg-json": "wp-scripts lint-pkg-json",
     "lint-e2e": "eslint -c ./tests/e2e-playwright/.eslintrc.js ./tests/e2e-playwright/ && tsc --noEmit --project tests/e2e-playwright/tsconfig.json",
     "run-phpcs": "./vendor/bin/phpcs --encoding=utf-8",
-    "start": "NODE_ENV=development calypso-build --watch",
+    "start": "cross-env NODE_ENV=development calypso-build --watch",
     "test": "npm run test-php && npm run test-js",
     "test-js": "wp-scripts test-unit-js",
     "test-js:watch": "wp-scripts test-unit-js --watch",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/node": "18.11.9",
     "@types/testing-library__jest-dom": "5.14.5",
     "@wordpress/babel-preset-default": "wp-5.9",
+    "@wordpress/dependency-extraction-webpack-plugin": "3.5.0",
     "@wordpress/e2e-test-utils": "wp-5.9",
     "@wordpress/env": "wp-6.0",
     "@wordpress/eslint-plugin": "wp-5.9",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Modify webpack to allow generating the assets with a unified list of assets -> dependencies on `assets.json`;
* Add job to run only on `trunk` to build the unified list of assets mentioned above and publish as an artifact;
* Add workflow with jobs to post a comment with the report (comparing list of dependencies, total size, diff, etc.);

### Testing instructions

Check comment below: https://github.com/Automattic/sensei/pull/6355#issuecomment-1374344805