### PR TITLE
Run activation hooks in the background

### DIFF
--- a/changelog/fix-wizard-atomic
+++ b/changelog/fix-wizard-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Run activation hooks when plugin is activated in the background.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -314,9 +314,7 @@ class Sensei_Main {
 		$this->init();
 
 		// Installation
-		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
-			$this->install();
-		}
+		$this->install();
 
 		// Run this on deactivation.
 		register_deactivation_hook( $this->main_plugin_file_name, array( $this, 'deactivation' ) );
@@ -832,13 +830,21 @@ class Sensei_Main {
 	public function activate_sensei() {
 
 		if ( false === get_option( 'sensei_installed', false ) ) {
-			set_transient( 'sensei_activation_redirect', 1, 30 );
 
-			update_option( Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
+			// Do not enable the wizard for sites that are created with the onboarding flow.
+			if ( 'sensei' !== get_option( 'site_intent' ) ) {
+
+				set_transient( 'sensei_activation_redirect', 1, 30 );
+				update_option( Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
+
+			} else {
+				Sensei_Setup_Wizard::instance()->finish_setup_wizard();
+			}
+		} else {
+			return;
 		}
 
 		update_option( 'sensei_installed', 1 );
-
 	}
 
 	/**

--- a/tests/e2e-playwright/specs/admin/students/setup-wizard.spec.ts
+++ b/tests/e2e-playwright/specs/admin/students/setup-wizard.spec.ts
@@ -5,6 +5,7 @@ import { test, expect } from '@playwright/test';
 
 import PluginsPage from '@e2e/pages/admin/plugins/plugins';
 import { adminRole } from '@e2e/helpers/context';
+import { cli } from '@e2e/helpers/database';
 
 /**
  * This test suit is installing and installing the plugin to test some scenarios and
@@ -19,7 +20,7 @@ test.describe.serial( 'Setup Wizard @setup', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.goTo( 'admin.php?page=sensei_setup_wizard' );
+		cli( 'wp option delete sensei_installed' );
 	} );
 
 	test( 'opens when first activating the Sensei LMS plugin', async () => {


### PR DESCRIPTION
Resolves this issue: https://github.com/Automattic/sensei-pro/issues/2122

Previously we were running activation hooks in admin screens only. This would cause the hooks to not run when Sensei was activated in other ways (e.g. wp-cli, calypso etc.). With this fix we now run the activation hooks in every case. Additionally, I added some logic for the setup wizard to not be triggered in sites created with the onboarding flow.


## Testing Instructions
1. Deactivate Sensei
2. Run `wp option delete sensei_installed`
3. Run `wp plugin activate sensei-lms`
4. Observe that the `sensei_installed` option is set
5. Navigate to admin and observe that the setup wizard is suggested to run

Steps to simulate and test the onboarding flow:
1. Repeat steps 1 and 2
2. Run `wp option set site_intent sensei`
3. Run `wp plugin activate sensei-lms`
4. Navigate to admin and observe that the setup wizard is not suggested, neither you are redirected to it.