### PR TITLE
 Fix students context menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@wordpress/base-styles": "wp-5.9",
         "@wordpress/block-editor": "wp-5.9",
         "@wordpress/blocks": "wp-5.9",
-        "@wordpress/components": "wp-5.9",
+        "@wordpress/components": "22.1.0",
         "@wordpress/compose": "wp-5.9",
         "@wordpress/core-data": "wp-5.9",
         "@wordpress/data": "wp-5.9",
@@ -6199,6 +6199,89 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@motionone/animation": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
+      "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+      "dependencies": {
+        "@motionone/easing": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/animation/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@motionone/dom": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
+      "dependencies": {
+        "@motionone/animation": "^10.12.0",
+        "@motionone/generators": "^10.12.0",
+        "@motionone/types": "^10.12.0",
+        "@motionone/utils": "^10.12.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/dom/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@motionone/easing": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
+      "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+      "dependencies": {
+        "@motionone/utils": "^10.15.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/easing/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@motionone/generators": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
+      "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+      "dependencies": {
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/generators/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@motionone/types": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
+      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+    },
+    "node_modules/@motionone/utils": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
+      "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+      "dependencies": {
+        "@motionone/types": "^10.15.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/utils/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents",
       "dev": true,
@@ -8888,13 +8971,13 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.10.0.tgz",
-      "integrity": "sha512-Igx80jb0Y5rX5tnjd7CKiKILr7yrDs7lZY4zEYNB+4gifm+aCh/+LOFZhXCHTkadKS7gMmLHJ65gv6ph3nNjuQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.25.0.tgz",
+      "integrity": "sha512-EAsrCLv5Kh9jhDnhe2GgGVyiJ5YzhDZXi9UDgfKsi1XSTFD0IJ0nEQ0adyNMms5C5PPBXL7ygjxQO9domKdzTw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^3.10.0",
-        "@wordpress/i18n": "^4.10.0"
+        "@wordpress/dom-ready": "^3.25.0",
+        "@wordpress/i18n": "^4.25.0"
       },
       "engines": {
         "node": ">=12"
@@ -9555,6 +9638,56 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+      "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.1.5",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.0",
+        "@wordpress/compose": "^4.2.0",
+        "@wordpress/date": "^4.2.0",
+        "@wordpress/deprecated": "^3.2.0",
+        "@wordpress/dom": "^3.2.0",
+        "@wordpress/element": "^3.2.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.0",
+        "@wordpress/icons": "^4.1.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.0",
+        "@wordpress/primitives": "^2.2.0",
+        "@wordpress/rich-text": "^4.2.0",
+        "@wordpress/warning": "^2.2.0",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-spring": "^8.0.20",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
+      }
+    },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/compose": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
@@ -9648,78 +9781,253 @@
       }
     },
     "node_modules/@wordpress/components": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
-      "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-22.1.0.tgz",
+      "integrity": "sha512-Hi3rhfqEjXW+LSj4ibLpSrIthqUn7/fvDlxUeBUXjDwkv+kXGVVFBPw2pin/mJgBF5K90VUFJhwd92VmCZWw0Q==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@emotion/cache": "^11.1.3",
-        "@emotion/css": "^11.1.3",
-        "@emotion/react": "^11.1.5",
-        "@emotion/styled": "^11.3.0",
-        "@emotion/utils": "1.0.0",
-        "@wordpress/a11y": "^3.2.0",
-        "@wordpress/compose": "^4.2.0",
-        "@wordpress/date": "^4.2.0",
-        "@wordpress/deprecated": "^3.2.0",
-        "@wordpress/dom": "^3.2.0",
-        "@wordpress/element": "^3.2.0",
-        "@wordpress/hooks": "^3.2.0",
-        "@wordpress/i18n": "^4.2.0",
-        "@wordpress/icons": "^4.1.0",
-        "@wordpress/is-shallow-equal": "^4.2.0",
-        "@wordpress/keycodes": "^3.2.0",
-        "@wordpress/primitives": "^2.2.0",
-        "@wordpress/rich-text": "^4.2.0",
-        "@wordpress/warning": "^2.2.0",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^1.0.0",
+        "@use-gesture/react": "^10.2.6",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/date": "^4.22.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/hooks": "^3.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/icons": "^9.13.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/primitives": "^3.20.0",
+        "@wordpress/rich-text": "^5.20.0",
+        "@wordpress/warning": "^2.22.0",
+        "change-case": "^4.1.2",
         "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "date-fns": "^2.28.0",
         "dom-scroll-into-view": "^1.2.1",
         "downshift": "^6.0.15",
+        "framer-motion": "^6.2.8",
         "gradient-parser": "^0.1.5",
         "highlight-words-core": "^1.2.2",
         "lodash": "^4.17.21",
         "memize": "^1.1.0",
-        "moment": "^2.22.1",
         "re-resizable": "^6.4.0",
-        "react-dates": "^17.1.1",
-        "react-resize-aware": "^3.1.0",
-        "react-spring": "^8.0.20",
-        "react-use-gesture": "^9.0.0",
+        "react-colorful": "^5.3.1",
         "reakit": "^1.3.8",
