### PR TITLE
Set the list of allowed blocks for email templates

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -291,6 +291,7 @@ class Sensei_Autoloader {
 			 */
 			\Sensei\Internal\Emails\Email_Post_Type::class => 'internal/emails/class-email-post-type.php',
 			\Sensei\Internal\Emails\Email_Customization::class => 'internal/emails/class-email-customization.php',
+			\Sensei\Internal\Emails\Email_Blocks::class => 'internal/emails/class-email-blocks.php',
 			\Sensei\Internal\Emails\Settings_Menu::class   => 'internal/emails/class-settings-menu.php',
 			\Sensei\Internal\Emails\Email_Settings_Tab::class => 'internal/emails/class-email-settings-tab.php',
 		);

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -291,7 +291,7 @@ class Sensei_Autoloader {
 			 */
 			\Sensei\Internal\Emails\Email_Post_Type::class => 'internal/emails/class-email-post-type.php',
 			\Sensei\Internal\Emails\Email_Customization::class => 'internal/emails/class-email-customization.php',
-			\Sensei\Internal\Emails\Email_Blocks::class => 'internal/emails/class-email-blocks.php',
+			\Sensei\Internal\Emails\Email_Blocks::class    => 'internal/emails/class-email-blocks.php',
 			\Sensei\Internal\Emails\Settings_Menu::class   => 'internal/emails/class-settings-menu.php',
 			\Sensei\Internal\Emails\Email_Settings_Tab::class => 'internal/emails/class-email-settings-tab.php',
 		);

--- a/includes/internal/emails/class-email-blocks.php
+++ b/includes/internal/emails/class-email-blocks.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * File containing the Email_Blocks class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Email_Blocks
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Email_Blocks {
+
+	/**
+	 *  List of allowed blocks.
+	 *
+	 *  @internal
+	 */
+	public const ALLOWED_BLOCKS = [
+		'core/paragraph',
+		'core/image',
+		'core/group',
+		'core/heading',
+		'core/buttons',
+	];
+	/**
+	 * Initialize the class and add hooks.
+	 *
+	 * @internal
+	 */
+	public function init(): void {
+		add_filter( 'allowed_block_types_all', [ $this, 'set_allowed_blocks' ], 25, 2 );
+	}
+
+	/**
+	 * Set the allowed blocks.
+	 *
+	 * @internal
+	 * @access private
+	 *
+	 * @param bool|string[]            $default_allowed_blocks List of default allowed blocks.
+	 * @param \WP_Block_Editor_Context $context     Block Editor Context.
+	 * @return bool|string[]
+	 */
+	public function set_allowed_blocks( $default_allowed_blocks, $context ) {
+		if ( Email_Post_Type::POST_TYPE === $context->post->post_type ) {
+			return self::ALLOWED_BLOCKS;
+		}
+
+		return $default_allowed_blocks;
+	}
+}
+

