### PR TITLE
Fix `the_content` hook called twice when viewing a lesson in learning mode

### DIFF
--- a/includes/blocks/course-theme/class-course-content.php
+++ b/includes/blocks/course-theme/class-course-content.php
@@ -78,15 +78,15 @@ class Course_Content {
 
 		$type = get_post_type();
 
-		$content = '';
-
 		switch ( $type ) {
 			case 'quiz':
 				$content = Quiz_Content::render_quiz();
 				break;
 			case 'lesson':
-				$content = $this->render_lesson_content();
+				$content = $this->render_lesson_content( $content );
 				break;
+			default:
+				$content = '';
 		}
 
 		add_filter( 'the_content', [ $this, 'render_content' ] );
@@ -98,26 +98,26 @@ class Course_Content {
 	/**
 	 * Render the current lesson page's content.
 	 *
-	 * @global string $_wp_current_template_content
+	 * @param string $content Content of the post.
 	 *
-	 * @return false|string
+	 * @return string
 	 */
-	private function render_lesson_content() {
+	private function render_lesson_content( string $content ): string {
 		global $_wp_current_template_content;
 
 		if ( ! in_the_loop() && have_posts() ) {
 			the_post();
 		}
 
-		ob_start();
-
 		if ( sensei_can_user_view_lesson() ) {
-			the_content();
-		} elseif ( empty( $_wp_current_template_content ) || ! has_block( 'core/post-excerpt', $_wp_current_template_content ) ) {
-			the_excerpt();
+			return $content;
 		}
 
-		return ob_get_clean();
+		if ( empty( $_wp_current_template_content ) || ! has_block( 'core/post-excerpt', $_wp_current_template_content ) ) {
+			return apply_filters( 'the_excerpt', get_the_excerpt() ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Intended.
+		}
+
+		return '';
 	}
 
 }


### PR DESCRIPTION
This PR improves performance by not triggering `the_content` filter twice on the lesson content when viewed in learning mode.

### Changes proposed in this Pull Request

* Apply `the_content` filters only once for the lesson's content in learning mode.

### Testing instructions

* Create a lesson.
* To detect the number of times `the_content` filter has been applied, use the following snippet:
```php
add_action( 'wp_footer', function() {
	$number_of_calls = did_filter( 'the_content' );

	echo <<<DEBUG
<pre style="position: fixed; bottom: 0; left: 0; right: 0; color: white; background: red; text-align: center; z-index: 9999">
	$number_of_calls
</pre>
DEBUG;
	exit;
} );
```
* Open the lesson in the front-end.
* The snippet should show `1` call. It can show `2` calls if you are using the `Video` learning mode template. More info [here](https://github.com/Automattic/sensei-pro/pull/2080). The number of calls can also be increased if there are glossary phrases, so remove those.
* If you are using the `Video` learning mode template. Make sure to switch to the default one and test again.
* Make sure the lesson content is working as before.