### PR TITLE
Order the email list by description

### DIFF
--- a/changelog/add-sort-emails-by-description
+++ b/changelog/add-sort-emails-by-description
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Order the email list by description
+
+

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -89,6 +89,9 @@ class Email_List_Table extends Sensei_List_Table {
 			'post_type'      => Email_Post_Type::POST_TYPE,
 			'posts_per_page' => $per_page,
 			'offset'         => $offset,
+			'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Query limited by pagination.
+			'orderby'        => 'meta_value',
+			'order'          => 'ASC',
 		];
 
 		if ( $type ) {

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -66,6 +66,9 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 					'post_type'      => Email_Post_Type::POST_TYPE,
 					'posts_per_page' => 20,
 					'offset'         => 20,
+					'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'orderby'        => 'meta_value',
+					'order'          => 'ASC',
 				]
 			)
 			->willReturn( [] );
@@ -94,6 +97,9 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 							'value' => 'student',
 						],
 					],
+					'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'orderby'        => 'meta_value',
+					'order'          => 'ASC',
 				]
 			)
 			->willReturn( [] );
@@ -116,6 +122,9 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 					'post_type'      => Email_Post_Type::POST_TYPE,
 					'posts_per_page' => 20,
 					'offset'         => 0,
+					'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'orderby'        => 'meta_value',
+					'order'          => 'ASC',
 				]
 			)
 			->willReturn( [] );
@@ -171,6 +180,8 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table = new Email_List_Table();
 		$post_id    = $this->factory->email->create();
 
+		update_post_meta( $post_id, 'sensei_email_description', 'description' );
+
 		/* Act. */
 		$list_table->prepare_items();
 
@@ -188,6 +199,8 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table = new Email_List_Table();
 		$post       = $this->factory->email->create_and_get();
 
+		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
+
 		/* Act. */
 		$list_table->prepare_items();
 
@@ -197,9 +210,10 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$expected = sprintf(
-			'<td class=\'subject column-subject column-primary\' data-colname="Subject" ><strong><a href="" class="row-title">%s</a></strong><div class="row-actions"><span class=\'edit\'><a href="" aria-label="Edit &#8220;%s&#8221;">Edit</a></span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td><td class=\'description column-description\' data-colname="Description" ></td><td class=\'last_modified column-last_modified\' data-colname="Last Modified" >1 second ago</td>',
+			'<td class=\'subject column-subject column-primary\' data-colname="Subject" ><strong><a href="" class="row-title">%s</a></strong><div class="row-actions"><span class=\'edit\'><a href="" aria-label="Edit &#8220;%s&#8221;">Edit</a></span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td><td class=\'description column-description\' data-colname="Description" >%s</td><td class=\'last_modified column-last_modified\' data-colname="Last Modified" >1 second ago</td>',
 			$post->post_title,
-			$post->post_title
+			$post->post_title,
+			'description'
 		);
 		$this->assertStringContainsString( $expected, $result );
 	}
@@ -208,6 +222,8 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$list_table = new Email_List_Table();
 		$post_id    = $this->factory->email->create( [ 'post_title' => '' ] );
+
+		update_post_meta( $post_id, 'sensei_email_description', 'description' );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -246,6 +262,8 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ),
 			]
 		);
+
+		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
 
 		/* Act. */
 		$list_table->prepare_items();

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -62,6 +62,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		$_GET['subtab']     = 'student';
 
 		update_post_meta( $post->ID, 'sensei_email_type', 'student' );
+		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
 
 		/* Act. */
 		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );
@@ -92,6 +93,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		$_GET['subtab']     = 'teacher';
 
 		update_post_meta( $post->ID, 'sensei_email_type', 'teacher' );
+		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
 
 		/* Act. */
 		$content = $email_settings_tab->tab_content( '', 'email-notification-settings' );


### PR DESCRIPTION
Fixes #6449

This PR sorts the emails by the `sensei_email_description` meta, but as a side effect, the email list now only shows posts that have that meta. A solution for showing the posts that don't have that meta would be a bit tricky and require some custom SQL. Gabriel [replied](https://github.com/Automattic/sensei/issues/6449#issuecomment-1433575183) that it was ok because we have control over the posts anyway.

### Changes proposed in this Pull Request

* Sorts the emails by description in alphabetical order.
* As a side effect, filters out posts that don't have the `sensei_email_description` meta.

### Testing instructions

* Enable the feature flag: add_filter( 'sensei_feature_flag_email_customization', '__return_true' );
* Have a few email posts that also have the `sensei_email_description` meta.
```php
update_post_meta( $post->ID, 'sensei_email_description', 'Welcome!' );
```
* Go to Sensei LMS -> Settings -> Emails and make sure the posts are sorted by the meta value in alphabetical order.
