### PR TITLE
Don't send emails to or about guest/preview users

### DIFF
--- a/includes/class-sensei-guest-user-cleaner.php
+++ b/includes/class-sensei-guest-user-cleaner.php
@@ -96,7 +96,7 @@ class Sensei_Guest_User_Cleaner {
 				Sensei_Utils::sensei_remove_user_from_course( $course_id, $user_id );
 			}
 
-			$this->delete_user( $user_id );
+			Sensei_Temporary_User::delete_user( $user_id );
 		}
 	}
 
@@ -135,26 +135,5 @@ class Sensei_Guest_User_Cleaner {
 		}
 
 		return array_values( array_diff( $guest_user_ids, array_column( $last_week_activities, 'user_id' ) ) );
-	}
-
-	/**
-	 * Delete a user for both single and multisite.
-	 *
-	 * @access private
-	 *
-	 * @param int $user_id ID of the user to be removed.
-	 */
-	private function delete_user( $user_id ) {
-		if ( is_multisite() ) {
-			if ( ! function_exists( 'wpmu_delete_user' ) ) {
-				require_once ABSPATH . '/wp-admin/includes/ms.php';
-			}
-			wpmu_delete_user( $user_id );
-		} else {
-			if ( ! function_exists( 'wp_delete_user' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/user.php';
-			}
-			wp_delete_user( $user_id );
-		}
 	}
 }

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -287,7 +287,7 @@ class Sensei_Guest_User {
 	private function create_guest_user() {
 		$user_count = Sensei_Utils::get_user_count_for_role( self::ROLE ) + 1;
 		$user_name  = self::LOGIN_PREFIX . wp_rand( 10000000, 99999999 ) . '_' . $user_count;
-		return wp_insert_user(
+		return Sensei_Temporary_User::create_user(
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -92,6 +92,7 @@ class Sensei_Guest_User {
 		add_action( 'wp', [ $this, 'create_guest_user_and_login_for_open_course' ], 9 );
 		add_action( 'sensei_is_enrolled', [ $this, 'open_course_always_enrolled' ], 10, 3 );
 		add_action( 'sensei_can_access_course_content', [ $this, 'open_course_enable_course_access' ], 10, 2 );
+		add_action( 'sensei_send_emails', [ $this, 'skip_sensei_email' ] );
 
 		$this->create_guest_student_role_if_not_exists();
 	}
@@ -375,5 +376,20 @@ class Sensei_Guest_User {
 		return isset( $_POST[ $field ] )
 			&& isset( $_POST[ $nonce ] )
 			&& wp_verify_nonce( wp_unslash( $_POST[ $nonce ] ), $nonce ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verification
+	}
+
+	/**
+	 * Prevent Sensei emails related to guest user actions.
+	 *
+	 * @access private
+	 * @since  $$next-version$$
+	 *
+	 * @param boolean $send_email Whether to send the email.
+	 *
+	 * @return boolean Whether to send the email.
+	 */
+	public function skip_sensei_email( $send_email ) {
+		return $this->is_current_user_guest() ? false : $send_email;
+
 	}
 }

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -44,7 +44,7 @@ class Sensei_Preview_User {
 		add_action( 'wp', [ $this, 'switch_to_preview_user' ], 9 );
 		add_action( 'wp', [ $this, 'switch_off_preview_user' ], 9 );
 		add_action( 'wp', [ $this, 'override_user' ], 8 );
-		add_action( 'wp', [ $this, 'add_preview_user_filters' ], 10 );
+		add_action( 'wp', [ $this, 'add_preview_user_filters' ], 9 );
 		add_action( 'show_admin_bar', [ $this, 'show_admin_bar_to_preview_user' ], 90 );
 		add_action( 'admin_bar_menu', [ $this, 'add_user_switch_to_admin_bar' ], 90 );
 		add_filter( 'sensei_is_enrolled', [ $this, 'preview_user_always_enrolled' ], 90, 3 );
@@ -62,6 +62,8 @@ class Sensei_Preview_User {
 			add_filter( 'map_meta_cap', [ $this, 'allow_post_preview' ], 10, 4 );
 			add_filter( 'pre_get_posts', [ $this, 'count_unpublished_lessons' ], 10 );
 			add_filter( 'sensei_notice', [ $this, 'hide_notices' ], 10, 1 );
+			add_action( 'sensei_send_emails', '__return_false' );
+
 		}
 
 	}

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -233,7 +233,7 @@ class Sensei_Preview_User {
 		$user_name    = 'preview_user_' . wp_rand( 10000000, 99999999 ) . '_' . $teacher->ID . '_' . $course_id;
 		$display_name = 'Preview Student ' . $course_id . $teacher->ID . ' (' . $teacher->display_name . ')';
 
-		return wp_insert_user(
+		return Sensei_Temporary_User::create_user(
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,
@@ -264,17 +264,7 @@ class Sensei_Preview_User {
 
 		$this->delete_meta( $teacher, $user_id, $course_id );
 
-		if ( is_multisite() ) {
-			if ( ! function_exists( 'wpmu_delete_user' ) ) {
-				require_once ABSPATH . '/wp-admin/includes/ms.php';
-			}
-			wpmu_delete_user( $user_id );
-		} else {
-			if ( ! function_exists( 'wp_delete_user' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/user.php';
-			}
-			wp_delete_user( $user_id );
-		}
+		Sensei_Temporary_User::delete_user( $user_id );
 	}
 
 	/**

--- a/includes/class-sensei-temporary-user.php
+++ b/includes/class-sensei-temporary-user.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Temporary User
+ *
+ * Handles operations related to allowing Temporary users take a course.
+ *
+ * @package Sensei\Frontend
+ * @since   1.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei Temporary User Class.
+ *
+ * @author  Automattic
+ *
+ * @since   $$next-version$$
+ * @package Core
+ */
+class Sensei_Temporary_User {
+
+	/**
+	 * Sensei_Temporary_User constructor.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function __construct() {
+
+	}
+
+	/**
+	 * Create a user without triggering user registration hooks.
+	 *
+	 * @param mixed $userdata wp_insert_user options.
+	 *
+	 * @return int|WP_Error
+	 */
+	public static function create_user( $userdata ) {
+		remove_all_filters( 'user_register' );
+		return wp_insert_user( $userdata );
+	}
+
+	/**
+	 * Deletes a user.
+	 *
+	 * @param int $user_id User ID to delete.
+	 *
+	 * @return void
+	 */
+	public static function delete_user( int $user_id ): void {
+		if ( is_multisite() ) {
+			if ( ! function_exists( 'wpmu_delete_user' ) ) {
+				require_once ABSPATH . '/wp-admin/includes/ms.php';
+			}
+			wpmu_delete_user( $user_id );
+		} else {
+			if ( ! function_exists( 'wp_delete_user' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/user.php';
+			}
+			wp_delete_user( $user_id );
+		}
+	}
+
+}

--- a/includes/class-sensei-temporary-user.php
+++ b/includes/class-sensei-temporary-user.php
@@ -23,15 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Temporary_User {
 
 	/**
-	 * Sensei_Temporary_User constructor.
-	 *
-	 * @since $$next-version$$
-	 */
-	public function __construct() {
-
-	}
-
-	/**
 	 * Create a user without triggering user registration hooks.
 	 *
 	 * @param mixed $userdata wp_insert_user options.
@@ -39,7 +30,17 @@ class Sensei_Temporary_User {
 	 * @return int|WP_Error
 	 */
 	public static function create_user( $userdata ) {
+
 		remove_all_filters( 'user_register' );
+
+		/*
+		 * Workaround for MailPoet. If its default 'WordPress Users' list is active, all users will show up as subscribers,
+		 * but at least with this the temporary users will start as 'Unsubscribed' instead of 'Unconfirmed', not counting
+		 * towards the subscriber count of the plan. The subscribers will disappear when the temporary users are deleted.
+		 *
+		 */
+		$_POST['mailpoet'] = [ 'subscribe_on_register_active' => true ];
+
 		return wp_insert_user( $userdata );
 	}
 


### PR DESCRIPTION
Fixes #6248 

### Changes proposed in this Pull Request

* Disable Sensei's email notifications for course actions of guest/preview users
* Unhook everything from `user_register` hook when creating the users
* Add workaround for MailPoet subscriber list
* Add a `Sensei_Temporary_User` class for some functions shared between guest and preview users

### Testing instructions

* Monitor outgoing emails of a site (for example Local has Mailhog built-in)
* Take an open access course as a guest user or preview a course as a preview student
* Complete lessons
* Make sure no emails are being sent out

### Notes

I covered our cases here and hopefully most plugins doing stuff on `user_register`. Going further, I think we should watch out for user reports and fix any issue that comes up with other plugins, since we can't realistically test every plugin preemptively.
