### PR TITLE
Make course list filters work in archive page

### DIFF
--- a/assets/blocks/course-list-filter-block/course-list-filter.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter.js
@@ -8,6 +8,8 @@ courseListFeaturedFilterElements.forEach( ( element ) => {
 		const queryId = evt.target.dataset.paramKey
 			.split( '-' )
 			.slice( -1 )[ 0 ];
+
+		url.pathname = url.pathname.replace( /\/page\/[0-9]+\//, '/' );
 		url.searchParams.delete( `query-${ queryId }-page` );
 		url.searchParams.set( evt.target.dataset.paramKey, evt.target.value );
 		window.location.href = url;

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -209,6 +209,7 @@ class Sensei_Setup_Wizard_Pages {
 						'blockName'    => 'core/query',
 						'innerContent' => [
 							'<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view">
+<!-- wp:sensei-lms/course-list-filter {"types":["featured"],"lock":{"move":true}} /-->
 <!-- wp:post-template {"align":"center"} -->
 <!-- wp:group {"align":"center","style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"}},"border":{"width":"1px","color":"#c7c3c34f"}},"className":"aligncenter","layout":{"inherit":false}} -->
 <div class="wp-block-group aligncenter has-border-color" style="border-color:#c7c3c34f;border-width:1px;padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px"><!-- wp:post-featured-image {"isLink":true,"height":"324px","align":"center"} /-->

--- a/includes/blocks/class-sensei-blocks-initializer.php
+++ b/includes/blocks/class-sensei-blocks-initializer.php
@@ -73,10 +73,11 @@ abstract class Sensei_Blocks_Initializer {
 
 		$this->initialize_blocks();
 
+		$is_archive_with_query_block = ( is_post_type_archive( 'course' ) || is_tax( 'course-category' ) ) && Sensei()->course->course_archive_page_has_query_block();
 		if (
 			is_admin() ||
 			Sensei()->blocks->has_sensei_blocks() ||
-			( is_post_type_archive( 'course' ) && Sensei()->course->course_archive_page_has_query_block() )
+			$is_archive_with_query_block
 		) {
 			add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		}

--- a/includes/blocks/course-list/class-sensei-course-list-block.php
+++ b/includes/blocks/course-list/class-sensei-course-list-block.php
@@ -67,7 +67,7 @@ class Sensei_Course_List_Block {
 			'course' === ( $parsed_block['attrs']['query']['postType'] ?? '' ) &&
 			false !== strpos( ( $parsed_block['attrs']['className'] ?? '' ), 'wp-block-sensei-lms-course-list' ) &&
 			Sensei()->course->course_archive_page_has_query_block() &&
-			is_post_type_archive( 'course' )
+			( is_post_type_archive( 'course' ) || is_tax( 'course-category' ) )
 		) {
 			$parsed_block['attrs']['query']['inherit'] = true;
 		}

--- a/includes/blocks/course-list/class-sensei-course-list-block.php
+++ b/includes/blocks/course-list/class-sensei-course-list-block.php
@@ -19,6 +19,7 @@ class Sensei_Course_List_Block {
 	 */
 	public function __construct() {
 		add_filter( 'render_block', [ $this, 'maybe_render_login_form' ], 10, 2 );
+		add_filter( 'render_block_data', [ $this, 'maybe_change_inherited_to_true' ], 1 );
 	}
 
 	/**
@@ -51,5 +52,25 @@ class Sensei_Course_List_Block {
 		}
 
 		return $block_content;
+	}
+
+	/**
+	 * If course list block is being rendered in Archive page, set inherited to true.
+	 *
+	 * @param array $parsed_block The block to be rendered.
+	 *
+	 * @return array
+	 */
+	public function maybe_change_inherited_to_true( $parsed_block ) {
+		if (
+			'core/query' === $parsed_block['blockName'] &&
+			'course' === ( $parsed_block['attrs']['query']['postType'] ?? '' ) &&
+			false !== strpos( ( $parsed_block['attrs']['className'] ?? '' ), 'wp-block-sensei-lms-course-list' ) &&
+			Sensei()->course->course_archive_page_has_query_block() &&
+			is_post_type_archive( 'course' )
+		) {
+			$parsed_block['attrs']['query']['inherit'] = true;
+		}
+		return $parsed_block;
 	}
 }

--- a/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
@@ -34,7 +34,8 @@ class Sensei_Course_List_Categories_Filter extends Sensei_Course_List_Filter_Abs
 	public function get_content( WP_Block $block ) : string {
 		$attributes        = $block->attributes;
 		$query_id          = $block->context['queryId'];
-		$filter_param_key  = self::PARAM_KEY . $query_id;
+		$is_inherited      = $block->context['query']['inherit'] ?? false;
+		$filter_param_key  = $is_inherited ? 'course_category_filter' : self::PARAM_KEY . $query_id;
 		$default_option    = $attributes['defaultOptions']['categories'] ?? -1;
 		$category_id       = isset( $_GET[ $filter_param_key ] ) ? intval( $_GET[ $filter_param_key ] ) : -1; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 		$course_categories = get_terms(

--- a/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
@@ -32,12 +32,17 @@ class Sensei_Course_List_Categories_Filter extends Sensei_Course_List_Filter_Abs
 	 * @param WP_Block $block The block instance.
 	 */
 	public function get_content( WP_Block $block ) : string {
-		$attributes        = $block->attributes;
-		$query_id          = $block->context['queryId'];
-		$is_inherited      = $block->context['query']['inherit'] ?? false;
-		$filter_param_key  = $is_inherited ? 'course_category_filter' : self::PARAM_KEY . $query_id;
-		$default_option    = $attributes['defaultOptions']['categories'] ?? -1;
-		$category_id       = isset( $_GET[ $filter_param_key ] ) ? intval( $_GET[ $filter_param_key ] ) : -1; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
+		$attributes       = $block->attributes;
+		$query_id         = $block->context['queryId'];
+		$is_inherited     = $block->context['query']['inherit'] ?? false;
+		$filter_param_key = $is_inherited ? 'course_category_filter' : self::PARAM_KEY . $query_id;
+		$default_option   = $attributes['defaultOptions']['categories'] ?? -1;
+		$category_id      = isset( $_GET[ $filter_param_key ] ) ? intval( $_GET[ $filter_param_key ] ) : -1; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
+
+		if ( $is_inherited && is_tax( 'course-category' ) ) {
+			return '';
+		}
+
 		$course_categories = get_terms(
 			[
 				'taxonomy'   => 'course-category',

--- a/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
@@ -51,7 +51,8 @@ class Sensei_Course_List_Featured_Filter extends Sensei_Course_List_Filter_Abstr
 	public function get_content( WP_Block $block ) : string {
 		$attributes       = $block->attributes;
 		$query_id         = $block->context['queryId'];
-		$filter_param_key = self::PARAM_KEY . $query_id;
+		$is_inherited     = $block->context['query']['inherit'] ?? false;
+		$filter_param_key = $is_inherited ? 'course_filter' : self::PARAM_KEY . $query_id;
 		$default_option   = $attributes['defaultOptions']['featured'] ?? 'all';
 		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 

--- a/includes/blocks/course-list/class-sensei-course-list-filter-block.php
+++ b/includes/blocks/course-list/class-sensei-course-list-filter-block.php
@@ -28,7 +28,7 @@ class Sensei_Course_List_Filter_Block {
 		$this->register_block();
 
 		add_filter( 'render_block_data', [ $this, 'filter_course_list' ] );
-		add_filter( 'sensei_archive_course_filter_by_options', [ $this, 'maybe_remove_extra_filters_from_archive_page' ], 11 );
+		add_action( 'sensei_archive_before_course_loop', [ $this, 'maybe_remove_extra_filters_and_sorting_from_archive_page' ], 9 );
 
 		$this->filters = [
 			new Sensei_Course_List_Categories_Filter(),
@@ -38,19 +38,19 @@ class Sensei_Course_List_Filter_Block {
 	}
 
 	/**
-	 * Remove extra filters from archive page if the Course List block is being used.
+	 * Remove extra filters and sorting from archive page if the Course List block is being used.
 	 *
 	 * @since $$next-version$$
+	 * @access private
+	 * @hooked sensei_archive_before_course_loop
 	 *
-	 * @param array $filter_links The incoming filter links.
-	 *
-	 * @return array The filtered filter links.
+	 * @return void
 	 */
-	public function maybe_remove_extra_filters_from_archive_page( array $filter_links ) : array {
+	public function maybe_remove_extra_filters_and_sorting_from_archive_page(): void {
 		if ( Sensei()->course->course_archive_page_has_query_block() ) {
-			return [];
+			remove_action( 'sensei_archive_before_course_loop', [ 'Sensei_Course', 'course_archive_sorting' ] );
+			remove_action( 'sensei_archive_before_course_loop', [ 'Sensei_Course', 'course_archive_filters' ] );
 		}
-		return $filter_links;
 	}
 
 	/**

--- a/includes/blocks/course-list/class-sensei-course-list-filter-block.php
+++ b/includes/blocks/course-list/class-sensei-course-list-filter-block.php
@@ -28,12 +28,29 @@ class Sensei_Course_List_Filter_Block {
 		$this->register_block();
 
 		add_filter( 'render_block_data', [ $this, 'filter_course_list' ] );
+		add_filter( 'sensei_archive_course_filter_by_options', [ $this, 'maybe_remove_extra_filters_from_archive_page' ], 11 );
 
 		$this->filters = [
 			new Sensei_Course_List_Categories_Filter(),
 			new Sensei_Course_List_Featured_Filter(),
 			new Sensei_Course_List_Student_Course_Filter(),
 		];
+	}
+
+	/**
+	 * Remove extra filters from archive page if the Course List block is being used.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $filter_links The incoming filter links.
+	 *
+	 * @return array The filtered filter links.
+	 */
+	public function maybe_remove_extra_filters_from_archive_page( array $filter_links ) : array {
+		if ( Sensei()->course->course_archive_page_has_query_block() ) {
+			return [];
+		}
+		return $filter_links;
 	}
 
 	/**

--- a/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
@@ -55,7 +55,8 @@ class Sensei_Course_List_Student_Course_Filter extends Sensei_Course_List_Filter
 
 		$attributes       = $block->attributes;
 		$query_id         = $block->context['queryId'];
-		$filter_param_key = self::PARAM_KEY . $query_id;
+		$is_inherited     = $block->context['query']['inherit'] ?? false;
+		$filter_param_key = $is_inherited ? 'student_course_filter' : self::PARAM_KEY . $query_id;
 		$default_option   = $attributes['defaultOptions']['student_course'] ?? 'all';
 		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -127,6 +127,9 @@ class Sensei_Course {
 		// filter the course query when featured filter is applied
 		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_featured_filter' ], 10, 1 );
 
+		// filter the course category when category filter is applied
+		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_category_filter' ], 10, 1 );
+
 		// Handle the ordering for the courses archive page.
 		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_set_order_by' ], 10, 1 );
 
@@ -2854,12 +2857,40 @@ class Sensei_Course {
 	 * @return WP_Query $query
 	 */
 	public static function course_archive_featured_filter( $query ) {
-
 		if ( isset( $_GET['course_filter'] ) && 'featured' == $_GET['course_filter'] && $query->is_main_query() ) {
 			// setup meta query for featured courses
 			$query->set( 'meta_value', 'featured' );
 			$query->set( 'meta_key', '_course_featured' );
 			$query->set( 'meta_compare', '=' );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * If the category filter is used on the course archive page
+	 * filter the courses returned to only show those in that category.
+	 *
+	 * Hooked into pre_get_posts
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param WP_Query $query Incoming WP_Query object.
+	 *
+	 * @return WP_Query $query
+	 */
+	public static function course_archive_category_filter( $query ) {
+		if ( isset( $_GET['course_category_filter'] ) && intval( $_GET['course_category_filter'] ) > 0 && $query->is_main_query() ) {
+			$query->set(
+				'tax_query',
+				[
+					[
+						'taxonomy' => 'course-category',
+						'field'    => 'id',
+						'terms'    => intval( $_GET['course_category_filter'] ),
+					],
+				]
+			);
 		}
 
 		return $query;

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -124,14 +124,14 @@ class Sensei_Course {
 		// attach the filter links to the course archive
 		add_action( 'sensei_archive_before_course_loop', [ 'Sensei_Course', 'course_archive_filters' ] );
 
-		// filter the course query when featured filter is applied
-		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_featured_filter' ], 10, 1 );
+		// Filter the course query when featured filter is applied.
+		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_featured_filter' ] );
 
 		// Filter by course category when category filter is applied.
-		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_category_filter' ], 10, 1 );
+		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_category_filter' ] );
 
 		// Filter by student course state when student course filter is applied.
-		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_student_course_state_filter' ], 10, 1 );
+		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_student_course_state_filter' ] );
 
 		// Handle the ordering for the courses archive page.
 		add_filter( 'pre_get_posts', [ __CLASS__, 'course_archive_set_order_by' ], 10, 1 );

--- a/templates/archive-course.php
+++ b/templates/archive-course.php
@@ -33,12 +33,14 @@
 
 	<?php
 
-	if ( have_posts() ) {
-		if ( Sensei()->course->course_archive_page_has_query_block() ) {
-			Sensei()->course->archive_page_content();
-		} else {
-			sensei_load_template( 'loop-course.php' );
-		}
+	if ( Sensei()->course->course_archive_page_has_query_block() ) {
+
+		Sensei()->course->archive_page_content();
+
+	} elseif ( have_posts() ) {
+
+		sensei_load_template( 'loop-course.php' );
+
 	} else {
 		?>
 

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -359,4 +359,104 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( $this->course1->post_title, $result );
 		$this->assertStringNotContainsString( $this->course2->post_title, $result );
 	}
+
+	public function testFilterForArchivePage_FeaturedCourseFilterIsSelected_UpdatesQueryWithProperParams() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+
+		/* ARRANGE */
+		$this->handler = new Sensei_Unsupported_Theme_Handler_Course_Archive();
+		$this->handler->handle_request();
+
+		/* ACT */
+		$this->go_to(
+			add_query_arg(
+				[ 'course_filter' => 'featured' ],
+				get_permalink( (int) Sensei()->settings->get( 'course_page' ) )
+			)
+		);
+
+		/* ASSERT */
+		global $wp_query;
+		$this->assertEquals( '_course_featured', $wp_query->query_vars['meta_key'] );
+		$this->assertEquals( 'featured', $wp_query->query_vars['meta_value'] );
+	}
+
+	public function testFilterForArchivePage_CategoryCourseFilterIsSelected_UpdatesQueryWithProperParams() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+
+		/* ARRANGE */
+		$this->handler = new Sensei_Unsupported_Theme_Handler_Course_Archive();
+		$this->handler->handle_request();
+
+		/* ACT */
+		$this->go_to(
+			add_query_arg(
+				[ 'course_category_filter' => 123 ],
+				get_permalink( (int) Sensei()->settings->get( 'course_page' ) )
+			)
+		);
+
+		/* ASSERT */
+		global $wp_query;
+		$this->assertIsArray( $wp_query->query_vars['tax_query'] );
+		$this->assertEquals( 'course-category', $wp_query->query_vars['tax_query'][0]['taxonomy'] );
+		$this->assertEquals( 123, $wp_query->query_vars['tax_query'][0]['terms'] );
+	}
+
+	public function testFilterForArchivePage_StudentCourseStatusFilterIsSelected_UpdatesQueryWithProperParams() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+
+		/* ARRANGE */
+		$student = $this->factory->user->create();
+		$this->login_as( $student );
+
+		$this->manuallyEnrolStudentInCourse( $student, $this->course1->ID );
+
+		$this->handler = new Sensei_Unsupported_Theme_Handler_Course_Archive();
+		$this->handler->handle_request();
+
+		/* ACT */
+		$this->go_to(
+			add_query_arg(
+				[ 'student_course_filter' => 'active' ],
+				get_permalink( (int) Sensei()->settings->get( 'course_page' ) )
+			)
+		);
+
+		/* ASSERT */
+		global $wp_query;
+		$this->assertEquals( [ $this->course1->ID ], $wp_query->query_vars['post__in'] );
+	}
+
+	public function testCourseFilterBlock_WhenFiltersAreInherited_ChangesFilterParamKeysToGlobal() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+		/* ARRANGE */
+		$student = $this->factory->user->create();
+		$this->login_as( $student );
+
+		$this->manuallyEnrolStudentInCourse( $student, $this->course1->ID );
+
+		/* ACT */
+		$old_result = do_blocks( $this->content );
+
+		$modified_content = str_replace( ',"sticky":""', ',"sticky":"","inherit":true', $this->content );
+
+		$result = do_blocks( $modified_content );
+
+		/* ASSERT */
+		$this->assertStringNotContainsString( 'course_filter', $old_result );
+		$this->assertStringNotContainsString( 'course_category_filter', $old_result );
+		$this->assertStringNotContainsString( 'student_course_filter', $old_result );
+		$this->assertStringContainsString( 'course_filter', $result );
+		$this->assertStringContainsString( 'course_category_filter', $result );
+		$this->assertStringContainsString( 'student_course_filter', $result );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6378

### Changes proposed in this Pull Request

* Make all three filters work in the Archive page for the Course List block
* Hide the filters in the top added by hook if the Course List block is being used for archive
* If the Course List block is being rendered for an Archive page, make it inherit the global query
* If filter is used from a page which is not the first one, move to the first page
* Add the filter block in page creation

### Testing instructions

- Remove the Courses page
- Run the Setup Wizard again
- Make sure the Courses page is created and it has the Course List block in it
- Hit the Courses page from the frontend, make sure the filter is working
- Go to page editor of Courses page and enable all the filters
- Make sure all of them work
