### PR TITLE
Add ability to course list feature filter to make it work with inherited global query

### DIFF
--- a/includes/blocks/class-sensei-global-blocks.php
+++ b/includes/blocks/class-sensei-global-blocks.php
@@ -43,14 +43,6 @@ class Sensei_Global_Blocks extends Sensei_Blocks_Initializer {
 			'sensei-global-blocks-style',
 			'blocks/global-blocks-style.css'
 		);
-		if ( ! is_admin() ) {
-			Sensei()->assets->enqueue(
-				'sensei-course-list-filter',
-				'blocks/course-list-filter-block/course-list-filter.js',
-				[],
-				true
-			);
-		}
 	}
 
 	/**

--- a/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
@@ -29,9 +29,10 @@ class Sensei_Course_List_Categories_Filter extends Sensei_Course_List_Filter_Abs
 	/**
 	 * Get the content to be be rendered inside the filtered block.
 	 *
-	 * @param int $query_id The id of the Query block this filter is rendering inside.
+	 * @param WP_Block $block The block instance.
 	 */
-	public function get_content( $query_id ) : string {
+	public function get_content( $block ) : string {
+		$query_id          = $block->context['queryId'];
 		$filter_param_key  = $this->param_key . $query_id;
 		$category_id       = isset( $_GET[ $filter_param_key ] ) ? intval( $_GET[ $filter_param_key ] ) : -1; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 		$course_categories = get_terms(

--- a/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
@@ -46,10 +46,12 @@ class Sensei_Course_List_Featured_Filter extends Sensei_Course_List_Filter_Abstr
 	/**
 	 * Get the content to be be rendered inside the filtered block.
 	 *
-	 * @param int $query_id The id of the Query block this filter is rendering inside.
+	 * @param WP_Block $block The block instance.
 	 */
-	public function get_content( $query_id ) : string {
-		$filter_param_key = $this->param_key . $query_id;
+	public function get_content( $block ) : string {
+		$query_id         = $block->context['queryId'];
+		$is_inherited     = $block->context['query']['inherit'] ?? false;
+		$filter_param_key = $is_inherited ? 'course_filter' : ( $this->param_key . $query_id );
 		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 
 		return '<select data-param-key="' . esc_attr( $filter_param_key ) . '">' .

--- a/includes/blocks/course-list/class-sensei-course-list-filter-abstract.php
+++ b/includes/blocks/course-list/class-sensei-course-list-filter-abstract.php
@@ -28,9 +28,9 @@ abstract class Sensei_Course_List_Filter_Abstract {
 	/**
 	 * Get the content to be rendered inside the filter block.
 	 *
-	 * @param int $query_id The id of the Query block this filter is rendering inside.
+	 * @param WP_Block $block The block instance.
 	 */
-	abstract public function get_content( int $query_id ): string;
+	abstract public function get_content( WP_Block $block ): string;
 
 	/**
 	 * Get a list of course Ids to be excluded from the course list block.

--- a/includes/blocks/course-list/class-sensei-course-list-filter-block.php
+++ b/includes/blocks/course-list/class-sensei-course-list-filter-block.php
@@ -71,7 +71,7 @@ class Sensei_Course_List_Filter_Block {
 
 		foreach ( $this->filters as $filter ) {
 			if ( in_array( $filter->get_filter_name(), $attributes['types'], true ) ) {
-				$content .= $filter->get_content( $block->context['queryId'] );
+				$content .= $filter->get_content( $block );
 			}
 		}
 

--- a/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
@@ -46,12 +46,13 @@ class Sensei_Course_List_Student_Course_Filter extends Sensei_Course_List_Filter
 	/**
 	 * Get the content to be rendered inside the filtered block.
 	 *
-	 * @param int $query_id The id of the Query block this filter is rendering inside.
+	 * @param WP_Block $block The block instance.
 	 */
-	public function get_content( $query_id ) : string {
+	public function get_content( $block ) : string {
 		if ( empty( get_current_user_id() ) ) {
 			return '';
 		}
+		$query_id         = $block->context['queryId'];
 		$filter_param_key = $this->param_key . $query_id;
 		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -148,7 +148,7 @@ class Sensei_Frontend {
 			Sensei()->assets->register( 'sensei-quiz-progress', 'blocks/progress-bar.js' );
 			Sensei()->assets->register( 'sensei-stop-double-submission', 'js/stop-double-submission.js', [], true );
 			Sensei()->assets->register( Sensei()->token . '-user-dashboard', 'js/user-dashboard.js', [ 'jquery-ui-tabs' ], true );
-
+			Sensei()->assets->enqueue( 'sensei-course-list-filter', 'blocks/course-list-filter-block/course-list-filter.js', [], true );
 			// Allow additional scripts to be loaded.
 			do_action( 'sensei_additional_scripts' );
 

--- a/tests/unit-tests/blocks/test-class-sensei-global-blocks.php
+++ b/tests/unit-tests/blocks/test-class-sensei-global-blocks.php
@@ -64,7 +64,6 @@ class Sensei_Global_Blocks_Test extends WP_UnitTestCase {
 		$this->global_blocks->enqueue_block_assets();
 
 		/* Assert */
-		$this->assertTrue( wp_script_is( 'sensei-course-list-filter' ) );
 		$this->assertTrue( wp_style_is( 'sensei-global-blocks-style' ) );
 	}
 


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/6378

Stacked on https://github.com/Automattic/sensei/pull/6354

### Changes proposed in this Pull Request

* Make course list feature filter work with Course List block in archive page

### Testing instructions

- Make sure you have an existing installation of Sensei having this branch checked out; keep it as it is
- Create a fully new local WP site containing this branch
- Install the Sensei Plugin in the new installation and complete the onboarding
- Create multiple Courses and publish them, and mark some of those as Featured
- Go to the Courses page from frontend
- Make sure you see courses rendered by the Course List block
- Make sure you see the Featured filter dropdown on the top
- Try filtering using that, make sure it works
- Now add the Course List block on another page which is not an archive page
- Now go the the frontend of the page, make sure the filter still works

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/212024787-ba3c2eec-1e39-4e72-9952-ac6256c99472.mov