### PR TITLE
Fix error in import job

### DIFF
--- a/includes/data-port/class-sensei-import-job-cli.php
+++ b/includes/data-port/class-sensei-import-job-cli.php
@@ -106,7 +106,7 @@ class Sensei_Import_Job_CLI extends WP_CLI_Command {
 					WP_CLI::error(
 						sprintf(
 							// translators: Placeholder %1$s is the name of the file; %2$s is the path provided.
-							__( 'File provided for "%1$s" (%1$s) was not found', 'sensei-lms' ),
+							__( 'File provided for "%1$s" (%2$s) was not found', 'sensei-lms' ),
 							$file_key,
 							$file_path
 						)


### PR DESCRIPTION
Fixes #4673

### Changes proposed in this Pull Request

Changes `%1$s` to `%2$s`. This fixes behaviour in the `wp sensei-import` WP CLI command that was errantly outputting the file name twice:

**Before change:**

```
wp sensei-import --user=admin --questions=bananas.csv

Error: File provided for "questions" (questions) was not found
```

**After change:**

```
wp sensei-import --user=admin --questions=bananas.csv

Error: File provided for "questions" (/path/to/bananas.csv) was not found
```

### Testing instructions

- Switch to `fix/string-error-in-class-sensei-import-job-cliphp` branch
- Run `wp sensei-import --user=admin --questions=bananas.csv` or any import command that references a file that doesn't exist
- 'Output is now shown as expected