-        "rememo": "^3.0.0",
-        "tinycolor2": "^1.4.2",
-        "uuid": "^8.3.0"
+        "remove-accents": "^0.4.2",
+        "use-lilius": "^2.0.1",
+        "uuid": "^8.3.0",
+        "valtio": "^1.7.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "reakit-utils": "^0.15.1"
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/@floating-ui/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-PL7g3dhA4dHgZfujkuD8Q+tfJJynEtnNQSPzmucCnxMvkxf4cLBJw/ZYqZUn4HCh33U3WHrAfv2R2tbi9UCSmw=="
+    },
+    "node_modules/@wordpress/components/node_modules/@floating-ui/dom": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.1.tgz",
+      "integrity": "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.1.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/@floating-ui/react-dom": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.2.2.tgz",
+      "integrity": "sha512-DbmFBLwFrZhtXgCI2ra7wXYT8L2BN4/4AMQKyu05qzsVji51tXOfF36VE2gpMB6nhJGHa85PdEg75FB4+vnLFQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@wordpress/components/node_modules/@wordpress/compose": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
-      "integrity": "sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+      "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@types/lodash": "4.14.149",
+        "@babel/runtime": "^7.16.0",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^3.2.0",
-        "@wordpress/dom": "^3.2.0",
-        "@wordpress/element": "^3.2.0",
-        "@wordpress/is-shallow-equal": "^4.2.0",
-        "@wordpress/keycodes": "^3.2.0",
-        "@wordpress/priority-queue": "^2.2.0",
-        "clipboard": "^2.0.1",
-        "lodash": "^4.17.21",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
         "mousetrap": "^1.6.5",
-        "react-resize-aware": "^3.1.0",
         "use-memo-one": "^1.1.1"
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
       }
+    },
+    "node_modules/@wordpress/components/node_modules/@wordpress/data": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+      "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/priority-queue": "^2.22.0",
+        "@wordpress/redux-routine": "^4.22.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "redux": "^4.1.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/@wordpress/icons": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.16.0.tgz",
+      "integrity": "sha512-t6BPT5FXlh1VsTvO+I4X1UBZYgtwPVnZWOWyKJSGFas2MgdHh++LJ6avPQoPdGNsaixpfXsVvSZ5Snqhb7pfXQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.2.0",
+        "@wordpress/primitives": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/@wordpress/primitives": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.23.0.tgz",
+      "integrity": "sha512-HeE1aVrQF8fT4qrVKFzGAjEMua9OBYXvhPa+3WQlGXfz0gRAgf17X+PABFeJRbwypZ+SVNA/21Bkf+/BL/V/0w==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.2.0",
+        "classnames": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/@wordpress/rich-text": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
+      "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/data": "^7.6.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/framer-motion": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "dependencies": {
+        "@motionone/dom": "10.12.0",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/rememo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
+    },
+    "node_modules/@wordpress/components/node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@wordpress/components/node_modules/uuid": {
       "version": "8.3.2",
@@ -9978,11 +10286,12 @@
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.10.0.tgz",
-      "integrity": "sha512-B+1JkrWRU/PhWaMzS8lAtYdnEp1Nfdd6hh3GGD+JSrj3/Lq0UXkIobz0zJaZZdgaoKfUErBVvj74eEkU8ZuEQA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.25.0.tgz",
+      "integrity": "sha512-aHDezuzMJQrSb+Yb2X36xmb4RZV0cPkAcZcyTk5KYz80glKTsTwIP+5dGVpFEpHL6ytOAWA9sWSPdynzqNSmhQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
+        "@wordpress/deprecated": "^3.25.0",
         "moment": "^2.22.1",
         "moment-timezone": "^0.5.31"
       },
@@ -10016,34 +10325,33 @@
       }
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.10.0.tgz",
-      "integrity": "sha512-qWY/pTNVxEfbJeUjJJlkwhQKh6W0nDxdTSmodX86IcTdk+1j0hDHAgFo3Pmigvs+DbsXaka+wZgtN4aZBlYodg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.25.0.tgz",
+      "integrity": "sha512-H4Lpnw/+9gkYqEUcLmjR3Gp2P06Nw5hAeGtt6wMIIXe2lFo1we5Z8rcpIHm6ZAtbsLrUdb2dNcp336llJcHOpg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.10.0"
+        "@wordpress/hooks": "^3.25.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.10.0.tgz",
-      "integrity": "sha512-InIho9Ih4/CPl1eKCLv/hI7vDJt9nU4xJrtuYLaAl6zgciuF9WbzOIp1EY++5mOf+5s3MSerwWej+/S2qCu9Bw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.25.0.tgz",
+      "integrity": "sha512-nZ0edv5MoRfw9nVk34vw5Iebemex4D0rJOt2ROwFTWnoIaLtDrYjo5BoSyRNcNEqUn8++LyM60rdsIk9efJcCQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.8.0",
-        "lodash": "^4.17.21"
+        "@wordpress/deprecated": "^3.25.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.10.0.tgz",
-      "integrity": "sha512-b2dCnAj/K39L4hwKlZvo/I0RFWHI9B+xL3jE/fWxQyFZ+Ct1oKx4TRklecsR9UPSXdPkJ+ebp3J0+RI2VIXeCQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.25.0.tgz",
+      "integrity": "sha512-O9Qo01H9+f3gasu/mPLOOH92YpyRTgIhkfe680UyXTT6Q5QRYImk1TFE0y88RqW29WQ92rVi7XO5LErf6VULEQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -10192,6 +10500,56 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/edit-post/node_modules/@wordpress/components": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+      "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.1.5",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.0",
+        "@wordpress/compose": "^4.2.0",
+        "@wordpress/date": "^4.2.0",
+        "@wordpress/deprecated": "^3.2.0",
+        "@wordpress/dom": "^3.2.0",
+        "@wordpress/element": "^3.2.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.0",
+        "@wordpress/icons": "^4.1.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.0",
+        "@wordpress/primitives": "^2.2.0",
+        "@wordpress/rich-text": "^4.2.0",
+        "@wordpress/warning": "^2.2.0",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-spring": "^8.0.20",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
       }
     },
     "node_modules/@wordpress/edit-post/node_modules/@wordpress/compose": {
@@ -11199,9 +11557,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.10.0.tgz",
-      "integrity": "sha512-EGG8MD5AAhK4UWcUBjxHjxYbxf7XZUKPQaGyaYB/Ns9YgNMCTo6unnULNLXIvOBEN6skc2U4yZI5PE3P6EAqlg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.25.0.tgz",
+      "integrity": "sha512-a+k2g/fg/E+XEAjq5O9iFFFMZ1+04JvaekF/ZUzDLLyBzk12D8Zfmg3UiHs0HkMFwZM1uyofpen9TOdGk9Op8Q==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -11402,9 +11760,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.10.0.tgz",
-      "integrity": "sha512-gfvHGoCR+BZ2lkpkIkQn441iHBfH8OiGrPl/CxECKpe3TOolHsB4Dwc+Ki9AREfMzkhJuw7fSyRxdlbeWY/DFA==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.25.0.tgz",
+      "integrity": "sha512-xdSUsyStn6b5Ts4vaMuCDsxy4D9hWPUkCItF3q16Zh6DgPAXeRvGozVt6Y+kW8xZ3dHI3t6uzP0VXSiVWkK8Gw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -11424,14 +11782,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.10.0.tgz",
-      "integrity": "sha512-FioQCvyPD7tSJEvdqX2Hb22VCbnzQ4oftuOMp+hL6A18VlFr8K2R4kf4d0CCZO9tGPlEqbxSs/6hOJKQ8ie66g==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.25.0.tgz",
+      "integrity": "sha512-cKU5Ox1DKa3WShRu+QrCU+QzNvyoQhrNtS6kcvw17DfMBjPe7AsYjd7ZBb7Io327jP97Oqh5BtaYdUq/4S1cIw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.10.0",
+        "@wordpress/hooks": "^3.25.0",
         "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.21",
         "memize": "^1.1.0",
         "sprintf-js": "^1.1.1",
         "tannin": "^1.2.0"
@@ -11490,6 +11847,56 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/interface/node_modules/@wordpress/components": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+      "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.1.5",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.0",
+        "@wordpress/compose": "^4.2.0",
+        "@wordpress/date": "^4.2.0",
+        "@wordpress/deprecated": "^3.2.0",
+        "@wordpress/dom": "^3.2.0",
+        "@wordpress/element": "^3.2.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.0",
+        "@wordpress/icons": "^4.1.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.0",
+        "@wordpress/primitives": "^2.2.0",
+        "@wordpress/rich-text": "^4.2.0",
+        "@wordpress/warning": "^2.2.0",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-spring": "^8.0.20",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
+      }
+    },
     "node_modules/@wordpress/interface/node_modules/@wordpress/compose": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
