### PR TITLE
Add LM template as CSS class of body element

### DIFF
--- a/changelog/add-learning-mode-template-css-class
+++ b/changelog/add-learning-mode-template-css-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add template name as CSS class to body element in Learning Mode

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -326,11 +326,8 @@ class Sensei_Course_Theme {
 	 * @return string[] $classes
 	 */
 	public function add_sensei_theme_body_class( $classes ) {
-		$classes[] = self::THEME_NAME;
-
-		return $classes;
+		return array_merge( $classes, [ self::THEME_NAME, Sensei_Course_Theme_Template_Selection::get_active_template_name() ] );
 	}
-
 
 	/**
 	 * Get the version of the active Learning Mode template.

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -326,7 +326,7 @@ class Sensei_Course_Theme {
 	 * @return string[] $classes
 	 */
 	public function add_sensei_theme_body_class( $classes ) {
-		return array_merge( $classes, [ self::THEME_NAME, Sensei_Course_Theme_Template_Selection::get_active_template_name() ] );
+		return array_merge( $classes, [ self::THEME_NAME, 'sensei-' . Sensei_Course_Theme_Template_Selection::get_active_template_name() ] );
 	}
 
 	/**


### PR DESCRIPTION
This PR is a prerequisite to enable fixing some styling issues with the Learning Mode templates.

### Testing instructions
- Enable Learning Mode & Sensei Pro.
- View a lesson and quiz on the front end.
- Ensure the appropriate CSS class has been added to the `body` element (`default`, `modern`, `video` or `video-full`) and that `sensei-course-theme` also appears there.
- Repeat for the other LM templates.