### PR TITLE
Add hooks to disable open access and student previews

### DIFF
--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -171,20 +171,24 @@ const CourseGeneralSidebar = () => {
 				/>
 			) : null }
 
-			<HorizontalRule />
+			{ window.sensei.courseSettingsSidebar.features?.open_access && (
+				<>
+					<HorizontalRule />
 
-			<h3>{ __( 'Access', 'sensei-lms' ) }</h3>
-			<CheckboxControl
-				label={ __( 'Open Access', 'sensei-lms' ) }
-				checked={ openAccess }
-				onChange={ ( checked ) =>
-					setMeta( { ...meta, open_access: checked } )
-				}
-				help={ __(
-					'Visitors can take this course without signing up.',
-					'sensei-lms'
-				) }
-			/>
+					<h3>{ __( 'Access', 'sensei-lms' ) }</h3>
+					<CheckboxControl
+						label={ __( 'Open Access', 'sensei-lms' ) }
+						checked={ openAccess }
+						onChange={ ( checked ) =>
+							setMeta( { ...meta, open_access: checked } )
+						}
+						help={ __(
+							'Visitors can take this course without signing up. Not available for paid courses.',
+							'sensei-lms'
+						) }
+					/>
+				</>
+			) }
 
 			<HorizontalRule />
 

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -71,8 +71,6 @@ class Sensei_Block_Take_Course {
 				}
 				$html = $this->render_with_start_course_form( $course_id, $content );
 			}
