### PR TITLE
Fix guest user not starting quiz timer

### DIFF
--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -98,6 +98,12 @@ class Sensei_Guest_User {
 			'nonce' => 'sensei_quiz_page_change_nonce',
 			'enrol' => true,
 		],
+		// Quiz timer.
+		[
+			'field' => 'start_quiz_timer',
+			'nonce' => 'sensei_start_quiz_timer_nonce',
+			'enrol' => true,
+		],
 	];
 
 	/**

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -98,12 +98,6 @@ class Sensei_Guest_User {
 			'nonce' => 'sensei_quiz_page_change_nonce',
 			'enrol' => true,
 		],
-		// Quiz timer.
-		[
-			'field' => 'start_quiz_timer',
-			'nonce' => 'sensei_start_quiz_timer_nonce',
-			'enrol' => true,
-		],
 	];
 
 	/**
@@ -423,7 +417,19 @@ class Sensei_Guest_User {
 	 */
 	private function get_current_action() {
 
-		foreach ( $this->supported_actions as $action ) {
+		/**
+		 * Filters the list of supported actions for Guest Users.
+		 *
+		 * @hook  sensei_guest_user_supported_actions
+		 * @since $$next-version$$
+		 *
+		 * @param {array} List of supported actions for guest users.
+		 *
+		 * @return {array} List of supported actions for guest users.
+		 */
+		$supported_actions = apply_filters( 'sensei_guest_user_supported_actions', $this->supported_actions );
+
+		foreach ( $supported_actions as $action ) {
 			if ( $this->is_action( $action['field'], $action['nonce'] ) ) {
 				return $action;
 			}


### PR DESCRIPTION
Fixes issue of guest user request not starting the quiz timer
Depends on https://github.com/Automattic/sensei-pro/pull/2082

### Changes proposed in this Pull Request

* Added a hook to allow more actions in the guest user allowed actions list

### Testing instructions

- Have both Sensei and Sensei pro enabled
- Create a course with open access enabled
- Create a lesson with a timed quiz
- Go to the course as a guest user (don't click on Take Course button)
- Open the lesson and click on the quiz
- Click on Start Timer
- The timer should start

### New/Updated Hooks

`sensei_guest_user_supported_actions`: Filter list of supported actions by guest users