### PR TITLE
Use "reply to" settings on the new emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage.xml
 tests/e2e-playwright/contexts/*
 *.tsbuildinfo
 playwright-report/
+.vscode

--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -105,7 +105,7 @@ class Email_Customization {
 		$this->settings_menu      = new Settings_Menu();
 		$this->settings_tab       = new Email_Settings_Tab( $settings );
 		$this->blocks             = new Email_Blocks();
-		$this->email_sender       = new Email_Sender( $repository );
+		$this->email_sender       = new Email_Sender( $repository, $settings );
 		$this->email_generator    = new Email_Generator();
 		$this->list_table_actions = new Email_List_Table_Actions();
 		$this->patterns           = new Email_Patterns();

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -123,13 +123,12 @@ class Email_Sender {
 			'Content-Type: text/html; charset=UTF-8',
 		];
 
-		list(
-			'email_reply_to_address' => $reply_to_address,
-			'email_reply_to_name' => $reply_to_name
-		) = $this->settings->get_settings();
+		$settings = $this->settings->get_settings();
 
-		if ( ! empty( $reply_to_address ) ) {
-			$headers[] = "Reply-To: $reply_to_name <$reply_to_address>";
+		if ( ! empty( $settings['email_reply_to_address'] ) ) {
+			$reply_to_address = $settings['email_reply_to_address'];
+			$reply_to_name    = $settings['email_reply_to_name'] || '';
+			$headers[]        = "Reply-To: $reply_to_name <$reply_to_address>";
 		}
 
 		foreach ( $replacements as $recipient => $replacement ) {

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -36,9 +36,8 @@ class Email_Sender {
 	 */
 	private $repository;
 
-
 	/**
-	 * Email repository instance.
+	 * Email settings instance.
 	 *
 	 * @var Sensei_Settings
 	 */
