### PR TITLE
Curate list of installed plugins that are logged

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -97,21 +97,24 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		if ( 1 === preg_match( '/(^sensei|\-sensei$)/', $plugin_slug ) ) {
 			return true;
 		}
+
 		$third_party_plugins = array(
+			'automatewoo',
 			'classic-editor',
 			'jetpack',
+			'mailpoet',
 			'polylang',
-			'sitepress-multilingual-cms',
+			'sitepress-multilingual-cms', // WPML.
 			'woocommerce',
+			'woocommerce-follow-up-emails',
 			'woocommerce-memberships',
-			'woocommerce-product-vendors',
-			'woocommerce-subscriptions',
-			'woothemes-updater',
-			'wp-quicklatex',
+			'woocommerce-subscriptions'
 		);
+
 		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {
 			return true;
 		}
+
 		return false;
 	}
 

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -108,7 +108,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 			'woocommerce',
 			'woocommerce-follow-up-emails',
 			'woocommerce-memberships',
-			'woocommerce-subscriptions'
+			'woocommerce-subscriptions',
 		);
 
 		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request
Curate the list of plugins that we log. I've removed some we don't care about (e.g. Product Vendors, Quick Latex) and added some email plugins. Some of these email plugins have Sensei integrations (i.e. Follow-Up Emails) while others are working on adding support (i.e. AutomateWoo). I added MailPoet as well since that could be an interesting one to track.

### Testing instructions
- Get copies of [AutomateWoo](https://woocommerce.com/products/automatewoo/), [MailPoet](https://woocommerce.com/products/mailpoet-business/) and [Follow-Ups](https://woocommerce.com/products/follow-up-emails/). Search the Secret Store for "WooCommerce.com Coupon" to purchase.
-  Install and activate the above plugins. 
- Enable Sensei usage tracking in settings.
- Install [WP Crontrol](https://en-ca.wordpress.org/plugins/wp-crontrol/).
- In _Tools_ > _Cron Events_, run the `sensei_usage_tracking_send_usage_data` job.
- Go to https://mc.a8c.com/tracks/live/?eventname=sensei_system_log and add your domain into the _Username_ field.
- Wait about 15 minutes.
- When the event is logged, check that the following details are nested under `eventprops` with the plugin version numbers:
  - `plugin_automatewoo`
  - `plugin_mailpoet`
  - `plugin_woocommerce_follow_up_emails`
- Disable Sensei usage tracking in settings so that we don't continue logging test data.