### PR TITLE
Fix error when calling `the_content` filter with no post context

### DIFF
--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -762,7 +762,7 @@ class Sensei_Messages {
 	public function message_content( $content ) {
 		global $post;
 
-		if ( get_post_type( $post->ID ) !== $this->post_type ) {
+		if ( ! $post || get_post_type( $post->ID ) !== $this->post_type ) {
 			return $content;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the following notice:

```
Notice: Trying to get property 'ID' of non-object in /Users/m1r0/Projects/sensei/includes/class-sensei-messages.php on line 765
```

It is generated when calling `apply_filters( 'the_content', 'some content' );` outside of the context of a post.

I've noticed this issue in a PHPUnit environment but any third party calling this filter manually and not having the global `$post` set yet will have the error.

### Testing instructions

* Add the following snippet:
```php
add_action( 'init', function() {
	$content = apply_filters( 'the_content', 'some content' );
} );
```
* Make sure there is no PHP error notice generated.