@@ -11531,10 +11938,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/interface/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.10.0.tgz",
-      "integrity": "sha512-LHA0F8mo6nJpoES0WU3rS3DXNzmen2jR7MvFjiekiqUh8CEPIg1V/uDnIKlOEUnWr7NsWoCL6s48Mmv0St1Uag==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.25.0.tgz",
+      "integrity": "sha512-XtvXgI8mf8s7RYmsygY7f0ROPHPdYgm3w9WrQkG1U3+Od4H4QTPIHU91UHifiLKzVkjYJbjvEMY69Ml2i6Z5zw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -12087,12 +12502,13 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.10.0.tgz",
-      "integrity": "sha512-Udr9a8m39v4yFVdOlRv/yG82RkzBHxMNVJ6M9bhuQttpqeO7SzkYH2HyFIxg0wFvmZLXz9EYLZkr9AI8jhnDJw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.25.0.tgz",
+      "integrity": "sha512-y55wL9bj/XrW7Uyvg6kyQeVjPQOezG7HTI+L3nzI12waL50eGhqM1DSOv6PhMrcoHG4CN5Lg8bXNUF6TrAntfA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.10.0",
+        "@wordpress/i18n": "^4.25.0",
+        "change-case": "^4.1.2",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -12275,24 +12691,25 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.10.0.tgz",
-      "integrity": "sha512-4O0ra/5fkhEBhYyssp1xd0Rs2dtIHR7oIrm8Wvtc7fjMLEfMZccqxVgjwy7risGFr7ey4SunbGiSaZQBNt6rmw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.25.0.tgz",
+      "integrity": "sha512-XW0LtR6r3eZapvrMEiFDdK/uHnIxTontEsrbWh0s4DfyQLzGCeiWhGmVMg9Makvgr39o9CUnK/NwqHaitIIZqA==",
       "dependencies": {
-        "@babel/runtime": "^7.16.0"
+        "@babel/runtime": "^7.16.0",
+        "requestidlecallback": "^0.3.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.10.0.tgz",
-      "integrity": "sha512-1KDWOPRmm6Vf13+LoqwrEEcOp7vhZ+lgqOlOsW1FkZldOSQMqk273DYmCk+5VwD1vso6Sf5AX3IzlSLqUG8Jkg==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.25.0.tgz",
+      "integrity": "sha512-U1j41goZ5VtRbgnYMO/w75JN3+XpzIfn9Kdifiq46U6YxqWsJHKxKyCfhz1JxE8P6goFhaJ7/oUI5UNzHGP2QQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
+        "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
-        "lodash": "^4.17.21",
         "rungen": "^0.3.2"
       },
       "engines": {
@@ -12300,6 +12717,14 @@
       },
       "peerDependencies": {
         "redux": ">=4"
+      }
+    },
+    "node_modules/@wordpress/redux-routine/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
@@ -12403,6 +12828,56 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+      "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.1.5",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.0",
+        "@wordpress/compose": "^4.2.0",
+        "@wordpress/date": "^4.2.0",
+        "@wordpress/deprecated": "^3.2.0",
+        "@wordpress/dom": "^3.2.0",
+        "@wordpress/element": "^3.2.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.0",
+        "@wordpress/icons": "^4.1.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.0",
+        "@wordpress/primitives": "^2.2.0",
+        "@wordpress/rich-text": "^4.2.0",
+        "@wordpress/warning": "^2.2.0",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-spring": "^8.0.20",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
       }
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/compose": {
@@ -15046,6 +15521,56 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+      "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.1.5",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.0",
+        "@wordpress/compose": "^4.2.0",
+        "@wordpress/date": "^4.2.0",
+        "@wordpress/deprecated": "^3.2.0",
+        "@wordpress/dom": "^3.2.0",
+        "@wordpress/element": "^3.2.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.0",
+        "@wordpress/icons": "^4.1.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.0",
+        "@wordpress/primitives": "^2.2.0",
+        "@wordpress/rich-text": "^4.2.0",
+        "@wordpress/warning": "^2.2.0",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-spring": "^8.0.20",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
+      }
+    },
     "node_modules/@wordpress/server-side-render/node_modules/@wordpress/compose": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
