### PR TITLE
Update node + npm version

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,8 +8,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - name: Updates the npm version
-              run: npm install -g npm@^8
             - name: npm install, and build docs
               run: |
                   npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,6 @@ jobs:
               id: composer-cache
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-            - name: Updates the npm version
-              run: npm install -g npm@^8
-
             - uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -55,9 +55,6 @@ jobs:
             -   name: Run tests with coverage
                 run: php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover ./coverage.xml
 
-            -   name: Updates the npm version
-                run: npm install -g npm@^8
-
             -   uses: actions/cache@v3
                 with:
                     path: ~/.npm

--- a/.github/workflows/dependencies-report.yml
+++ b/.github/workflows/dependencies-report.yml
@@ -21,8 +21,6 @@ jobs:
                 with:
                     path: ${{ github.workspace }}/assets/dist
                     key: ${{ runner.os }}-dist-${{ steps.trunk-commit.outputs.commit }}
-            -   name: Updates the npm version
-                run: npm install -g npm@^8
                 if: steps.dist-cache.outputs.cache-hit != 'true'
             -   name: Get npm cache directory
                 id: npm-cache

--- a/.github/workflows/dependencies-report.yml
+++ b/.github/workflows/dependencies-report.yml
@@ -64,8 +64,6 @@ jobs:
                     key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
                     restore-keys: |
                         ${{ runner.os }}-node-
-            -   name: Updates the npm version
-                run: npm install -g npm@^8
             -   name: Install JS dependencies
                 run: npm ci
             -   name: Build Combined Assets

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,10 +20,7 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v3
-
-            - name: Updates the npm version
-              run: npm install -g npm@^8
-
+              
             - name: Install dependencies
               run: npm ci
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -10,10 +10,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-
-            - name: Updates the CI npm
-              run: npm install -g npm@^8
-
             - uses: actions/cache@v3
               with:
                   path: ~/.npm/

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -30,10 +30,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-
-            - name: Updates the CI npm
-              run: npm install -g npm@8.9.0
-
             - uses: actions/cache@v3
               with:
                   path: ~/.npm/
@@ -53,10 +49,6 @@ jobs:
         steps:
             # clone the repository
             - uses: actions/checkout@v3
-
-            - name: Updates the npm version
-              run: npm install -g npm@^8
-
             - uses: actions/cache@v3
               with:
                   path: ~/.npm

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -45,12 +45,16 @@ export function CourseCategoryEdit( props ) {
 		blockEditorStore
 	);
 