--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -35,6 +35,13 @@ class Email_Customization {
 	private $post_type;
 
 	/**
+	 * Email blocks configurations.
+	 *
+	 * @var Email_Blocks
+	 */
+	private $blocks;
+
+	/**
 	 * Settings_Menu instance.
 	 *
 	 * @var Settings_Menu
@@ -57,6 +64,7 @@ class Email_Customization {
 		$this->post_type     = new Email_Post_Type();
 		$this->settings_menu = new Settings_Menu();
 		$this->settings_tab  = new Email_Settings_Tab();
+		$this->blocks        = new Email_Blocks();
 	}
 
 	/**
@@ -83,5 +91,6 @@ class Email_Customization {
 		$this->post_type->init();
 		$this->settings_menu->init();
 		$this->settings_tab->init();
+		$this->blocks->init();
 	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-blocks.php
+++ b/tests/unit-tests/internal/emails/test-class-email-blocks.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SenseiTest\Internal\Emails;
+
+use Sensei\Internal\Emails\Email_Blocks;
+use Sensei\Internal\Emails\Email_Post_Type;
+use WP_Post;
+
+/**
+ * Tests for the Email_Blocks class.
+ *
+ * @covers \Sensei\Internal\Emails\Email_Blocks
+ */
+class Email_Blocks_Test extends \WP_UnitTestCase {
+
+	public function testInit_WhenCalled_AddsFilter() {
+		/* Arrange. */
+		$blocks = new Email_Blocks();
+
+		/* Act. */
+		$blocks->init();
+
+		/* Assert. */
+		$priority = has_filter( 'allowed_block_types_all', [ $blocks, 'set_allowed_blocks' ] );
+		self::assertSame( 25, $priority );
+	}
+
+
+	public function testSetAllowedBlocks_WhenCalledWithANonEmailPostType_ReturnDefaultBlocks() {
+		/* Arrange. */
+		$blocks = new Email_Blocks();
+		$default_block = ['core/a', 'core/b', 'core/c'];
+		$block_editor_context = new \WP_Block_Editor_Context(['post' => new WP_Post((object) array('post_type' => 'any_post_type'))]);
+
+		/* Act. */
+		$allowed_blocks =  $blocks->set_allowed_blocks( $default_block, $block_editor_context);
+
+		/* Assert. */
+		self::assertSame( $allowed_blocks, $default_block);
+	}
+
+	public function testSetAllowedBlocks_WhenCalledWithEmailPostType_ReturnAllowedBlocks() {
+		/* Arrange. */
+		$blocks = new Email_Blocks();
+		$default_block = ['core/block-a', 'core/block-b', 'core/block-c'];
+		$block_editor_context = new \WP_Block_Editor_Context(['post' => new WP_Post((object) array('post_type' => Email_Post_Type::POST_TYPE ))]);
+
+		/* Act. */
+		$allowed_blocks = $blocks->set_allowed_blocks( $default_block, $block_editor_context);
+
+		/* Assert. */
+		self::assertSame( $allowed_blocks, Email_Blocks::ALLOWED_BLOCKS);
+	}
+}

--- a/tests/unit-tests/internal/emails/test-class-email-blocks.php
+++ b/tests/unit-tests/internal/emails/test-class-email-blocks.php
@@ -28,27 +28,27 @@ class Email_Blocks_Test extends \WP_UnitTestCase {
 
 	public function testSetAllowedBlocks_WhenCalledWithANonEmailPostType_ReturnDefaultBlocks() {
 		/* Arrange. */
-		$blocks = new Email_Blocks();
-		$default_block = ['core/a', 'core/b', 'core/c'];
-		$block_editor_context = new \WP_Block_Editor_Context(['post' => new WP_Post((object) array('post_type' => 'any_post_type'))]);
+		$blocks               = new Email_Blocks();
+		$default_block        = [ 'core/a', 'core/b', 'core/c' ];
+		$block_editor_context = new \WP_Block_Editor_Context( [ 'post' => new WP_Post( (object) array( 'post_type' => 'any_post_type' ) ) ] );
 
 		/* Act. */
-		$allowed_blocks =  $blocks->set_allowed_blocks( $default_block, $block_editor_context);
+		$allowed_blocks = $blocks->set_allowed_blocks( $default_block, $block_editor_context );
 
 		/* Assert. */
-		self::assertSame( $allowed_blocks, $default_block);
+		self::assertSame( $allowed_blocks, $default_block );
 	}
 
 	public function testSetAllowedBlocks_WhenCalledWithEmailPostType_ReturnAllowedBlocks() {
 		/* Arrange. */
-		$blocks = new Email_Blocks();
-		$default_block = ['core/block-a', 'core/block-b', 'core/block-c'];
-		$block_editor_context = new \WP_Block_Editor_Context(['post' => new WP_Post((object) array('post_type' => Email_Post_Type::POST_TYPE ))]);
+		$blocks               = new Email_Blocks();
+		$default_block        = [ 'core/block-a', 'core/block-b', 'core/block-c' ];
+		$block_editor_context = new \WP_Block_Editor_Context( [ 'post' => new WP_Post( (object) array( 'post_type' => Email_Post_Type::POST_TYPE ) ) ] );
 
 		/* Act. */
-		$allowed_blocks = $blocks->set_allowed_blocks( $default_block, $block_editor_context);
+		$allowed_blocks = $blocks->set_allowed_blocks( $default_block, $block_editor_context );
 
 		/* Assert. */
-		self::assertSame( $allowed_blocks, Email_Blocks::ALLOWED_BLOCKS);
+		self::assertSame( $allowed_blocks, Email_Blocks::ALLOWED_BLOCKS );
 	}
 }


### PR DESCRIPTION
Fixes #6510

### Changes proposed in this Pull Request

* Set the email template allowed blocks, disallowing the other ones. 

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
* Go To `wp-admin/post-new.php?post_type=sensei_email` 
* Check if is possible to add [these blocks ](https://github.com/Automattic/sensei/blob/55234b0d6aab7847be4f60f475f9f1879bba5088/includes/internal/emails/class-email-blocks.php#L29-L33)
* Check if is not possible to add any other block. 