@@ -15182,9 +15707,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.10.0.tgz",
-      "integrity": "sha512-CZiByt1/puje/EahYIHFGBCnys3u6kRdlvPPI+F53Hu79Kyb+6r97AGY7tdjXVTjlC+slnVX/hwFZEe3rVLYgg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.25.0.tgz",
+      "integrity": "sha512-w8+zalxDN2SLBa/SbkMgSvNJpRF9wXYps85+310Dm+s9dPkjPz6T4ZIKFdjEpRCvw8MhUhEylzR3FZa/CnhoHw==",
       "engines": {
         "node": ">=12"
       }
@@ -16585,6 +17110,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/camel-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
@@ -16633,6 +17172,21 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/capital-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -16730,6 +17284,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/change-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -17691,6 +18269,21 @@
     "node_modules/consolidated-events": {
       "version": "2.0.2",
       "license": "MIT"
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "node_modules/constant-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -18764,6 +19357,18 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "dev": true,
@@ -19287,6 +19892,20 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -22368,6 +22987,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/header-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/hex-color-regex": {
       "version": "1.1.0",
@@ -29992,6 +30625,19 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -30942,6 +31588,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/nock": {
       "version": "13.2.4",
       "dev": true,
@@ -31828,6 +32488,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/param-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "license": "MIT",
@@ -31904,6 +32578,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pascal-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "dev": true,
@@ -31911,6 +32599,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
@@ -33987,6 +34689,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.4.0.tgz",
+      "integrity": "sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg=="
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "dev": true,
@@ -34377,7 +35084,8 @@
     },
     "node_modules/react-addons-shallow-compare": {
       "version": "15.6.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz",
+      "integrity": "sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==",
       "dependencies": {
         "object-assign": "^4.1.0"
       }
@@ -34603,7 +35311,8 @@
     },
     "node_modules/react-with-styles": {
       "version": "3.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+      "integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
       "dependencies": {
         "hoist-non-react-statics": "^3.2.1",
         "object.assign": "^4.1.0",
@@ -34617,7 +35326,8 @@
     },
     "node_modules/react-with-styles-interface-css": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+      "integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
       "dependencies": {
         "array.prototype.flat": "^1.2.1",
         "global-cache": "^1.2.1"
@@ -35024,6 +35734,11 @@
       "version": "3.0.0",
       "license": "MIT"
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg=="
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "dev": true,
@@ -35104,6 +35819,11 @@
       "peerDependencies": {
         "request": "^2.34"
       }
+    },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -35674,6 +36394,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/sentence-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/serialize-javascript": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -35983,6 +36718,20 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snake-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -38470,6 +39219,32 @@
         "yarn": "*"
       }
     },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/upper-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/uri-js": {
       "version": "4.2.2",
       "license": "BSD-2-Clause",
@@ -38562,11 +39337,31 @@
         }
       }
     },
+    "node_modules/use-lilius": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.3.tgz",
+      "integrity": "sha512-+Q7nspdv+QGnyHGVMd6yAdLrqv5EGB4n3ix4GJH0JEE27weKCLCLmZSuAr5Nw+yPBCZn/iZ+KjL5+UykLCWXrw==",
+      "dependencies": {
+        "date-fns": "^2.29.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/use-memo-one": {
       "version": "1.1.2",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -38631,6 +39426,26 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/valtio": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.9.0.tgz",
+      "integrity": "sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==",
+      "dependencies": {
+        "proxy-compare": "2.4.0",
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vary": {
@@ -43882,6 +44697,99 @@
       "version": "3.0.3",
       "dev": true
     },
+    "@motionone/animation": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
+      "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+      "requires": {
+        "@motionone/easing": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@motionone/dom": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
+      "requires": {
+        "@motionone/animation": "^10.12.0",
+        "@motionone/generators": "^10.12.0",
+        "@motionone/types": "^10.12.0",
+        "@motionone/utils": "^10.12.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@motionone/easing": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
+      "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+      "requires": {
+        "@motionone/utils": "^10.15.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@motionone/generators": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
+      "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+      "requires": {
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@motionone/types": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
+      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+    },
+    "@motionone/utils": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
+      "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+      "requires": {
+        "@motionone/types": "^10.15.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents",
       "dev": true,
@@ -45809,13 +46717,13 @@
       }
     },
     "@wordpress/a11y": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.10.0.tgz",
-      "integrity": "sha512-Igx80jb0Y5rX5tnjd7CKiKILr7yrDs7lZY4zEYNB+4gifm+aCh/+LOFZhXCHTkadKS7gMmLHJ65gv6ph3nNjuQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.25.0.tgz",
+      "integrity": "sha512-EAsrCLv5Kh9jhDnhe2GgGVyiJ5YzhDZXi9UDgfKsi1XSTFD0IJ0nEQ0adyNMms5C5PPBXL7ygjxQO9domKdzTw==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^3.10.0",
-        "@wordpress/i18n": "^4.10.0"
+        "@wordpress/dom-ready": "^3.25.0",
+        "@wordpress/i18n": "^4.25.0"
       }
     },
     "@wordpress/api-fetch": {
@@ -46378,6 +47286,50 @@
             "uuid": "^8.3.0"
           }
         },
