### PR TITLE
Fix archive page going on infinite loop in Astra theme

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php
@@ -59,6 +59,9 @@ class Sensei_Unsupported_Theme_Handler_Course_Archive
 
 		// Disable pagination.
 		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
+
+		// Fix infinite loop issue on Astra.
+		add_filter( 'astra_remove_entry_header_content', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6391

### Changes proposed in this Pull Request

* Astra >= 4.0.0 tries to fetch some extra details on top, like the Archive Description on top of our archive page. The [have_posts](https://themes.trac.wordpress.org/browser/astra/4.0.2/inc/blog/blog.php#L365) call after [the_post()](https://themes.trac.wordpress.org/browser/astra/4.0.2/inc/class-astra-loop.php#L194) function here causes it go on an infinite loop. Adding a fix for Astra to not try to show the archive description on top of the Course archive page as it only happens when our Unsupported theme handling is being used.

### Testing instructions

- Install the latest Astra theme
- Go to Sensei's course archive page from the frontend
- Make sure it's fully loading and not going in an infinite loop
