### PR TITLE
Add quiz answer tables based repository

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -291,6 +291,7 @@ class Sensei_Autoloader {
 			 * Quiz Submission
 			 */
 			\Sensei\Internal\Quiz_Submission\Answer\Models\Answer::class => 'internal/quiz-submission/answer/models/class-answer.php',
+			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Aggregate_Answer_Repository::class => 'internal/quiz-submission/answer/repositories/class-aggregate-answer-repository.php',
 			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository::class => 'internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php',
 			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository::class => 'internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php',
 			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory::class => 'internal/quiz-submission/answer/repositories/class-answer-repository-factory.php',

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -292,6 +292,7 @@ class Sensei_Autoloader {
 			 */
 			\Sensei\Internal\Quiz_Submission\Answer\Models\Answer::class => 'internal/quiz-submission/answer/models/class-answer.php',
 			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository::class => 'internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php',
+			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository::class => 'internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php',
 			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory::class => 'internal/quiz-submission/answer/repositories/class-answer-repository-factory.php',
 			\Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface::class => 'internal/quiz-submission/answer/repositories/class-answer-repository-interface.php',
 			\Sensei\Internal\Quiz_Submission\Grade\Models\Grade::class => 'internal/quiz-submission/grade/models/class-grade.php',

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -567,7 +567,7 @@ class Sensei_Main {
 
 		// Quiz submission repositories.
 		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $use_tables ) )->create();
-		$this->quiz_answer_repository     = ( new Answer_Repository_Factory() )->create();
+		$this->quiz_answer_repository     = ( new Answer_Repository_Factory( $use_tables ) )->create();
 		$this->quiz_grade_repository      = ( new Grade_Repository_Factory() )->create();
 
 		// Init student progress handlers.

--- a/includes/internal/quiz-submission/answer/repositories/class-aggregate-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-aggregate-answer-repository.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * File containing the Aggregate_Answer_Repository class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
+
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Aggregate_Answer_Repository.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Aggregate_Answer_Repository implements Answer_Repository_Interface {
+	/**
+	 * Comments based quiz answer repository implementation.
+	 *
+	 * @var Comments_Based_Answer_Repository
+	 */
+	private $comments_based_repository;
+
+	/**
+	 * Tables based quiz answer repository implementation.
+	 *
+	 * @var Tables_Based_Answer_Repository
+	 */
+	private $tables_based_repository;
+
+	/**
+	 * The flag if the tables based implementation is available for use.
+	 *
+	 * @var bool
+	 */
+	private $use_tables;
+
+	/**
+	 * Constructor.
+	 *
+	 * @internal
+	 *
+	 * @param Comments_Based_Answer_Repository $comments_based_repository Comments based quiz answer repository implementation.
+	 * @param Tables_Based_Answer_Repository   $tables_based_repository  Tables based quiz answer repository implementation.
+	 * @param bool                             $use_tables  The flag if the tables based implementation is available for use.
+	 */
+	public function __construct( Comments_Based_Answer_Repository $comments_based_repository, Tables_Based_Answer_Repository $tables_based_repository, bool $use_tables ) {
+		$this->comments_based_repository = $comments_based_repository;
+		$this->tables_based_repository   = $tables_based_repository;
+		$this->use_tables                = $use_tables;
+	}
+
+	/**
+	 * Create a new answer.
+	 *
+	 * @internal
+	 *
+	 * @param int    $submission_id The submission ID.
+	 * @param int    $question_id   The question ID.
+	 * @param string $value         The answer value.
+	 *
+	 * @return Answer The answer model.
+	 */
+	public function create( int $submission_id, int $question_id, string $value ): Answer {
+		$answer = $this->comments_based_repository->create( $submission_id, $question_id, $value );
+
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->create( $submission_id, $question_id, $value );
+		}
+
+		return $answer;
+	}
+
+	/**
+	 * Get all answers for a quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $submission_id The submission ID.
+	 *
+	 * @return Answer[] An array of answers.
+	 */
+	public function get_all( int $submission_id ): array {
+		return $this->comments_based_repository->get_all( $submission_id );
+	}
+
+	/**
+	 * Delete all answers for a submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $submission_id The submission ID.
+	 */
+	public function delete_all( int $submission_id ): void {
+		$this->comments_based_repository->delete_all( $submission_id );
+
+		if ( $this->use_tables ) {
+			$this->tables_based_repository->delete_all( $submission_id );
+		}
+	}
+}

