### PR TITLE
Drop custom tables on uninstall

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -6,6 +6,8 @@
  * @package Core
  */
 
+use Sensei\Internal\Installer\Installer;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	// Exit if accessed directly.
 	exit;
@@ -279,6 +281,7 @@ class Sensei_Data_Cleaner {
 		self::cleanup_transients();
 		self::cleanup_options();
 		self::cleanup_user_meta();
+		self::cleanup_custom_tables();
 	}
 
 	/**
@@ -454,6 +457,20 @@ class Sensei_Data_Cleaner {
 
 		foreach ( self::$post_meta as $post_meta ) {
 			$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $post_meta ) );
+		}
+	}
+
+	/**
+	 * Drop the custom tables.
+	 */
+	private static function cleanup_custom_tables(): void {
+		global $wpdb;
+
+		$tables = Installer::instance()->get_schema()->get_tables();
+
+		foreach ( $tables as $table ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Intended.
+			$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 		}
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -80,8 +80,10 @@ class Sensei_Course_Enrolment_Manager {
 		add_action( 'sensei_before_learners_enrolled_courses_query', [ $this, 'recalculate_enrolments' ] );
 		add_action( 'transition_post_status', [ $this, 'recalculate_on_course_post_status_change' ], 10, 3 );
 
-		add_action( 'shutdown', [ Sensei_Enrolment_Provider_State_Store::class, 'persist_all' ] );
-		add_action( 'shutdown', [ Sensei_Enrolment_Provider_Journal_Store::class, 'persist_all' ] );
+		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+			add_action( 'shutdown', [ Sensei_Enrolment_Provider_State_Store::class, 'persist_all' ] );
+			add_action( 'shutdown', [ Sensei_Enrolment_Provider_Journal_Store::class, 'persist_all' ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5877

### Changes proposed in this Pull Request

* Drops the custom tables on uninstall when the "Delete data on uninstall" setting is enabled.
* Fixes some PHP error notices generated during uninstall.

I didn't find a good way to add tests for it.

### Testing instructions

* Install the plugin on a separate instance if you value your data.
* Make sure the new custom tables are in the database.
* From Sensei LMS -> Settings -> General, enable the "Delete data on uninstall" setting.
* Uninstall the plugin.
* Make sure the tables are deleted and there are no errors generated during uninstall.
