### PR TITLE
Disable relative css units for email templates

### DIFF
--- a/includes/internal/emails/class-email-blocks.php
+++ b/includes/internal/emails/class-email-blocks.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Emails;
 
+use \WP_Theme_JSON_Data;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -33,6 +35,24 @@ class Email_Blocks {
 		'core/buttons',
 	];
 
+	public const EMAIL_THEME_SETTINGS = [
+		'settings' => [
+			'typography' => [
+				'fluid'     => false,
+				'fontSizes' => [
+					'theme' => null,
+				],
+			],
+			'spacing'    =>
+				[
+					'units'        => 'px',
+					'spacingScale' => [
+						'steps' => 0,
+					],
+				],
+		],
+	];
+
 	/**
 	 * Initialize the class and add hooks.
 	 *
@@ -40,6 +60,8 @@ class Email_Blocks {
 	 */
 	public function init(): void {
 		add_filter( 'allowed_block_types_all', [ $this, 'set_allowed_blocks' ], 25, 2 );
+		add_filter( 'wp_theme_json_data_theme', [ $this, 'set_email_css_units' ], 25, 2 );
+
 		add_action( 'current_screen', [ $this, 'load_admin_assets' ] );
 	}
 
@@ -77,6 +99,32 @@ class Email_Blocks {
 
 		Sensei()->assets->enqueue( 'sensei-email-editor-setup', 'blocks/email-editor.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-email-editor-style', 'blocks/email-editor-style.css' );
+	}
+
+	/**
+	 * Set the allowed blocks.
+	 *
+	 * @internal
+	 * @access private
+	 *
+	 * @param WP_Theme_JSON_Data $theme       Original theme settings.
+	 *
+	 * @return WP_Theme_JSON_Data Updated theme settings.
+	 */
+	public function set_email_css_units( $theme ):\WP_Theme_JSON_Data {
+
+		if ( ! is_admin() ) {
+			return $theme;
+		}
+
+		$screen = get_current_screen();
+		if ( Email_Post_Type::POST_TYPE !== $screen->post_type ) {
+			return $theme;
+		}
+
+		$updated = $theme->update_with( self::EMAIL_THEME_SETTINGS );
+
+		return $updated;
 	}
 }
 

--- a/includes/internal/emails/class-email-blocks.php
+++ b/includes/internal/emails/class-email-blocks.php
@@ -36,6 +36,7 @@ class Email_Blocks {
 	];
 
 	public const EMAIL_THEME_SETTINGS = [
+		'version'  => 2,
 		'settings' => [
 			'typography' => [
 				'fluid'     => false,

--- a/includes/internal/emails/class-email-blocks.php
+++ b/includes/internal/emails/class-email-blocks.php
@@ -118,8 +118,13 @@ class Email_Blocks {
 			return $theme;
 		}
 
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return $theme;
+		}
+
 		$screen = get_current_screen();
-		if ( Email_Post_Type::POST_TYPE !== $screen->post_type ) {
+
+		if ( Email_Post_Type::POST_TYPE !== $screen->post_type || ! $screen->is_block_editor() ) {
 			return $theme;
 		}
 

--- a/tests/unit-tests/internal/emails/test-class-email-blocks.php
+++ b/tests/unit-tests/internal/emails/test-class-email-blocks.php
@@ -107,8 +107,9 @@ class Email_Blocks_Test extends \WP_UnitTestCase {
 
 	public function testSetEmailCssUnits_WhenCalledWithTheEmailPostType_ReturnsTheUpdatedTheme() {
 		/* Arrange. */
-		$blocks     = new Email_Blocks();
-		$theme_json = $this->createMock( 'WP_Theme_JSON_Data' );
+		$blocks             = new Email_Blocks();
+		$theme_json         = $this->createMock( 'WP_Theme_JSON_Data' );
+		$updated_theme_json = $this->createMock( 'WP_Theme_JSON_Data' );
 
 		$screen                  = \WP_Screen::get( 'edit-sensei_email' );
 		$screen->base            = 'edit-sensei_email';
@@ -119,22 +120,23 @@ class Email_Blocks_Test extends \WP_UnitTestCase {
 		$theme_json->expects( $this->once() )
 			->method( 'update_with' )
 			->with( Email_Blocks::EMAIL_THEME_SETTINGS )
-			->willReturn( 'updated' );
+			->willReturn( $updated_theme_json );
 
 		/* Act. */
-		$this->assertSame( 'updated', $blocks->set_email_css_units( $theme_json ) );
+		$this->assertSame( $updated_theme_json, $blocks->set_email_css_units( $theme_json ) );
 	}
 
 	public function testSetEmailCssUnits_WhenCalledWithTheOtherPostType_ReturnsTheOriginalTheme() {
 		/* Arrange. */
-		$blocks     = new Email_Blocks();
-		$theme_json = $this->createMock( 'WP_Theme_JSON_Data' );
+		$blocks             = new Email_Blocks();
+		$theme_json         = $this->createMock( 'WP_Theme_JSON_Data' );
+		$updated_theme_json = $this->createMock( 'WP_Theme_JSON_Data' );
 
 		$theme_json
 			->method( 'update_with' )
-			->willReturn( 'updated' );
+			->willReturn( $updated_theme_json );
 
 		/* Act. */
-		$this->assertNotSame( 'updated', $blocks->set_email_css_units( $theme_json ) );
+		$this->assertSame( $theme_json, $blocks->set_email_css_units( $theme_json ) );
 	}
 }


### PR DESCRIPTION
Resolves #6531 

## Proposed Changes
* Update the theme settings when the user is editing the sensei_email post type to disable the CSS relative units.

## Testing Instructions
- Edit an e-mail settings template
- Go to the Dimensions > margin | padding panel
- Check if it is only displaying PX as unit
- Go to the font size panel
- Check if it is only displaying PX as unit

<img width="274" alt="Screenshot 2023-02-22 at 18 46 57" src="https://user-images.githubusercontent.com/38718/220728719-d6d2de18-ee6b-4d20-9a40-b835f7db16a1.png">


<img width="275" alt="Screenshot 2023-02-22 at 18 46 14" src="https://user-images.githubusercontent.com/38718/220728528-169f2e80-06f4-4088-af89-7090d3c1c124.png">


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
- [x] Continuous Integration build is passing
