### PR TITLE
Auto select specific template for pattern at course creation if specified

### DIFF
--- a/includes/block-patterns/course/life-coach.php
+++ b/includes/block-patterns/course/life-coach.php
@@ -13,4 +13,5 @@ return [
 	'categories' => [ \Sensei_Block_Patterns::get_patterns_category_name() ],
 	'blockTypes' => [ \Sensei_Block_Patterns::get_post_content_block_type_name() ],
 	'content'    => ob_get_clean(),
+	'template'   => 'wide-no-featured-no-title',
 ];

--- a/includes/block-patterns/course/long-sales-page.php
+++ b/includes/block-patterns/course/long-sales-page.php
@@ -13,4 +13,5 @@ return [
 	'categories' => [ \Sensei_Block_Patterns::get_patterns_category_name() ],
 	'blockTypes' => [ \Sensei_Block_Patterns::get_post_content_block_type_name() ],
 	'content'    => ob_get_clean(),
+	'template'   => 'wide-no-featured-no-title',
 ];

--- a/includes/block-patterns/course/video-hero.php
+++ b/includes/block-patterns/course/video-hero.php
@@ -13,4 +13,5 @@ return [
 	'categories' => [ \Sensei_Block_Patterns::get_patterns_category_name() ],
 	'blockTypes' => [ \Sensei_Block_Patterns::get_post_content_block_type_name() ],
 	'content'    => ob_get_clean(),
+	'template'   => 'wide-no-featured-no-title',
 ];


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6192

### Changes proposed in this Pull Request

* Added chosen templates in course pattern lists so that if we select a pattern in the third step of creating a course, it selects a specific template if available.

### Testing instructions
- Enable the Course theme
- Create a new course
- Follow the course creation steps
- In the third step, select any from the **Long Sales, Video Hero or Life Coach** templates
- Make sure the **Wide - No Featured Image, No Title.** gets selected by default

### Screenshot / Video
https://user-images.githubusercontent.com/6820724/218106006-551f70c8-2f68-4b3f-99be-c14b3e22248b.mov