### PR TITLE
Fix Twenty Fifteen and Learning Mode layout issue

### DIFF
--- a/assets/css/sensei-course-theme/theme-fixes.scss
+++ b/assets/css/sensei-course-theme/theme-fixes.scss
@@ -55,3 +55,8 @@
 .wp-block:not(.has-background) {
 	background-color: unset;
 }
+
+// Twenty Fifteen
+.sensei-course-theme::before {
+	width: 0px;
+}


### PR DESCRIPTION
Fixes #6021

### Changes proposed in this Pull Request

* Fixes layout issue for learning mode and Twenty Fifteen

### Testing instructions
1. Install and activate the Twenty Fifteen theme
2. Create a Lesson and make sure Learning Mode is active
3. View that lesson
4. Verify that there are no layout issues with the sidebar

### Screenshot / Video

## Before
<img width="901" alt="Screenshot 2023-01-09 at 1 41 13 PM" src="https://user-images.githubusercontent.com/3220162/211413921-0a678ef6-3067-4914-ba94-5a1991758dba.png">

Note:  I made the sidebar colour Green to make it more easy to see the problem - the default setting for the theme will be white.

## After
<img width="1022" alt="Screenshot 2023-01-09 at 1 41 20 PM" src="https://user-images.githubusercontent.com/3220162/211413950-732dcd3e-5e55-48c4-8874-6bceaaabe033.png">