-	useEffect( () => {
-		if ( options ) {
-			setBackgroundColor( options.backgroundColor );
-			setTextColor( options.textColor );
-		}
-	}, [] );
+	useEffect(
+		() => {
+			if ( options ) {
+				setBackgroundColor( options.backgroundColor );
+				setTextColor( options.textColor );
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
 
 	// We need to store the colors inside the option attribute because
 	// by default the root backgroundColor and textColor are overwritten by

--- a/assets/blocks/course-categories-block/utils/style.test.js
+++ b/assets/blocks/course-categories-block/utils/style.test.js
@@ -1,7 +1,6 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-
 import { getStyleAndClassesFromAttributes } from './style';
 
 describe( 'useCourseCategoriesProps', () => {

--- a/assets/blocks/course-list-block/featured-label/index.test.js
+++ b/assets/blocks/course-list-block/featured-label/index.test.js
@@ -7,6 +7,9 @@ import { render } from '@testing-library/react';
  */
 import FeaturedLabel from '.';
 
+/**
+ * WordPress dependencies
+ */
 import { useEntityProp } from '@wordpress/core-data';
 import { when } from 'jest-when';
 

--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -144,16 +144,20 @@ export const ModuleEdit = ( props ) => {
 		);
 	}
 
-	useEffect( () => {
-		const courseTeacherInput = document.querySelector(
-			'select[name="sensei-course-teacher-author"]'
-		);
-		if ( courseTeacherInput ) {
-			courseTeacherInput.addEventListener( 'change', ( event ) => {
-				setAttributes( { teacherId: event.target.value } );
-			} );
-		}
-	}, [] );
+	useEffect(
+		() => {
+			const courseTeacherInput = document.querySelector(
+				'select[name="sensei-course-teacher-author"]'
+			);
+			if ( courseTeacherInput ) {
+				courseTeacherInput.addEventListener( 'change', ( event ) => {
+					setAttributes( { teacherId: event.target.value } );
+				} );
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
 
 	const bordered =
 		undefined !== borderedSelected ? borderedSelected : outlineBordered;

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@babel/cli": "7.13.14",
         "@babel/core": "7.17.12",
         "@babel/preset-env": "7.17.12",
-        "@babel/runtime": "7.17.9",
+        "@babel/runtime": "7.20.0",
         "@es-joy/jsdoccomment": "0.36.1",
         "@lifeomic/attempt": "3.0.3",
         "@playwright/test": "1.28.0",
@@ -97,7 +97,7 @@
       },
       "engines": {
         "node": "^18.14.0",
-        "npm": "^8.19.4"
+        "npm": "^9.3.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3438,11 +3438,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.0.tgz",
+      "integrity": "sha512-NDYdls71fTXoU8TZHfbBWg7DiZfNzClcKui/+kyi6ppD2L1qnWW3VV6CjtaBXSUGGhiTWJ6ereOIkUvenif66Q==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -34804,8 +34804,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.5",
-      "license": "MIT"
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -41801,11 +41802,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.0.tgz",
+      "integrity": "sha512-NDYdls71fTXoU8TZHfbBWg7DiZfNzClcKui/+kyi6ppD2L1qnWW3VV6CjtaBXSUGGhiTWJ6ereOIkUvenif66Q==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/runtime-corejs3": {
@@ -64353,7 +64354,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5"
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
       },
       "engines": {
         "node": "^18.14.0",
-        "npm": "^9.5.0"
+        "npm": "^8.19.4"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@babel/core": "7.17.12",
         "@babel/preset-env": "7.17.12",
         "@babel/runtime": "7.17.9",
-        "@es-joy/jsdoccomment": "0.8.0",
+        "@es-joy/jsdoccomment": "0.36.1",
         "@lifeomic/attempt": "3.0.3",
         "@playwright/test": "1.28.0",
         "@svgr/webpack": "6.1.2",
@@ -73,7 +73,7 @@
         "eslint-config-prettier": "8.1.0",
         "eslint-import-resolver-typescript": "3.5.2",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jsdoc": "35.4.1",
+        "eslint-plugin-jsdoc": "39.3.1",
         "eslint-plugin-playwright": "0.11.1",
         "expect-puppeteer": "4.4.0",
         "gettext-parser": "4.0.4",
@@ -96,8 +96,8 @@
         "wp-hookdoc": "0.2.0"
       },
       "engines": {
-        "node": "^16.14.0",
-        "npm": "^8.9.0"
+        "node": "^18.14.0",
+        "npm": "^9.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3751,16 +3751,26 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.8.0",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "comment-parser": "^1.1.5",
+        "comment-parser": "1.3.1",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "1.0.4"
+        "jsdoc-type-pratt-parser": "~3.1.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -11245,15 +11255,6 @@
         }
       }
     },
-    "node_modules/@wordpress/eslint-plugin/node_modules/comment-parser": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
-      "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/@wordpress/eslint-plugin/node_modules/cosmiconfig": {
       "version": "7.0.0",
       "dev": true,
@@ -11269,23 +11270,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@wordpress/eslint-plugin/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@wordpress/eslint-plugin/node_modules/eslint-config-prettier": {
       "version": "7.2.0",
       "dev": true,
@@ -11295,27 +11279,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc": {
-      "version": "30.7.13",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz",
-      "integrity": "sha512-YM4WIsmurrp0rHX6XiXQppqKB8Ne5ATiZLJe2+/fkp9l9ExXFr43BbAbjZaVrpCT+tuPYOZ8k1MICARHnURUNQ==",
-      "dev": true,
-      "dependencies": {
-        "comment-parser": "^0.7.6",
-        "debug": "^4.3.1",
-        "jsdoctypeparser": "^9.0.0",
-        "lodash": "^4.17.20",
-        "regextras": "^0.7.1",
-        "semver": "^7.3.4",
-        "spdx-expression-parse": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/import-fresh": {
@@ -11332,12 +11295,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/parse-json": {
       "version": "5.2.0",
@@ -11368,36 +11325,12 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/@wordpress/eslint-plugin/node_modules/regextras": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.14"
-      }
-    },
     "node_modules/@wordpress/eslint-plugin/node_modules/resolve-from": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@wordpress/hooks": {
@@ -12558,20 +12491,6 @@
         "react-dom": "^17.0.0"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/@es-joy/jsdoccomment": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
-      "integrity": "sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==",
-      "dev": true,
-      "dependencies": {
-        "comment-parser": "1.3.0",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~2.2.3"
-      },
-      "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -13191,15 +13110,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/comment-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/core-js": {
       "version": "3.22.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz",
@@ -13497,28 +13407,6 @@
         "jest": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint-plugin-jsdoc": {
-      "version": "37.9.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
-      "integrity": "sha512-8alON8yYcStY94o0HycU2zkLKQdcS+qhhOUNQpfONHHwvI99afbmfpYuPqf6PbLz5pLZldG3Te5I0RbAiTN42g==",
-      "dev": true,
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.20.1",
-        "comment-parser": "1.3.0",
-        "debug": "^4.3.3",
-        "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "regextras": "^0.8.0",
-        "semver": "^7.3.5",
-        "spdx-expression-parse": "^3.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/eslint-scope": {
@@ -13958,15 +13846,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/jsdoc-type-pratt-parser": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-      "integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
@@ -20001,31 +19880,40 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "35.4.1",
+      "version": "39.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.1.tgz",
+      "integrity": "sha512-EVee7DW7mIKjQ+i86O3sV8n1BdXXiBo0gqY7S7TYTMEBzZoo4B/xNg0fl+b9ktIJtj6H0einhO3eMpwY2jyJRg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "^0.8.0",
-        "comment-parser": "1.1.5",
-        "debug": "^4.3.1",
+        "@es-joy/jsdoccomment": "~0.31.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "^1.0.4",
-        "lodash": "^4.17.21",
-        "regextras": "^0.8.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^14 || ^16 || ^17 || ^18"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
-      "version": "4.3.2",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -20038,15 +19926,29 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-jsdoc/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.3.5",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -28902,9 +28804,10 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "1.0.4",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -28923,18 +28826,6 @@
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jsdoctypeparser": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
-      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
-      "dev": true,
-      "bin": {
-        "jsdoctypeparser": "bin/jsdoctypeparser"
       },
       "engines": {
         "node": ">=10"
@@ -34985,14 +34876,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/regextras": {
-      "version": "0.8.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.14"
       }
     },
     "node_modules/regjsgen": {
@@ -42152,12 +42035,22 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.8.0",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
       "dev": true,
       "requires": {
-        "comment-parser": "^1.1.5",
+        "comment-parser": "1.3.1",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "1.0.4"
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      },
+      "dependencies": {
+        "comment-parser": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+          "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+          "dev": true
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -47768,7 +47661,7 @@
         "eslint-config-prettier": "^7.1.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jest": "^24.1.3",
-        "eslint-plugin-jsdoc": "^30.7.13",
+        "eslint-plugin-jsdoc": "39.3.1",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-prettier": "^3.3.0",
         "eslint-plugin-react": "^7.22.0",
@@ -47778,12 +47671,6 @@
         "requireindex": "^1.2.0"
       },
       "dependencies": {
-        "comment-parser": {
-          "version": "0.7.6",
-          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
-          "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
-          "dev": true
-        },
         "cosmiconfig": {
           "version": "7.0.0",
           "dev": true,
@@ -47795,34 +47682,10 @@
             "yaml": "^1.10.0"
           }
         },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "eslint-config-prettier": {
           "version": "7.2.0",
           "dev": true,
           "requires": {}
-        },
-        "eslint-plugin-jsdoc": {
-          "version": "30.7.13",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz",
-          "integrity": "sha512-YM4WIsmurrp0rHX6XiXQppqKB8Ne5ATiZLJe2+/fkp9l9ExXFr43BbAbjZaVrpCT+tuPYOZ8k1MICARHnURUNQ==",
-          "dev": true,
-          "requires": {
-            "comment-parser": "^0.7.6",
-            "debug": "^4.3.1",
-            "jsdoctypeparser": "^9.0.0",
-            "lodash": "^4.17.20",
-            "regextras": "^0.7.1",
-            "semver": "^7.3.4",
-            "spdx-expression-parse": "^3.0.1"
-          }
         },
         "import-fresh": {
           "version": "3.3.0",
@@ -47831,12 +47694,6 @@
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         },
         "parse-json": {
           "version": "5.2.0",
@@ -47852,24 +47709,9 @@
           "version": "npm:wp-prettier@2.2.1-beta-1",
           "dev": true
         },
-        "regextras": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-          "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "4.0.0",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -48801,17 +48643,6 @@
         "webpack-dev-server": "^4.4.0"
       },
       "dependencies": {
-        "@es-joy/jsdoccomment": {
-          "version": "0.20.1",
-          "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
-          "integrity": "sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==",
-          "dev": true,
-          "requires": {
-            "comment-parser": "1.3.0",
-            "esquery": "^1.4.0",
-            "jsdoc-type-pratt-parser": "~2.2.3"
-          }
-        },
         "@eslint/eslintrc": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -49081,7 +48912,7 @@
             "eslint-config-prettier": "^8.3.0",
             "eslint-plugin-import": "^2.25.2",
             "eslint-plugin-jest": "^25.2.3",
-            "eslint-plugin-jsdoc": "^37.0.3",
+            "eslint-plugin-jsdoc": "39.3.1",
             "eslint-plugin-jsx-a11y": "^6.5.1",
             "eslint-plugin-prettier": "^3.3.0",
             "eslint-plugin-react": "^7.27.0",
@@ -49227,12 +49058,6 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
           "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-          "dev": true
-        },
-        "comment-parser": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-          "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
           "dev": true
         },
         "core-js": {
@@ -49470,22 +49295,6 @@
           "dev": true,
           "requires": {
             "@typescript-eslint/experimental-utils": "^5.0.0"
-          }
-        },
-        "eslint-plugin-jsdoc": {
-          "version": "37.9.7",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
-          "integrity": "sha512-8alON8yYcStY94o0HycU2zkLKQdcS+qhhOUNQpfONHHwvI99afbmfpYuPqf6PbLz5pLZldG3Te5I0RbAiTN42g==",
-          "dev": true,
-          "requires": {
-            "@es-joy/jsdoccomment": "~0.20.1",
-            "comment-parser": "1.3.0",
-            "debug": "^4.3.3",
-            "escape-string-regexp": "^4.0.0",
-            "esquery": "^1.4.0",
-            "regextras": "^0.8.0",
-            "semver": "^7.3.5",
-            "spdx-expression-parse": "^3.0.1"
           }
         },
         "eslint-scope": {
@@ -49787,12 +49596,6 @@
           "requires": {
             "argparse": "^2.0.1"
           }
-        },
-        "jsdoc-type-pratt-parser": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-          "integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
-          "dev": true
         },
         "json-schema-traverse": {
           "version": "1.0.0",
@@ -54192,33 +53995,51 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "35.4.1",
+      "version": "39.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.1.tgz",
+      "integrity": "sha512-EVee7DW7mIKjQ+i86O3sV8n1BdXXiBo0gqY7S7TYTMEBzZoo4B/xNg0fl+b9ktIJtj6H0einhO3eMpwY2jyJRg==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "^0.8.0",
-        "comment-parser": "1.1.5",
-        "debug": "^4.3.1",
+        "@es-joy/jsdoccomment": "0.36.1",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "^1.0.4",
-        "lodash": "^4.17.21",
-        "regextras": "^0.8.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "spdx-expression-parse": "^3.0.1"
       },
       "dependencies": {
+        "comment-parser": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+          "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+          "dev": true
+        },
         "debug": {
-          "version": "4.3.2",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -60289,13 +60110,9 @@
       }
     },
     "jsdoc-type-pratt-parser": {
-      "version": "1.0.4",
-      "dev": true
-    },
-    "jsdoctypeparser": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
-      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
       "dev": true
     },
     "jsdom": {
@@ -64588,10 +64405,6 @@
         "unicode-match-property-ecmascript": "^2.0.0",
         "unicode-match-property-value-ecmascript": "^2.0.0"
       }
-    },
-    "regextras": {
-      "version": "0.8.0",
-      "dev": true
     },
     "regjsgen": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/cli": "7.13.14",
     "@babel/core": "7.17.12",
     "@babel/preset-env": "7.17.12",
-    "@babel/runtime": "7.17.9",
+    "@babel/runtime": "7.20.0",
     "@es-joy/jsdoccomment": "0.36.1",
     "@lifeomic/attempt": "3.0.3",
     "@playwright/test": "1.28.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Automattic/sensei/issues"
   },
   "engines": {
-    "npm": "^8.19.4",
+    "npm": "^9.3.1",
     "node": "^18.14.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Automattic/sensei/issues"
   },
   "engines": {
-    "npm": "^9.5.0",
+    "npm": "^8.19.4",
     "node": "^18.14.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/Automattic/sensei/issues"
   },
   "engines": {
-    "npm": "^8.9.0",
-    "node": "^16.14.0"
+    "npm": "^9.5.0",
+    "node": "^18.14.0"
   },
   "dependencies": {
     "@wordpress/api-fetch": "wp-5.9",
@@ -54,7 +54,9 @@
   "overrides": {
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "@wordpress/element": "$@wordpress/element"
+    "@wordpress/element": "$@wordpress/element",
+    "@es-joy/jsdoccomment": "0.36.1",
+    "eslint-plugin-jsdoc": "39.3.1"
   },
   "devDependencies": {
     "@automattic/calypso-build": "10.0.0",
@@ -62,7 +64,7 @@
     "@babel/core": "7.17.12",
     "@babel/preset-env": "7.17.12",
     "@babel/runtime": "7.17.9",
-    "@es-joy/jsdoccomment": "0.8.0",
+    "@es-joy/jsdoccomment": "0.36.1",
     "@lifeomic/attempt": "3.0.3",
     "@playwright/test": "1.28.0",
     "@svgr/webpack": "6.1.2",
@@ -90,7 +92,7 @@
     "eslint-config-prettier": "8.1.0",
     "eslint-import-resolver-typescript": "3.5.2",
     "eslint-plugin-import": "2.26.0",
-    "eslint-plugin-jsdoc": "35.4.1",
+    "eslint-plugin-jsdoc": "39.3.1",
     "eslint-plugin-playwright": "0.11.1",
     "expect-puppeteer": "4.4.0",
     "gettext-parser": "4.0.4",


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Fix the pipeline issue 
* Update the npm + node engine to use the current node LTS
* Update some dev dependencies that were not supporting the current node LTS.
* Update formatting on some files to cover issues introduced by the new linter version


### Extra Notes
1. The dependency report step will not work until we merge this PR on the trunk. 

## Testing instructions 
- Install the node lts/hydrogen  `nvm install lts/hydrogen` 
- Check if the npm version was updated
- Clean up the current node module
- Run fresh `npm install` 
- Run the `npm run start` 
- Check on the browser if the project is running. 
- Run all javascript tests