-		} elseif ( ! is_user_logged_in() && get_post_meta( $course_id, 'open_access', true ) ) {
-			$html = $this->render_with_start_course_form( $course_id, $content );
 		} elseif ( ! is_user_logged_in() ) {
 			$html = $this->render_with_login( $content );
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -277,6 +277,9 @@ class Sensei_Course {
 			'nonce_value' => wp_create_nonce( Sensei()->teacher::NONCE_ACTION_NAME ),
 			'nonce_name'  => Sensei()->teacher::NONCE_FIELD_NAME,
 			'teachers'    => Sensei()->teacher->get_teachers_and_authors_with_fields( [ 'ID', 'display_name' ] ),
+			'features'    => [
+				'open_access' => apply_filters( 'sensei_feature_open_access_courses', true ),
+			],
 			'courses'     => get_posts(
 				[
 					'post_type'        => 'course',

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3372,14 +3372,11 @@ class Sensei_Course {
 	 * @return bool
 	 */
 	public static function can_current_user_manually_enrol( $course_id ) {
-		if ( ! is_user_logged_in() ) {
-			return false;
-		}
 
 		// Check if the user is already enrolled through any provider.
 		$is_user_enrolled = self::is_user_enrolled( $course_id, get_current_user_id() );
 
-		$default_can_user_manually_enrol = ! $is_user_enrolled;
+		$default_can_user_manually_enrol = is_user_logged_in() && ! $is_user_enrolled;
 
 		$can_user_manually_enrol = apply_filters_deprecated(
 			'sensei_display_start_course_form',
@@ -3417,15 +3414,12 @@ class Sensei_Course {
 			'3.0.0',
 			null
 		);
+		if ( is_user_logged_in() && $is_course_content_restricted ) {
+			self::add_course_access_permission_message( '' );
+		}
 
-		if ( is_user_logged_in() ) {
-			$should_display_start_course_form = self::can_current_user_manually_enrol( $post->ID );
-			if ( $is_course_content_restricted && false == $should_display_start_course_form ) {
-				self::add_course_access_permission_message( '' );
-			}
-			if ( $should_display_start_course_form ) {
+		if ( self::can_current_user_manually_enrol( $post->ID ) ) {
 				sensei_start_course_form( $post->ID );
-			}
 		} else {
 			if ( get_option( 'users_can_register' ) ) {
 

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -117,6 +117,7 @@ class Sensei_Guest_User {
 		add_action( 'wp', [ $this, 'create_guest_user_and_login_for_open_course' ], 9 );
 		add_action( 'sensei_is_enrolled', [ $this, 'open_course_always_enrolled' ], 10, 3 );
 		add_action( 'sensei_can_access_course_content', [ $this, 'open_course_enable_course_access' ], 10, 2 );
+		add_action( 'sensei_can_user_manually_enrol', [ $this, 'open_course_user_can_manualy_enroll' ], 10, 2 );
 
 		$this->create_guest_student_role_if_not_exists();
 
@@ -136,6 +137,22 @@ class Sensei_Guest_User {
 	public function open_course_always_enrolled( $is_enrolled, $user_id, $course_id ) {
 		$in_course_content = is_singular( [ 'lesson', 'quiz' ] );
 		return ( $in_course_content && $this->is_course_open_access( $course_id ) ) ? true : $is_enrolled;
+	}
+
+	/**
+	 * Filter manual enrolment check to always allow users to manually enrol if the course is open access.
+	 *
+	 * @since  $$next-version$$
+	 *
+	 * @param bool $can_enroll Initial value.
+	 * @param int  $course_id   Course ID.
+	 *
+	 * @return bool
+	 */
+	public function open_course_user_can_manualy_enroll( $can_enroll, $course_id ) {
+
+		$is_user_enrolled = is_user_logged_in() && Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() );
+		return $this->is_course_open_access( $course_id ) ? ! $is_user_enrolled : $can_enroll;
 	}
 
 	/**

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -44,10 +44,10 @@ class Sensei_Guest_User {
 	 * List of actions to create a guest user for if the course is open access.
 	 *
 	 * @var array[] {
-	 *  @type string $field Form field.
-	 *  @type string $nonce Nonce field.
-	 *  @type bool $enrol Whether to enrol the guest user before this action.
-	 * }
+	 * @type string $field Form field.
+	 * @type string $nonce Nonce field.
+	 * @type bool   $enrol Whether to enrol the guest user before this action.
+	 *                     }
 	 */
 	protected $supported_actions = [
 		// Take course.
@@ -88,12 +88,38 @@ class Sensei_Guest_User {
 	 * @since $$next-version$$
 	 */
 	public function __construct() {
+
+		add_action( 'wp', [ $this, 'init' ], 1 );
+
+	}
+
+	/**
+	 * Initialize guest user feature.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function init() {
+		/**
+		 * Enable or disable 'open access course' feature.
+		 *
+		 * @hook  sensei_feature_open_access_courses
+		 * @since $$next-version$$
+		 *
+		 * @param {bool} $enable Enable feature. Default true.
+		 *
+		 * @return {bool} Wether to enable feature.
+		 */
+		if ( ! apply_filters( 'sensei_feature_open_access_courses', true ) ) {
+			return;
+		}
+
 		add_action( 'wp', [ $this, 'sensei_set_current_user_to_none_if_not_open_course_related_action' ], 8 );
 		add_action( 'wp', [ $this, 'create_guest_user_and_login_for_open_course' ], 9 );
 		add_action( 'sensei_is_enrolled', [ $this, 'open_course_always_enrolled' ], 10, 3 );
 		add_action( 'sensei_can_access_course_content', [ $this, 'open_course_enable_course_access' ], 10, 2 );
 
 		$this->create_guest_student_role_if_not_exists();
+
 	}
 
 	/**
@@ -102,8 +128,8 @@ class Sensei_Guest_User {
 	 * @since  $$next-version$$
 	 *
 	 * @param bool $is_enrolled Initial value.
-	 * @param int  $user_id     User ID. Unused.
-	 * @param int  $course_id   Course ID.
+	 * @param int  $user_id User ID. Unused.
+	 * @param int  $course_id Course ID.
 	 *
 	 * @return bool
 	 */
@@ -118,7 +144,7 @@ class Sensei_Guest_User {
 	 * @since  $$next-version$$
 	 *
 	 * @param bool $can_view_course_content Initial value.
-	 * @param int  $course_id               Course ID.
+	 * @param int  $course_id Course ID.
 	 *
 	 * @return bool
 	 */
@@ -190,7 +216,7 @@ class Sensei_Guest_User {
 	 * @since $$next-version$$
 	 * @access private
 	 *
-	 *  @param array $views List of tabs.
+	 * @param array $views List of tabs.
 	 */
 	public static function filter_out_guest_user_tab_from_users_list( $views ) {
 		unset( $views[ self::ROLE ] );
@@ -203,7 +229,7 @@ class Sensei_Guest_User {
 	 * @since $$next-version$$
 	 * @access private
 	 *
-	 *  @param array $roles List of roles.
+	 * @param array $roles List of roles.
 	 */
 	public static function filter_out_guest_student_role( $roles ) {
 		unset( $roles[ self::ROLE ] );
@@ -216,7 +242,7 @@ class Sensei_Guest_User {
 	 * @since $$next-version$$
 	 * @access private
 	 *
-	 *  @param WP_User_Query $query The user query.
+	 * @param WP_User_Query $query The user query.
 	 */
 	public static function filter_out_guest_users( WP_User_Query $query ) {
 		global $wpdb;
@@ -252,7 +278,20 @@ class Sensei_Guest_User {
 	 * @return boolean|mixed
 	 */
 	private function is_course_open_access( $course_id ) {
-		return get_post_meta( $course_id, 'open_access', true );
+		$is_open_access = get_post_meta( $course_id, 'open_access', true );
+
+		/**
+		 * Filter if the given course has open access turned on.
+		 *
+		 * @hook  sensei_course_open_access
+		 * @since $$next-version$$
+		 *
+		 * @param {bool} $is_open_access Open access setting value.
+		 * @param {int} $course_id Course ID.
+		 *
+		 * @return {bool} Open access setting value.
+		 */
+		return apply_filters( 'sensei_course_open_access', $is_open_access, $course_id );
 	}
 
 	/**
@@ -265,6 +304,7 @@ class Sensei_Guest_User {
 		$user = wp_get_current_user();
 		return in_array( self::ROLE, (array) $user->roles, true );
 	}
+
 	/**
 	 * Recreate nonce after logging in user invalidates existing one.
 	 *
@@ -314,7 +354,7 @@ class Sensei_Guest_User {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param int $user_id   User ID.
+	 * @param int $user_id User ID.
 	 * @param int $course_id Course ID.
 	 */
 	private function enrol_user( $user_id, $course_id ) {

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -36,11 +36,37 @@ class Sensei_Preview_User {
 	const META = 'sensei_previewing_user';
 
 	/**
-	 * Set up preview user hooks.
+	 * Preview user class constructor.
 	 *
 	 * @since $$next-version$$
 	 */
 	public function __construct() {
+
+		add_action( 'wp', [ $this, 'init' ], 1 );
+
+	}
+
+	/**
+	 * Initialize preview user feature.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function init() {
+
+		/**
+		 * Enable or disable 'preview as student' feature.
+		 *
+		 * @hook sensei_feature_preview_students
+		 * @since $$next-version$$
+		 *
+		 * @param {bool} $enable Enable feature. Default true.
+		 *
+		 * @return {bool} Wether to enable feature.
+		 */
+		if ( ! apply_filters( 'sensei_feature_preview_students', true ) ) {
+			return;
+		}
+
 		add_action( 'wp', [ $this, 'switch_to_preview_user' ], 9 );
 		add_action( 'wp', [ $this, 'switch_off_preview_user' ], 9 );
 		add_action( 'wp', [ $this, 'override_user' ], 8 );
@@ -69,7 +95,7 @@ class Sensei_Preview_User {
 	/**
 	 * Change the current user to the preview user if its set for the teacher.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 * @access private
 	 */
 	public function override_user() {
@@ -97,7 +123,7 @@ class Sensei_Preview_User {
 	/**
 	 * Create and switch to a preview user.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 * @access private
 	 */
 	public function switch_to_preview_user() {
@@ -118,7 +144,7 @@ class Sensei_Preview_User {
 	/**
 	 * Switch back to original user and delete preview user.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 * @access private
 	 */
 	public function switch_off_preview_user() {
@@ -136,7 +162,7 @@ class Sensei_Preview_User {
 	/**
 	 * Add switch to user link to admin bar.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 * @access private
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar The WordPress Admin Bar object.
@@ -181,7 +207,7 @@ class Sensei_Preview_User {
 	/**
 	 * Enable admin bar for preview user.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 * @access private
 	 *
 	 * @param bool $show Initial state.
@@ -343,7 +369,7 @@ class Sensei_Preview_User {
 	 *
 	 * @note This hook should only run when the preview user is active, it does not do checks on its own.
 	 *
-	 * @since  $$next-version$$
+	 * @since $$next-version$$
 	 * @access private
 	 *
 	 * @param WP_Query $query Lesson query.

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -130,4 +130,51 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 		$this->assertEquals( count( $result1 ), count( $result2 ) );
 	}
 
+
+
+	/**
+	 * Feature can be disabled with a filter.
+	 */
+	public function testFeatureDisabled() {
+
+		add_filter( 'sensei_feature_open_access_courses', '__return_false' );
+
+		$this->setup_course( true );
+		$this->logout();
+
+		$_POST['course_start']                         = 1;
+		$_POST['woothemes_sensei_start_course_noonce'] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
+
+		do_action( 'wp' );
+
+		$this->assertEquals( false, is_user_logged_in(), 'Logged out user should not be able to start course when feature is disabled.' );
+
+	}
+
+	/**
+	 * Feature can be disabled for a single course with a filter.
+	 */
+	public function testOpenAccessDisabledForCourse() {
+
+		[ 'course_id' => $course_id ] = $this->setup_course( true );
+		$this->logout();
+
+		add_filter(
+			'sensei_course_open_access',
+			function( $is_open_access, $filtered_course_id ) use ( $course_id ) {
+				return ( $course_id === $filtered_course_id ) ? false : $is_open_access;
+			},
+			10,
+			2
+		);
+
+		$_POST['course_start']                         = 1;
+		$_POST['woothemes_sensei_start_course_noonce'] = wp_create_nonce( 'woothemes_sensei_start_course_noonce' );
+
+		do_action( 'wp' );
+
+		$this->assertEquals( false, is_user_logged_in(), 'Logged out user should not be able to start course when open access is disabled for the course.' );
+
+	}
+
 }

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -53,9 +53,9 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 		$this->go_to( add_query_arg( [ 'sensei-preview-as-student' => wp_create_nonce( 'sensei-preview-as-student' ) ], $course_link ) );
 
-		$this->assertNotEquals( $admin_id, get_current_user_id(), 'Current user not changed.' );
+		$this->assertNotEquals( $admin_id, get_current_user_id(), 'Current user should be changed.' );
 		$preview_user = wp_get_current_user();
-		$this->assertRegexp( '/^Preview Student.*$/', $preview_user->display_name, 'Current user is not a preview student.' );
+		$this->assertRegexp( '/^Preview Student.*$/', $preview_user->display_name, 'Current user should be a preview student.' );
 
 		// Switch off preview user.
 
@@ -118,7 +118,7 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 		$this->go_to( get_permalink( $lesson_id ) );
 
-		$this->assertNotEquals( $admin_id, get_current_user_id(), 'Preview user is not used for the lesson.' );
+		$this->assertNotEquals( $admin_id, get_current_user_id(), 'Preview user should be used for the lesson.' );
 
 	}
 
@@ -163,6 +163,23 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 		parent::go_to( $lesson_link );
 
 		$this->assertEquals( $lesson_content, get_the_content(), 'Preview user should see unpublished lesson content.' );
+	}
+
+	/**
+	 * Feature can be disabled with a filter.
+	 */
+	public function testFeatureDisabled() {
+
+		add_filter( 'sensei_feature_preview_students', '__return_false' );
+
+		$course_id = $this->factory->course->create();
+		$admin_id  = $this->get_user_by_role( 'administrator' );
+		$this->login_as( $admin_id );
+
+		$this->go_to( add_query_arg( [ 'sensei-preview-as-student' => wp_create_nonce( 'sensei-preview-as-student' ) ], get_permalink( $course_id ) ) );
+
+		$this->assertEquals( $admin_id, get_current_user_id(), 'Preview user should not be used when feature is disabled.' );
+
 	}
 
 }


### PR DESCRIPTION
Fixes #6303 

### Changes proposed in this Pull Request

* Add hooks described below

### Testing instructions

- Set a course to open access
- Add snippet `add_filter( 'sensei_feature_open_access_courses', '__return_false' );`
- Check that the open access course cannot be accessed as guest
- Check that the 'Open access' option is not visible in the course editor settings sidebar
- Replace previous snippet with `add_filter( 'sensei_course_open_access', '__return_false' );`
- Check that the 'Open access' option is visible, but the course is not accessible as guest even when its turned on.
--
- Add snippet `add_filter( 'sensei_feature_preview_students', '__return_false' );`
- Open a course frontend as admin/teacher
- Check that the 'Preview as student' link in the admin bar is not visible

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

`sensei_feature_open_access_courses` (`() : bool`, `true` default) → When set to false, don't show the 'Open access' option in course settings, and don't allow guest users.

`sensei_course_open_access` (`( $course_id ) : bool`, setting from meta as default) → Override when checking if an individual course is open access.

`sensei_feature_preview_students` (`() : bool`, `true` default) → When set to false, don't show the 'Preview as Student' link in the admin bar, and disable all the preview user functions.
