### PR TITLE
Redirect to email listing from standard custom post type listing

### DIFF
--- a/changelog/fix-redirect-to-email-list
+++ b/changelog/fix-redirect-to-email-list
@@ -1,5 +1,6 @@
 Significance: patch
 Type: fixed
-Comment: Fix redirect for email post type
+Comment: 
 
+Fix redirect for email post type
 

--- a/changelog/fix-redirect-to-email-list
+++ b/changelog/fix-redirect-to-email-list
@@ -1,6 +1,4 @@
 Significance: patch
 Type: fixed
-Comment: 
-
-Fix redirect for email post type
+Comment: Fix redirect for email post type
 

--- a/changelog/fix-redirect-to-email-list
+++ b/changelog/fix-redirect-to-email-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix redirect for email post type
+
+

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -31,6 +31,7 @@ class Email_Post_Type {
 	 */
 	public function init(): void {
 		add_action( 'init', [ $this, 'register_post_type' ] );
+		add_action( 'load-edit.php', [ $this, 'maybe_redirect_to_listing' ] );
 	}
 
 	/**
@@ -70,6 +71,21 @@ class Email_Post_Type {
 				'supports'     => [ 'title', 'editor', 'author', 'revisions' ],
 			]
 		);
+	}
+
+	/**
+	 * Redirect to the Email settings page if the user is trying to access the Email post type listing.
+	 *
+	 * @internal
+	 * @access private
+	 */
+	public function maybe_redirect_to_listing(): void {
+		if ( ! isset( $_GET['post_type'] ) || self::POST_TYPE !== $_GET['post_type'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		wp_safe_redirect( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ), 301 );
+		exit;
 	}
 }
 

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -10,6 +10,9 @@ use Sensei\Internal\Emails\Email_Post_Type;
  * @covers \Sensei\Internal\Emails\Email_Post_Type
  */
 class Email_Post_Type_Test extends \WP_UnitTestCase {
+
+	use \Sensei_Test_Redirect_Helpers;
+
 	public function testRegisterPostType_WhenCalled_RegistersEmailPostType() {
 		/* Arrange. */
 		$email_post_type = new Email_Post_Type();
@@ -31,5 +34,59 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$priority = has_action( 'init', [ $email_post_type, 'register_post_type' ] );
 		$this->assertSame( 10, $priority );
+	}
+
+	public function testInit_WhenCalled_AddsLoadEditAction() {
+		/* Arrange. */
+		$email_post_type = new Email_Post_Type();
+
+		/* Act. */
+		$email_post_type->init();
+
+		/* Assert. */
+		$priority = has_action( 'load-edit.php', [ $email_post_type, 'maybe_redirect_to_listing' ] );
+		$this->assertSame( 10, $priority );
+	}
+
+	public function testMaybeRedirectToListing_WhenCalledWithEmailPostType_RedirectsToEmailsPage() {
+		/* Arrange. */
+		$email_post_type   = new Email_Post_Type();
+		$_GET['post_type'] = 'sensei_email';
+		$this->prevent_wp_redirect();
+
+		/* Act. */
+		$redirect_status   = 0;
+		$redirect_location = '';
+		try {
+			$email_post_type->maybe_redirect_to_listing();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status   = $e->getCode();
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert. */
+		$this->assertSame( 301, $redirect_status );
+		$this->assertSame( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ), $redirect_location );
+	}
+
+	public function testMaybeRedirectToListing_WhenCalledWithNonEmailPostType_RedirectsToEmailsPage() {
+		/* Arrange. */
+		$email_post_type   = new Email_Post_Type();
+		$_GET['post_type'] = 'non_sensei_email';
+		$this->prevent_wp_redirect();
+
+		/* Act. */
+		$redirect_status   = 0;
+		$redirect_location = '';
+		try {
+			$email_post_type->maybe_redirect_to_listing();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status   = $e->getCode();
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert. */
+		$this->assertSame( 0, $redirect_status );
+		$this->assertSame( '', $redirect_location );
 	}
 }


### PR DESCRIPTION
Resolves #6561

## Proposed Changes
* Redirect from the standard post type listing to our custom listing in Email settings.

## Testing Instructions

1. Enable the feature flag: add_filter( 'sensei_feature_flag_email_customization', '__return_true' );
2. Go to Sensei LMS -> Settings -> Email.
3. Click on one of emails to go to the editor.
4. Click on the View Posts button (WP logo) in the top left corner.
5. Make sure you are navigated to the Email list in settings.

## Video

https://user-images.githubusercontent.com/329356/221513825-44de85d7-d379-4541-955c-74def881bbde.mp4



## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
