### PR TITLE
Setup email templates

### DIFF
--- a/changelog/add-email-templates-setup
+++ b/changelog/add-email-templates-setup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add default email templates

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -298,6 +298,10 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Emails\Email_Sender::class    => 'internal/emails/class-email-sender.php',
 			\Sensei\Internal\Emails\Email_Generator::class => 'internal/emails/class-email-generator.php',
 			\Sensei\Internal\Emails\Email_List_Table_Actions::class => 'internal/emails/class-email-list-table-actions.php',
+			\Sensei\Internal\Emails\Email_Data::class      => 'internal/emails/class-email-data.php',
+			\Sensei\Internal\Emails\Template_Wizard::class => 'internal/emails/class-template-wizard.php',
+			\Sensei\Internal\Emails\Recreate_Emails_Tool::class => 'internal/emails/class-recreate-emails-tool.php',
+			\Sensei\Internal\Emails\Email_Repository::class => 'internal/emails/class-email-repository.php',
 		);
 	}
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -6,6 +6,10 @@
  * @since 1.1.0
  */
 
+use Sensei\Internal\Emails\Email_Data;
+use Sensei\Internal\Emails\Email_Repository;
+use Sensei\Internal\Emails\Template_Wizard;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -81,9 +85,30 @@ class Sensei_Updates {
 		$this->v3_9_fix_question_author();
 		$this->v3_9_remove_abandoned_multiple_question();
 		$this->v4_10_update_install_time();
+		$this->v4_12_create_default_emails();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
+	}
+
+	/**
+	 * Create default emails.
+	 *
+	 * @return void
+	 */
+	private function v4_12_create_default_emails() {
+		if ( ! Sensei()->feature_flags->is_enabled( 'email_customization' ) ) {
+			return;
+		}
+
+		$repository = new Email_Repository();
+		if ( $repository->has_emails() ) {
+			return;
+		}
+
+		$wizard = new Template_Wizard( new Email_Data(), $repository );
+		$wizard->init();
+		$wizard->create_all();
 	}
 
 	/**

--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -77,6 +77,13 @@ class Email_Customization {
 	private $list_table_actions;
 
 	/**
+	 * Recreate_Emails_Tool instance.
+	 *
+	 * @var Recreate_Emails_Tool
+	 */
+	private $recreate_emails_tool;
+
+	/**
 	 * Email_Customization constructor.
 	 *
 	 * Prevents other instances from being created outside of `self::instance()`.
@@ -89,6 +96,9 @@ class Email_Customization {
 		$this->email_sender       = new Email_Sender();
 		$this->email_generator    = new Email_Generator();
 		$this->list_table_actions = new Email_List_Table_Actions();
+
+		$wizrard                    = new Template_Wizard( new Email_Data(), new Email_Repository() );
+		$this->recreate_emails_tool = new Recreate_Emails_Tool( $wizrard );
 	}
 
 	/**
@@ -119,5 +129,6 @@ class Email_Customization {
 		$this->email_sender->init();
 		$this->email_generator->init();
 		$this->list_table_actions->init();
+		$this->recreate_emails_tool->init();
 	}
 }

--- a/includes/internal/emails/class-email-data.php
+++ b/includes/internal/emails/class-email-data.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * File containing the Email_Data class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Email_Data class.
+ *
+ * Contains all available email data.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Email_Data {
+
+	/**
+	 * Email data.
+	 *
+	 * @var array
+	 */
+	private $emails;
+
+	/**
+	 * Get all available emails with corresponding data.
+	 *
+	 * @return array
+	 */
+	public function get_email_data(): array {
+		if ( ! empty( $this->emails ) ) {
+			return $this->emails;
+		}
+
+		$this->emails = [
+			'quiz_graded'              => [
+				'types'       => [ 'student' ],
+				'subject'     => __( 'Quiz Qraded - [lesson:name]', 'sensei-lms' ),
+				'description' => __( 'Quiz Graded', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'course_completed'         => [
+				'types'       => [ 'student' ],
+				'subject'     => __( '[student:displayname] completed [course:name]', 'sensei-lms' ),
+				'description' => __( 'Course Complete', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'student_starts_course'    => [
+				'types'       => [ 'teacher' ],
+				'subject'     => __( '[student:displayname] started [course:name]', 'sensei-lms' ),
+				'description' => __( 'Course Started', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'student_completes_course' => [
+				'types'       => [ 'teacher' ],
+				'subject'     => __( '[student:displayname] completed [course:name]', 'sensei-lms' ),
+				'description' => __( 'Course Completed', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'student_completes_lesson' => [
+				'types'       => [ 'teacher' ],
+				'subject'     => __( '[student:displayname] completed [lesson:name]', 'sensei-lms' ),
+				'description' => __( 'Lesson Completed', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'student_submits_quiz'     => [
+				'types'       => [ 'teacher' ],
+				'subject'     => __( '[student:displayname] has submitted a quiz', 'sensei-lms' ),
+				'description' => __( 'Quiz Submitted', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'student_sends_message'    => [
+				'types'       => [ 'teacher' ],
+				'subject'     => __( '[student:displayname] - [subject:displaysubject]', 'sensei-lms' ),
+				'description' => __( 'Student Sent Message', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'new_course_assigned'      => [
+				'types'       => [ 'teacher' ],
+				'subject'     => __( 'New Course Assigned: [course:name]', 'sensei-lms' ),
+				'description' => __( 'Course Assigned', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'new_message_reply'        => [
+				'types'       => [ 'student', 'teacher' ],
+				'subject'     => __( '[author:displayname] - [subject:displaysubject]', 'sensei-lms' ),
+				'description' => __( 'Message Reply Received', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'content_drip'             => [
+				'types'       => [ 'student' ],
+				'subject'     => __( 'Get ready - [lesson:name] - starts [date:dtext]', 'sensei-lms' ),
+				'description' => __( 'Lessons Available (Content Drip)', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'course_expiration_today'  => [
+				'types'       => [ 'student' ],
+				'subject'     => __( '[course:name] expires [date:dtext]!', 'sensei-lms' ),
+				'description' => __( 'Course Expiration - Today', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'course_expiration_3_days' => [
+				'types'       => [ 'student' ],
+				'subject'     => __( '[course:name] expires [date:dtext]!', 'sensei-lms' ),
+				'description' => __( 'Course Expiration - in 3 days', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+			'course_expiration_7_days' => [
+				'types'       => [ 'student' ],
+				'subject'     => __( '[course:name] expires [date:dtext]!', 'sensei-lms' ),
+				'description' => __( 'Course Expiration - in 7 days', 'sensei-lms' ),
+				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+			],
+		];
+
+		return $this->emails;
+	}
+}

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -89,7 +89,7 @@ class Email_List_Table extends Sensei_List_Table {
 			'post_type'      => Email_Post_Type::POST_TYPE,
 			'posts_per_page' => $per_page,
 			'offset'         => $offset,
-			'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Query limited by pagination.
+			'meta_key'       => '_sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Query limited by pagination.
 			'orderby'        => 'meta_value',
 			'order'          => 'ASC',
 		];
@@ -97,7 +97,7 @@ class Email_List_Table extends Sensei_List_Table {
 		if ( $type ) {
 			$query_args['meta_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Query limited by pagination.
 				[
-					'key'   => 'sensei_email_type', // TODO: Replace the meta key by a constant defined elsewhere.
+					'key'   => '_sensei_email_type', // TODO: Replace the meta key by a constant defined elsewhere.
 					'value' => $type,
 				],
 			];
@@ -134,7 +134,7 @@ class Email_List_Table extends Sensei_List_Table {
 			$this->row_actions( $actions )
 		);
 
-		$description = get_post_meta( $post->ID, 'sensei_email_description', true );
+		$description = get_post_meta( $post->ID, '_sensei_email_description', true );
 
 		$last_modified = sprintf(
 			/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */

--- a/includes/internal/emails/class-email-repository.php
+++ b/includes/internal/emails/class-email-repository.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * File containing the Email_Repository class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+use WP_Query;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Email_Repository class.
+ *
+ * @since $$next-version$$
+ */
+class Email_Repository {
+
+	/**
+	 * Email identifier meta key.
+	 *
+	 * @var string
+	 */
+	private const META_IDENTIFIER = '_sensei_email_identifier';
+
+	/**
+	 * Email type meta key.
+	 *
+	 * @var string
+	 */
+	private const META_TYPE = '_sensei_email_type';
+
+	/**
+	 * Email description meta key.
+	 *
+	 * @param string
+	 */
+	private const META_DESCRIPTION = '_sensei_email_description';
+
+	/**
+	 * Check if email exists for identifier.
+	 *
+	 * @internal
+	 *
+	 * @param string $identifier Email identifier.
+	 * @return bool
+	 */
+	public function has( string $identifier ): bool {
+		$query = new WP_Query(
+			[
+				'post_type'  => Email_Post_Type::POST_TYPE,
+				'meta_key'   => self::META_IDENTIFIER, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value,
+			]
+		);
+
+		return $query->post_count > 0;
+	}
+
+	/**
+	 * Create email for identifier.
+	 *
+	 * @internal
+	 *
+	 * @param string $identifier  Email identifier.
+	 * @param array  $types       Email types.
+	 * @param string $subject     Email subject.
+	 * @param string $description Email description.
+	 * @param string $content     Email content.
+	 *
+	 * @return int|false Email post ID. Returns false if email already exists. Returns WP_Error on failure.
+	 */
+	public function create( string $identifier, array $types, string $subject, string $description, string $content ) {
+		if ( $this->has( $identifier ) ) {
+			return false;
+		}
+
+		$email_data = [
+			'post_status'  => 'publish',
+			'post_type'    => Email_Post_Type::POST_TYPE,
+			'post_title'   => $subject,
+			'post_content' => $content,
+			'meta_input'   => [
+				self::META_IDENTIFIER  => $identifier,
+				self::META_DESCRIPTION => $description,
+			],
+		];
+
+		$email_id = wp_insert_post( $email_data );
+
+		foreach ( $types as $type ) {
+			add_post_meta( $email_id, self::META_TYPE, $type );
+		}
+
+		return $email_id;
+	}
+
+	/**
+	 * Delete email for identifier.
+	 *
+	 * @internal
+	 *
+	 * @param string $identifier Email identifier.
+	 * @return bool
+	 */
+	public function delete( string $identifier ): bool {
+		$query = new WP_Query(
+			[
+				'select'     => 'ID',
+				'post_type'  => Email_Post_Type::POST_TYPE,
+				'meta_key'   => self::META_IDENTIFIER, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+
+		if ( 0 === $query->post_count ) {
+			return false;
+		}
+
+		$result = true;
+		foreach ($query->posts as $post) {
+			$last_result = wp_delete_post( $post->ID, true );
+			if ( ! $last_result ) {
+				$result = false;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get email for identifier.
+	 *
+	 * @internal
+	 *
+	 * @param string $identifier Email identifier.
+	 * @return \WP_Post|null
+	 */
+	public function get( string $identifier ) {
+		$query = new WP_Query(
+			[
+				'post_type'  => Email_Post_Type::POST_TYPE,
+				'meta_key'   => self::META_IDENTIFIER, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+
+		if ( 0 === $query->post_count ) {
+			return null;
+		}
+
+		return $query->posts[0];
+	}
+
+	/**
+	 * Get all emails for type.
+	 *
+	 * @internal
+	 *
+	 * @param string $type Email type.
+	 * @param int    $limit Limit. Default 10.
+	 * @param int    $offset Offset. Default 0.
+	 * @return \WP_Post[]
+	 */
+	public function get_all( string $type, $limit = 10, $offset = 0 ): array {
+		return get_posts(
+			[
+				'post_type'      => Email_Post_Type::POST_TYPE,
+				'meta_key'       => self::META_TYPE, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $type, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'posts_per_page' => $limit,
+				'offset'         => $offset,
+			]
+		);
+	}
+
+	/**
+	 * Returns if there are any emails in the repository.
+	 *
+	 * @internal
+	 *
+	 * @return bool
+	 */
+	public function has_emails() {
+		$query = new WP_Query(
+			[
+				'post_type' => Email_Post_Type::POST_TYPE,
+				'posts_per_page' => 1,
+			]
+		);
+
+		return 0 === (int) $query->post_count;
+	}
+}
+

--- a/includes/internal/emails/class-email-repository.php
+++ b/includes/internal/emails/class-email-repository.php
@@ -122,7 +122,7 @@ class Email_Repository {
 		}
 
 		$result = true;
-		foreach ($query->posts as $post) {
+		foreach ( $query->posts as $post ) {
 			$last_result = wp_delete_post( $post->ID, true );
 			if ( ! $last_result ) {
 				$result = false;
@@ -188,7 +188,7 @@ class Email_Repository {
 	public function has_emails() {
 		$query = new WP_Query(
 			[
-				'post_type' => Email_Post_Type::POST_TYPE,
+				'post_type'      => Email_Post_Type::POST_TYPE,
 				'posts_per_page' => 1,
 			]
 		);

--- a/includes/internal/emails/class-recreate-emails-tool.php
+++ b/includes/internal/emails/class-recreate-emails-tool.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * File containing Recreate_Emails_Tool class.
+ *
+ * @package sensei-lms
+ * @since 3.7.0
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Recreate_Emails_Tool class.
+ *
+ * @since $$next-version$$
+ */
+class Recreate_Emails_Tool implements \Sensei_Tool_Interface {
+
+	/**
+	 * Template_Wizard instance.
+	 *
+	 * @var Template_Wizard
+	 */
+	private $template_wizard;
+
+
+	/**
+	 * Recreate_Emails_Tool constructor.
+	 *
+	 * @param Template_Wizard $template_wizard Template_Wizard instance.
+	 */
+	public function __construct( Template_Wizard $template_wizard ) {
+		$this->template_wizard = $template_wizard;
+	}
+
+	/**
+	 * Initialize the tool.
+	 */
+	public function init() {
+		add_filter( 'sensei_tools', [ $this, 'register_tool' ] );
+	}
+
+	/**
+	 * Register the tool.
+	 *
+	 * @param array $tools List of tools.
+	 *
+	 * @return array
+	 */
+	public function register_tool( $tools ) {
+		$tools[] = $this;
+		return $tools;
+	}
+
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'recreate-emails';
+	}
+
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Re-create Emails', 'sensei-lms' );
+	}
+
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return __(
+			'Forcefully recreate all emails. If you have any changes in default templates those change will be lost.',
+			'sensei-lms'
+		);
+	}
+
+	/**
+	 * Run the tool.
+	 */
+	public function process() {
+		$this->template_wizard->init();
+		$result = $this->template_wizard->create_all( true );
+
+		$message = $result
+			? __( 'Emails were recreated successfully.', 'sensei-lms' )
+			: __( 'There were errors while recreating emails.', 'sensei-lms' );
+		\Sensei_Tools::instance()->add_user_message( $message, ! $result );
+	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
+}

--- a/includes/internal/emails/class-template-wizard.php
+++ b/includes/internal/emails/class-template-wizard.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * File containing the Template_Wizard class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+use Sensei\Internal\Emails\Email_Data;
+use Sensei\Internal\Emails\Email_Repository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Template_Wizard class.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Template_Wizard {
+	/**
+	 * Email_Data instance.
+	 *
+	 * @var Email_Data
+	 */
+	private $email_data;
+
+	/**
+	 * Email repository.
+	 *
+	 * @var Email_Repository
+	 */
+	private $email_repository;
+
+	/**
+	 * Email data.
+	 *
+	 * @var array
+	 */
+	private $emails;
+
+	/**
+	 * Template_Wizard constructor.
+	 *
+	 * @internal
+	 *
+	 * @param Email_Data       $email_data Email_Data instance. Keeps information about all default emails.
+	 * @param Email_Repository $email_repository Email repository.
+	 */
+	public function __construct( Email_Data $email_data, Email_Repository $email_repository ) {
+		$this->email_data       = $email_data;
+		$this->email_repository = $email_repository;
+		$this->emails           = [];
+	}
+
+	/**
+	 * Initialize the wizard.
+	 *
+	 * @internal
+	 */
+	public function init() {
+		/**
+		 * Filter the email data.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $emails Email data.
+		 * @return array Filtered array of email data.
+		 */
+		$this->emails = apply_filters( 'sensei_emails_email_data', $this->email_data->get_email_data() );
+	}
+
+	/**
+	 * Create email.
+	 *
+	 * @internal
+	 *
+	 * @param string $identifier Email identifier.
+	 * @param bool   $force      Force creation.
+	 *
+	 * @return bool
+	 */
+	public function create_email( string $identifier, bool $force = false ): bool {
+		$email_exists = $this->email_repository->has( $identifier );
+		if ( $email_exists ) {
+			if ( ! $force ) {
+				return false;
+			}
+
+			$this->email_repository->delete( $identifier );
+		}
+
+		$email_data = $this->emails[ $identifier ] ?? [];
+		if ( empty( $email_data ) ) {
+			return false;
+		}
+
+		$types = $email_data['types'] ?? [];
+		if ( empty( $types ) ) {
+			return false;
+		}
+
+		$subject = $email_data['subject'] ?? '';
+		if ( empty( $subject ) ) {
+			return false;
+		}
+
+		$content = $email_data['content'] ?? '';
+		if ( empty( $content ) ) {
+			return false;
+		}
+
+		$description = $email_data['description'] ?? '';
+
+		$email_id = $this->email_repository->create( $identifier, $types, $subject, $description, $content );
+
+		return is_int( $email_id) && $email_id > 0;
+	}
+
+	/**
+	 * Create all emails from templates.
+	 *
+	 * @internal
+	 *
+	 * @param bool $force Delete an old email if exists and re-create it with default data.
+	 * @return bool
+	 */
+	public function create_all( $force = false ): bool {
+		$result = true;
+		foreach ( $this->get_email_identifiers() as $type ) {
+			$last_result = $this->create_email( $type, $force );
+			if ( ! $last_result ) {
+				$result = false;
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Get all available email identifiers.
+	 *
+	 * @return array
+	 */
+	private function get_email_identifiers(): array {
+		return array_keys( $this->emails );
+	}
+}

--- a/includes/internal/emails/class-template-wizard.php
+++ b/includes/internal/emails/class-template-wizard.php
@@ -118,7 +118,7 @@ class Template_Wizard {
 
 		$email_id = $this->email_repository->create( $identifier, $types, $subject, $description, $content );
 
-		return is_int( $email_id) && $email_id > 0;
+		return is_int( $email_id ) && $email_id > 0;
 	}
 
 	/**

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -67,7 +67,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 					'post_type'      => Email_Post_Type::POST_TYPE,
 					'posts_per_page' => 20,
 					'offset'         => 20,
-					'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_key'       => '_sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'orderby'        => 'meta_value',
 					'order'          => 'ASC',
 				]
@@ -94,11 +94,11 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 					'offset'         => 0,
 					'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						[
-							'key'   => 'sensei_email_type',
+							'key'   => '_sensei_email_type',
 							'value' => 'student',
 						],
 					],
-					'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_key'       => '_sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'orderby'        => 'meta_value',
 					'order'          => 'ASC',
 				]
@@ -123,7 +123,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 					'post_type'      => Email_Post_Type::POST_TYPE,
 					'posts_per_page' => 20,
 					'offset'         => 0,
-					'meta_key'       => 'sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_key'       => '_sensei_email_description', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'orderby'        => 'meta_value',
 					'order'          => 'ASC',
 				]
@@ -181,7 +181,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table = new Email_List_Table();
 		$post_id    = $this->factory->email->create();
 
-		update_post_meta( $post_id, 'sensei_email_description', 'description' );
+		update_post_meta( $post_id, '_sensei_email_description', 'description' );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -200,7 +200,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table = new Email_List_Table();
 		$post       = $this->factory->email->create_and_get();
 
-		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
+		update_post_meta( $post->ID, '_sensei_email_description', 'description' );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -226,7 +226,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table = new Email_List_Table();
 		$post_id    = $this->factory->email->create( [ 'post_title' => '' ] );
 
-		update_post_meta( $post_id, 'sensei_email_description', 'description' );
+		update_post_meta( $post_id, '_sensei_email_description', 'description' );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -244,7 +244,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$list_table = new Email_List_Table();
 		$post_id    = $this->factory->email->create();
 
-		update_post_meta( $post_id, 'sensei_email_description', 'Welcome Student' );
+		update_post_meta( $post_id, '_sensei_email_description', 'Welcome Student' );
 
 		/* Act. */
 		$list_table->prepare_items();
@@ -266,7 +266,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 			]
 		);
 
-		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
+		update_post_meta( $post->ID, '_sensei_email_description', 'description' );
 
 		/* Act. */
 		$list_table->prepare_items();

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -11,6 +11,13 @@ use Sensei_Factory;
  * @covers \Sensei\Internal\Emails\Email_Settings_Tab
  */
 class Email_Settings_Tab_Test extends \WP_UnitTestCase {
+	/**
+	 * Factory for creating test data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
@@ -61,8 +68,8 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'student';
 
-		update_post_meta( $post->ID, 'sensei_email_type', 'student' );
-		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
+		update_post_meta( $post->ID, '_sensei_email_type', 'student' );
+		update_post_meta( $post->ID, '_sensei_email_description', 'description' );
 
 		/* Act. */
 		$content = $email_settings_tab->get_content( 'email-notification-settings' );
@@ -77,7 +84,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'student';
 
-		update_post_meta( $post->ID, 'sensei_email_type', 'teacher' );
+		update_post_meta( $post->ID, '_sensei_email_type', 'teacher' );
 
 		/* Act. */
 		$content = $email_settings_tab->get_content( 'email-notification-settings' );
@@ -92,8 +99,8 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'teacher';
 
-		update_post_meta( $post->ID, 'sensei_email_type', 'teacher' );
-		update_post_meta( $post->ID, 'sensei_email_description', 'description' );
+		update_post_meta( $post->ID, '_sensei_email_type', 'teacher' );
+		update_post_meta( $post->ID, '_sensei_email_description', 'description' );
 
 		/* Act. */
 		$content = $email_settings_tab->get_content( 'email-notification-settings' );
@@ -108,7 +115,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		$email_settings_tab = new Email_Settings_Tab();
 		$_GET['subtab']     = 'teacher';
 
-		update_post_meta( $post->ID, 'sensei_email_type', 'student' );
+		update_post_meta( $post->ID, '_sensei_email_type', 'student' );
 
 		/* Act. */
 		$content = $email_settings_tab->get_content( 'email-notification-settings' );


### PR DESCRIPTION
Fixes part of #6509 

Tests and some minor changes are expected in a separate PR.

### Changes proposed in this Pull Request

* Adds creation of default emails to Sensei_Updates
* Add a tool for default emails creation.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
* Go to Sensei LMS -> Tools -> Re-create Emails -> Run Action.
* Go to Sensei LMS -> Settings -> Emails.
* Check emails exist.

### New/Updated Hooks

* `sensei_emails_email_data` - Filters email data.


### Screenshot / Video
<img width="1680" alt="CleanShot 2023-02-20 at 01 23 32@2x" src="https://user-images.githubusercontent.com/329356/219967668-521e5203-3eba-4746-98f1-c5ac518b4a71.png">
<img width="1680" alt="CleanShot 2023-02-20 at 01 26 22@2x" src="https://user-images.githubusercontent.com/329356/219967679-4fcae274-9843-4591-b85e-749bc18eb799.png">