@@ -48,10 +47,11 @@ class Email_Sender {
 	 * Email_Sender constructor.
 	 *
 	 * @param Email_Repository $repository Email repository instance.
+	 * @param Sensei_Settings  $settings Sensei settings instance.
 	 */
 	public function __construct( Email_Repository $repository, Sensei_Settings $settings ) {
 		$this->repository = $repository;
-		$this->settings = $settings;
+		$this->settings   = $settings;
 	}
 
 	/**
@@ -126,9 +126,9 @@ class Email_Sender {
 		list(
 			'email_reply_to_address' => $reply_to_address,
 			'email_reply_to_name' => $reply_to_name
-		  ) = $this->settings->get_settings();
+		) = $this->settings->get_settings();
 
-		if( !empty($reply_to_address) ) {
+		if ( ! empty( $reply_to_address ) ) {
 			$headers[] = "Reply-To: $reply_to_name <$reply_to_address>";
 		}
 

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -127,7 +127,7 @@ class Email_Sender {
 
 		if ( ! empty( $settings['email_reply_to_address'] ) ) {
 			$reply_to_address = $settings['email_reply_to_address'];
-			$reply_to_name    = $settings['email_reply_to_name'] || '';
+			$reply_to_name    = isset( $settings['email_reply_to_name'] ) ? $settings['email_reply_to_name'] : '';
 			$headers[]        = "Reply-To: $reply_to_name <$reply_to_address>";
 		}
 

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -119,18 +119,6 @@ class Email_Sender {
 
 		$subject_text = wp_strip_all_tags( $email_post->post_title );
 
-		$headers = [
-			'Content-Type: text/html; charset=UTF-8',
-		];
-
-		$settings = $this->settings->get_settings();
-
-		if ( ! empty( $settings['email_reply_to_address'] ) ) {
-			$reply_to_address = $settings['email_reply_to_address'];
-			$reply_to_name    = isset( $settings['email_reply_to_name'] ) ? $settings['email_reply_to_name'] : '';
-			$headers[]        = "Reply-To: $reply_to_name <$reply_to_address>";
-		}
-
 		foreach ( $replacements as $recipient => $replacement ) {
 			$email_body    = do_blocks( $email_post->post_content );
 			$email_subject = $subject_text;
@@ -147,7 +135,7 @@ class Email_Sender {
 				$recipient,
 				$email_subject,
 				$email_body,
-				$headers,
+				$this->get_email_headers(),
 				null
 			);
 		}
@@ -273,5 +261,25 @@ class Email_Sender {
 		}
 
 		return $header_styles;
+	}
+
+	/**
+	 * Return the email headers.
+	 *
+	 * @return array Headers.
+	 */
+	private function get_email_headers():array {
+		$settings = $this->settings->get_settings();
+		$headers  = [
+			'Content-Type: text/html; charset=UTF-8',
+		];
+
+		if ( ! empty( $settings['email_reply_to_address'] ) ) {
+			$reply_to_address = $settings['email_reply_to_address'];
+			$reply_to_name    = isset( $settings['email_reply_to_name'] ) ? $settings['email_reply_to_name'] : '';
+			$headers[]        = "Reply-To: $reply_to_name <$reply_to_address>";
+		}
+
+		return $headers;
 	}
 }

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -201,7 +201,7 @@ class Email_Settings_Tab {
 		$fields_to_display = array_filter(
 			$wp_settings_fields['sensei-settings']['email-notification-settings'] ?? [],
 			function( $field_key ) {
-				return in_array( $field_key, [ 'email_from_name', 'email_from_address', 'email_reply_to_address' ], true );
+				return in_array( $field_key, [ 'email_from_name', 'email_from_address', 'email_reply_to_name' , 'email_reply_to_address' ], true );
 			},
 			ARRAY_FILTER_USE_KEY
 		);
@@ -253,6 +253,16 @@ class Email_Settings_Tab {
 	 * @return array The fields with the Reply To email address field added.
 	 */
 	public function add_reply_to_setting( $fields ) {
+
+		$fields['email_reply_to_name'] = [
+			'name'     => __( '"Reply To" Name', 'sensei-lms' ),
+			'type'     => 'input',
+			'default'  => '',
+			'section'  => 'email-notification-settings',
+			'required' => 0,
+		];
+
+
 		$fields['email_reply_to_address'] = [
 			'name'     => __( '"Reply To" Address', 'sensei-lms' ),
 			'type'     => 'email',

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -221,7 +221,7 @@ class Email_Settings_Tab {
 		);
 
 		$options = $this->settings->get_settings() ?? [];
-		unset( $options['email_from_name'], $options['email_from_address'], $options['email_reply_to_address'] );
+		unset( $options['email_fropm_name'], $options['email_from_address'], $options['email_reply_to_address'] );
 
 		include dirname( __FILE__ ) . '/views/html-settings.php';
 	}
@@ -261,7 +261,6 @@ class Email_Settings_Tab {
 			'section'  => 'email-notification-settings',
 			'required' => 0,
 		];
-
 
 		$fields['email_reply_to_address'] = [
 			'name'     => __( '"Reply To" Address', 'sensei-lms' ),

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -201,7 +201,7 @@ class Email_Settings_Tab {
 		$fields_to_display = array_filter(
 			$wp_settings_fields['sensei-settings']['email-notification-settings'] ?? [],
 			function( $field_key ) {
-				return in_array( $field_key, [ 'email_from_name', 'email_from_address', 'email_reply_to_name' , 'email_reply_to_address' ], true );
+				return in_array( $field_key, [ 'email_from_name', 'email_from_address', 'email_reply_to_name', 'email_reply_to_address' ], true );
 			},
 			ARRAY_FILTER_USE_KEY
 		);

--- a/includes/internal/emails/class-email-settings-tab.php
+++ b/includes/internal/emails/class-email-settings-tab.php
@@ -221,7 +221,7 @@ class Email_Settings_Tab {
 		);
 
 		$options = $this->settings->get_settings() ?? [];
-		unset( $options['email_fropm_name'], $options['email_from_address'], $options['email_reply_to_address'] );
+		unset( $options['email_from_name'], $options['email_from_address'], $options['email_reply_to_address'], $options['email_reply_to_name'] );
 
 		include dirname( __FILE__ ) . '/views/html-settings.php';
 	}

--- a/tests/unit-tests/internal/emails/test-class-email-sender.php
+++ b/tests/unit-tests/internal/emails/test-class-email-sender.php
@@ -52,14 +52,6 @@ class Email_Sender_Test extends \WP_UnitTestCase {
 	 */
 	protected $skip_did_filter = false;
 
-
-	protected $mailer = null;
-
-
-	function set_mailer( $mailer  ) {
-		$this->mailer = $mailer;
-	}
-
 	public function setUp(): void {
 		parent::setUp();
 		reset_phpmailer_instance();

--- a/tests/unit-tests/internal/emails/test-class-email-sender.php
+++ b/tests/unit-tests/internal/emails/test-class-email-sender.php
@@ -56,7 +56,7 @@ class Email_Sender_Test extends \WP_UnitTestCase {
 		parent::setUp();
 		reset_phpmailer_instance();
 
-		$this->settings = new Sensei_Settings();
+		$this->settings     = new Sensei_Settings();
 		$this->factory      = new Sensei_Factory();
 		$this->email_sender = new Email_Sender( new Email_Repository(), $this->settings );
 		$this->email_sender->init();
@@ -182,30 +182,9 @@ class Email_Sender_Test extends \WP_UnitTestCase {
 
 	public function testSendEmail_WhenTheReplyToIsSet_SetReplyTo() {
 		/* Arrange. */
-		$this->settings->set('email_reply_to_address', 'address_to_be_replied@gmail.com');
-		$this->settings->set('email_reply_to_name', 'John Reply');
+		$this->settings->set( 'email_reply_to_address', 'address_to_be_replied@gmail.com' );
+		$this->settings->set( 'email_reply_to_name', 'John Reply' );
 		$mailer = tests_retrieve_phpmailer_instance();
-
-		/* Act */
-		$this->email_sender->send_email(
-			'student_starts_course',
-				[
-					'a@a.test' => [
-						'student:displayname' => 'Test Student',
-					],
-				]
-
-		);
-
-		/* Assert. */
-		$last_email = $mailer->get_sent(0);
-		self::assertStringContainsString( 'Reply-To: John Reply <address_to_be_replied@gmail.com>', $last_email->header );
-	}
-
-	public function testSendEmail_WhenTheReplyToIsNotSet_SetReplyTo() {
-		/* Arrange. */
-		$this->settings->set('email_reply_to_address', null);
-
 
 		/* Act */
 		$this->email_sender->send_email(
@@ -218,31 +197,48 @@ class Email_Sender_Test extends \WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$email_sent = tests_retrieve_phpmailer_instance()->get_sent(0);
+		$last_email = $mailer->get_sent( 0 );
+		self::assertStringContainsString( 'Reply-To: John Reply <address_to_be_replied@gmail.com>', $last_email->header );
+	}
+
+	public function testSendEmail_WhenTheReplyToIsNotSet_SetReplyTo() {
+		/* Arrange. */
+		$this->settings->set( 'email_reply_to_address', null );
+
+		/* Act */
+		$this->email_sender->send_email(
+			'student_starts_course',
+			[
+				'a@a.test' => [
+					'student:displayname' => 'Test Student',
+				],
+			]
+		);
+
+		/* Assert. */
+		$email_sent = tests_retrieve_phpmailer_instance()->get_sent( 0 );
 		self::assertStringNotContainsString( 'Reply-To', $email_sent->header );
 	}
 
 	public function testSendEmail_WhenTheReplyToNameIsNotSet_SetReplyTo() {
 		/* Arrange. */
-		$this->settings->set('email_reply_to_address', 'address_to_be_replied@gmail.com');
-		$this->settings->set('email_reply_to_name', null);
+		$this->settings->set( 'email_reply_to_address', 'address_to_be_replied@gmail.com' );
+		$this->settings->set( 'email_reply_to_name', null );
 		$mailer = tests_retrieve_phpmailer_instance();
 
 		/* Act */
 		$this->email_sender->send_email(
 			'student_starts_course',
-				[
-					'a@a.test' => [
-						'student:displayname' => 'Test Student',
-					],
-				]
-
+			[
+				'a@a.test' => [
+					'student:displayname' => 'Test Student',
+				],
+			]
 		);
 
 		/* Assert. */
-		$last_email = $mailer->get_sent(0);
+		$last_email = $mailer->get_sent( 0 );
 		self::assertStringContainsString( 'Reply-To: address_to_be_replied@gmail.com', $last_email->header );
-
 	}
 
 	private function create_test_email_template() {

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -257,6 +257,12 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 			->method( 'get_settings' )
 			->willReturn(
 				[
+					'email_reply_to_name' => [
+						'name' => __( '"Reply To" Name', 'sensei-lms' ),
+						'type' => 'email',
+					],
+				],
+				[
 					'email_reply_to_address' => [
 						'name' => __( '"Reply To" Address', 'sensei-lms' ),
 						'type' => 'email',
@@ -275,6 +281,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertStringContainsString( '<input id="email_reply_to_address" name="sensei-settings[email_reply_to_address]" size="40" type="email"', $content );
+		self::assertStringContainsString( '<input id="email_reply_to_name" name="sensei-settings[email_reply_to_name]" size="40" ', $content );
 	}
 
 	public function testTabContent_WhenInSettingsSubtab_HasEmailFromAddressAsTypeEmail() {


### PR DESCRIPTION
Resolves #6563 

## Proposed Changes
* Add the "reply to"  name field on the  email>settings pages
* Use the reply to settings on the new email sender


## Testing Instructions
* Enable the email customization feature flag
* Go to `wp-admin/admin.php?page=sensei-settings&tab=email-notification-settings&subtab=settings`
* Set  "reply to" name and address
*  Trigger one of the available emails
* Check on the headers if the "reply to" header  is set.
* Check the acceptance criteria

<img width="1339" alt="Screenshot 2023-02-28 at 19 24 53" src="https://user-images.githubusercontent.com/38718/221959070-7837430d-0221-4620-b1b1-c75e6f3bd381.png">



## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing

