### PR TITLE
Prevent html entities from showing up in module titles in editor

### DIFF
--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -13,6 +13,7 @@ import { compose } from '@wordpress/compose';
 import { useContext, useState, useEffect } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -183,7 +184,7 @@ export const ModuleEdit = ( props ) => {
 						<SingleLineInput
 							className="wp-block-sensei-lms-course-outline-module__title-input"
 							placeholder={ __( 'Module name', 'sensei-lms' ) }
-							value={ title }
+							value={ decodeEntities( title ) }
 							onChange={ updateName }
 						/>
 						{ slug && (


### PR DESCRIPTION
Fixes #4696

### Changes proposed in this Pull Request

* Decode the entities in the module title in the editor 

### Testing instructions
1. Go to Sensei -> Courses
2. Add a Course
3. Add a Module to that course
4. Add a title with an `&` 
5. Save the Course
6. Verify that the `&` shows up correctly


### Screenshot / Video

## Before
<img width="428" alt="Screenshot 2023-01-10 at 4 21 54 PM" src="https://user-images.githubusercontent.com/3220162/211689488-0ddd4ee9-868a-48e2-a95b-c9b8c31f45f1.png">

## After
<img width="534" alt="Screenshot 2023-01-10 at 4 21 39 PM" src="https://user-images.githubusercontent.com/3220162/211689473-a58d1dce-6c5b-428c-a45a-d949a0ec8fd8.png">

