### PR TITLE
Fix students context menu

### DIFF
--- a/assets/css/modules-admin.css
+++ b/assets/css/modules-admin.css
@@ -67,3 +67,9 @@
 .student-action-menu .components-popover:not(.is-without-arrow)::after {
 	content: none;
 }
+
+@media screen and (max-width: 782px) {
+	.wp_list_table_sensei_learner_admins .is-expanded td:not(.hidden) {
+		overflow: visible;
+	}
+}

--- a/assets/css/modules-admin.css
+++ b/assets/css/modules-admin.css
@@ -50,3 +50,20 @@
 .chosen-container-multi .chosen-choices li.search-field input[type="text"] {
 	min-height: 25px !important;
 }
+
+/* Fixes action menu display in WP 6+ */
+.student-action-menu .components-popover {
+	opacity: 1;
+}
+
+.student-action-menu .components-popover__content {
+	left: -185px;
+}
+
+.student-action-menu .components-dropdown-menu__menu {
+	width: auto;
+}
+
+.student-action-menu .components-popover:not(.is-without-arrow)::after {
+	content: none;
+}

--- a/assets/css/modules-admin.css
+++ b/assets/css/modules-admin.css
@@ -57,7 +57,7 @@
 }
 
 .student-action-menu .components-popover__content {
-	left: -185px;
+	transform:translateX(-90%);
 }
 
 .student-action-menu .components-dropdown-menu__menu {


### PR DESCRIPTION
Fixes #6123

### Changes proposed in this Pull Request

* Previously, I tried to update `wp-components` to a newer version, but that caused a lot of other problems.
* Now I'm just using Good Ol' CSS to make it appear.
* I tested in WP 5.9.5, 6.0.3, 6.1, and 6.1.1 and it looked good in each.


### Testing instructions

* Go to Sensei -> Students
* Click the `...` menu
* Make sure it opens up

Example:  
![student-context-menu](https://user-images.githubusercontent.com/3220162/202825245-cf52fa13-d90f-4195-b34c-672580357d88.gif)