### PR TITLE
Fix quick edit for lessons

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1118,7 +1118,11 @@ class Sensei_Lesson {
 
 		// Check if the user has permission to edit the target course.
 		if ( 'lesson_course' === $post_key && ! current_user_can( get_post_type_object( 'course' )->cap->edit_post, $new_meta_value ) ) {
-			return;
+			if ( empty( $new_meta_value ) ) {
+				$new_meta_value = '';
+			} else {
+				return;
+			}
 		}
 
 		// Parse the value for `lesson_length` field as integer.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1116,13 +1116,14 @@ class Sensei_Lesson {
 			$new_meta_value = '-1';
 		}
 
+		// If course is empty, unassign from course.
+		if ( 'lesson_course' === $post_key && empty( $new_meta_value ) ) {
+			$new_meta_value = '';
+		}
+
 		// Check if the user has permission to edit the target course.
-		if ( 'lesson_course' === $post_key && ! current_user_can( get_post_type_object( 'course' )->cap->edit_post, $new_meta_value ) ) {
-			if ( empty( $new_meta_value ) ) {
-				$new_meta_value = '';
-			} else {
-				return;
-			}
+		if ( 'lesson_course' === $post_key && ! current_user_can( get_post_type_object( 'course' )->cap->edit_post, $new_meta_value ) && '' !== $new_meta_value ) {
+			return;
 		}
 
 		// Parse the value for `lesson_length` field as integer.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1073,7 +1073,6 @@ class Sensei_Lesson {
 	 * @access private
 	 * @param string $post_key (default: '')
 	 * @param int    $post_id (default: 0)
-	 * @return int|bool meta id or saved status
 	 */
 	private function save_post_meta( $post_key = '', $post_id = 0 ) {
 		/*

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1115,11 +1115,6 @@ class Sensei_Lesson {
 			$new_meta_value = '-1';
 		}
 
-		// If course is empty, unassign from course.
-		if ( 'lesson_course' === $post_key && empty( $new_meta_value ) ) {
-			$new_meta_value = '';
-		}
-
 		// Check if the user has permission to edit the target course.
 		if ( 'lesson_course' === $post_key && ! current_user_can( get_post_type_object( 'course' )->cap->edit_post, $new_meta_value ) && '' !== $new_meta_value ) {
 			return;


### PR DESCRIPTION
Fixes #6136

### Changes proposed in this Pull Request

* Adds a check for when a `lesson_course` is empty so that the lesson is unassigned from a course.

### Testing instructions
- Go to Sensei -> Course
- Create a Course
- Go to Sensei -> Lessons
- Create a Lesson
- Go to quick edit that lesson, and change the Lesson Course to "None"
- Verify that it worked
- Now change it back to the Course
- Verify that it worked again :) 
