### PR TITLE
Disable the changelog check when the "No Changelog" label is used

### DIFF
--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -16,6 +16,7 @@ defaults:
 
 jobs:
     changelogger_used:
+        if: ${{ !contains( github.event.pull_request.labels.*.name, 'No Changelog') }}
         name: Changelogger used
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -2,6 +2,7 @@ name: Changelogger checks
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     branches-ignore:
       - 'release/**'
       - 'feature/**'


### PR DESCRIPTION
This is another way of skipping the changelog entry for a PR.

Originally suggested in p6rkRX-3rb-p2#comment-4010.

### Changes proposed in this Pull Request

* Disable the changelog check when the "No Changelog" label is used.

### Testing instructions

* Create a new PR using this branch as a base.
* Add the "No Changelog" label.
* The CI check should be "Skipped".
* Remove the "No Changelog" label.
* The CI check should fail.