### PR TITLE
Add email post type

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
               run: npm run build:assets
 
             - name: Install Playwright
-              run: npx playwright install --with-deps
+              run: npx playwright install --with-deps chromium
 
             - name: Start wp-env
               run: npm run wp-env start 

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -285,6 +285,11 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository::class => 'internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory::class => 'internal/quiz-submission/submission/repositories/class-submission-repository-factory.php',
 			\Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface::class => 'internal/quiz-submission/submission/repositories/class-submission-repository-interface.php',
+
+			/**
+			 * Email Customization
+			 */
+			\Sensei\Internal\Emails\Email_Post_Type::class => 'internal/emails/class-email-post-type.php',
 		);
 	}
 

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -54,6 +54,7 @@ class Sensei_Feature_Flags {
 			'sensei_default_feature_flag_settings',
 			[
 				'enrolment_provider_tooltip' => false,
+				'email_customization'        => false,
 			]
 		);
 	}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1,5 +1,6 @@
 <?php
 
+use Sensei\Internal\Emails\Email_Post_Type;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory;
@@ -568,6 +569,11 @@ class Sensei_Main {
 
 		// Cron for periodically cleaning guest user related data.
 		Sensei_Temporary_User_Cleaner::instance()->init();
+
+		$email_customization_enabled = $this->feature_flags->is_enabled( 'email_customization' );
+		if ( $email_customization_enabled ) {
+			( new Email_Post_Type() )->init();
+		}
 	}
 
 	/**

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * File containing the Post_Type class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Post_Type
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Email_Post_Type {
+	/**
+	 * Post type name.
+	 */
+	public const POST_TYPE = 'sensei_email';
+
+	/**
+	 * Initialize the class and add hooks.
+	 *
+	 * @internal
+	 */
+	public function init(): void {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	/**
+	 * Register the Email post type.
+	 *
+	 * @internal
+	 */
+	public function register_post_type(): void {
+		if ( post_type_exists( self::POST_TYPE ) ) {
+			return;
+		}
+
+		register_post_type(
+			self::POST_TYPE,
+			[
+				'labels'       => [
+					'name'               => __( 'Emails', 'sensei-lms' ),
+					'singular_name'      => __( 'Email', 'sensei-lms' ),
+					'add_new'            => __( 'Add New', 'sensei-lms' ),
+					'add_new_item'       => __( 'Add New Email', 'sensei-lms' ),
+					'edit_item'          => __( 'Edit Email', 'sensei-lms' ),
+					'new_item'           => __( 'New Email', 'sensei-lms' ),
+					'view_item'          => __( 'View Email', 'sensei-lms' ),
+					'search_items'       => __( 'Search Emails', 'sensei-lms' ),
+					'not_found'          => __( 'No emails found.', 'sensei-lms' ),
+					'not_found_in_trash' => __( 'No emails found in trash.', 'sensei-lms' ),
+					'parent_item_colon'  => __( 'Parent Email:', 'sensei-lms' ),
+					'menu_name'          => __( 'Emails', 'sensei-lms' ),
+					'name_admin_bar'     => __( 'Email', 'sensei-lms' ),
+				],
+				'public'       => false,
+				'show_ui'      => true,
+				'show_in_menu' => false,
+				'show_in_rest' => true, // Enables the Gutenberg editor.
+				'hierarchical' => false,
+				'rewrite'      => false,
+				'supports'     => [ 'title', 'editor', 'author', 'revisions' ],
+			]
+		);
+	}
+}
+

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SenesiTest\Internal\Emails;
+namespace SenseiTest\Internal\Emails;
 
 use Sensei\Internal\Emails\Email_Post_Type;
 

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SenesiTest\Internal\Emails;
+
+use Sensei\Internal\Emails\Email_Post_Type;
+
+/**
+ * Tests for the Email_Post_Type class.
+ *
+ * @covers \Sensei\Internal\Emails\Email_Post_Type
+ */
+class Email_Post_Type_Test extends \WP_UnitTestCase {
+	public function testRegisterPostType_WhenCalled_RegistersEmailPostType() {
+		/* Arrange. */
+		$email_post_type = new Email_Post_Type();
+
+		/* Act. */
+		$email_post_type->register_post_type();
+
+		/* Assert. */
+		$this->assertTrue( post_type_exists( 'sensei_email' ) );
+	}
+
+	public function testInit_WhenCalled_AddsInitAction() {
+		/* Arrange. */
+		$email_post_type = new Email_Post_Type();
+
+		/* Act. */
+		$email_post_type->init();
+
+		/* Assert. */
+		$priority = has_action( 'init', [ $email_post_type, 'register_post_type' ] );
+		$this->assertSame( 10, $priority );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-feature-flags.php
+++ b/tests/unit-tests/test-class-sensei-feature-flags.php
@@ -40,11 +40,11 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 		$flags = new Sensei_Feature_Flags();
 
 		add_filter( 'sensei_feature_flag_email_customization', '__return_true' );
-		
+
 		/* Act. */
 		$actual = $flags->is_enabled( 'email_customization' );
 
-		/* Assert. */ 
+		/* Assert. */
 		$this->assertTrue( $actual );
 	}
 
@@ -53,11 +53,11 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 		$flags = new Sensei_Feature_Flags();
 
 		add_filter( 'sensei_feature_flag_email_customization', '__return_false' );
-		
+
 		/* Act. */
 		$actual = $flags->is_enabled( 'email_customization' );
 
-		/* Assert. */ 
+		/* Assert. */
 		$this->assertFalse( $actual );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-feature-flags.php
+++ b/tests/unit-tests/test-class-sensei-feature-flags.php
@@ -35,4 +35,29 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 		$this->assertFalse( $flags->is_enabled( 'foo_feature' ), 'overriden by filter' );
 	}
 
+	public function testIsEnabled_WhenEmailFeatureGivenAndFlagEnabled_ReturnsTrue(): void {
+		/* Arrange. */
+		$flags = new Sensei_Feature_Flags();
+
+		add_filter( 'sensei_feature_flag_email_customization', '__return_true' );
+		
+		/* Act. */
+		$actual = $flags->is_enabled( 'email_customization' );
+
+		/* Assert. */ 
+		$this->assertTrue( $actual );
+	}
+
+	public function testIsEnabled_WhenEmailFeatureGivenAndFlagDisabled_ReturnsFalse(): void {
+		/* Arrange. */
+		$flags = new Sensei_Feature_Flags();
+
+		add_filter( 'sensei_feature_flag_email_customization', '__return_false' );
+		
+		/* Act. */
+		$actual = $flags->is_enabled( 'email_customization' );
+
+		/* Assert. */ 
+		$this->assertFalse( $actual );
+	}
 }


### PR DESCRIPTION
Fixes #6458 

### Changes proposed in this Pull Request

* Add the feature flag: `sensei_feature_flag_email_customization`.
* Add the Email post type: `sensei_email`.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
* Go to http://{your-dev-wordpress-site}/wp-admin/edit.php?post_type=sensei_email

### Screenshot / Video
<img width="1680" alt="CleanShot 2023-02-06 at 14 58 17@2x" src="https://user-images.githubusercontent.com/329356/216916183-bd866f47-4025-45bb-ae18-27bb4dbc6614.png">
