### PR TITLE
Remove separator from course list pattern

### DIFF
--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -144,10 +144,6 @@ class Sensei_Setup_Wizard_Pages {
 <!-- /wp:group -->
 <!-- /wp:post-template -->
 
-<!-- wp:separator {"opacity":"css","align":"center","className":"alignwide is-style-wide"} -->
-<hr class="wp-block-separator aligncenter has-css-opacity alignwide is-style-wide"/>
-<!-- /wp:separator -->
-
 <!-- wp:query-pagination {"paginationArrow":"arrow","align":"center","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <!-- wp:query-pagination-previous {"fontSize":"small"} /-->
 

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -21,11 +21,7 @@ class Sensei_Course_List_Block_Patterns {
 	 */
 	public function register_course_list_block_patterns() {
 		$pagination =
-			'<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
-				<hr class="wp-block-separator alignwide is-style-wide"/>
-			<!-- /wp:separator -->
-
-			<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+			'<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 				<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
 
 				<!-- wp:query-pagination-numbers /-->


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6387

### Changes proposed in this Pull Request

* Removed the separator block from the bottom of course list block patterns and page creation wizard

### Testing instructions

- Remove My Courses page
- Run Sensei setup wizard again
- Make sure the newly created My Course page doesn't have the separator block at bottom
- Now add the Course List block in any page
- Select both of the list and the grid patterns
- Make sure none of them show any separator line below
