### PR TITLE
Fix issue where Quiz Timer options would appear only when the Random Question Order is enabled

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -258,9 +258,9 @@ const QuizSettings = ( {
 									) }
 								/>
 							</PanelRow>
-							<Slot name="SenseiQuizSettings" />
 						</Fragment>
 					) }
+					<Slot name="SenseiQuizSettings" />
 					{ ! hideQuizTimer && (
 						<PanelRow>
 							<QuizTimerPromo />


### PR DESCRIPTION
Fixes 856-gh-Automattic/sensei-pro

### Changes proposed in this Pull Request

* Move `<Slot />` where the Quiz Timer is rendered outside of the condition to show/hide the fields for Random Question Order;

### Testing instructions

Follow the "Steps to Reproduce" reported in 856-gh-Automattic/sensei-pro, and make sure that the Quiz Timer Settings now appear independently of the Random Question Order option.  