### PR TITLE
Remove align wide setting from blocks in GB editor for email post type

### DIFF
--- a/assets/blocks/email-editor.js
+++ b/assets/blocks/email-editor.js
@@ -22,24 +22,42 @@ export default function handleEmailBlocksEditor() {
 	 * @param {Object} settings Block settings.
 	 */
 	function removeIrrelevantSettings( settings ) {
+		const supports = { ...( settings.supports ? settings.supports : {} ) };
+
+		// Remove font family setting.
 		if (
 			has( settings, 'supports.typography.fontFamily' ) ||
 			has( settings, 'supports.typography.__experimentalFontFamily' )
 		) {
-			settings = {
-				...settings,
-				supports: {
-					...settings.supports,
-					typography: {
-						...settings.supports.typography,
-						__experimentalFontFamily: false,
-						fontFamily: false,
-					},
-				},
+			supports.typography = {
+				...supports.typography,
+				__experimentalFontFamily: false,
+				fontFamily: false,
 			};
 		}
 
-		return settings;
+		// Remove alignWide setting.
+		if (
+			has( settings, 'supports.alignWide' ) &&
+			settings.supports.alignWide
+		) {
+			supports.alignWide = false;
+		}
+
+		// Remove wide from align options.
+		if (
+			has( settings, 'supports.align.length' ) &&
+			settings.supports.align.length > 0
+		) {
+			supports.align = supports.align.filter( ( item ) => {
+				return item !== 'wide';
+			} );
+		}
+
+		return {
+			...settings,
+			supports,
+		};
 	}
 }
 

--- a/assets/blocks/email-editor.js
+++ b/assets/blocks/email-editor.js
@@ -37,10 +37,7 @@ export default function handleEmailBlocksEditor() {
 		}
 
 		// Remove alignWide setting.
-		if (
-			has( settings, 'supports.alignWide' ) &&
-			settings.supports.alignWide
-		) {
+		if ( has( settings, 'supports.alignWide' ) ) {
 			supports.alignWide = false;
 		}
 

--- a/assets/blocks/email-editor.js
+++ b/assets/blocks/email-editor.js
@@ -45,10 +45,7 @@ export default function handleEmailBlocksEditor() {
 		}
 
 		// Remove wide from align options.
-		if (
-			has( settings, 'supports.align.length' ) &&
-			settings.supports.align.length > 0
-		) {
+		if ( has( settings, 'supports.align.length' ) ) {
 			supports.align = supports.align.filter( ( item ) => {
 				return item !== 'wide';
 			} );

--- a/assets/blocks/email-editor.test.js
+++ b/assets/blocks/email-editor.test.js
@@ -108,4 +108,26 @@ describe( 'handleEmailBlocksEditor', () => {
 
 		expect( settingsOutput.supports.align ).toEqual( [ 'full' ] );
 	} );
+
+	it( 'should not throw any error if align is not there', () => {
+		let settingsOutput = {};
+
+		addFilter(
+			'blocks.registerBlockType',
+			'sensei-lms/email-blocks-test',
+			( settings ) => {
+				settingsOutput = settings;
+				return settings;
+			},
+			20
+		);
+
+		registerTestBlock( {
+			supports: {
+				align: undefined,
+			},
+		} );
+
+		expect( settingsOutput.supports.align ).toEqual( undefined );
+	} );
 } );

--- a/assets/blocks/email-editor.test.js
+++ b/assets/blocks/email-editor.test.js
@@ -90,4 +90,22 @@ describe( 'handleEmailBlocksEditor', () => {
 
 		expect( settingsOutput.supports.alignWide ).toBe( false );
 	} );
+
+	it( 'should remove wide option from align settings in supports', () => {
+		let settingsOutput = {};
+
+		addFilter(
+			'blocks.registerBlockType',
+			'sensei-lms/email-blocks-test',
+			( settings ) => {
+				settingsOutput = settings;
+				return settings;
+			},
+			20
+		);
+
+		registerTestBlock();
+
+		expect( settingsOutput.supports.align ).toEqual( [ 'full' ] );
+	} );
 } );

--- a/assets/blocks/email-editor.test.js
+++ b/assets/blocks/email-editor.test.js
@@ -21,6 +21,8 @@ const registerTestBlock = ( settings = {} ) => {
 			typography: {
 				__experimentalFontFamily: true,
 			},
+			alignWide: true,
+			align: [ 'wide', 'full' ],
 		},
 		...settings,
 	} );
@@ -69,5 +71,23 @@ describe( 'handleEmailBlocksEditor', () => {
 		expect(
 			settingsOutput.supports.typography.__experimentalFontFamily
 		).toBe( true );
+	} );
+
+	it( 'should change alignWide to false in supports', () => {
+		let settingsOutput = {};
+
+		addFilter(
+			'blocks.registerBlockType',
+			'sensei-lms/email-blocks-test',
+			( settings ) => {
+				settingsOutput = settings;
+				return settings;
+			},
+			20
+		);
+
+		registerTestBlock();
+
+		expect( settingsOutput.supports.alignWide ).toBe( false );
 	} );
 } );

--- a/changelog/add-remove-wide-width-setting-from-email-block
+++ b/changelog/add-remove-wide-width-setting-from-email-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Support for align wide in blocks inside email editor


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/6530

### Changes proposed in this Pull Request

* Remove alignWide support from blocks in email editor

### Testing instructions

- Enable the feature flag with `add_filter( 'sensei_feature_flag_email_customization', '__return_true' );`
- Try to create a new email or edit an existing email
- Add a block that should have wide align settings (group, heading etc)
- Make sure option to align wide is not appearing

### Screenshot / Video
## Before
<img width="849" alt="image" src="https://user-images.githubusercontent.com/6820724/220571668-16dd006a-8ec7-4f8a-a4c5-a76e83b57b71.png">

## After
<img width="849" alt="image" src="https://user-images.githubusercontent.com/6820724/220571833-e3ae2c22-ac4d-44f0-a012-8bccbf473dfd.png">