### PR TITLE
Change open access meta to private

### DIFF
--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -51,7 +51,7 @@ const CourseGeneralSidebar = () => {
 	const featured = meta._course_featured;
 	const prerequisite = meta._course_prerequisite;
 	const notification = meta.disable_notification;
-	const openAccess = meta.open_access;
+	const openAccess = meta._open_access;
 
 	useEffect( () =>
 		editorLifecycle( {
@@ -180,7 +180,7 @@ const CourseGeneralSidebar = () => {
 						label={ __( 'Open Access', 'sensei-lms' ) }
 						checked={ openAccess }
 						onChange={ ( checked ) =>
-							setMeta( { ...meta, open_access: checked } )
+							setMeta( { ...meta, _open_access: checked } )
 						}
 						help={ __(
 							'Visitors can take this course without signing up. Not available for paid courses.',

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -458,7 +458,7 @@ class Sensei_Course {
 		);
 		register_post_meta(
 			'course',
-			'open_access',
+			Sensei_Guest_User::COURSE_OPEN_ACCESS_META,
 			[
 				'show_in_rest'  => true,
 				'single'        => true,

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -41,6 +41,15 @@ class Sensei_Guest_User {
 	const LOGIN_PREFIX = 'sensei_guest_';
 
 	/**
+	 * Meta key for course open access setting.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const COURSE_OPEN_ACCESS_META = '_open_access';
+
+	/**
 	 * List of actions to create a guest user for if the course is open access.
 	 *
 	 * @var array[] {
@@ -296,7 +305,7 @@ class Sensei_Guest_User {
 	 * @return boolean|mixed
 	 */
 	private function is_course_open_access( $course_id ) {
-		$is_open_access = get_post_meta( $course_id, 'open_access', true );
+		$is_open_access = get_post_meta( $course_id, self::COURSE_OPEN_ACCESS_META, true );
 
 		/**
 		 * Filter if the given course has open access turned on.

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -81,7 +81,7 @@ class Sensei_Usage_Tracking_Data {
 				'posts_per_page' => -1,
 				'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Only used for usage stats, not always called.
 					array(
-						'key'   => 'open_access',
+						'key'   => Sensei_Guest_User::COURSE_OPEN_ACCESS_META,
 						'value' => true,
 					),
 				),

--- a/tests/unit-tests/test-class-sensei-guest-user-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-guest-user-cleaner.php
@@ -34,7 +34,7 @@ class Sensei_Guest_User_Cleaner_Test extends WP_UnitTestCase {
 
 		$course_data = $this->factory->get_course_with_lessons();
 		$course_id   = $course_data['course_id'];
-		update_post_meta( $course_id, 'open_access', true );
+		update_post_meta( $course_id, '_open_access', true );
 
 		$post                  = get_post( $course_id );
 		$wp_query->post        = $post;

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -33,7 +33,7 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 	private function setup_course( $open_access ) {
 		$course_data = $this->factory->get_course_with_lessons();
 		$course_id   = $course_data['course_id'];
-		update_post_meta( $course_id, 'open_access', $open_access );
+		update_post_meta( $course_id, '_open_access', $open_access );
 		global $post;
 		$post = get_post( $course_id );
 

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1692,7 +1692,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetCourseOpenAccessCount_WhenCalled_ReturnsCorrectNumberOfCourses() {
 		/* Arrange */
 		$course_ids = $this->factory->course->create_many( 2 );
-		update_post_meta( $course_ids[0], 'open_access', 1 );
+		update_post_meta( $course_ids[0], '_open_access', 1 );
 
 		/* Act */
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();


### PR DESCRIPTION
Fixes #6301

### Changes proposed in this Pull Request

* Add `_` prefix for the course meta for the open access setting (`open_access` → `_open_access`), marking it private, so it doesn't show up under 'Custom Fields'

### Testing instructions

* Open a course in the block editor
* Turn on the Custom fields panel in ⠇→ Preferences → Panels
* Turn on the open access setting for the course
* Check that it works
* Check that the meta doesn't show up in the Custom fields panel:

<img width="973" alt="image" src="https://user-images.githubusercontent.com/176949/212338862-3324e85b-a8f9-4101-929e-1d9c8260c3ea.png">

