### PR TITLE
Prepend sensei in CSS collapsed class

### DIFF
--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -203,7 +203,7 @@ export const ModuleEdit = ( props ) => {
 							type="button"
 							className={ classnames(
 								'wp-block-sensei-lms-course-outline__arrow',
-								{ collapsed: ! isExpanded }
+								{ 'sensei-collapsed': ! isExpanded }
 							) }
 							onClick={ () => setExpanded( ! isExpanded ) }
 						>

--- a/assets/blocks/course-outline/outline-block/outline.scss
+++ b/assets/blocks/course-outline/outline-block/outline.scss
@@ -21,7 +21,7 @@
 			text-decoration: none;
 		}
 
-		&.collapsed {
+		&.sensei-collapsed {
 			svg {
 				transform: rotate(180deg)
 			}

--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -25,7 +25,7 @@ window.addEventListener( 'load', () => {
 
 		let originalHeight = content.offsetHeight + 'px';
 
-		if ( content.classList.contains( 'collapsed' ) ) {
+		if ( content.classList.contains( 'sensei-collapsed' ) ) {
 			const transition = content.style.transition;
 			content.style.transition = 'unset';
 			content.style.maxHeight = 'unset';
@@ -39,8 +39,8 @@ window.addEventListener( 'load', () => {
 
 		toggleButton.addEventListener( 'click', ( e ) => {
 			e.preventDefault();
-			const collapsed = content.classList.toggle( 'collapsed' );
-			toggleButton.classList.toggle( 'collapsed', collapsed );
+			const collapsed = content.classList.toggle( 'sensei-collapsed' );
+			toggleButton.classList.toggle( 'sensei-collapsed', collapsed );
 			toggleButton.setAttribute( 'aria-expanded', ! collapsed );
 
 			if ( ! collapsed ) {
@@ -54,7 +54,7 @@ window.addEventListener( 'load', () => {
 		content.addEventListener( 'transitionend', ( e ) => {
 			if (
 				'max-height' === e.propertyName &&
-				content.classList.contains( 'collapsed' )
+				content.classList.contains( 'sensei-collapsed' )
 			) {
 				content.style.visibility = 'hidden';
 			}

--- a/assets/css/sensei-course-theme/blocks/course-navigation.scss
+++ b/assets/css/sensei-course-theme/blocks/course-navigation.scss
@@ -44,7 +44,7 @@
 			height: 24px;
 		}
 
-		&.collapsed .sensei-lms-course-navigation-module__collapsible-icon {
+		&.sensei-collapsed .sensei-lms-course-navigation-module__collapsible-icon {
 			transform: rotate(180deg);
 		}
 	}
@@ -76,7 +76,7 @@
 		transition-delay: 150ms;
 	}
 
-	&__lessons.collapsed ~ &__summary {
+	&__lessons.sensei-collapsed ~ &__summary {
 		visibility: visible;
 		max-height: 50px;
 	}

--- a/assets/shared/styles/collapsible-content.scss
+++ b/assets/shared/styles/collapsible-content.scss
@@ -6,7 +6,7 @@
 
 	transition: max-height 350ms ease-in-out, opacity 350ms ease-in-out;
 
-	&.collapsed {
+	&.sensei-collapsed {
 		opacity: 0;
 		max-height: 0;
 	}

--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -203,7 +203,7 @@ class Course_Navigation {
 		$classes   = [ 'sensei-lms-course-navigation-module sensei-collapsible' ];
 		$collapsed = '';
 		if ( ! $is_current_module ) {
-			$collapsed = 'collapsed';
+			$collapsed = 'sensei-collapsed';
 		}
 
 		$content_id = esc_attr( 'sensei-course-navigation-module-' . $module_id . '-' . wp_generate_uuid4() );


### PR DESCRIPTION
This was raised [here](https://a8c.slack.com/archives/C02P7FHLVR9/p1675419755695429). I added a prefix to the CSS class to make sure that there won't be any conflicts in the future.

### Testing instructions
- Open the course outline block in the frontend and in the editor and make sure that the collapse button works.
- Open a lesson in Learning Mode and make sure that in the sidebar the modules can be collapsed normally.