### PR TITLE
[POC] List the emails CPT in a custom subpage

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -290,6 +290,7 @@ class Sensei_Autoloader {
 			 * Email Customization
 			 */
 			\Sensei\Internal\Emails\Email_Post_Type::class => 'internal/emails/class-email-post-type.php',
+			\Sensei\Internal\Emails\Email_List_Table::class => 'internal/emails/class-email-list-table.php',
 		);
 	}
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1,4 +1,7 @@
 <?php
+
+use Sensei\Internal\Emails\Email_List_Table;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -102,6 +105,23 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'manage_sensei',
 			$this->page_slug,
 			array( $this, 'settings_screen' )
+		);
+
+		add_submenu_page(
+			'sensei',
+			'Emails Listing',
+			'Emails Listing',
+			'manage_sensei',
+			'emails-listing',
+			function() {
+				?>
+				<h1>Emails Listing</h1>
+				<?php
+
+				$list_table = new Email_List_Table();
+				$list_table->prepare_items();
+				$list_table->display();
+			}
 		);
 
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the Email_List_Table class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+use Sensei_List_Table;
+use WP_Query;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Email_List_Table
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Email_List_Table extends Sensei_List_Table {
+	public function __construct() {
+		parent::__construct( 'emails' );
+
+		// Remove the search form.
+		remove_action( 'sensei_before_list_table', array( $this, 'table_search_form' ), 5 );
+	}
+
+	public function get_columns() {
+		return [
+			'subject'       => __( 'Subject', 'sensei-lms' ),
+			'description'   => __( 'Description', 'sensei-lms' ),
+			'last_modified' => __( 'Last Modified', 'sensei-lms' ),
+		];
+	}
+
+	public function prepare_items() {
+		$query = new WP_Query(
+			[
+				'post_type'      => Email_Post_Type::POST_TYPE,
+				'posts_per_page' => -1,
+			]
+		);
+
+		$this->items = $query->posts;
+	}
+
+	protected function get_row_data( $item ) {
+		return [
+			'subject'       => '<a href="' . esc_url( get_edit_post_link( $item ) ) . '">' . esc_html( $item->post_title ) . '</a>',
+			'description'   => 'description',
+			'last_modified' => $item->post_modified,
+		];
+	}
+}
+


### PR DESCRIPTION
Part of #6466

This is a proof of concept. It shows the bare minimum needed to list the new emails CPT on a custom admin page.

### Changes proposed in this Pull Request

* Adds a new admin sub-menu page and lists the email posts with the help of `Sensei_List_Table`.

### Testing instructions

* Create a few email posts.
* Go to Sensei LMS -> Emails listing

### Screenshots

![image](https://user-images.githubusercontent.com/1612178/217384513-cfe2da69-b90b-4118-bed0-000b36fd2ae1.png)