+        "@wordpress/components": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+          "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.1.3",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.1.5",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.0",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/date": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.0",
+            "@wordpress/icons": "^4.1.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/primitives": "^2.2.0",
+            "@wordpress/rich-text": "^4.2.0",
+            "@wordpress/warning": "^2.2.0",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-spring": "^8.0.20",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
         "@wordpress/compose": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
@@ -46457,69 +47409,209 @@
       "dev": true
     },
     "@wordpress/components": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
-      "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-22.1.0.tgz",
+      "integrity": "sha512-Hi3rhfqEjXW+LSj4ibLpSrIthqUn7/fvDlxUeBUXjDwkv+kXGVVFBPw2pin/mJgBF5K90VUFJhwd92VmCZWw0Q==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@emotion/cache": "^11.1.3",
-        "@emotion/css": "^11.1.3",
-        "@emotion/react": "^11.1.5",
-        "@emotion/styled": "^11.3.0",
-        "@emotion/utils": "1.0.0",
-        "@wordpress/a11y": "^3.2.0",
-        "@wordpress/compose": "^4.2.0",
-        "@wordpress/date": "^4.2.0",
-        "@wordpress/deprecated": "^3.2.0",
-        "@wordpress/dom": "^3.2.0",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^1.0.0",
+        "@use-gesture/react": "^10.2.6",
+        "@wordpress/a11y": "^3.22.0",
+        "@wordpress/compose": "^5.20.0",
+        "@wordpress/date": "^4.22.0",
+        "@wordpress/deprecated": "^3.22.0",
+        "@wordpress/dom": "^3.22.0",
         "@wordpress/element": "wp-5.9",
-        "@wordpress/hooks": "^3.2.0",
-        "@wordpress/i18n": "^4.2.0",
-        "@wordpress/icons": "^4.1.0",
-        "@wordpress/is-shallow-equal": "^4.2.0",
-        "@wordpress/keycodes": "^3.2.0",
-        "@wordpress/primitives": "^2.2.0",
-        "@wordpress/rich-text": "^4.2.0",
-        "@wordpress/warning": "^2.2.0",
+        "@wordpress/escape-html": "^2.22.0",
+        "@wordpress/hooks": "^3.22.0",
+        "@wordpress/i18n": "^4.22.0",
+        "@wordpress/icons": "^9.13.0",
+        "@wordpress/is-shallow-equal": "^4.22.0",
+        "@wordpress/keycodes": "^3.22.0",
+        "@wordpress/primitives": "^3.20.0",
+        "@wordpress/rich-text": "^5.20.0",
+        "@wordpress/warning": "^2.22.0",
+        "change-case": "^4.1.2",
         "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "date-fns": "^2.28.0",
         "dom-scroll-into-view": "^1.2.1",
         "downshift": "^6.0.15",
+        "framer-motion": "^6.2.8",
         "gradient-parser": "^0.1.5",
         "highlight-words-core": "^1.2.2",
         "lodash": "^4.17.21",
         "memize": "^1.1.0",
-        "moment": "^2.22.1",
         "re-resizable": "^6.4.0",
-        "react-dates": "^17.1.1",
-        "react-resize-aware": "^3.1.0",
-        "react-spring": "^8.0.20",
-        "react-use-gesture": "^9.0.0",
+        "react-colorful": "^5.3.1",
         "reakit": "^1.3.8",
-        "rememo": "^3.0.0",
-        "tinycolor2": "^1.4.2",
-        "uuid": "^8.3.0"
+        "remove-accents": "^0.4.2",
+        "use-lilius": "^2.0.1",
+        "uuid": "^8.3.0",
+        "valtio": "^1.7.0"
       },
       "dependencies": {
-        "@wordpress/compose": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
-          "integrity": "sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==",
+        "@floating-ui/core": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.1.tgz",
+          "integrity": "sha512-PL7g3dhA4dHgZfujkuD8Q+tfJJynEtnNQSPzmucCnxMvkxf4cLBJw/ZYqZUn4HCh33U3WHrAfv2R2tbi9UCSmw=="
+        },
+        "@floating-ui/dom": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.1.tgz",
+          "integrity": "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==",
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@types/lodash": "4.14.149",
+            "@floating-ui/core": "^1.1.0"
+          }
+        },
+        "@floating-ui/react-dom": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.2.2.tgz",
+          "integrity": "sha512-DbmFBLwFrZhtXgCI2ra7wXYT8L2BN4/4AMQKyu05qzsVji51tXOfF36VE2gpMB6nhJGHa85PdEg75FB4+vnLFQ==",
+          "requires": {
+            "@floating-ui/dom": "^1.1.1"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.20.0.tgz",
+          "integrity": "sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
             "@types/mousetrap": "^1.6.8",
-            "@wordpress/deprecated": "^3.2.0",
-            "@wordpress/dom": "^3.2.0",
+            "@wordpress/deprecated": "^3.22.0",
+            "@wordpress/dom": "^3.22.0",
             "@wordpress/element": "wp-5.9",
-            "@wordpress/is-shallow-equal": "^4.2.0",
-            "@wordpress/keycodes": "^3.2.0",
-            "@wordpress/priority-queue": "^2.2.0",
-            "clipboard": "^2.0.1",
-            "lodash": "^4.17.21",
+            "@wordpress/is-shallow-equal": "^4.22.0",
+            "@wordpress/keycodes": "^3.22.0",
+            "@wordpress/priority-queue": "^2.22.0",
+            "change-case": "^4.1.2",
+            "clipboard": "^2.0.8",
             "mousetrap": "^1.6.5",
-            "react-resize-aware": "^3.1.0",
             "use-memo-one": "^1.1.1"
           }
