### PR TITLE
Add/show filter only for non inherited course list

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -100,11 +100,10 @@ const observeAndRemoveSettingsFromPanel = ( blockSettingsPanel ) => {
 // Hide the settings which are inherited from the Query Loop block
 // but not applicable to our Course List block.
 const hideUnnecessarySettingsForCourseList = () => {
-	const postTypeContainerQuery = '.components-input-control__label',
-		inheritContextContainerQuery = '.components-toggle-control__label';
+	const postTypeContainerQuery = '.components-input-control__label';
 
 	const toBeHiddenSettingContainers = document.querySelectorAll(
-		`${ postTypeContainerQuery },${ inheritContextContainerQuery }`
+		postTypeContainerQuery
 	);
 
 	if (
@@ -119,8 +118,6 @@ const hideUnnecessarySettingsForCourseList = () => {
 			[
 				/* eslint-disable-next-line @wordpress/i18n-text-domain */
 				__( 'Post type' ).toLowerCase(),
-				/* eslint-disable-next-line @wordpress/i18n-text-domain */
-				__( 'Inherit query from template' ).toLowerCase(),
 			].includes( element.textContent.toLowerCase() )
 		) {
 			element.closest( '.components-base-control' ).style.display =

--- a/assets/blocks/course-list-filter-block/course-list-filter-edit.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter-edit.js
@@ -123,6 +123,10 @@ function CourseListFilter( {
 		);
 	}
 
+	if ( query?.inherit ) {
+		return <> </>;
+	}
+
 	return (
 		<div { ...blockProps }>
 			<InspectorControls>

--- a/assets/blocks/course-list-filter-block/course-list-filter-edit.test.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter-edit.test.js
@@ -91,4 +91,18 @@ describe( 'CourseListFilterBlockEdit', () => {
 
 		expect( getByText( message ) ).toBeInTheDocument();
 	} );
+
+	it( 'should not render in inherited context', () => {
+		useSelect.mockReturnValue( categories );
+		const { queryByText } = render(
+			<CourseListFilter
+				clientId="some-client-id"
+				attributes={ { types: [ 'categories' ] } }
+				context={ { query: { ...context.query, inherit: true } } }
+			/>
+		);
+		categories.forEach( ( category ) =>
+			expect( queryByText( category.name ) ).toBeFalsy()
+		);
+	} );
 } );

--- a/includes/blocks/course-list/class-sensei-course-list-filter-block.php
+++ b/includes/blocks/course-list/class-sensei-course-list-filter-block.php
@@ -63,7 +63,8 @@ class Sensei_Course_List_Filter_Block {
 			! isset( $attributes['types'] ) ||
 			! is_array( $attributes['types'] ) ||
 			! isset( $block->context['queryId'] ) ||
-			'course' !== ( $block->context['query']['postType'] ?? '' )
+			'course' !== ( $block->context['query']['postType'] ?? '' ) ||
+			( $block->context['query']['inherit'] ?? false )
 		) {
 			return '';
 		}

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -359,4 +359,21 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( $this->course1->post_title, $result );
 		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
+
+	public function testCourseFilterBlock_WhenRenderedInInheritedContext_DoesNotRender() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+
+		/* ARRANGE */
+		$inherited_content = str_replace( '"sticky":""', '"inherit":true,"sticky":""', $this->content );
+
+		/* ACT */
+		$default_result   = do_blocks( $this->content );
+		$inherited_result = do_blocks( $inherited_content );
+
+		/* ASSERT */
+		$this->assertStringContainsString( 'wp-block-sensei-lms-course-list-filter', $default_result );
+		$this->assertStringNotContainsString( 'wp-block-sensei-lms-course-list-filter', $inherited_result );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6405

### Changes proposed in this Pull Request

* Unhide the inherited toggle of Query Loop. As we are using it in archive pages in inherited context and user may also want to toggle to be able to toggle.
- Not render the Course List Filter block when the Course List block is inheriting query

### Testing instructions

- Add the Course List block on any page
- Toggle the Inherit Query button on
- Make sure the Filtering Dropdowns are not rendering 
- Now turn the inherit toggle off
- Make sure the dropdowns are rendering as expected