--- a/includes/internal/quiz-submission/answer/repositories/class-answer-repository-factory.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-answer-repository-factory.php
@@ -20,6 +20,24 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Answer_Repository_Factory {
 	/**
+	 * Use tables-based repository.
+	 *
+	 * @var bool
+	 */
+	private $use_tables;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @internal
+	 *
+	 * @param bool $use_tables Use tables-based repository.
+	 */
+	public function __construct( bool $use_tables = false ) {
+		$this->use_tables = $use_tables;
+	}
+
+	/**
 	 * Create a repository for the answers.
 	 *
 	 * @internal
@@ -27,6 +45,12 @@ class Answer_Repository_Factory {
 	 * @return Answer_Repository_Interface
 	 */
 	public function create(): Answer_Repository_Interface {
-		return new Comments_Based_Answer_Repository();
+		global $wpdb;
+
+		return new Aggregate_Answer_Repository(
+			new Comments_Based_Answer_Repository(),
+			new Tables_Based_Answer_Repository( $wpdb ),
+			$this->use_tables
+		);
 	}
 }

--- a/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * File containing the Tables_Based_Answer_Repository class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use wpdb;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Tables_Based_Answer_Repository.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
+	/**
+	 * WordPress database object.
+	 *
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * Constructor.
+	 *
+	 * @internal
+	 *
+	 * @param wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Create a new answer.
+	 *
+	 * @internal
+	 *
+	 * @param int    $submission_id The submission ID.
+	 * @param int    $question_id   The question ID.
+	 * @param string $value         The answer value.
+	 *
+	 * @return Answer The answer model.
+	 */
+	public function create( int $submission_id, int $question_id, string $value ): Answer {
+		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$date_format      = 'Y-m-d H:i:s';
+
+		$this->wpdb->insert(
+			$this->get_table_name(),
+			[
+				'submission_id' => $submission_id,
+				'question_id'   => $question_id,
+				'value'         => $value,
+				'created_at'    => $current_datetime->format( $date_format ),
+				'updated_at'    => $current_datetime->format( $date_format ),
+			],
+			[
+				'%d',
+				'%d',
+				'%s',
+				'%s',
+				'%s',
+			]
+		);
+
+		return new Answer(
+			$this->wpdb->insert_id,
+			$submission_id,
+			$question_id,
+			$value,
+			$current_datetime,
+			$current_datetime
+		);
+	}
+
+	/**
+	 * Get all answers for a quiz submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $submission_id The submission ID.
+	 *
+	 * @return Answer[] An array of answers.
+	 */
+	public function get_all( int $submission_id ): array {
+		$query = $this->wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT * FROM {$this->get_table_name()} WHERE submission_id = %d",
+			$submission_id
+		);
+
+		$answers = [];
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared earlier.
+		foreach ( $this->wpdb->get_results( $query ) as $result ) {
+			$answers[] = new Answer(
+				$result->id,
+				$result->submission_id,
+				$result->question_id,
+				$result->value,
+				new DateTimeImmutable( $result->created_at, new DateTimeZone( 'UTC' ) ),
+				new DateTimeImmutable( $result->updated_at, new DateTimeZone( 'UTC' ) )
+			);
+		}
+
+		return $answers;
+	}
+
+	/**
+	 * Delete all answers for a submission.
+	 *
+	 * @internal
+	 *
+	 * @param int $submission_id The submission ID.
+	 */
+	public function delete_all( int $submission_id ): void {
+		$this->wpdb->delete(
+			$this->get_table_name(),
+			[
+				'submission_id' => $submission_id,
+			],
+			[
+				'%d',
+			]
+		);
+	}
+
+	/**
+	 * Get the quiz answers table name.
+	 *
+	 * @return string
+	 */
+	private function get_table_name(): string {
+		return $this->wpdb->prefix . 'sensei_lms_quiz_answers';
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-aggregate-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-aggregate-answer-repository.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Repositories\Aggregate_Answer_Repository;
+use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
+use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
+
+/**
+ * Class Aggregate_Answer_Repository_Test
+ *
+ * @covers \Sensei\Internal\Quiz_Submission\Answer\Repositories\Aggregate_Answer_Repository
+ */
+class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
+	public function testCreate_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'create' )
+			->with( 1, 2, 'value' );
+
+		$repository->create( 1, 2, 'value' );
+	}
+
+	public function testCreate_UseTablesOn_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'create' )
+			->with( 1, 2, 'value' );
+
+		$repository->create( 1, 2, 'value' );
+	}
+
+	public function testCreate_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'create' );
+
+		$repository->create( 1, 2, 'value' );
+	}
+
+	public function testCreate_UseTablesOff_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'create' )
+			->with( 1, 2, 'value' );
+
+		$repository->create( 1, 2, 'value' );
+	}
+
+	public function testGetAll_Always_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'get_all' )
+			->with( 1 );
+
+		$repository->get_all( 1 );
+	}
+
+	public function testDeleteAll_UseTablesOff_DoesntCallTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, false );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'delete_all' );
+
+		$repository->delete_all( 1 );
+	}
+
+	public function testDeleteAll_UseTablesOn_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, true );
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'delete_all' )
+			->with( 1 );
+
+		$repository->delete_all( 1 );
+	}
+
+	/**
+	 * Test that the repository will always use comments based repository while deleting.
+	 *
+	 * @param bool $use_tables
+	 *
+	 * @dataProvider providerDeleteAll_Always_CallsCommentsBasedRepository
+	 */
+	public function testDeleteAll_Always_CallsCommentsBasedRepository( bool $use_tables ): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
+		$repository     = new Aggregate_Answer_Repository( $comments_based, $tables_based, $use_tables );
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'delete_all' );
+
+		$repository->delete_all( 1 );
+	}
+
+	public function providerDeleteAll_Always_CallsCommentsBasedRepository(): array {
+		return [
+			'uses tables'         => [ true ],
+			'does not use tables' => [ false ],
+		];
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-answer-repository-factory.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-answer-repository-factory.php
@@ -2,7 +2,7 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Answer\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface;
+use Sensei\Internal\Quiz_Submission\Answer\Repositories\Aggregate_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
 
 /**
@@ -12,15 +12,26 @@ use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factor
  */
 class Answer_Repository_Factory_Test extends \WP_UnitTestCase {
 
-	public function testCreate_WhenCalled_ReturnsAnswerRepository(): void {
+	/**
+	 * Tests that the factory creates the correct repository.
+	 *
+	 * @dataProvider providerCreate_WhenCalled_ReturnsAnswerRepository
+	 */
+	public function testCreate_WhenCalled_ReturnsAnswerRepository( bool $use_tables ): void {
 		/* Arrange. */
-		$factory = new Answer_Repository_Factory();
+		$factory = new Answer_Repository_Factory( $use_tables );
 
 		/* Act. */
 		$actual = $factory->create();
 
 		/* Assert. */
-		self::assertInstanceOf( Answer_Repository_Interface::class, $actual );
+		self::assertInstanceOf( Aggregate_Answer_Repository::class, $actual );
 	}
 
+	public function providerCreate_WhenCalled_ReturnsAnswerRepository(): array {
+		return [
+			'use tables'        => [ true ],
+			'do not use tables' => [ false ],
+		];
+	}
 }

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace SenseiTest\Internal\Quiz_Submission\Answer\Repositories;
+
+use DateTimeImmutable;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
+use wpdb;
+
+/**
+ * Class Tables_Based_Answer_Repository_Test
+ *
+ * @covers \Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository
+ */
+class Tables_Based_Answer_Repository_Test extends \WP_UnitTestCase {
+	protected $factory;
+
+	public function setUp(): void {
+		parent::setup();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	public function testCreate_WhenCalled_InsertsToWpdb(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Answer_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				'sensei_lms_quiz_answers',
+				$this->callback(
+					function ( $array ) {
+						return 1 === $array['submission_id']
+							&& 2 === $array['question_id']
+							&& 'value' === $array['value'];
+					}
+				),
+				[
+					'%d',
+					'%d',
+					'%s',
+					'%s',
+					'%s',
+				]
+			);
+
+		$repository->create( 1, 2, 'value' );
+	}
+
+	public function testCreate_WhenCalled_ReturnsAnswer(): void {
+		/* Arrange. */
+		$wpdb            = $this->createMock( wpdb::class );
+		$wpdb->insert_id = 3;
+		$repository      = new Tables_Based_Answer_Repository( $wpdb );
+
+		/* Act. */
+		$answer = $repository->create( 1, 2, 'value' );
+
+		/* Assert. */
+		$expected = [
+			'id'            => 3,
+			'submission_id' => 1,
+			'question_id'   => 2,
+			'value'         => 'value',
+		];
+
+		$this->assertSame( $expected, $this->export_answer( $answer ) );
+	}
+
+	public function testGetAll_WhenHasNoAnswers_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		$wpdb = $this->createMock( wpdb::class );
+		$wpdb
+			->method( 'get_results' )
+			->willReturn( [] );
+		$repository = new Tables_Based_Answer_Repository( $wpdb );
+
+		/* Act. */
+		$answers = $repository->get_all( 1 );
+
+		/* Assert. */
+		$this->assertEmpty( $answers );
+	}
+
+	public function testGetAll_WhenHasAnswers_ReturnsAnswers(): void {
+		/* Arrange. */
+		$wpdb = $this->createMock( wpdb::class );
+		$wpdb
+			->method( 'get_results' )
+			->willReturn(
+				[
+					(object) [
+						'id'            => 3,
+						'submission_id' => 1,
+						'question_id'   => 2,
+						'value'         => 'value 1',
+						'created_at'    => '2022-01-01 00:00:00',
+						'updated_at'    => '2022-01-02 00:00:00',
+					],
+					(object) [
+						'id'            => 4,
+						'submission_id' => 1,
+						'question_id'   => 3,
+						'value'         => 'value 2',
+						'created_at'    => '2022-01-02 00:00:00',
+						'updated_at'    => '2022-01-03 00:00:00',
+					],
+				]
+			);
+		$repository = new Tables_Based_Answer_Repository( $wpdb );
+
+		/* Act. */
+		$answers = $repository->get_all( 1 );
+
+		/* Assert. */
+		$expected = [
+			[
+				'id'            => 3,
+				'submission_id' => 1,
+				'question_id'   => 2,
+				'value'         => 'value 1',
+				'created_at'    => '2022-01-01 00:00:00',
+				'updated_at'    => '2022-01-02 00:00:00',
+			],
+			[
+				'id'            => 4,
+				'submission_id' => 1,
+				'question_id'   => 3,
+				'value'         => 'value 2',
+				'created_at'    => '2022-01-02 00:00:00',
+				'updated_at'    => '2022-01-03 00:00:00',
+			],
+		];
+
+		$this->assertSame( $expected, array_map( [ $this, 'export_answer_with_dates' ], $answers ) );
+	}
+
+	public function testGetAll_WhenHasAnswersInDB_ReturnsAnswers(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$date = ( new DateTimeImmutable() )->format( 'Y-m-d H:i:s' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_quiz_answers',
+			[
+				'submission_id' => 1,
+				'question_id'   => 2,
+				'value'         => 'value',
+				'created_at'    => $date,
+				'updated_at'    => $date,
+			],
+			[
+				'%d',
+				'%d',
+				'%s',
+				'%s',
+				'%s',
+			]
+		);
+		$answer_id  = $wpdb->insert_id;
+		$repository = new Tables_Based_Answer_Repository( $wpdb );
+
+		/* Act. */
+		$answers = $repository->get_all( 1 );
+
+		/* Assert. */
+		$expected = [
+			[
+				'id'            => $answer_id,
+				'submission_id' => 1,
+				'question_id'   => 2,
+				'value'         => 'value',
+			],
+		];
+		self::assertSame( $expected, array_map( [ $this, 'export_answer' ], $answers ) );
+	}
+
+	public function testDeleteAll_WhenCalled_DeletesAllFromTheDatabase(): void {
+		/* Arrange. */
+		$wpdb       = $this->createMock( wpdb::class );
+		$repository = new Tables_Based_Answer_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'delete' )
+			->with(
+				'sensei_lms_quiz_answers',
+				[
+					'submission_id' => 1,
+				],
+				[
+					'%d',
+				]
+			);
+
+		$repository->delete_all( 1 );
+	}
+
+	private function export_answer( Answer $answer ): array {
+		return [
+			'id'            => $answer->get_id(),
+			'submission_id' => $answer->get_submission_id(),
+			'question_id'   => $answer->get_question_id(),
+			'value'         => $answer->get_value(),
+		];
+	}
+
+	private function export_answer_with_dates( Answer $answer ): array {
+		return array_merge(
+			$this->export_answer( $answer ),
+			[
+				'created_at' => $answer->get_created_at()->format( 'Y-m-d H:i:s' ),
+				'updated_at' => $answer->get_updated_at()->format( 'Y-m-d H:i:s' ),
+			]
+		);
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-submission-repository-factory.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-submission-repository-factory.php
@@ -2,7 +2,7 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface;
+use Sensei\Internal\Quiz_Submission\Submission\Repositories\Aggregate_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory;
 
 /**
@@ -25,7 +25,7 @@ class Submission_Repository_Factory_Test extends \WP_UnitTestCase {
 		$actual = $factory->create();
 
 		/* Assert. */
-		self::assertInstanceOf( Submission_Repository_Interface::class, $actual );
+		self::assertInstanceOf( Aggregate_Submission_Repository::class, $actual );
 	}
 
 	public function providerCreate_WhenCalled_ReturnsSubmissionRepository(): array {


### PR DESCRIPTION
Part of #5434

### Changes proposed in this Pull Request

* Add custom tables based repositories for quiz answers.
* Add aggregate repositories that use both types of repositories (comments based and tables based).

### Testing instructions

* Enable the tables based progress feature.
```php
add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
```
* Make a course, a lesson, and a quiz that has every question type.
* Submit the quiz in the front-end.
* Make sure there is an entry for each question in the `wp_sensei_lms_quiz_answers` table and the values are the same as in the `quiz_answers` comments meta.
* Allow quiz retakes and reset the quiz. Make sure the entries are deleted from the answers table.