+        },
+        "@wordpress/data": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-7.6.0.tgz",
+          "integrity": "sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/compose": "^5.20.0",
+            "@wordpress/deprecated": "^3.22.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/is-shallow-equal": "^4.22.0",
+            "@wordpress/priority-queue": "^2.22.0",
+            "@wordpress/redux-routine": "^4.22.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-plain-object": "^5.0.0",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "redux": "^4.1.2",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "9.16.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.16.0.tgz",
+          "integrity": "sha512-t6BPT5FXlh1VsTvO+I4X1UBZYgtwPVnZWOWyKJSGFas2MgdHh++LJ6avPQoPdGNsaixpfXsVvSZ5Snqhb7pfXQ==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/primitives": "^3.23.0"
+          }
+        },
+        "@wordpress/primitives": {
+          "version": "3.23.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.23.0.tgz",
+          "integrity": "sha512-HeE1aVrQF8fT4qrVKFzGAjEMua9OBYXvhPa+3WQlGXfz0gRAgf17X+PABFeJRbwypZ+SVNA/21Bkf+/BL/V/0w==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/element": "wp-5.9",
+            "classnames": "^2.3.1"
+          }
+        },
+        "@wordpress/rich-text": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.20.0.tgz",
+          "integrity": "sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/a11y": "^3.22.0",
+            "@wordpress/compose": "^5.20.0",
+            "@wordpress/data": "^7.6.0",
+            "@wordpress/deprecated": "^3.22.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/escape-html": "^2.22.0",
+            "@wordpress/i18n": "^4.22.0",
+            "@wordpress/keycodes": "^3.22.0",
+            "memize": "^1.1.0",
+            "rememo": "^4.0.0"
+          }
+        },
+        "framer-motion": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+          "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+          "requires": {
+            "@emotion/is-prop-valid": "^0.8.2",
+            "@motionone/dom": "10.12.0",
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "popmotion": "11.0.3",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "framesync": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "popmotion": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+          "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+          "requires": {
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "rememo": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+          "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
+        },
+        "style-value-types": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+          "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+          "requires": {
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -46738,11 +47830,12 @@
       }
     },
     "@wordpress/date": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.10.0.tgz",
-      "integrity": "sha512-B+1JkrWRU/PhWaMzS8lAtYdnEp1Nfdd6hh3GGD+JSrj3/Lq0UXkIobz0zJaZZdgaoKfUErBVvj74eEkU8ZuEQA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.25.0.tgz",
+      "integrity": "sha512-aHDezuzMJQrSb+Yb2X36xmb4RZV0cPkAcZcyTk5KYz80glKTsTwIP+5dGVpFEpHL6ytOAWA9sWSPdynzqNSmhQ==",
       "requires": {
         "@babel/runtime": "^7.16.0",
+        "@wordpress/deprecated": "^3.25.0",
         "moment": "^2.22.1",
         "moment-timezone": "^0.5.31"
       }
@@ -46766,28 +47859,27 @@
       }
     },
     "@wordpress/deprecated": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.10.0.tgz",
-      "integrity": "sha512-qWY/pTNVxEfbJeUjJJlkwhQKh6W0nDxdTSmodX86IcTdk+1j0hDHAgFo3Pmigvs+DbsXaka+wZgtN4aZBlYodg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.25.0.tgz",
+      "integrity": "sha512-H4Lpnw/+9gkYqEUcLmjR3Gp2P06Nw5hAeGtt6wMIIXe2lFo1we5Z8rcpIHm6ZAtbsLrUdb2dNcp336llJcHOpg==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.10.0"
+        "@wordpress/hooks": "^3.25.0"
       }
     },
     "@wordpress/dom": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.10.0.tgz",
-      "integrity": "sha512-InIho9Ih4/CPl1eKCLv/hI7vDJt9nU4xJrtuYLaAl6zgciuF9WbzOIp1EY++5mOf+5s3MSerwWej+/S2qCu9Bw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.25.0.tgz",
+      "integrity": "sha512-nZ0edv5MoRfw9nVk34vw5Iebemex4D0rJOt2ROwFTWnoIaLtDrYjo5BoSyRNcNEqUn8++LyM60rdsIk9efJcCQ==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.8.0",
-        "lodash": "^4.17.21"
+        "@wordpress/deprecated": "^3.25.0"
       }
     },
     "@wordpress/dom-ready": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.10.0.tgz",
-      "integrity": "sha512-b2dCnAj/K39L4hwKlZvo/I0RFWHI9B+xL3jE/fWxQyFZ+Ct1oKx4TRklecsR9UPSXdPkJ+ebp3J0+RI2VIXeCQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.25.0.tgz",
+      "integrity": "sha512-O9Qo01H9+f3gasu/mPLOOH92YpyRTgIhkfe680UyXTT6Q5QRYImk1TFE0y88RqW29WQ92rVi7XO5LErf6VULEQ==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -46919,6 +48011,50 @@
                 "uuid": "^8.3.0"
               }
             }
+          }
+        },
+        "@wordpress/components": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+          "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.1.3",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.1.5",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.0",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/date": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.0",
+            "@wordpress/icons": "^4.1.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/primitives": "^2.2.0",
+            "@wordpress/rich-text": "^4.2.0",
+            "@wordpress/warning": "^2.2.0",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-spring": "^8.0.20",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
           }
         },
         "@wordpress/compose": {
@@ -47754,9 +48890,9 @@
       }
     },
     "@wordpress/escape-html": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.10.0.tgz",
-      "integrity": "sha512-EGG8MD5AAhK4UWcUBjxHjxYbxf7XZUKPQaGyaYB/Ns9YgNMCTo6unnULNLXIvOBEN6skc2U4yZI5PE3P6EAqlg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.25.0.tgz",
+      "integrity": "sha512-a+k2g/fg/E+XEAjq5O9iFFFMZ1+04JvaekF/ZUzDLLyBzk12D8Zfmg3UiHs0HkMFwZM1uyofpen9TOdGk9Op8Q==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -47881,9 +49017,9 @@
       }
     },
     "@wordpress/hooks": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.10.0.tgz",
