### PR TITLE
Fix badge style in settings

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -134,6 +134,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			return;
 		}
 
+		Sensei()->assets->enqueue_style( 'wp-components' );
 		?>
 		<div id="woothemes-sensei" class="wrap <?php echo esc_attr( $this->token ); ?>">
 			<h1>


### PR DESCRIPTION
Fixes part of #6448 

### Changes proposed in this Pull Request

* Fix styles for the "New" badge on the Emails tab.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
* Go to Sensei LMS -> Settings -> Emails
* Ensure the New badge next to Appearance has blue background.

### Screenshot / Video
<img width="885" alt="CleanShot 2023-02-09 at 17 48 53@2x" src="https://user-images.githubusercontent.com/329356/217791925-866ab326-7aec-4199-a6d4-d266348b3cef.png">

