### PR TITLE
Handle block editors with no post in email block class

### DIFF
--- a/changelog/add-handle-block-editors-with-no-post
+++ b/changelog/add-handle-block-editors-with-no-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix showing error message when block editor opened in non post context

--- a/includes/internal/emails/class-email-blocks.php
+++ b/includes/internal/emails/class-email-blocks.php
@@ -32,6 +32,7 @@ class Email_Blocks {
 		'core/heading',
 		'core/buttons',
 	];
+
 	/**
 	 * Initialize the class and add hooks.
 	 *
@@ -49,10 +50,11 @@ class Email_Blocks {
 	 *
 	 * @param bool|string[]            $default_allowed_blocks List of default allowed blocks.
 	 * @param \WP_Block_Editor_Context $context     Block Editor Context.
+	 *
 	 * @return bool|string[]
 	 */
 	public function set_allowed_blocks( $default_allowed_blocks, $context ) {
-		if ( Email_Post_Type::POST_TYPE === $context->post->post_type ) {
+		if ( Email_Post_Type::POST_TYPE === ( $context->post->post_type ?? '' ) ) {
 			return self::ALLOWED_BLOCKS;
 		}
 

--- a/tests/unit-tests/internal/emails/test-class-email-blocks.php
+++ b/tests/unit-tests/internal/emails/test-class-email-blocks.php
@@ -51,4 +51,17 @@ class Email_Blocks_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		self::assertSame( $allowed_blocks, Email_Blocks::ALLOWED_BLOCKS );
 	}
+
+	public function testSetAllowedBlocks_WhenCalledWithoutAnyPostInContext_ThrowsNoException() {
+		/* Arrange. */
+		$blocks               = new Email_Blocks();
+		$default_block        = [ 'core/block-a', 'core/block-b', 'core/block-c' ];
+		$block_editor_context = new \WP_Block_Editor_Context( [] );
+
+		/* Assert. */
+		$this->expectNotToPerformAssertions();
+
+		/* Act. */
+		$blocks->set_allowed_blocks( $default_block, $block_editor_context );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6532

### Changes proposed in this Pull Request

* Fixes added null check for block editor event in case the editor is open in a context where there is no post, like the site editor

### Testing instructions

- Enable the Email feature flag `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
- Go to Appearance -> Customize
- Make sure there is no error message being shown
- Go to the block editor of sensei_email post type
- Make sure you only see the subset of blocks you should see there