-      "integrity": "sha512-gfvHGoCR+BZ2lkpkIkQn441iHBfH8OiGrPl/CxECKpe3TOolHsB4Dwc+Ki9AREfMzkhJuw7fSyRxdlbeWY/DFA==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.25.0.tgz",
+      "integrity": "sha512-xdSUsyStn6b5Ts4vaMuCDsxy4D9hWPUkCItF3q16Zh6DgPAXeRvGozVt6Y+kW8xZ3dHI3t6uzP0VXSiVWkK8Gw==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -47897,14 +49033,13 @@
       }
     },
     "@wordpress/i18n": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.10.0.tgz",
-      "integrity": "sha512-FioQCvyPD7tSJEvdqX2Hb22VCbnzQ4oftuOMp+hL6A18VlFr8K2R4kf4d0CCZO9tGPlEqbxSs/6hOJKQ8ie66g==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.25.0.tgz",
+      "integrity": "sha512-cKU5Ox1DKa3WShRu+QrCU+QzNvyoQhrNtS6kcvw17DfMBjPe7AsYjd7ZBb7Io327jP97Oqh5BtaYdUq/4S1cIw==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.10.0",
+        "@wordpress/hooks": "^3.25.0",
         "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.21",
         "memize": "^1.1.0",
         "sprintf-js": "^1.1.1",
         "tannin": "^1.2.0"
@@ -47951,6 +49086,50 @@
         "lodash": "^4.17.21"
       },
       "dependencies": {
+        "@wordpress/components": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+          "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.1.3",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.1.5",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.0",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/date": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.0",
+            "@wordpress/icons": "^4.1.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/primitives": "^2.2.0",
+            "@wordpress/rich-text": "^4.2.0",
+            "@wordpress/warning": "^2.2.0",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-spring": "^8.0.20",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
         "@wordpress/compose": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
@@ -47985,13 +49164,18 @@
             "lodash": "^4.17.21",
             "memize": "^1.1.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
     "@wordpress/is-shallow-equal": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.10.0.tgz",
-      "integrity": "sha512-LHA0F8mo6nJpoES0WU3rS3DXNzmen2jR7MvFjiekiqUh8CEPIg1V/uDnIKlOEUnWr7NsWoCL6s48Mmv0St1Uag==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.25.0.tgz",
+      "integrity": "sha512-XtvXgI8mf8s7RYmsygY7f0ROPHPdYgm3w9WrQkG1U3+Od4H4QTPIHU91UHifiLKzVkjYJbjvEMY69Ml2i6Z5zw==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -48418,12 +49602,13 @@
       }
     },
     "@wordpress/keycodes": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.10.0.tgz",
-      "integrity": "sha512-Udr9a8m39v4yFVdOlRv/yG82RkzBHxMNVJ6M9bhuQttpqeO7SzkYH2HyFIxg0wFvmZLXz9EYLZkr9AI8jhnDJw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.25.0.tgz",
+      "integrity": "sha512-y55wL9bj/XrW7Uyvg6kyQeVjPQOezG7HTI+L3nzI12waL50eGhqM1DSOv6PhMrcoHG4CN5Lg8bXNUF6TrAntfA==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.10.0",
+        "@wordpress/i18n": "^4.25.0",
+        "change-case": "^4.1.2",
         "lodash": "^4.17.21"
       }
     },
@@ -48561,22 +49746,30 @@
       }
     },
     "@wordpress/priority-queue": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.10.0.tgz",
-      "integrity": "sha512-4O0ra/5fkhEBhYyssp1xd0Rs2dtIHR7oIrm8Wvtc7fjMLEfMZccqxVgjwy7risGFr7ey4SunbGiSaZQBNt6rmw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.25.0.tgz",
+      "integrity": "sha512-XW0LtR6r3eZapvrMEiFDdK/uHnIxTontEsrbWh0s4DfyQLzGCeiWhGmVMg9Makvgr39o9CUnK/NwqHaitIIZqA==",
       "requires": {
-        "@babel/runtime": "^7.16.0"
+        "@babel/runtime": "^7.16.0",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "@wordpress/redux-routine": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.10.0.tgz",
-      "integrity": "sha512-1KDWOPRmm6Vf13+LoqwrEEcOp7vhZ+lgqOlOsW1FkZldOSQMqk273DYmCk+5VwD1vso6Sf5AX3IzlSLqUG8Jkg==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.25.0.tgz",
+      "integrity": "sha512-U1j41goZ5VtRbgnYMO/w75JN3+XpzIfn9Kdifiq46U6YxqWsJHKxKyCfhz1JxE8P6goFhaJ7/oUI5UNzHGP2QQ==",
       "requires": {
         "@babel/runtime": "^7.16.0",
+        "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
-        "lodash": "^4.17.21",
         "rungen": "^0.3.2"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
       }
     },
     "@wordpress/reusable-blocks": {
@@ -48669,6 +49862,50 @@
             "rememo": "^3.0.0",
             "showdown": "^1.9.1",
             "simple-html-tokenizer": "^0.5.7",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/components": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+          "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.1.3",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.1.5",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.0",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/date": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.0",
+            "@wordpress/icons": "^4.1.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/primitives": "^2.2.0",
+            "@wordpress/rich-text": "^4.2.0",
+            "@wordpress/warning": "^2.2.0",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-spring": "^8.0.20",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
             "tinycolor2": "^1.4.2",
             "uuid": "^8.3.0"
           }
@@ -50537,6 +51774,50 @@
             "uuid": "^8.3.0"
           }
         },
