### PR TITLE
Add the email list tables

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -293,6 +293,7 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Emails\Email_Customization::class => 'internal/emails/class-email-customization.php',
 			\Sensei\Internal\Emails\Settings_Menu::class   => 'internal/emails/class-settings-menu.php',
 			\Sensei\Internal\Emails\Email_Settings_Tab::class => 'internal/emails/class-email-settings-tab.php',
+			\Sensei\Internal\Emails\Email_List_Table::class => 'internal/emails/class-email-list-table.php',
 		);
 	}
 

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -30,14 +30,23 @@ class Email_List_Table extends Sensei_List_Table {
 	private $group;
 
 	/**
+	 * The WP_Query instance.
+	 *
+	 * @var WP_Query
+	 */
+	private $query;
+
+	/**
 	 * The constructor.
 	 *
 	 * @internal
 	 *
-	 * @param string|null $group The email group.
+	 * @param string|null   $group The email group.
+	 * @param WP_Query|null $query The WP_Query instance.
 	 */
-	public function __construct( string $group = null ) {
+	public function __construct( string $group = null, WP_Query $query = null ) {
 		$this->group = $group;
+		$this->query = $query ? $query : new WP_Query();
 
 		parent::__construct( 'emails' );
 
@@ -98,14 +107,14 @@ class Email_List_Table extends Sensei_List_Table {
 			];
 		}
 
-		$query = new WP_Query( $query_args );
+		$this->query->query( $query_args );
 
-		$this->items = $query->posts;
+		$this->items = $this->query->posts;
 
 		$this->set_pagination_args(
 			[
-				'total_items' => $query->found_posts,
-				'total_pages' => $query->max_num_pages,
+				'total_items' => $this->query->found_posts,
+				'total_pages' => $this->query->max_num_pages,
 				'per_page'    => $per_page,
 			]
 		);

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -23,13 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Email_List_Table extends Sensei_List_Table {
 	/**
-	 * The email group that will be listed.
-	 *
-	 * @var string|null
-	 */
-	private $group;
-
-	/**
 	 * The WP_Query instance.
 	 *
 	 * @var WP_Query
@@ -41,11 +34,9 @@ class Email_List_Table extends Sensei_List_Table {
 	 *
 	 * @internal
 	 *
-	 * @param string|null   $group The email group.
 	 * @param WP_Query|null $query The WP_Query instance.
 	 */
-	public function __construct( string $group = null, WP_Query $query = null ) {
-		$this->group = $group;
+	public function __construct( WP_Query $query = null ) {
 		$this->query = $query ? $query : new WP_Query();
 
 		parent::__construct( 'emails' );
@@ -85,9 +76,11 @@ class Email_List_Table extends Sensei_List_Table {
 	/**
 	 * Prepares the list of items for displaying.
 	 *
+	 * @param string|null $group The email group that will be listed.
+	 *
 	 * @internal
 	 */
-	public function prepare_items() {
+	public function prepare_items( string $group = null ) {
 		$per_page = $this->get_items_per_page( 'sensei_emails_per_page' );
 		$pagenum  = $this->get_pagenum();
 		$offset   = $pagenum > 1 ? $per_page * ( $pagenum - 1 ) : 0;
@@ -98,11 +91,11 @@ class Email_List_Table extends Sensei_List_Table {
 			'offset'         => $offset,
 		];
 
-		if ( $this->group ) {
+		if ( $group ) {
 			$query_args['meta_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Query limited by pagination.
 				[
 					'key'   => 'sensei_email_group', // TODO: Replace the meta key by a constant defined elsewhere.
-					'value' => $this->group,
+					'value' => $group,
 				],
 			];
 		}

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -23,9 +23,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Email_List_Table extends Sensei_List_Table {
 	/**
-	 * The constructor.
+	 * The email group that will be listed.
+	 *
+	 * @var string|null
 	 */
-	public function __construct() {
+	private $group;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param string|null $group The email group.
+	 */
+	public function __construct( string $group = null ) {
+		$this->group = $group;
+
 		parent::__construct( 'emails' );
 
 		// Remove the search form.
@@ -60,8 +71,6 @@ class Email_List_Table extends Sensei_List_Table {
 
 	/**
 	 * Prepares the list of items for displaying.
-	 *
-	 * @param array $query_args The WP_Query arguments.
 	 */
 	public function prepare_items() {
 		$per_page = $this->get_items_per_page( 'sensei_emails_per_page' );
@@ -73,6 +82,15 @@ class Email_List_Table extends Sensei_List_Table {
 			'posts_per_page' => $per_page,
 			'offset'         => $offset,
 		];
+
+		if ( $this->group ) {
+			$query_args['meta_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Query limited by pagination.
+				[
+					'key'   => 'sensei_email_group', // TODO: Replace the meta key by a constant defined elsewhere.
+					'value' => $this->group,
+				],
+			];
+		}
 
 		$query = new WP_Query( $query_args );
 

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * File containing the Email_List_Table class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+use Sensei_List_Table;
+use WP_Query;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The class responsible for generating the email list table in the settings.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Email_List_Table extends Sensei_List_Table {
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'emails' );
+
+		// Remove the search form.
+		remove_action( 'sensei_before_list_table', [ $this, 'table_search_form' ], 5 );
+	}
+
+	/**
+	 * Define the columns that are going to be used in the table.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		$columns = [
+			'subject'       => __( 'Subject', 'sensei-lms' ),
+			'description'   => __( 'Description', 'sensei-lms' ),
+			'last_modified' => __( 'Last Modified', 'sensei-lms' ),
+		];
+
+		/**
+		 * Filter the columns that are displayed in email list.
+		 *
+		 * @since $$next-version$$
+		 * @hook sensei_email_list_columns
+		 *
+		 * @param {array}  $columns    The table columns.
+		 * @param {object} $list_table Email_List_Table instance.
+		 *
+		 * @return {array} The modified table columns.
+		 */
+		return apply_filters( 'sensei_email_list_columns', $columns, $this );
+	}
+
+	/**
+	 * Prepares the list of items for displaying.
+	 *
+	 * @param array $query_args The WP_Query arguments.
+	 */
+	public function prepare_items() {
+		$per_page = $this->get_items_per_page( 'sensei_emails_per_page' );
+		$pagenum  = $this->get_pagenum();
+		$offset   = $pagenum > 1 ? $per_page * ( $pagenum - 1 ) : 0;
+
+		$query_args = [
+			'post_type'      => Email_Post_Type::POST_TYPE,
+			'posts_per_page' => $per_page,
+			'offset'         => $offset,
+		];
+
+		$query = new WP_Query( $query_args );
+
+		$this->items = $query->posts;
+
+		$this->set_pagination_args(
+			[
+				'total_items' => $query->found_posts,
+				'total_pages' => $query->max_num_pages,
+				'per_page'    => $per_page,
+			]
+		);
+	}
+
+	/**
+	 * Get the data for each row.
+	 *
+	 * @param \WP_Post $item The email post.
+	 *
+	 * @return array
+	 */
+	protected function get_row_data( $item ) {
+		$title = _draft_or_post_title( $item );
+
+		$actions['edit'] = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			get_edit_post_link( $item->ID ),
+			/* translators: %s: Post title. */
+			esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), $title ) ),
+			__( 'Edit', 'sensei-lms' )
+		);
+
+		// TODO: Add the "Disable" action.
+
+		$subject = sprintf(
+			'<strong><a href="%s" class="row-title">%s</a></strong>%s',
+			esc_url( get_edit_post_link( $item ) ),
+			esc_html( $title ),
+			$this->row_actions( $actions )
+		);
+
+		$description = get_post_meta( $item->ID, 'sensei_email_description', true );
+
+		$last_modified = sprintf(
+			/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */
+			__( '%s ago', 'sensei-lms' ),
+			human_time_diff( strtotime( $item->post_modified_gmt ) )
+		);
+
+		$row_data = [
+			'subject'       => $subject,
+			'description'   => $description,
+			'last_modified' => $last_modified,
+		];
+
+		/**
+		 * Filter sensei_learner_admin_get_row_data, for adding/removing row data.
+		 *
+		 * @since $$next-version$$
+		 * @hook sensei_email_list_row_data
+		 *
+		 * @param {array}  $row_data The Row Data.
+		 * @param {object} $post The post instance.
+		 * @param {object} $list_table Email_List_Table instance.
+		 *
+		 * @return {array}
+		 */
+		return apply_filters( 'sensei_email_list_row_data', $row_data, $item, $this );
+	}
+}

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -56,7 +56,7 @@ class Email_List_Table extends Sensei_List_Table {
 		];
 
 		/**
-		 * Filter the columns that are displayed in email list.
+		 * Filter the columns that are displayed in the email list.
 		 *
 		 * @since $$next-version$$
 		 * @hook sensei_email_list_columns
@@ -108,16 +108,16 @@ class Email_List_Table extends Sensei_List_Table {
 	/**
 	 * Get the data for each row.
 	 *
-	 * @param \WP_Post $item The email post.
+	 * @param \WP_Post $post The email post.
 	 *
 	 * @return array
 	 */
-	protected function get_row_data( $item ) {
-		$title = _draft_or_post_title( $item );
+	protected function get_row_data( $post ) {
+		$title = _draft_or_post_title( $post );
 
 		$actions['edit'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
-			get_edit_post_link( $item->ID ),
+			get_edit_post_link( $post->ID ),
 			/* translators: %s: Post title. */
 			esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), $title ) ),
 			__( 'Edit', 'sensei-lms' )
@@ -127,17 +127,17 @@ class Email_List_Table extends Sensei_List_Table {
 
 		$subject = sprintf(
 			'<strong><a href="%s" class="row-title">%s</a></strong>%s',
-			esc_url( get_edit_post_link( $item ) ),
+			esc_url( get_edit_post_link( $post ) ),
 			esc_html( $title ),
 			$this->row_actions( $actions )
 		);
 
-		$description = get_post_meta( $item->ID, 'sensei_email_description', true );
+		$description = get_post_meta( $post->ID, 'sensei_email_description', true );
 
 		$last_modified = sprintf(
 			/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */
 			__( '%s ago', 'sensei-lms' ),
-			human_time_diff( strtotime( $item->post_modified_gmt ) )
+			human_time_diff( strtotime( $post->post_modified_gmt ) )
 		);
 
 		$row_data = [
@@ -147,17 +147,17 @@ class Email_List_Table extends Sensei_List_Table {
 		];
 
 		/**
-		 * Filter sensei_learner_admin_get_row_data, for adding/removing row data.
+		 * Filter the row data displayed in the email list.
 		 *
 		 * @since $$next-version$$
 		 * @hook sensei_email_list_row_data
 		 *
-		 * @param {array}  $row_data The Row Data.
-		 * @param {object} $post The post instance.
+		 * @param {array}  $row_data The row data.
+		 * @param {object} $post The post.
 		 * @param {object} $list_table Email_List_Table instance.
 		 *
 		 * @return {array}
 		 */
-		return apply_filters( 'sensei_email_list_row_data', $row_data, $item, $this );
+		return apply_filters( 'sensei_email_list_row_data', $row_data, $post, $this );
 	}
 }

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -76,11 +76,11 @@ class Email_List_Table extends Sensei_List_Table {
 	/**
 	 * Prepares the list of items for displaying.
 	 *
-	 * @param string|null $group The email group that will be listed.
+	 * @param string|null $type The email group that will be listed.
 	 *
 	 * @internal
 	 */
-	public function prepare_items( string $group = null ) {
+	public function prepare_items( string $type = null ) {
 		$per_page = $this->get_items_per_page( 'sensei_emails_per_page' );
 		$pagenum  = $this->get_pagenum();
 		$offset   = $pagenum > 1 ? $per_page * ( $pagenum - 1 ) : 0;
@@ -91,11 +91,11 @@ class Email_List_Table extends Sensei_List_Table {
 			'offset'         => $offset,
 		];
 
-		if ( $group ) {
+		if ( $type ) {
 			$query_args['meta_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Query limited by pagination.
 				[
-					'key'   => 'sensei_email_group', // TODO: Replace the meta key by a constant defined elsewhere.
-					'value' => $group,
+					'key'   => 'sensei_email_type', // TODO: Replace the meta key by a constant defined elsewhere.
+					'value' => $type,
 				],
 			];
 		}

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -32,6 +32,8 @@ class Email_List_Table extends Sensei_List_Table {
 	/**
 	 * The constructor.
 	 *
+	 * @internal
+	 *
 	 * @param string|null $group The email group.
 	 */
 	public function __construct( string $group = null ) {
@@ -45,6 +47,8 @@ class Email_List_Table extends Sensei_List_Table {
 
 	/**
 	 * Define the columns that are going to be used in the table.
+	 *
+	 * @internal
 	 *
 	 * @return array
 	 */
@@ -71,6 +75,8 @@ class Email_List_Table extends Sensei_List_Table {
 
 	/**
 	 * Prepares the list of items for displaying.
+	 *
+	 * @internal
 	 */
 	public function prepare_items() {
 		$per_page = $this->get_items_per_page( 'sensei_emails_per_page' );

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -115,6 +115,7 @@ class Email_List_Table extends Sensei_List_Table {
 	protected function get_row_data( $post ) {
 		$title = _draft_or_post_title( $post );
 
+		$actions         = [];
 		$actions['edit'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
 			get_edit_post_link( $post->ID ),

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -19,7 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since $$next-version$$
  */
 class Email_Settings_Tab {
-
 	/**
 	 * Initialize the class and add hooks.
 	 *
@@ -137,8 +136,8 @@ class Email_Settings_Tab {
 	 * Render the student emails subtab.
 	 */
 	private function render_student_subtab(): void {
-		$list_table = new Email_List_Table( 'student' );
-		$list_table->prepare_items();
+		$list_table = new Email_List_Table();
+		$list_table->prepare_items( 'student' );
 		$list_table->display();
 	}
 
@@ -146,8 +145,8 @@ class Email_Settings_Tab {
 	 * Render the teacher emails subtab.
 	 */
 	private function render_teacher_subtab(): void {
-		$list_table = new Email_List_Table( 'teacher' );
-		$list_table->prepare_items();
+		$list_table = new Email_List_Table();
+		$list_table->prepare_items( 'teacher' );
 		$list_table->display();
 	}
 

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -45,12 +45,10 @@ class Email_Settings_Tab {
 		}
 
 		ob_start();
+
 		$this->render_submenu();
 
-		// For demo purposes.
-		require_once ABSPATH . 'wp-admin/includes/class-wp-posts-list-table.php';
-		set_current_screen( 'edit-sensei_email' );
-		$list_table = new \WP_Posts_List_Table( [ 'screen' => get_current_screen() ] );
+		$list_table = new Email_List_Table();
 		$list_table->prepare_items();
 		$list_table->display();
 

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -137,7 +137,7 @@ class Email_Settings_Tab {
 	 * Render the student emails subtab.
 	 */
 	private function render_student_subtab(): void {
-		$list_table = new Email_List_Table();
+		$list_table = new Email_List_Table( 'student' );
 		$list_table->prepare_items();
 		$list_table->display();
 	}
@@ -146,7 +146,7 @@ class Email_Settings_Tab {
 	 * Render the teacher emails subtab.
 	 */
 	private function render_teacher_subtab(): void {
-		$list_table = new Email_List_Table();
+		$list_table = new Email_List_Table( 'teacher' );
 		$list_table->prepare_items();
 		$list_table->display();
 	}

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -44,53 +44,117 @@ class Email_Settings_Tab {
 			return $content;
 		}
 
+		$current_subtab = $this->get_current_subtab();
+
 		ob_start();
 
-		$this->render_submenu();
-
-		$list_table = new Email_List_Table();
-		$list_table->prepare_items();
-		$list_table->display();
+		$this->render_submenu( $current_subtab );
+		$this->render_subtab( $current_subtab );
 
 		return ob_get_clean();
 	}
 
 	/**
-	 * Render the submenu.
+	 * Get the currently selected subtab.
+	 * Defaults to the first defined in none is selected.
+	 *
+	 * @return array
 	 */
-	private function render_submenu() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$current_subtab = sanitize_key( wp_unslash( $_GET['subtab'] ?? 'student' ) );
+	private function get_current_subtab(): array {
+		$subtabs        = $this->get_subtabs();
+		$default_subtab = $subtabs[0];
 
-		$tabs = [
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current_subtab_key = sanitize_key( wp_unslash( $_GET['subtab'] ?? $default_subtab['key'] ) );
+
+		foreach ( $subtabs as $subtab ) {
+			if ( $subtab['key'] === $current_subtab_key ) {
+				return $subtab;
+			}
+		}
+
+		return $default_subtab;
+	}
+
+	/**
+	 * Get all available subtabs.
+	 *
+	 * @return array[]
+	 */
+	private function get_subtabs(): array {
+		return [
 			[
-				'name' => __( 'Student Emails', 'sensei-lms' ),
-				'href' => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ),
-				'key'  => 'student',
+				'name'            => __( 'Student Emails', 'sensei-lms' ),
+				'href'            => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ),
+				'key'             => 'student',
+				'render_callback' => [ $this, 'render_student_subtab' ],
 			],
 			[
-				'name' => __( 'Teacher Emails', 'sensei-lms' ),
-				'href' => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings&subtab=teacher' ),
-				'key'  => 'teacher',
+				'name'            => __( 'Teacher Emails', 'sensei-lms' ),
+				'href'            => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings&subtab=teacher' ),
+				'key'             => 'teacher',
+				'render_callback' => [ $this, 'render_teacher_subtab' ],
 			],
 			[
-				'name' => __( 'Settings', 'sensei-lms' ),
-				'href' => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings&subtab=settings' ),
-				'key'  => 'settings',
+				'name'            => __( 'Settings', 'sensei-lms' ),
+				'href'            => admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings&subtab=settings' ),
+				'key'             => 'settings',
+				'render_callback' => [ $this, 'render_settings_subtab' ],
 			],
 		];
+	}
 
+	/**
+	 * Render the submenu.
+	 *
+	 * @param array $current_subtab The selected subtab.
+	 */
+	private function render_submenu( array $current_subtab ): void {
 		?>
 		<div class="sensei-custom-navigation">
 			<div class="sensei-custom-navigation__tabbar">
-				<?php foreach ( $tabs as $tab ) : ?>
-					<a class="sensei-custom-navigation__tab <?php echo $tab['key'] === $current_subtab ? 'active' : ''; ?>"
-						href="<?php echo esc_url( $tab['href'] ); ?>">
-						<?php echo esc_html( $tab['name'] ); ?>
+				<?php foreach ( $this->get_subtabs() as $subtab ) : ?>
+					<a class="sensei-custom-navigation__tab <?php echo $subtab['key'] === $current_subtab['key'] ? 'active' : ''; ?>"
+						href="<?php echo esc_url( $subtab['href'] ); ?>">
+						<?php echo esc_html( $subtab['name'] ); ?>
 					</a>
 				<?php endforeach; ?>
 			</div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Render the subtab by calling the render callback.
+	 *
+	 * @param array $subtab The subtab to render.
+	 */
+	private function render_subtab( array $subtab ): void {
+		call_user_func( $subtab['render_callback'] );
+	}
+
+	/**
+	 * Render the student emails subtab.
+	 */
+	private function render_student_subtab(): void {
+		$list_table = new Email_List_Table();
+		$list_table->prepare_items();
+		$list_table->display();
+	}
+
+	/**
+	 * Render the teacher emails subtab.
+	 */
+	private function render_teacher_subtab(): void {
+		$list_table = new Email_List_Table();
+		$list_table->prepare_items();
+		$list_table->display();
+	}
+
+	/**
+	 * Render the settings subtab.
+	 */
+	private function render_settings_subtab(): void {
+		echo 'TODO';
 	}
 }

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -55,7 +55,7 @@ class Email_Settings_Tab {
 
 	/**
 	 * Get the currently selected subtab.
-	 * Defaults to the first defined in none is selected.
+	 * Defaults to the first defined if none is selected.
 	 *
 	 * @return array
 	 */

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -85,7 +85,9 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 	public $message;
 
 	/**
-	 * @var WP_UnitTest_Factory_For_Email
+	 * The email post type factory.
+	 *
+	 * @var Sensei_UnitTest_Factory_For_Email
 	 */
 	public $email;
 
@@ -103,9 +105,9 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-lesson.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-module.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-message.php';
-		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-email.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-question-category.php';
 		require_once dirname( __FILE__ ) . '/class-sensei-unittest-factory-for-course-category.php';
+		require_once dirname( __FILE__ ) . '/class-sensei-unittest-factory-for-email.php';
 
 		$this->course            = new WP_UnitTest_Factory_For_Course( $this );
 		$this->lesson            = new WP_UnitTest_Factory_For_Lesson( $this );
@@ -114,9 +116,9 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		$this->multiple_question = new WP_UnitTest_Factory_For_Multiple_Question( $this );
 		$this->module            = new WP_UnitTest_Factory_For_Module( $this );
 		$this->message           = new WP_UnitTest_Factory_For_Message( $this );
-		$this->email             = new WP_UnitTest_Factory_For_Email( $this );
 		$this->question_category = new WP_UnitTest_Factory_For_Question_Category( $this );
 		$this->course_category   = new Sensei_UnitTest_Factory_For_Course_Category( $this );
+		$this->email             = new Sensei_UnitTest_Factory_For_Email( $this );
 	}
 
 	/**

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -85,6 +85,11 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 	public $message;
 
 	/**
+	 * @var WP_UnitTest_Factory_For_Email
+	 */
+	public $email;
+
+	/**
 	 * constructor function
 	 *
 	 * This sets up some basic demo data
@@ -98,6 +103,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-lesson.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-module.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-message.php';
+		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-email.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-question-category.php';
 		require_once dirname( __FILE__ ) . '/class-sensei-unittest-factory-for-course-category.php';
 
@@ -108,6 +114,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		$this->multiple_question = new WP_UnitTest_Factory_For_Multiple_Question( $this );
 		$this->module            = new WP_UnitTest_Factory_For_Module( $this );
 		$this->message           = new WP_UnitTest_Factory_For_Message( $this );
+		$this->email             = new WP_UnitTest_Factory_For_Email( $this );
 		$this->question_category = new WP_UnitTest_Factory_For_Question_Category( $this );
 		$this->course_category   = new Sensei_UnitTest_Factory_For_Course_Category( $this );
 	}

--- a/tests/framework/factories/class-sensei-unittest-factory-for-email.php
+++ b/tests/framework/factories/class-sensei-unittest-factory-for-email.php
@@ -2,7 +2,7 @@
 
 use Sensei\Internal\Emails\Email_Post_Type;
 
-class WP_UnitTest_Factory_For_Email extends WP_UnitTest_Factory_For_Post_Sensei {
+class Sensei_UnitTest_Factory_For_Email extends WP_UnitTest_Factory_For_Post_Sensei {
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
 		$this->default_generation_definitions = array(

--- a/tests/framework/factories/class-wp-unittest-factory-for-email.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-email.php
@@ -1,0 +1,15 @@
+<?php
+
+use Sensei\Internal\Emails\Email_Post_Type;
+
+class WP_UnitTest_Factory_For_Email extends WP_UnitTest_Factory_For_Post_Sensei {
+	public function __construct( $factory = null ) {
+		parent::__construct( $factory );
+		$this->default_generation_definitions = array(
+			'post_status'  => 'publish',
+			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Email title %s' ),
+			'post_content' => new WP_UnitTest_Generator_Sequence( 'Email content %s' ),
+			'post_type'    => Email_Post_Type::POST_TYPE,
+		);
+	}
+}

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -11,7 +11,7 @@ use WP_Post;
 /**
  * Tests for Sensei\Internal\Emails\Email_List_Table.
  *
- * @covers \Sensei\Internal\Emails\Email_Settings_Tab
+ * @covers \Sensei\Internal\Emails\Email_List_Table
  */
 class Email_List_Table_Test extends \WP_UnitTestCase {
 

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -84,7 +84,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 					'post_type'      => Email_Post_Type::POST_TYPE,
 					'posts_per_page' => 20,
 					'offset'         => 0,
-					'meta_query'     => [
+					'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						[
 							'key'   => 'sensei_email_group',
 							'value' => 'student',

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -74,7 +74,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table->prepare_items();
 	}
 
-	public function testPrepareItems_WhenGroupSet_SetsTheMetaQuery() {
+	public function testPrepareItems_WhenEmailTypeSet_SetsTheMetaQuery() {
 		/* Arrange. */
 		$query      = $this->createMock( \WP_Query::class );
 		$list_table = new Email_List_Table( $query );
@@ -90,7 +90,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 					'offset'         => 0,
 					'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						[
-							'key'   => 'sensei_email_group',
+							'key'   => 'sensei_email_type',
 							'value' => 'student',
 						],
 					],
@@ -102,7 +102,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table->prepare_items( 'student' );
 	}
 
-	public function testPrepareItems_WhenNoGroupSet_DoesntSetTheMetaQuery() {
+	public function testPrepareItems_WhenNoEmailTypeSet_DoesntSetTheMetaQuery() {
 		/* Arrange. */
 		$query      = $this->createMock( \WP_Query::class );
 		$list_table = new Email_List_Table( $query );

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace SenseiTest\Internal\Emails;
+
+use Sensei\Internal\Emails\Email_List_Table;
+use Sensei\Internal\Emails\Email_Post_Type;
+use Sensei_Factory;
+use stdClass;
+use WP_Post;
+
+/**
+ * Tests for Sensei\Internal\Emails\Email_List_Table.
+ *
+ * @covers \Sensei\Internal\Emails\Email_Settings_Tab
+ */
+class Email_List_Table_Test extends \WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	public function testConstruct_WhenCalled_RemovesTableSearchFormHook() {
+		/* Act. */
+		$list_table = new Email_List_Table();
+
+		/* Assert. */
+		$priority = has_action( 'sensei_before_list_table', [ $list_table, 'table_search_form' ] );
+		$this->assertFalse( $priority );
+	}
+
+	public function testGetColumns_WhenCalled_AppliesHook() {
+		/* Arrange. */
+		$list_table = new Email_List_Table();
+
+		/* Act. */
+		$columns = $list_table->get_columns();
+
+		/* Assert. */
+		$applied = did_filter( 'sensei_email_list_columns' );
+		$this->assertSame( 1, $applied );
+	}
+
+	public function testPrepareItems_WhenPaginated_SetsTheCorrectOffset() {
+		/* Arrange. */
+		$query      = $this->createMock( \WP_Query::class );
+		$list_table = new Email_List_Table( null, $query );
+
+		$_REQUEST['paged'] = 2;
+
+		/* Assert. */
+		$query
+			->expects( $this->once() )
+			->method( 'query' )
+			->with(
+				[
+					'post_type'      => Email_Post_Type::POST_TYPE,
+					'posts_per_page' => 20,
+					'offset'         => 20,
+				]
+			)
+			->willReturn( [] );
+
+		/* Act. */
+		$list_table->prepare_items();
+	}
+
+	public function testPrepareItems_WhenGroupSet_SetsTheMetaQuery() {
+		/* Arrange. */
+		$query      = $this->createMock( \WP_Query::class );
+		$list_table = new Email_List_Table( 'student', $query );
+
+		/* Assert. */
+		$query
+			->expects( $this->once() )
+			->method( 'query' )
+			->with(
+				[
+					'post_type'      => Email_Post_Type::POST_TYPE,
+					'posts_per_page' => 20,
+					'offset'         => 0,
+					'meta_query'     => [
+						[
+							'key'   => 'sensei_email_group',
+							'value' => 'student',
+						],
+					],
+				]
+			)
+			->willReturn( [] );
+
+		/* Act. */
+		$list_table->prepare_items();
+	}
+
+	public function testPrepareItems_WhenNoGroupSet_DoesntSetTheMetaQuery() {
+		/* Arrange. */
+		$query      = $this->createMock( \WP_Query::class );
+		$list_table = new Email_List_Table( null, $query );
+
+		/* Assert. */
+		$query
+			->expects( $this->once() )
+			->method( 'query' )
+			->with(
+				[
+					'post_type'      => Email_Post_Type::POST_TYPE,
+					'posts_per_page' => 20,
+					'offset'         => 0,
+				]
+			)
+			->willReturn( [] );
+
+		/* Act. */
+		$list_table->prepare_items();
+	}
+
+	public function testPrepareItems_WhenPaginated_SetsTheCorrectPaginationArgs() {
+		/* Arrange. */
+		$query                = $this->createMock( \WP_Query::class );
+		$query->found_posts   = 50;
+		$query->max_num_pages = 5;
+		$list_table           = new Email_List_Table( null, $query );
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		$result = [
+			'total_items' => $list_table->get_pagination_arg( 'total_items' ),
+			'total_pages' => $list_table->get_pagination_arg( 'total_pages' ),
+		];
+
+		/* Assert. */
+		$expected = [
+			'total_items' => 50,
+			'total_pages' => 5,
+		];
+
+		$this->assertSame( $expected, $result );
+	}
+
+	public function testPrepareItems_WhenHasItems_SetsTheItems() {
+		/* Arrange. */
+		$posts        = [ new WP_Post( new stdClass() ), new WP_Post( new stdClass() ) ];
+		$query        = $this->createMock( \WP_Query::class );
+		$query->posts = $posts;
+		$list_table   = new Email_List_Table( null, $query );
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		/* Assert. */
+		$this->assertSame( $posts, $list_table->items );
+	}
+
+	public function testGetRowData_WhenCalled_AppliesHook() {
+		/* Arrange. */
+		$list_table = new Email_List_Table();
+		$post       = $this->factory->email->create();
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		ob_start();
+		$list_table->display_rows();
+		ob_end_clean();
+
+		/* Assert. */
+		$applied = did_filter( 'sensei_email_list_row_data' );
+		$this->assertSame( 1, $applied );
+	}
+
+	public function testGetRowData_WhenHasItem_ReturnsTheItemRowData() {
+		/* Arrange. */
+		$list_table = new Email_List_Table();
+		$post       = $this->factory->email->create_and_get();
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		ob_start();
+		$list_table->display_rows();
+		$result = ob_get_clean();
+
+		/* Assert. */
+		$expected = sprintf(
+			'<td class=\'subject column-subject column-primary\' data-colname="Subject" ><strong><a href="" class="row-title">%s</a></strong><div class="row-actions"><span class=\'edit\'><a href="" aria-label="Edit &#8220;%s&#8221;">Edit</a></span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td><td class=\'description column-description\' data-colname="Description" ></td><td class=\'last_modified column-last_modified\' data-colname="Last Modified" >1 second ago</td>',
+			$post->post_title,
+			$post->post_title
+		);
+		$this->assertStringContainsString( $expected, $result );
+	}
+
+	public function testGetRowData_WhenHasItemWithNoTitle_ReturnsNoTitleText() {
+		/* Arrange. */
+		$list_table = new Email_List_Table();
+		$post       = $this->factory->email->create( [ 'post_title' => '' ] );
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		ob_start();
+		$list_table->display_rows();
+		$result = ob_get_clean();
+
+		/* Assert. */
+		$this->assertStringContainsString( '(no title)', $result );
+	}
+
+	public function testGetRowData_WhenHasDescription_ReturnsTheDescription() {
+		/* Arrange. */
+		$list_table = new Email_List_Table();
+		$post       = $this->factory->email->create();
+
+		update_post_meta( $post, 'sensei_email_description', 'Welcome Student' );
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		ob_start();
+		$list_table->display_rows();
+		$result = ob_get_clean();
+
+		/* Assert. */
+		$this->assertStringContainsString( 'Welcome Student', $result );
+	}
+
+	public function testGetRowData_WhenWasModified1HourAgo_ReturnsTheCorrectModifiedTime() {
+		/* Arrange. */
+		$list_table = new Email_List_Table();
+		$post       = $this->factory->email->create_and_get(
+			[
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ),
+			]
+		);
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		ob_start();
+		$list_table->display_rows();
+		$result = ob_get_clean();
+
+		/* Assert. */
+		$this->assertStringContainsString( '1 hour ago', $result );
+	}
+}

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -49,7 +49,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 	public function testPrepareItems_WhenPaginated_SetsTheCorrectOffset() {
 		/* Arrange. */
 		$query      = $this->createMock( \WP_Query::class );
-		$list_table = new Email_List_Table( null, $query );
+		$list_table = new Email_List_Table( $query );
 
 		$_REQUEST['paged'] = 2;
 
@@ -73,7 +73,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 	public function testPrepareItems_WhenGroupSet_SetsTheMetaQuery() {
 		/* Arrange. */
 		$query      = $this->createMock( \WP_Query::class );
-		$list_table = new Email_List_Table( 'student', $query );
+		$list_table = new Email_List_Table( $query );
 
 		/* Assert. */
 		$query
@@ -95,13 +95,13 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 			->willReturn( [] );
 
 		/* Act. */
-		$list_table->prepare_items();
+		$list_table->prepare_items( 'student' );
 	}
 
 	public function testPrepareItems_WhenNoGroupSet_DoesntSetTheMetaQuery() {
 		/* Arrange. */
 		$query      = $this->createMock( \WP_Query::class );
-		$list_table = new Email_List_Table( null, $query );
+		$list_table = new Email_List_Table( $query );
 
 		/* Assert. */
 		$query
@@ -125,7 +125,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$query                = $this->createMock( \WP_Query::class );
 		$query->found_posts   = 50;
 		$query->max_num_pages = 5;
-		$list_table           = new Email_List_Table( null, $query );
+		$list_table           = new Email_List_Table( $query );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -149,7 +149,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$posts        = [ new WP_Post( new stdClass() ), new WP_Post( new stdClass() ) ];
 		$query        = $this->createMock( \WP_Query::class );
 		$query->posts = $posts;
-		$list_table   = new Email_List_Table( null, $query );
+		$list_table   = new Email_List_Table( $query );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -161,7 +161,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 	public function testGetRowData_WhenCalled_AppliesHook() {
 		/* Arrange. */
 		$list_table = new Email_List_Table();
-		$post       = $this->factory->email->create();
+		$post_id    = $this->factory->email->create();
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -199,7 +199,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 	public function testGetRowData_WhenHasItemWithNoTitle_ReturnsNoTitleText() {
 		/* Arrange. */
 		$list_table = new Email_List_Table();
-		$post       = $this->factory->email->create( [ 'post_title' => '' ] );
+		$post_id    = $this->factory->email->create( [ 'post_title' => '' ] );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -215,9 +215,9 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 	public function testGetRowData_WhenHasDescription_ReturnsTheDescription() {
 		/* Arrange. */
 		$list_table = new Email_List_Table();
-		$post       = $this->factory->email->create();
+		$post_id    = $this->factory->email->create();
 
-		update_post_meta( $post, 'sensei_email_description', 'Welcome Student' );
+		update_post_meta( $post_id, 'sensei_email_description', 'Welcome Student' );
 
 		/* Act. */
 		$list_table->prepare_items();

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -35,6 +35,10 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 	}
 
 	public function testGetColumns_WhenCalled_AppliesHook() {
+		if ( ! version_compare( get_bloginfo( 'version' ), '6.1.0', '>=' ) ) {
+			$this->markTestSkipped( 'Requires `did_filter()` which was introduced in WordPress 6.1.0.' );
+		}
+
 		/* Arrange. */
 		$list_table = new Email_List_Table();
 
@@ -159,6 +163,10 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 	}
 
 	public function testGetRowData_WhenCalled_AppliesHook() {
+		if ( ! version_compare( get_bloginfo( 'version' ), '6.1.0', '>=' ) ) {
+			$this->markTestSkipped( 'Requires `did_filter()` which was introduced in WordPress 6.1.0.' );
+		}
+
 		/* Arrange. */
 		$list_table = new Email_List_Table();
 		$post_id    = $this->factory->email->create();

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -3,6 +3,7 @@
 namespace SenseiTest\Internal\Emails;
 
 use Sensei\Internal\Emails\Email_Settings_Tab;
+use Sensei_Factory;
 
 /**
  * Tests for Sensei\Internal\Emails\Email_Settings_Tab.
@@ -10,6 +11,16 @@ use Sensei\Internal\Emails\Email_Settings_Tab;
  * @covers \Sensei\Internal\Emails\Email_Settings_Tab
  */
 class Email_Settings_Tab_Test extends \WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
 	public function testInit_WhenCalled_AddsFilter() {
 		/* Arrange. */
 		$email_settings_tab = new Email_Settings_Tab();
@@ -42,5 +53,65 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertSame( 'a', $content );
+	}
+
+	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfThatGroup_ReturnsContantWithTheEmail() {
+		/* Arrange. */
+		$post               = $this->factory->email->create_and_get();
+		$email_settings_tab = new Email_Settings_Tab();
+		$_GET['subtab']     = 'student';
+
+		update_post_meta( $post->ID, 'sensei_email_group', 'student' );
+
+		/* Act. */
+		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
+
+		/* Assert. */
+		self::assertStringContainsString( $post->post_title, $content );
+	}
+
+	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfAnotherGroup_ReturnsContentWithoutTheEmail() {
+		/* Arrange. */
+		$post               = $this->factory->email->create_and_get();
+		$email_settings_tab = new Email_Settings_Tab();
+		$_GET['subtab']     = 'student';
+
+		update_post_meta( $post->ID, 'sensei_email_group', 'teacher' );
+
+		/* Act. */
+		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
+
+		/* Assert. */
+		self::assertStringNotContainsString( $post->post_title, $content );
+	}
+
+	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfThatGroup_ReturnsContantWithTheEmail() {
+		/* Arrange. */
+		$post               = $this->factory->email->create_and_get();
+		$email_settings_tab = new Email_Settings_Tab();
+		$_GET['subtab']     = 'teacher';
+
+		update_post_meta( $post->ID, 'sensei_email_group', 'teacher' );
+
+		/* Act. */
+		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
+
+		/* Assert. */
+		self::assertStringContainsString( $post->post_title, $content );
+	}
+
+	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfAnotherGroup_ReturnsContentWithoutTheEmail() {
+		/* Arrange. */
+		$post               = $this->factory->email->create_and_get();
+		$email_settings_tab = new Email_Settings_Tab();
+		$_GET['subtab']     = 'teacher';
+
+		update_post_meta( $post->ID, 'sensei_email_group', 'student' );
+
+		/* Act. */
+		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
+
+		/* Assert. */
+		self::assertStringNotContainsString( $post->post_title, $content );
 	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -55,7 +55,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		self::assertSame( 'a', $content );
 	}
 
-	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfThatGroup_ReturnsContantWithTheEmail() {
+	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfThatGroup_ReturnsContentWithTheEmail() {
 		/* Arrange. */
 		$post               = $this->factory->email->create_and_get();
 		$email_settings_tab = new Email_Settings_Tab();
@@ -85,7 +85,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		self::assertStringNotContainsString( $post->post_title, $content );
 	}
 
-	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfThatGroup_ReturnsContantWithTheEmail() {
+	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfThatGroup_ReturnsContentWithTheEmail() {
 		/* Arrange. */
 		$post               = $this->factory->email->create_and_get();
 		$email_settings_tab = new Email_Settings_Tab();

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -55,13 +55,13 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		self::assertSame( 'a', $content );
 	}
 
-	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfThatGroup_ReturnsContentWithTheEmail() {
+	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfThatType_ReturnsContentWithTheEmail() {
 		/* Arrange. */
 		$post               = $this->factory->email->create_and_get();
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'student';
 
-		update_post_meta( $post->ID, 'sensei_email_group', 'student' );
+		update_post_meta( $post->ID, 'sensei_email_type', 'student' );
 
 		/* Act. */
 		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
@@ -70,13 +70,13 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		self::assertStringContainsString( $post->post_title, $content );
 	}
 
-	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfAnotherGroup_ReturnsContentWithoutTheEmail() {
+	public function testTabContent_WhenInStudentSubtabAndHasAnEmailOfAnotherType_ReturnsContentWithoutTheEmail() {
 		/* Arrange. */
 		$post               = $this->factory->email->create_and_get();
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'student';
 
-		update_post_meta( $post->ID, 'sensei_email_group', 'teacher' );
+		update_post_meta( $post->ID, 'sensei_email_type', 'teacher' );
 
 		/* Act. */
 		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
@@ -85,13 +85,13 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		self::assertStringNotContainsString( $post->post_title, $content );
 	}
 
-	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfThatGroup_ReturnsContentWithTheEmail() {
+	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfThatType_ReturnsContentWithTheEmail() {
 		/* Arrange. */
 		$post               = $this->factory->email->create_and_get();
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'teacher';
 
-		update_post_meta( $post->ID, 'sensei_email_group', 'teacher' );
+		update_post_meta( $post->ID, 'sensei_email_type', 'teacher' );
 
 		/* Act. */
 		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
@@ -100,13 +100,13 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		self::assertStringContainsString( $post->post_title, $content );
 	}
 
-	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfAnotherGroup_ReturnsContentWithoutTheEmail() {
+	public function testTabContent_WhenInTeacherSubtabAndHasAnEmailOfAnotherType_ReturnsContentWithoutTheEmail() {
 		/* Arrange. */
 		$post               = $this->factory->email->create_and_get();
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'teacher';
 
-		update_post_meta( $post->ID, 'sensei_email_group', 'student' );
+		update_post_meta( $post->ID, 'sensei_email_type', 'student' );
 
 		/* Act. */
 		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );


### PR DESCRIPTION
Fixes #6449

### Changes proposed in this Pull Request

* Render two lists of emails filtered by type (student, teacher) using post meta.
* The lists are rendered in their own email settings sub-tab.
* The lists support pagination.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
* Go to `/wp-admin/edit.php?post_type=sensei_email`
* Create a few email posts.
* To some of them add post meta `sensei_email_type` with the value `student`.
```php
update_post_meta( $post->ID, 'sensei_email_type', 'student' );
```
* To the others add post meta `sensei_email_type` with the value `teacher`.
```php
update_post_meta( $post->ID, 'sensei_email_type', 'teacher' );
```
* Add a description to some of them.
```php
update_post_meta( $post->ID, 'sensei_email_description', 'Welcome Student' );
```
* Go to Sensei LMS -> Settings -> Emails -> Student Emails.
* Make sure you see the posts with the `student` post meta.
* Go to Sensei LMS -> Settings -> Emails -> Teacher Emails.
* Make sure you see the posts with the `teacher` post meta.
* Make sure you see the description.
* Make sure the pagination works.
* Modify a post and make sure the last modified date works.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_email_list_columns` – Filter the columns that are displayed in the email list.
* `sensei_email_list_row_data` – Filter the row data displayed in the email list.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![image](https://user-images.githubusercontent.com/1612178/217957167-1013bdf2-c4d9-4d94-ad24-affe0dac21d5.png)
