### PR TITLE
Replace old hook name with new hook name in tests

### DIFF
--- a/tests/unit-tests/internal/emails/test-class-email-generator.php
+++ b/tests/unit-tests/internal/emails/test-class-email-generator.php
@@ -122,7 +122,7 @@ class Email_Generator_Test extends \WP_UnitTestCase {
 		];
 
 		add_action(
-			'sensei_send_html_email',
+			'sensei_email_send',
 			function ( $email_name, $replacements ) use ( &$email_data ) {
 				$email_data['name'] = $email_name;
 				$email_data['data'] = $replacements;
@@ -165,7 +165,7 @@ class Email_Generator_Test extends \WP_UnitTestCase {
 		];
 
 		add_action(
-			'sensei_send_html_email',
+			'sensei_email_send',
 			function ( $email_name, $replacements ) use ( &$email_data ) {
 				$email_data['name'] = $email_name;
 				$email_data['data'] = $replacements;
@@ -203,7 +203,7 @@ class Email_Generator_Test extends \WP_UnitTestCase {
 		];
 
 		add_action(
-			'sensei_send_html_email',
+			'sensei_email_send',
 			function ( $email_name, $replacements ) use ( &$email_data ) {
 				$email_data['name'] = $email_name;
 				$email_data['data'] = $replacements;


### PR DESCRIPTION
## Proposed Changes
Replaces use of the old hook `sensei_send_html_email` with the new hook `sensei_email_send` in order to fix the build.

## Testing Instructions
Ensure the tests pass.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [x] Continuous Integration build is passing
