### PR TITLE
Fix View Quiz for draft lessons

### DIFF
--- a/includes/blocks/class-sensei-view-quiz-block.php
+++ b/includes/blocks/class-sensei-view-quiz-block.php
@@ -66,6 +66,6 @@ class Sensei_View_Quiz_Block {
 			1
 		);
 
-		return '<form class="lesson_button_form" data-id="complete-lesson-form" method="GET" action="' . $quiz_permalink . '">' . $content . '</form>';
+		return '<form class="lesson_button_form" data-id="complete-lesson-form" method="POST" action="' . $quiz_permalink . '">' . $content . '</form>';
 	}
 }

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -117,7 +117,7 @@ class Lesson_Actions {
 		$text           = esc_html__( 'Take Quiz', 'sensei-lms' );
 
 		return ( '
-			<form method="GET" action="' . $quiz_permalink . '" class="sensei-course-theme-lesson-actions__take-quiz-form">
+			<form method="POST" action="' . $quiz_permalink . '" class="sensei-course-theme-lesson-actions__take-quiz-form">
 				<button type="submit" data-id="complete-lesson-button" class="sensei-course-theme-lesson-actions__take-quiz sensei-course-theme__button is-primary" ' . $disabled . '>
 					' . $text . '
 			</button>


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6312
Alternative to https://github.com/Automattic/sensei/pull/6365

### Changes proposed in this Pull Request

* Change the forms around the 'View quiz' button to `method=POST`
  * This fixes an issue of GET forms overriding query string parameters, which are used for previewing draft posts, including the quiz permalink
  * Tradeoff: the quiz page is rendered directly as a response to the POST request, so the browser would pop up a warning if reloading, like in the screenshot. I didn't add an additional redirect to mitigate this to keep things simple for now. This also already happened for some quiz actions, like Save quiz

### Testing instructions

* Open a lesson with a quiz as a student and click View Quiz
* Also do this for an unpublished lesson, using Preview as Student

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/176949/214143472-10fdf3db-30ba-4bb2-a306-616f3f629d0a.png">

