### PR TITLE
Change reset progress copy

### DIFF
--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -43,7 +43,7 @@ export const StudentActionMenu = ( {
 			onClick: () => removeFromCourse(),
 		},
 		{
-			title: __( 'Reset or Remove Progress', 'sensei-lms' ),
+			title: __( 'Reset Progress', 'sensei-lms' ),
 			onClick: () => resetProgress(),
 		},
 		{

--- a/assets/admin/students/student-action-menu/index.test.js
+++ b/assets/admin/students/student-action-menu/index.test.js
@@ -70,7 +70,7 @@ describe( '<StudentActionMenu />', () => {
 		expect( screen.getByRole( 'dialog' ) ).toBeTruthy();
 	} );
 
-	it( 'Should display modal when "Reset or Remove progress" is selected', async () => {
+	it( 'Should display modal when "Reset progress" is selected', async () => {
 		useSelect.mockReturnValue( { courses: [], isFetching: false } );
 		render(
 			<StudentActionMenu studentDisplayName={ studentDisplayName } />
@@ -85,8 +85,8 @@ describe( '<StudentActionMenu />', () => {
 			preventDefault: () => {},
 		} );
 
-		// Click the "Reset or Remove Progress" menu item.
-		const menuItem = screen.getByText( 'Reset or Remove Progress' );
+		// Click the "Reset Progress" menu item.
+		const menuItem = screen.getByText( 'Reset Progress' );
 
 		await act( async () => {
 			fireEvent.click( menuItem );

--- a/assets/admin/students/student-bulk-action-button/index.test.js
+++ b/assets/admin/students/student-bulk-action-button/index.test.js
@@ -80,7 +80,7 @@ describe( '<StudentBulkActionButton />', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'Should render the `Reset or Remove Progress` modal', () => {
+	it( 'Should render the `Reset Progress` modal', () => {
 		setupSelector( [
 			{ value: 'enrol_restore_enrolment' },
 			{ value: 'remove_progress', selected: true },
@@ -93,7 +93,7 @@ describe( '<StudentBulkActionButton />', () => {
 		expect(
 			screen.getByText(
 				ignoreInlineTags(
-					'Select the course(s) you would like to reset or remove progress from for 3 students:'
+					'Select the course(s) you would like to reset progress from for 3 students:'
 				)
 			)
 		).toBeInTheDocument();

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -98,7 +98,7 @@ const getAction = ( action, studentCount, studentDisplayName ) => {
 					? sprintf(
 							// Translators: placeholder is the number of selected students.
 							__(
-								'Select the course(s) you would like to reset or remove progress from for <strong>%d students</strong>:',
+								'Select the course(s) you would like to reset progress from for <strong>%d students</strong>:',
 								'sensei-lms'
 							),
 							studentCount
@@ -106,16 +106,16 @@ const getAction = ( action, studentCount, studentDisplayName ) => {
 					: sprintf(
 							// Translators: placeholder is the student's name.
 							__(
-								'Select the course(s) you would like to reset or remove progress from for <strong>%s</strong>:',
+								'Select the course(s) you would like to reset progress from for <strong>%s</strong>:',
 								'sensei-lms'
 							),
 							safeStudentDisplayName
 					  ),
-			buttonLabel: __( 'Reset or Remove Progress', 'sensei-lms' ),
+			buttonLabel: __( 'Reset Progress', 'sensei-lms' ),
 			errorMessage: ( students ) =>
 				_n(
-					'Unable to reset or remove progress for this student. Please try again.',
-					'Unable to reset or remove progress for these students. Please try again.',
+					'Unable to reset progress for this student. Please try again.',
+					'Unable to reset progress for these students. Please try again.',
 					students.length,
 					'sensei-lms'
 				),

--- a/assets/admin/students/student-modal/index.test.js
+++ b/assets/admin/students/student-modal/index.test.js
@@ -224,7 +224,7 @@ describe( '<StudentModal />', () => {
 	describe( 'Reset/Remove Progress action', () => {
 		const onClose = jest.fn();
 		const descriptionLookupText =
-			'Select the course(s) you would like to reset or remove progress from for ';
+			'Select the course(s) you would like to reset progress from for ';
 
 		beforeEach( () => {
 			render(
@@ -259,7 +259,7 @@ describe( '<StudentModal />', () => {
 
 		it( 'Should display the action button', async () => {
 			expect(
-				await buttonByLabel( 'Reset or Remove Progress' )
+				await buttonByLabel( 'Reset Progress' )
 			).toBeInTheDocument();
 		} );
 
@@ -278,9 +278,7 @@ describe( '<StudentModal />', () => {
 
 			fireEvent.click( await courseOptionAt( 0 ) );
 
-			fireEvent.click(
-				await buttonByLabel( 'Reset or Remove Progress' )
-			);
+			fireEvent.click( await buttonByLabel( 'Reset Progress' ) );
 
 			await waitFor( () => {
 				expect( onClose ).toHaveBeenCalledWith( true );
@@ -316,7 +314,7 @@ describe( '<StudentModal />', () => {
 					.once()
 					.reply( 200, { status: 'ok' } );
 
-				// Reset or remove progress
+				// Reset progress
 				nock( 'http://localhost' )
 					.post( '/sensei-internal/v1/course-progress/batch', {
 						student_ids: [ students[ 0 ] ],
@@ -378,14 +376,12 @@ describe( '<StudentModal />', () => {
 				);
 
 				fireEvent.click( await courseOptionAt( 0 ) );
-				fireEvent.click(
-					await buttonByLabel( 'Reset or Remove Progress' )
-				);
+				fireEvent.click( await buttonByLabel( 'Reset Progress' ) );
 
 				expect(
 					// In addition to the notice, there is an ARIA element that has this text.
 					await findAllByText(
-						'Unable to reset or remove progress for this student. Please try again.'
+						'Unable to reset progress for this student. Please try again.'
 					)
 				).toHaveLength( 2 ); // ARIA + notice
 			} );
@@ -418,7 +414,7 @@ describe( '<StudentModal />', () => {
 					.once()
 					.reply( 200, { status: 'ok' } );
 
-				// Reset or remove progress
+				// Reset progress
 				nock( 'http://localhost' )
 					.post( '/sensei-internal/v1/course-progress/batch', {
 						student_ids: students,
@@ -480,13 +476,11 @@ describe( '<StudentModal />', () => {
 				);
 
 				fireEvent.click( await courseOptionAt( 0 ) );
-				fireEvent.click(
-					await buttonByLabel( 'Reset or Remove Progress' )
-				);
+				fireEvent.click( await buttonByLabel( 'Reset Progress' ) );
 
 				expect(
 					await findAllByText(
-						'Unable to reset or remove progress for these students. Please try again.'
+						'Unable to reset progress for these students. Please try again.'
 					)
 				).toHaveLength( 2 ); // ARIA + notice
 			} );

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -124,7 +124,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		$this->known_bulk_actions = [
 			self::ENROL_RESTORE_ENROLMENT => __( 'Add to Course', 'sensei-lms' ),
 			self::REMOVE_ENROLMENT        => __( 'Remove from Course', 'sensei-lms' ),
-			self::REMOVE_PROGRESS         => __( 'Reset or Remove Progress', 'sensei-lms' ),
+			self::REMOVE_PROGRESS         => __( 'Reset Progress', 'sensei-lms' ),
 		];
 
 		if ( is_admin() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It updates the label "Remove or Reset Progress" to "Reset Progress".

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enroll a user to a course.
* Go to WP Admin > Sensei LMS > Students.
* Click on the 3 dots.
* Check that the text is "Reset Progress" now.
* Also, on the same screen, check the "Select Bulk Actions" select, and make sure the text of the option is "Reset Progress" there too.