### PR TITLE
Redirect to correct contact form if the user has a WPCOM subscription

### DIFF
--- a/includes/admin/home/help/class-sensei-home-help-provider.php
+++ b/includes/admin/home/help/class-sensei-home-help-provider.php
@@ -101,7 +101,7 @@ class Sensei_Home_Help_Provider {
 		if ( apply_filters( 'sensei_home_support_ticket_creation_upsell_show', true ) ) {
 			$extra_link = $this->create_extra_link( __( 'Upgrade to Sensei Pro', 'sensei-lms' ), 'https://senseilms.com/pricing/' );
 			$icon       = 'lock';
-		} elseif ( Sensei_Utils::is_atomic_platform() || Sensei_Utils::has_wpcom_subscription() ) {
+		} elseif ( Sensei_Utils::has_wpcom_subscription() ) {
 			$url = 'https://wordpress.com/help/contact';
 		} else {
 			$url = 'https://senseilms.com/contact/';

--- a/includes/admin/home/help/class-sensei-home-help-provider.php
+++ b/includes/admin/home/help/class-sensei-home-help-provider.php
@@ -101,7 +101,7 @@ class Sensei_Home_Help_Provider {
 		if ( apply_filters( 'sensei_home_support_ticket_creation_upsell_show', true ) ) {
 			$extra_link = $this->create_extra_link( __( 'Upgrade to Sensei Pro', 'sensei-lms' ), 'https://senseilms.com/pricing/' );
 			$icon       = 'lock';
-		} elseif ( Sensei_Utils::is_atomic_platform() ) {
+		} elseif ( Sensei_Utils::is_atomic_platform() || Sensei_Utils::has_wpcom_subscription() ) {
 			$url = 'https://wordpress.com/help/contact';
 		} else {
 			$url = 'https://senseilms.com/contact/';

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2699,6 +2699,16 @@ class Sensei_Utils {
 	public static function is_atomic_platform(): bool {
 		return defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID && defined( 'ATOMIC_CLIENT_ID' ) && ATOMIC_CLIENT_ID;
 	}
+
+	/**
+	 * Tells if the current site is hosted in wordpress.com and the
+	 * plan includes an active woothemes-sensei paid plan.
+	 */
+	public static function has_wpcom_subscription(): bool {
+		$subscriptions = get_option( 'wpcom_active_subscriptions', [] );
+
+		return isset( $subscriptions['woothemes-sensei'] );
+	}
 }
 
 /**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2702,7 +2702,7 @@ class Sensei_Utils {
 
 	/**
 	 * Tells if the current site is hosted in wordpress.com and the
-	 * plan includes an active woothemes-sensei paid plan.
+	 * plan includes an active subscription for a paid Sensei product.
 	 *
 	 * @return bool {bool} If there is an active WPCOM subscription or not.
 	 * @since $$next-version$$

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2703,6 +2703,9 @@ class Sensei_Utils {
 	/**
 	 * Tells if the current site is hosted in wordpress.com and the
 	 * plan includes an active woothemes-sensei paid plan.
+	 *
+	 * @return bool {bool} If there is an active WPCOM subscription or not.
+	 * @since $$next-version$$
 	 */
 	public static function has_wpcom_subscription(): bool {
 		$subscriptions = get_option( 'wpcom_active_subscriptions', [] );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2707,7 +2707,24 @@ class Sensei_Utils {
 	public static function has_wpcom_subscription(): bool {
 		$subscriptions = get_option( 'wpcom_active_subscriptions', [] );
 
-		return isset( $subscriptions['woothemes-sensei'] );
+		/**
+		 * Filter to allow adding slugs to check for on WPCOM active subscriptions.
+		 *
+		 * @hook sensei_wpcom_product_slugs
+		 * @since $$next-version$$
+		 *
+		 * @param array $products Array of slugs to check for on WPCOM active subscriptions.
+		 *
+		 * @return {array}
+		 */
+		$product_slugs = apply_filters( 'sensei_wpcom_product_slugs', [] );
+		foreach ($product_slugs as $product_slug) {
+			if ( array_key_exists( $product_slug, $subscriptions ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2718,7 +2718,7 @@ class Sensei_Utils {
 		 * @return {array}
 		 */
 		$product_slugs = apply_filters( 'sensei_wpcom_product_slugs', [] );
-		foreach ($product_slugs as $product_slug) {
+		foreach ( $product_slugs as $product_slug ) {
 			if ( array_key_exists( $product_slug, $subscriptions ) ) {
 				return true;
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2716,7 +2716,7 @@ class Sensei_Utils {
 		 * @hook sensei_wpcom_product_slugs
 		 * @since $$next-version$$
 		 *
-		 * @param array $products Array of products slugs to check if it has an active WPCOM subscription.
+		 * @param {Array} $products Array of products slugs to check if it has an active WPCOM subscription.
 		 *
 		 * @return {array}
 		 */

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2708,12 +2708,12 @@ class Sensei_Utils {
 		$subscriptions = get_option( 'wpcom_active_subscriptions', [] );
 
 		/**
-		 * Filter to allow adding slugs to check for on WPCOM active subscriptions.
+		 * Filter to allow adding products slugs to check if it has an active WPCOM subscription.
 		 *
 		 * @hook sensei_wpcom_product_slugs
 		 * @since $$next-version$$
 		 *
-		 * @param array $products Array of slugs to check for on WPCOM active subscriptions.
+		 * @param array $products Array of products slugs to check if it has an active WPCOM subscription.
 		 *
 		 * @return {array}
 		 */


### PR DESCRIPTION
Fixes #6382 

### Changes proposed in this Pull Request

* Add method to check for WPCOM subscription;
* Adapt condition to redirect user to correct contact form if the user already has a WPCOM subscription;

### New/Updated Hooks

* `sensei_wpcom_product_slugs` - Filter to allow adding/removing product slugs to check for while checking for active WPCOM subscriptions;

### Testing instructions

On a WordPress.org installation using this branch of the plugin:

Without Sensei Pro installed: 
1. Visit Sensei Home;
2. Make sure the link "Create a support ticket" is followed by an upsell "Upgrade to Sensei Pro", which links to a page to buy Sensei Pro;

With Sensei Pro installed (on the latest version):
1. Visit Sensei Home;
2. Make sure the link "Create a support ticket" links to the contact page on senseilms.com;

As you can see, this PR shouldn't change the behavior (of linking to senseilms.com and showing an upsell) with the latest version of Sensei Pro.

Now, to make sure this PR is working:

1. Add the following snippet:

```php
add_filter( "sensei_wpcom_product_slugs", function($slugs) {
    return array_merge( $slugs, [ "test" ]);
});
add_filter( "default_option_wpcom_active_subscriptions", function( $value ) {
    $value[ "test" ] = 1;
    return $value;
});
```
2. Visit Sensei Home;
3. Make sure the link "Create a support ticket" links to the contact page on wordpress.com;