### PR TITLE
Replace email settings with post type list when feature enabled

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -64,13 +64,17 @@ jQuery( document ).ready( function ( $ ) {
 		show( defaultSectionId );
 	}
 
-	$senseiSettings.find( 'a.tab' ).on( 'click', function () {
+	$senseiSettings.find( 'a.tab' ).on( 'click', function ( e ) {
+		const queryString = window.location.search;
+		const urlParams = new URLSearchParams( queryString );
+
 		const href = $( this ).attr( 'href' );
-		if ( ! href?.startsWith( '#' ) ) {
+		if ( urlParams.has( 'tab' ) || ! href?.includes( '#' ) ) {
 			return true;
 		}
 
-		const sectionId = href?.replace( '#', '' );
+		e.preventDefault();
+		const sectionId = href.split( '#' )[ 1 ];
 		window.location.hash = '#' + sectionId;
 		hideAllSections();
 		show( sectionId );

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -65,7 +65,12 @@ jQuery( document ).ready( function ( $ ) {
 	}
 
 	$senseiSettings.find( 'a.tab' ).on( 'click', function () {
-		const sectionId = $( this ).attr( 'href' )?.replace( '#', '' );
+		const href = $( this ).attr( 'href' );
+		if ( ! href?.startsWith( '#' ) ) {
+			return true;
+		}
+
+		const sectionId = href?.replace( '#', '' );
 		window.location.hash = '#' + sectionId;
 		hideAllSections();
 		show( sectionId );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -240,6 +240,11 @@ class Sensei_Admin {
 			$_wp_real_parent_file[''] = 'sensei';
 			$submenu_file             = 'edit.php?post_type=sensei_message';
 
+		} elseif ( in_array( $screen->id, [ 'sensei_email', 'edit-sensei_email' ], true ) ) {
+			// Message pages.
+			$parent_file              = 'sensei';
+			$_wp_real_parent_file[''] = 'sensei';
+			$submenu_file             = 'sensei-settings';
 		}
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 	}

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -291,7 +291,7 @@ class Sensei_Autoloader {
 			 */
 			\Sensei\Internal\Emails\Email_Post_Type::class => 'internal/emails/class-email-post-type.php',
 			\Sensei\Internal\Emails\Email_Customization::class => 'internal/emails/class-email-customization.php',
-			\Sensei\Internal\Emails\Settings_Menu::class => 'internal/emails/class-settings-menu.php',
+			\Sensei\Internal\Emails\Settings_Menu::class   => 'internal/emails/class-settings-menu.php',
 			\Sensei\Internal\Emails\Email_Settings_Tab::class => 'internal/emails/class-email-settings-tab.php',
 		);
 	}

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -292,6 +292,7 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Emails\Email_Post_Type::class => 'internal/emails/class-email-post-type.php',
 			\Sensei\Internal\Emails\Email_Customization::class => 'internal/emails/class-email-customization.php',
 			\Sensei\Internal\Emails\Settings_Menu::class => 'internal/emails/class-settings-menu.php',
+			\Sensei\Internal\Emails\Email_Settings_Tab::class => 'internal/emails/class-email-settings-tab.php',
 		);
 	}
 

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -290,6 +290,8 @@ class Sensei_Autoloader {
 			 * Email Customization
 			 */
 			\Sensei\Internal\Emails\Email_Post_Type::class => 'internal/emails/class-email-post-type.php',
+			\Sensei\Internal\Emails\Email_Customization::class => 'internal/emails/class-email-customization.php',
+			\Sensei\Internal\Emails\Settings_Menu::class => 'internal/emails/class-settings-menu.php',
 		);
 	}
 

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -207,10 +207,6 @@ class Sensei_Settings_API {
 					$classes .= ' current';
 				}
 
-				if ( isset( $v['class'] ) ) {
-					$classes .= ' ' . $v['class'];
-				}
-
 				$sections[ $k ] = array(
 					'href'  => isset( $v['href'] )
 						? esc_attr( $v['href'] )

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -212,7 +212,9 @@ class Sensei_Settings_API {
 				}
 
 				$sections[ $k ] = array(
-					'href'  => isset( $v['href'] ) ? esc_attr( $v['href'] ) : '#' . esc_attr( $k ),
+					'href'  => isset( $v['href'] ) 
+						? esc_attr( $v['href'] ) 
+						: admin_url('admin.php?page=' . $this->token . '#' . esc_attr( $k ) ),
 					'name'  => esc_attr( $v['name'] ),
 					'class' => esc_attr( $classes ),
 				);

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -212,9 +212,9 @@ class Sensei_Settings_API {
 				}
 
 				$sections[ $k ] = array(
-					'href'  => isset( $v['href'] ) 
-						? esc_attr( $v['href'] ) 
-						: admin_url('admin.php?page=' . $this->token . '#' . esc_attr( $k ) ),
+					'href'  => isset( $v['href'] )
+						? esc_attr( $v['href'] )
+						: admin_url( 'admin.php?page=' . $this->token . '#' . esc_attr( $k ) ),
 					'name'  => esc_attr( $v['name'] ),
 					'class' => esc_attr( $classes ),
 				);

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -207,8 +207,12 @@ class Sensei_Settings_API {
 					$classes .= ' current';
 				}
 
+				if ( isset( $v['class'] ) ) {
+					$classes .= ' ' . $v['class'];
+				}
+
 				$sections[ $k ] = array(
-					'href'  => '#' . esc_attr( $k ),
+					'href'  => isset( $v['href'] ) ? esc_attr( $v['href'] ) : '#' . esc_attr( $k ),
 					'name'  => esc_attr( $v['name'] ),
 					'class' => esc_attr( $classes ),
 				);

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -112,6 +112,44 @@ class Sensei_Settings extends Sensei_Settings_API {
 	}
 
 	/**
+	 * Output the settings screen.
+	 */
+	public function settings_screen()
+	{
+		/**
+		 * Filters settings tab content.
+		 *
+		 * @hook  sensei_settings_tab_content
+		 * @since $$next-version$$
+		 *
+		 * @param {string} $content The tab content.
+		 * @param {string} $tab     The tab slug.
+		 *
+		 * @return {string} Filtered tab content.
+		 */
+		$tab_content = apply_filters( 'sensei_settings_tab_content', '', ( $_GET['tab'] ?? '' ) );
+		if ( empty( $tab_content ) ) {
+			parent::settings_screen();
+			return;
+		}
+
+		?>
+		<div id="woothemes-sensei" class="wrap <?php echo esc_attr( $this->token ); ?>">
+			<h1>
+				<?php echo esc_html( $this->name ); ?>
+				<?php
+				if ( '' != $this->settings_version ) {
+					echo ' <span class="version">' . esc_html( $this->settings_version ) . '</span>';
+				}
+				?>
+			</h1>
+			<?php $this->settings_tabs(); ?>
+			<?php echo $tab_content; ?>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Add legacy options to alloptions if they don't exist.
 	 *
 	 * @since 3.0.1

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -114,9 +114,10 @@ class Sensei_Settings extends Sensei_Settings_API {
 	/**
 	 * Output the settings screen.
 	 */
-	public function settings_screen()
-	{
-		/**
+	public function settings_screen() {
+		$tab_name = wp_unslash( $_GET['tab'] ?? '' );
+		$tab_name = esc_attr( $tab_name );
+		 /**
 		 * Filters settings tab content.
 		 *
 		 * @hook  sensei_settings_tab_content
@@ -127,7 +128,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		 *
 		 * @return {string} Filtered tab content.
 		 */
-		$tab_content = apply_filters( 'sensei_settings_tab_content', '', ( $_GET['tab'] ?? '' ) );
+		$tab_content = apply_filters( 'sensei_settings_tab_content', '', $tab_name );
 		if ( empty( $tab_content ) ) {
 			parent::settings_screen();
 			return;
@@ -138,13 +139,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<h1>
 				<?php echo esc_html( $this->name ); ?>
 				<?php
-				if ( '' != $this->settings_version ) {
+				if ( '' !== $this->settings_version ) {
 					echo ' <span class="version">' . esc_html( $this->settings_version ) . '</span>';
 				}
 				?>
 			</h1>
 			<?php $this->settings_tabs(); ?>
-			<?php echo $tab_content; ?>
+			<?php echo $tab_content; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 		<?php
 	}

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -115,9 +115,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * Output the settings screen.
 	 */
 	public function settings_screen() {
-		$tab_name = wp_unslash( $_GET['tab'] ?? '' );
-		$tab_name = esc_attr( $tab_name );
-		 /**
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verification not required.
+		$tab_name = sanitize_key( wp_unslash( $_GET['tab'] ?? '' ) );
+		/**
 		 * Filters settings tab content.
 		 *
 		 * @hook  sensei_settings_tab_content

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1,5 +1,6 @@
 <?php
 
+use Sensei\Internal\Emails\Email_Customization;
 use Sensei\Internal\Emails\Email_Post_Type;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface;
@@ -572,7 +573,7 @@ class Sensei_Main {
 
 		$email_customization_enabled = $this->feature_flags->is_enabled( 'email_customization' );
 		if ( $email_customization_enabled ) {
-			( new Email_Post_Type() )->init();
+			Email_Customization::instance()->init();
 		}
 	}
 

--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -20,6 +20,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Email_Customization {
 
+	/**
+	 * Class instance.
+	 *
+	 * @var self
+	 */
 	private static $instance;
 
 	/**

--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -52,6 +52,7 @@ class Email_Customization {
 	public function init(): void {
 		( new Email_Post_Type() )->init();
 		( new Settings_Menu() )->init();
+		( new Email_Settings_Tab() )->init();
 	}
 
 }

--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * File containing the Email_Customization class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Email_Customization
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Email_Customization {
+
+	private static $instance;
+
+	/**
+	 * Email_Customization constructor.
+	 *
+	 * Prevents other instances from being created outside of `self::instance()`.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @internal
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the class and add hooks.
+	 *
+	 * @internal
+	 */
+	public function init(): void {
+		( new Email_Post_Type() )->init();
+		( new Settings_Menu() )->init();
+	}
+
+}

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -37,10 +37,11 @@ class Email_Settings_Tab {
 	 *
 	 * @param string $content  Existing content.
 	 * @param string $tab_name The current tab name.
+	 * @return string
 	 */
-	public function tab_content(string $contet, string $tab_name ): string {
+	public function tab_content( string $content, string $tab_name ): string {
 		if ( 'email-notification-settings' !== $tab_name ) {
-			return $contet;
+			return $content;
 		}
 
 		ob_start();

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File containing the Email_Settings_Tab class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Email_Settings_Tab
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Email_Settings_Tab {
+
+	/**
+	 * Initialize the class and add hooks.
+	 *
+	 * @internal
+	 */
+	public function init() {
+		add_filter( 'sensei_settings_tab_content', [ $this, 'tab_content' ], 10, 2 );
+	}
+
+	/**
+	 * Render the email settings tab.
+	 *
+	 * @internal
+	 * @access private
+	 *
+	 * @param string $content  Existing content.
+	 * @param string $tab_name The current tab name.
+	 */
+	public function tab_content(string $contet, string $tab_name ): string {
+		if ( 'email-notification-settings' !== $tab_name ) {
+			return $contet;
+		}
+
+		ob_start();
+		?>
+			<?php
+			// For demo purposes.
+			require_once ABSPATH . 'wp-admin/includes/class-wp-posts-list-table.php';
+			set_current_screen( 'edit-sensei_email' );
+			$list_table = new \WP_Posts_List_Table( [ 'screen' => get_current_screen() ] );
+			$list_table->prepare_items();
+			$list_table->display();
+			?>
+		<?php
+
+		return ob_get_clean();
+	}
+}

--- a/includes/internal/emails/class-settings-menu.php
+++ b/includes/internal/emails/class-settings-menu.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * File containing the Settings_Menu class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Settings_Menu
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Settings_Menu {
+	
+
+	public function init() {
+		add_action( 'sensei_settings_tabs', [ $this, 'replace_email_tab' ] );
+	}
+
+	public function replace_email_tab( array $sections ) {
+		$sections['email-notification-settings'] = array(
+			'name'        => __( 'Emails', 'sensei-lms' ),
+			'description' => __( 'Settings for email notifications sent from your site.', 'sensei-lms' ),
+			'href'        => admin_url( 'edit.php?post_type=' . Email_Post_Type::POST_TYPE ),
+		);
+		return $sections;
+	}
+
+}

--- a/includes/internal/emails/class-settings-menu.php
+++ b/includes/internal/emails/class-settings-menu.php
@@ -19,12 +19,26 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since $$next-version$$
  */
 class Settings_Menu {
-	
 
+	/**
+	 * Initialize the class and add hooks.
+	 *
+	 * @internal
+	 */
 	public function init() {
 		add_action( 'sensei_settings_tabs', [ $this, 'replace_email_tab' ] );
 	}
 
+
+	/**
+	 * Replace the email tab with a link to new settings.
+	 *
+	 * @internal
+	 * @access private
+	 *
+	 * @param array $sections The existing sections.
+	 * @return array
+	 */
 	public function replace_email_tab( array $sections ) {
 		$sections['email-notification-settings'] = array(
 			'name'        => __( 'Emails', 'sensei-lms' ),
@@ -33,5 +47,5 @@ class Settings_Menu {
 		);
 		return $sections;
 	}
-
 }
+

--- a/includes/internal/emails/class-settings-menu.php
+++ b/includes/internal/emails/class-settings-menu.php
@@ -26,7 +26,7 @@ class Settings_Menu {
 	 * @internal
 	 */
 	public function init() {
-		add_action( 'sensei_settings_tabs', [ $this, 'replace_email_tab' ] );
+		add_filter( 'sensei_settings_tabs', [ $this, 'replace_email_tab' ] );
 	}
 
 

--- a/includes/internal/emails/class-settings-menu.php
+++ b/includes/internal/emails/class-settings-menu.php
@@ -29,7 +29,7 @@ class Settings_Menu {
 		$sections['email-notification-settings'] = array(
 			'name'        => __( 'Emails', 'sensei-lms' ),
 			'description' => __( 'Settings for email notifications sent from your site.', 'sensei-lms' ),
-			'href'        => admin_url( 'edit.php?post_type=' . Email_Post_Type::POST_TYPE ),
+			'href'        => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ),
 		);
 		return $sections;
 	}

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -31,8 +31,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-add_filter( 'sensei_feature_flag_email_customization', '__return_true' );
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -31,6 +31,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+add_filter( 'sensei_feature_flag_email_customization', '__return_true' );
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }

--- a/tests/unit-tests/internal/emails/test-class-email-customization.php
+++ b/tests/unit-tests/internal/emails/test-class-email-customization.php
@@ -1,0 +1,20 @@
+<?php
+namespace SenseiTest\Internal\Emails;
+
+use Sensei\Internal\Emails\Email_Customization;
+use Sensei\Internal\Emails\Email_Post_Type;
+
+/**
+ * Tests for the Email_Customization class.
+ *
+ * @covers \Sensei\Internal\Emails\Email_Customization
+ */
+class Email_Customization_Test extends \WP_UnitTestCase {
+	public function testInstance_WhenCalled_ReturnsInstance() {
+		/* Act. */
+		$result = Email_Customization::instance();
+
+		/* Assert. */
+		$this->assertInstanceOf( Email_Customization::class, $result );
+	}
+}

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SenseiTest\Internal\Emails;
+
+use Sensei\Internal\Emails\Email_Settings_Tab;
+
+/**
+ * Tests for Sensei\Internal\Emails\Email_Settings_Tab.
+ *
+ * @covers \Sensei\Internal\Emails\Email_Settings_Tab
+ */
+class Email_Settings_Tab_Test extends \WP_UnitTestCase {
+	public function testInit_WhenCalled_AddsFilter() {
+		/* Arrange. */
+		$email_settings_tab = new Email_Settings_Tab();
+
+		/* Act. */
+		$sections = $email_settings_tab->init();
+
+		/* Assert. */
+		$priority = has_filter( 'sensei_settings_tab_content', [ $email_settings_tab, 'tab_content' ] );
+		self::assertSame( 10, $priority );
+	}
+
+	public function testTabContent_WhenCalledWithEmailNotificationSettings_ReturnsContentWithTable() {
+		/* Arrange. */
+		$email_settings_tab = new Email_Settings_Tab();
+
+		/* Act. */
+		$content = $email_settings_tab->tab_content( 'a', 'email-notification-settings' );
+
+		/* Assert. */
+		self::assertStringContainsString( '<table', $content );
+	}
+
+	public function testTabContent_WhenCalledWithAnotherTab_ReturnsDefaultContent() {
+		/* Arrange. */
+		$email_settings_tab = new Email_Settings_Tab();
+
+		/* Act. */
+		$content = $email_settings_tab->tab_content( 'a', 'other-tab' );
+
+		/* Assert. */
+		self::assertSame( 'a', $content );
+	}
+}

--- a/tests/unit-tests/internal/emails/test-class-settings-menu.php
+++ b/tests/unit-tests/internal/emails/test-class-settings-menu.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SenseiTest\Internal\Emails;
+
+use Sensei\Internal\Emails\Settings_Menu;
+
+class Settings_Menu_Test extends \WP_UnitTestCase {
+	/**
+	 * Tests that the email tab is replaced.
+	 */
+	public function testReplaceEmailTab() {
+		/* Arrange. */
+		$settings_menu = new Settings_Menu();
+
+		/* Act. */
+		$sections = $settings_menu->replace_email_tab( [] );
+
+		/* Assert. */
+		$expected = [
+			'email-notification-settings' => [
+				'name' 	  => 'Emails', 
+				'description' => 'Settings for email notifications sent from your site.',
+				'href' => admin_url( 'edit.php?post_type=sensei_email' ),
+			],
+		];
+		self::assertSame( $expected, $sections );
+	}
+}

--- a/tests/unit-tests/internal/emails/test-class-settings-menu.php
+++ b/tests/unit-tests/internal/emails/test-class-settings-menu.php
@@ -18,9 +18,9 @@ class Settings_Menu_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$expected = [
 			'email-notification-settings' => [
-				'name' 	  => 'Emails', 
+				'name'        => 'Emails',
 				'description' => 'Settings for email notifications sent from your site.',
-				'href' => admin_url( 'edit.php?post_type=sensei_email' ),
+				'href'        => admin_url( 'edit.php?post_type=sensei_email' ),
 			],
 		];
 		self::assertSame( $expected, $sections );

--- a/tests/unit-tests/internal/emails/test-class-settings-menu.php
+++ b/tests/unit-tests/internal/emails/test-class-settings-menu.php
@@ -20,7 +20,7 @@ class Settings_Menu_Test extends \WP_UnitTestCase {
 			'email-notification-settings' => [
 				'name'        => 'Emails',
 				'description' => 'Settings for email notifications sent from your site.',
-				'href'        => admin_url( 'edit.php?post_type=sensei_email' ),
+				'href'        => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ),
 			],
 		];
 		self::assertSame( $expected, $sections );


### PR DESCRIPTION
Fixes part of #6448 

### Changes proposed in this Pull Request

* When feature flag is enabled replace Email settings with our post type listing.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
* Go to Sensei LMS -> Settings -> Email

### Hooks

* `sensei_settings_tab_content` – Filters settings tab content.

### Screenshot / Video



