### PR TITLE
Fix type error when `the_content` is not a string

### DIFF
--- a/includes/blocks/course-theme/class-course-content.php
+++ b/includes/blocks/course-theme/class-course-content.php
@@ -102,7 +102,7 @@ class Course_Content {
 	 *
 	 * @return string
 	 */
-	private function render_lesson_content( string $content ): string {
+	private function render_lesson_content( $content ) {
 		global $_wp_current_template_content;
 
 		if ( ! in_the_loop() && have_posts() ) {

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -185,7 +185,7 @@ class Sensei_Notices {
 	 *
 	 * @return string The modified content.
 	 */
-	public function prepend_notices_to_content( string $content ) : string {
+	public function prepend_notices_to_content( $content ) {
 		if ( in_the_loop() && is_main_query() ) {
 
 			ob_start();


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fixes the following errors caused by strict types on `the_content` hook.

When viewing a course:

```
Uncaught TypeError: Argument 1 passed to Sensei_Notices::prepend_notices_to_content() must be of the type string, null given
```

When viewing a lesson:
```
Uncaught TypeError: Argument 1 passed to Sensei\Blocks\Course_Theme\Course_Content::render_lesson_content() must be of the type string, null given
```

### Testing instructions

* Add the following snippet:
```php
add_filter( 'the_content', function ( $content ) {
	return null;
} );
```
* Open a course in the front-end and make sure there are no errors.
* Open a lesson in the front-end and make sure there are no errors.

### Context

p1675423340105359-slack-C02P7FHLVR9