### PR TITLE
Add reply to setting for email and email type input

### DIFF
--- a/changelog/add-reply-to-setting-for-email
+++ b/changelog/add-reply-to-setting-for-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Reply To setting for email

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -602,7 +602,9 @@ class Sensei_Settings_API {
 	public function form_field_text( $args ) {
 		$options = $this->get_settings();
 
-		echo '<input id="' . esc_attr( $args['key'] ) . '" name="' . esc_attr( $this->token ) . '[' . esc_attr( $args['key'] ) . ']" size="40" type="text" value="' . esc_attr( $options[ $args['key'] ] ) . '" />' . "\n";
+		$type = in_array( $args['data']['type'] ?? '', [ 'email', 'text' ], true ) ? $args['data']['type'] : 'text';
+
+		echo '<input id="' . esc_attr( $args['key'] ) . '" name="' . esc_attr( $this->token ) . '[' . esc_attr( $args['key'] ) . ']" size="40" type="' . esc_attr( $type ) . '" value="' . esc_attr( $options[ $args['key'] ] ) . '" />' . "\n";
 		if ( isset( $args['data']['description'] ) ) {
 			echo '<span class="description">' . wp_kses_post( $args['data']['description'] ) . '</span>' . "\n";
 		}

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -716,7 +716,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$fields['email_from_address'] = array(
 			'name'        => __( '"From" Address', 'sensei-lms' ),
 			'description' => __( 'The address from which all emails will be sent.', 'sensei-lms' ),
-			'type'        => 'text',
+			'type'        => 'email',
 			'default'     => get_bloginfo( 'admin_email' ),
 			'section'     => 'email-notification-settings',
 			'required'    => 1,

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -44,6 +44,7 @@ class Email_Settings_Tab {
 	public function init() {
 		add_action( 'sensei_settings_after_links', [ $this, 'render_tabs' ] );
 		add_filter( 'sensei_settings_content', [ $this, 'get_content' ], 10, 2 );
+		add_filter( 'sensei_settings_fields', [ $this, 'add_reply_to_setting' ] );
 	}
 
 	/**
@@ -193,10 +194,11 @@ class Email_Settings_Tab {
 		$fields_to_display = array_filter(
 			$wp_settings_fields['sensei-settings']['email-notification-settings'] ?? [],
 			function( $field_key ) {
-				return in_array( $field_key, [ 'email_from_name', 'email_from_address' ], true );
+				return in_array( $field_key, [ 'email_from_name', 'email_from_address', 'email_reply_to_address' ], true );
 			},
 			ARRAY_FILTER_USE_KEY
 		);
+
 		$fields_to_display = array_map(
 			function( $field ) {
 				unset( $field['args']['data']['description'] );
@@ -204,6 +206,7 @@ class Email_Settings_Tab {
 				if ( $class ) {
 					$class = ' class="' . esc_attr( $field['args']['class'] ) . '"';
 				}
+
 				$field['args']['class'] = $class;
 				return $field;
 			},
@@ -211,7 +214,7 @@ class Email_Settings_Tab {
 		);
 
 		$options = $this->settings->get_settings() ?? [];
-		unset( $options['email_from_name'], $options['email_from_address'] );
+		unset( $options['email_from_name'], $options['email_from_address'], $options['email_reply_to_address'] );
 
 		include dirname( __FILE__ ) . '/views/html-settings.php';
 	}
@@ -230,5 +233,27 @@ class Email_Settings_Tab {
 				echo '<input name="sensei-settings[' . esc_attr( $key ) . '][]" type="hidden" value="' . esc_attr( $v ) . '" />' . "\n";
 			}
 		}
+	}
+
+	/**
+	 * Add the Reply To email address setting field.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 *
+	 * @param array $fields The fields to add to.
+	 *
+	 * @return array The fields with the Reply To email address field added.
+	 */
+	public function add_reply_to_setting( $fields ) {
+		$fields['email_reply_to_address'] = [
+			'name'     => __( '"Reply To" Address', 'sensei-lms' ),
+			'type'     => 'email',
+			'default'  => get_bloginfo( 'admin_email' ),
+			'section'  => 'email-notification-settings',
+			'required' => 0,
+		];
+
+		return $fields;
 	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -276,4 +276,25 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		self::assertStringContainsString( '<input id="email_reply_to_address" name="sensei-settings[email_reply_to_address]" size="40" type="email"', $content );
 	}
+
+	public function testTabContent_WhenInSettingsSubtab_HasEmailFromAddressAsTypeEmail() {
+		/* Arrange. */
+		$settings = $this->createMock( Sensei_Settings::class );
+		$settings
+			->method( 'get_settings' )
+			->willReturn(
+				[
+					'email_from_address' => 'a',
+				]
+			);
+
+		$email_settings_tab = new Email_Settings_Tab( $settings );
+		$_GET['subtab']     = 'settings';
+
+		/* Act. */
+		$content = $email_settings_tab->get_content( 'email-notification-settings' );
+
+		/* Assert. */
+		self::assertStringContainsString( '<input id="email_from_address" name="sensei-settings[email_from_address]" size="40" type="email"', $content );
+	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -237,4 +237,16 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		self::assertStringContainsString( '<input type="submit" name="submit" ', $content );
 	}
+
+	public function testSetting_WhenLoaded_AddsTheReplyToSettingFilterHook() {
+		/* Arrange. */
+		$settings           = $this->createMock( Sensei_Settings::class );
+		$email_settings_tab = new Email_Settings_Tab( $settings );
+
+		/* Act. */
+		$email_settings_tab->init();
+
+		/* Assert. */
+		self::assertEquals( 10, has_filter( 'sensei_settings_fields', [ $email_settings_tab, 'add_reply_to_setting' ] ) );
+	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -238,7 +238,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		self::assertStringContainsString( '<input type="submit" name="submit" ', $content );
 	}
 
-	public function testSetting_WhenLoaded_AddsTheReplyToSettingFilterHook() {
+	public function testInit_WhenLoaded_AddsTheReplyToSettingFilterHook() {
 		/* Arrange. */
 		$settings           = $this->createMock( Sensei_Settings::class );
 		$email_settings_tab = new Email_Settings_Tab( $settings );

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -249,4 +249,31 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		self::assertEquals( 10, has_filter( 'sensei_settings_fields', [ $email_settings_tab, 'add_reply_to_setting' ] ) );
 	}
+
+	public function testTabContent_WhenInSettingsSubtab_HasReplyToInContent() {
+		/* Arrange. */
+		$settings = $this->createMock( Sensei_Settings::class );
+		$settings
+			->method( 'get_settings' )
+			->willReturn(
+				[
+					'email_reply_to_address' => [
+						'name' => __( '"Reply To" Address', 'sensei-lms' ),
+						'type' => 'email',
+					],
+				]
+			);
+
+		$email_settings_tab = new Email_Settings_Tab( $settings );
+		$email_settings_tab->init();
+		Sensei()->settings->general_init();
+		Sensei()->settings->settings_fields();
+		$_GET['subtab'] = 'settings';
+
+		/* Act. */
+		$content = $email_settings_tab->get_content( 'email-notification-settings' );
+
+		/* Assert. */
+		self::assertStringContainsString( '<input id="email_reply_to_address" name="sensei-settings[email_reply_to_address]" size="40" type="email"', $content );
+	}
 }


### PR DESCRIPTION
Fixes #6534 

### Changes proposed in this Pull Request

* Added a `"Reply To" Address` sensei setting field
* Updated the setting field rendering code to enable validating email
* Updated type of Email From field

### Testing instructions

- Enable the feature flag using `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
- Go to Sensei LMS -> Settings -> Emails -> Settings
- Make sure you see `Reply To" Address` Field
- Make sure you can update it
- Write an invalid string in the input field, make sure it shows you a message pointing out that the address is invalid

### Screenshot / Video

Uploading Screen Recording 2023-02-22 at 1.07.15 PM.mov…