+        "@wordpress/components": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-14.2.0.tgz",
+          "integrity": "sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.1.3",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.1.5",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.0",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/date": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "wp-5.9",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.0",
+            "@wordpress/icons": "^4.1.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/primitives": "^2.2.0",
+            "@wordpress/rich-text": "^4.2.0",
+            "@wordpress/warning": "^2.2.0",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-spring": "^8.0.20",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
         "@wordpress/compose": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
@@ -50647,9 +51928,9 @@
       }
     },
     "@wordpress/warning": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.10.0.tgz",
-      "integrity": "sha512-CZiByt1/puje/EahYIHFGBCnys3u6kRdlvPPI+F53Hu79Kyb+6r97AGY7tdjXVTjlC+slnVX/hwFZEe3rVLYgg=="
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.25.0.tgz",
+      "integrity": "sha512-w8+zalxDN2SLBa/SbkMgSvNJpRF9wXYps85+310Dm+s9dPkjPz6T4ZIKFdjEpRCvw8MhUhEylzR3FZa/CnhoHw=="
     },
     "@wordpress/wordcount": {
       "version": "3.10.0",
@@ -51587,6 +52868,22 @@
       "version": "2.0.0",
       "dev": true
     },
+    "camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "requires": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "camelcase": {
       "version": "5.3.1"
     },
@@ -51613,6 +52910,23 @@
     },
     "caniuse-lite": {
       "version": "1.0.30001338"
+    },
+    "capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -51680,6 +52994,32 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "requires": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         }
       }
     },
@@ -52337,6 +53677,23 @@
     },
     "consolidated-events": {
       "version": "2.0.2"
+    },
+    "constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -53090,6 +54447,11 @@
         }
       }
     },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+    },
     "debug": {
       "version": "2.6.9",
       "dev": true,
@@ -53448,6 +54810,22 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
       }
     },
     "dot-prop": {
@@ -55555,6 +56933,22 @@
           "requires": {
             "is-buffer": "^1.1.5"
           }
+        }
+      }
+    },
+    "header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "requires": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         }
       }
     },
@@ -61046,6 +62440,21 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "lowercase-keys": {
       "version": "2.0.0",
       "dev": true
@@ -61713,6 +63122,22 @@
       "version": "1.0.4",
       "dev": true
     },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "nock": {
       "version": "13.2.4",
       "dev": true,
@@ -62304,6 +63729,22 @@
     "p-try": {
       "version": "2.2.0"
     },
+    "param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "requires": {
@@ -62356,9 +63797,41 @@
       "version": "1.3.3",
       "dev": true
     },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "dev": true
+    },
+    "path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -63891,6 +65364,11 @@
         }
       }
     },
+    "proxy-compare": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.4.0.tgz",
+      "integrity": "sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg=="
+    },
     "proxy-from-env": {
       "version": "1.1.0",
       "dev": true
@@ -64163,6 +65641,8 @@
     },
     "react-addons-shallow-compare": {
       "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz",
+      "integrity": "sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==",
       "requires": {
         "object-assign": "^4.1.0"
       }
@@ -64324,6 +65804,8 @@
     },
     "react-with-styles": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+      "integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
       "requires": {
         "hoist-non-react-statics": "^3.2.1",
         "object.assign": "^4.1.0",
@@ -64333,6 +65815,8 @@
     },
     "react-with-styles-interface-css": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+      "integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
       "requires": {
         "array.prototype.flat": "^1.2.1",
         "global-cache": "^1.2.1"
@@ -64623,6 +66107,11 @@
     "rememo": {
       "version": "3.0.0"
     },
+    "remove-accents": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg=="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "dev": true
@@ -64676,6 +66165,11 @@
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
+    },
+    "requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ=="
     },
     "require-directory": {
       "version": "2.1.1"
@@ -65046,6 +66540,23 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -65280,6 +66791,22 @@
     "slash": {
       "version": "2.0.0",
       "dev": true
+    },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -67035,6 +68562,36 @@
       "dev": true,
       "optional": true
     },
+    "upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "requires": {
@@ -67087,8 +68644,22 @@
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
       "requires": {}
     },
+    "use-lilius": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.3.tgz",
+      "integrity": "sha512-+Q7nspdv+QGnyHGVMd6yAdLrqv5EGB4n3ix4GJH0JEE27weKCLCLmZSuAr5Nw+yPBCZn/iZ+KjL5+UykLCWXrw==",
+      "requires": {
+        "date-fns": "^2.29.2"
+      }
+    },
     "use-memo-one": {
       "version": "1.1.2",
+      "requires": {}
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
     },
     "util-deprecate": {
@@ -67135,6 +68706,15 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "valtio": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.9.0.tgz",
+      "integrity": "sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==",
+      "requires": {
+        "proxy-compare": "2.4.0",
+        "use-sync-external-store": "1.2.0"
       }
     },
     "vary": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@wordpress/base-styles": "wp-5.9",
     "@wordpress/block-editor": "wp-5.9",
     "@wordpress/blocks": "wp-5.9",
-    "@wordpress/components": "wp-5.9",
+    "@wordpress/components": "22.1.0",
     "@wordpress/compose": "wp-5.9",
     "@wordpress/core-data": "wp-5.9",
     "@wordpress/data": "wp-5.9",


### PR DESCRIPTION
Fixes #6123

### Changes proposed in this Pull Request

* Update `@wp-components` to version `wp-6.1`

With the old component, there is a problem with the students context menu not showing properly.  Updating to the latest component fixes that issue.

### Testing instructions

* Go to Sensei -> Students
* Click the `...` menu
* Make sure it opens up

Example:  
![student-context-menu](https://user-images.githubusercontent.com/3220162/202825245-cf52fa13-d90f-4195-b34c-672580357d88.gif)


Also, I wasn't sure if I needed to push `package-lock.json`?   It wasn't in `.gitignore` so.... let me know!