### PR TITLE
Add teacher course assigned email, fix course not allowing to set a course teacher

### DIFF
--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -43,7 +43,7 @@ const CourseGeneralSidebar = () => {
 	let teachers = window.sensei.courseSettingsSidebar.teachers;
 	if ( teachers && teachers.length ) {
 		teachers = teachers.map( ( usr ) => {
-			return { label: usr.display_name, value: usr.id };
+			return { label: usr.display_name, value: usr.ID };
 		} );
 	}
 

--- a/changelog/add-teacher-course-assigned-email
+++ b/changelog/add-teacher-course-assigned-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Send email to teacher when new course is assigned

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -308,6 +308,7 @@ class Sensei_Autoloader {
 			\Sensei\Internal\Emails\Student_Completes_Course::class => 'internal/emails/generators/class-student-completes-course.php',
 			\Sensei\Internal\Emails\Student_Submits_Quiz::class => 'internal/emails/generators/class-student-submits-quiz.php',
 			\Sensei\Internal\Emails\Course_Completed::class => 'internal/emails/generators/class-course-completed.php',
+			\Sensei\Internal\Emails\New_Course_Assigned::class => 'internal/emails/generators/class-new-course-assigned.php',
 		);
 	}
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -110,6 +110,7 @@ class Sensei_Teacher {
 		// If slug changed to custom, try to extract and save teacher id.
 		add_action( 'edit_module', [ $this, 'extract_and_save_teacher_to_meta_from_slug' ] );
 
+		add_action( 'sensei_course_new_teacher_assigned', [ $this, 'teacher_course_assigned_notification' ], 10, 2 );
 	}
 
 	/**
@@ -425,8 +426,17 @@ class Sensei_Teacher {
 		// ensure the modules are update so that then new teacher has access to them.
 		self::update_course_modules_author( $course_id, $new_teacher );
 
-		// notify the new teacher
-		$this->teacher_course_assigned_notification( $new_teacher, $course_id );
+		/**
+		 * Fires when a new teacher is assigned to a course.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @hook sensei_course_new_teacher_assigned
+		 *
+		 * @param {int} $new_teacher The ID of the new teacher.
+		 * @param {int} $course_id   The ID of the course.
+		 */
+		do_action( 'sensei_course_new_teacher_assigned', $new_teacher, $course_id );
 	}
 
 	/**

--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -159,5 +159,6 @@ class Email_Customization {
 		remove_action( 'sensei_user_course_start', [ \Sensei()->emails, 'teacher_started_course' ] );
 		remove_action( 'sensei_user_quiz_submitted', [ \Sensei()->emails, 'teacher_quiz_submitted' ] );
 		remove_action( 'sensei_course_status_updated', [ \Sensei()->emails, 'learner_completed_course' ] );
+		remove_action( 'sensei_course_new_teacher_assigned', [ \Sensei()->teacher, 'teacher_course_assigned_notification' ] );
 	}
 }

--- a/includes/internal/emails/class-email-generator.php
+++ b/includes/internal/emails/class-email-generator.php
@@ -54,6 +54,7 @@ class Email_Generator {
 			Student_Completes_Course::IDENTIFIER_NAME => new Student_Completes_Course( $this->email_repository ),
 			Student_Submits_Quiz::IDENTIFIER_NAME     => new Student_Submits_Quiz( $this->email_repository ),
 			Course_Completed::IDENTIFIER_NAME         => new Course_Completed( $this->email_repository ),
+			New_Course_Assigned::IDENTIFIER_NAME      => new New_Course_Assigned( $this->email_repository ),
 		];
 
 		add_action( 'init', [ $this, 'init_email_generators' ] );

--- a/includes/internal/emails/class-email-patterns.php
+++ b/includes/internal/emails/class-email-patterns.php
@@ -95,6 +95,12 @@ class Email_Patterns {
 					'categories' => [ 'sensei-emails' ],
 					'content'    => $this->get_pattern_content_from_file( 'course-completed' ),
 				],
+			'new-course-assigned'      =>
+				[
+					'title'      => __( 'Email sent to the teacher if a new course is assigned', 'sensei-lms' ),
+					'categories' => [ 'sensei-emails' ],
+					'content'    => $this->get_pattern_content_from_file( 'new-course-assigned' ),
+				],
 		];
 
 		foreach ( $patterns as $key => $pattern ) {

--- a/includes/internal/emails/class-email-seeder-data.php
+++ b/includes/internal/emails/class-email-seeder-data.php
@@ -88,7 +88,7 @@ class Email_Seeder_Data {
 				'types'       => [ 'teacher' ],
 				'subject'     => __( 'New Course Assigned: [course:name]', 'sensei-lms' ),
 				'description' => __( 'Course Assigned', 'sensei-lms' ),
-				'content'     => '<!-- wp:pattern {"slug":"sensei-emails/footer"} /-->',
+				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/new-course-assigned"} /-->',
 			],
 			'new_message_reply'        => [
 				'types'       => [ 'student', 'teacher' ],

--- a/includes/internal/emails/generators/class-new-course-assigned.php
+++ b/includes/internal/emails/generators/class-new-course-assigned.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * File containing the New_Course_Assigned class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Emails;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class New_Course_Assigned
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class New_Course_Assigned extends Email_Generators_Abstract {
+	/**
+	 * Identifier of the email.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER_NAME = 'new_course_assigned';
+
+	/**
+	 * Initialize the email hooks.
+	 *
+	 * @access public
+	 * @since $$next-version$$
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'sensei_course_new_teacher_assigned', [ $this, 'course_new_teacher_assigned_email' ], 10, 2 );
+	}
+
+	/**
+	 * Send email to student when a course is completed.
+	 *
+	 * @param int $teacher_id Teacher ID.
+	 * @param int $course_id  Course ID.
+	 *
+	 * @access private
+	 */
+	public function course_new_teacher_assigned_email( $teacher_id, $course_id ) {
+
+		if ( 'course' !== get_post_type( $course_id ) || ! get_userdata( $teacher_id ) ) {
+			return;
+		}
+
+		// If new user is the same as the current logged-in user, they don't need an email.
+		if ( get_current_user_id() === $teacher_id ) {
+			return;
+		}
+
+		$teacher   = new \WP_User( $teacher_id );
+		$recipient = stripslashes( $teacher->user_email );
+
+		// Course edit link.
+		$edit_link = esc_url(
+			add_query_arg(
+				array(
+					'post'   => $course_id,
+					'action' => 'edit',
+				),
+				admin_url( 'post.php' )
+			)
+		);
+
+		$this->send_email_action(
+			[
+				$recipient => [
+					'teacher:displayname' => $teacher->display_name,
+					'course:name'         => get_the_title( $course_id ),
+					'editcourse:url'      => esc_url( $edit_link ),
+				],
+			]
+		);
+	}
+}

--- a/includes/internal/emails/patterns/new-course-assigned.php
+++ b/includes/internal/emails/patterns/new-course-assigned.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * New Course Assigned email pattern.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+
+<!-- wp:post-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"40px"},"color":{"text":"#020202"},"spacing":{"margin":{"bottom":"48px"}}}} /-->
+
+<!-- wp:group {"style":{"color":{"background":"#f6f7f7"},"spacing":{"padding":{"top":"32px","right":"32px","bottom":"32px","left":"32px"}}}} -->
+<div class="wp-block-group has-background" style="background-color:#f6f7f7;padding-top:32px;padding-right:32px;padding-bottom:32px;padding-left:32px"><!-- wp:paragraph {"style":{"typography":{"fontSize":"32px"},"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"color":{"text":"#010101"}}} -->
+	<p class="has-text-color" style="color:#010101;font-size:32px;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><strong>[teacher:displayname]</strong></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"10px"}}} -->
+	<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontSize":"16px","lineHeight":"2"},"spacing":{"margin":{"top":"24px","bottom":"0px"}},"color":{"text":"#020202"}}} -->
+		<p class="has-text-color" style="color:#020202;font-size:16px;line-height:2;margin-top:24px;margin-bottom:0px"><strong>Course Name</strong></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px","lineHeight":"1"},"color":{"text":"#020202"}}} -->
+		<p class="has-text-color" style="color:#020202;font-size:16px;line-height:1">[course:name]</p>
+		<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->
+
+	<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"40px"},"blockGap":"0px"}}} -->
+	<div class="wp-block-buttons" style="margin-top:40px"><!-- wp:button {"style":{"spacing":{"padding":{"top":"16px","bottom":"16px","left":"20px","right":"20px"}},"color":{"background":"#020202","text":"#fefefe"},"border":{"radius":"4px"}},"className":"inline-block"} -->
+		<div class="wp-block-button inline-block"><a class="wp-block-button__link has-text-color has-background" href="[editcourse:url]" style="border-radius:4px;background-color:#020202;color:#fefefe;padding-top:16px;padding-right:20px;padding-bottom:16px;padding-left:20px">Edit The Course</a></div>
+		<!-- /wp:button --></div>
+	<!-- /wp:buttons --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->

--- a/tests/unit-tests/internal/emails/generators/test-class-new-course-assigned.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-new-course-assigned.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SenseiTest\Internal\Emails;
+
+use Sensei\Internal\Emails\Email_Repository;
+use Sensei\Internal\Emails\New_Course_Assigned;
+use Sensei_Factory;
+
+/**
+ * Tests for Sensei\Internal\Emails\New_Course_Assigned class.
+ *
+ * @covers \Sensei\Internal\Emails\New_Course_Assigned
+ */
+class New_Course_Assigned_Test extends \WP_UnitTestCase {
+	use \Sensei_Test_Login_Helpers;
+
+	/**
+	 * Factory for creating test data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Email repository instance.
+	 *
+	 * @var Email_Repository
+	 */
+	protected $email_repository;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory          = new Sensei_Factory();
+		$this->email_repository = new Email_Repository();
+	}
+
+	public function testSendNewCourseEmail_WhenTeacherAssignedToNewCourseEventFires_CallsEmailSendingActionWithRightData() {
+		/* Arrange. */
+		$teacher_id = $this->factory->user->create(
+			[
+				'user_email' => 'test@a.com',
+			]
+		);
+		$course     = $this->factory->course->create_and_get(
+			[
+				'post_title'  => 'Test Course',
+				'post_author' => $teacher_id,
+			]
+		);
+
+		$edit_link = esc_url(
+			add_query_arg(
+				array(
+					'post'   => $course->ID,
+					'action' => 'edit',
+				),
+				admin_url( 'post.php' )
+			)
+		);
+		( new New_Course_Assigned( $this->email_repository ) )->init();
+
+		$email_data = [
+			'name' => '',
+			'data' => null,
+		];
+		$user_name  = get_user_by( 'id', $teacher_id )->display_name;
+		add_action(
+			'sensei_email_send',
+			function ( $email_name, $replacements ) use ( &$email_data ) {
+				$email_data['name'] = $email_name;
+				$email_data['data'] = $replacements;
+			},
+			10,
+			2
+		);
+
+		/* Act. */
+		do_action( 'sensei_course_new_teacher_assigned', $teacher_id, $course->ID );
+
+		/* Assert. */
+		self::assertEquals( 'new_course_assigned', $email_data['name'] );
+		self::assertArrayHasKey( 'test@a.com', $email_data['data'] );
+		self::assertEquals( $user_name, $email_data['data']['test@a.com']['teacher:displayname'] );
+		self::assertEquals( 'Test Course', $email_data['data']['test@a.com']['course:name'] );
+		self::assertArrayHasKey( 'editcourse:url', $email_data['data']['test@a.com'] );
+		self::assertEquals( $edit_link, $email_data['data']['test@a.com']['editcourse:url'] );
+	}
+
+	public function testSendNewCourseEmail_WhenTeacherAssignedToNewCourseEventFires_DoesNotSendEmailIfSameLoggedInUser() {
+		/* Arrange. */
+		$this->login_as_teacher();
+
+		$teacher_id = $this->factory->user->create(
+			[
+				'user_email' => 'test@a.com',
+			]
+		);
+		$course     = $this->factory->course->create_and_get(
+			[
+				'post_title'  => 'Test Course',
+				'post_author' => $teacher_id,
+			]
+		);
+
+		( new New_Course_Assigned( $this->email_repository ) )->init();
+
+		$email_data = [
+			'name' => '',
+			'data' => null,
+		];
+
+		add_action(
+			'sensei_email_send',
+			function ( $email_name, $replacements ) use ( &$email_data ) {
+				$email_data['name'] = $email_name;
+				$email_data['data'] = $replacements;
+			},
+			10,
+			2
+		);
+
+		/* Act. */
+		do_action( 'sensei_course_new_teacher_assigned', get_current_user_id(), $course->ID );
+
+		/* Assert. */
+		self::assertEquals( '', $email_data['name'] );
+	}
+}

--- a/tests/unit-tests/internal/emails/test-class-email-customization.php
+++ b/tests/unit-tests/internal/emails/test-class-email-customization.php
@@ -39,29 +39,31 @@ class Email_Customization_Test extends \WP_UnitTestCase {
 	 *
 	 * @param string $action_name The name of the action.
 	 * @param string $function_name The name of the function.
+	 * @param object $hook_instance The instance of the hook's class.
 	 *
 	 * @dataProvider legacyHooksDataProvider
 	 */
-	public function testDisableLegacy_WhenCalled_RemovesLegacyEmailHooks( $action_name, $function_name ) {
+	public function testDisableLegacy_WhenCalled_RemovesLegacyEmailHooks( $action_name, $function_name, $hook_instance ) {
 		/* Arrange. */
 		$settings        = $this->createMock( Sensei_Settings::class );
 		$instance        = Email_Customization::instance( $settings );
-		$priority_before = has_action( $action_name, [ \Sensei()->emails, $function_name ] );
+		$priority_before = has_action( $action_name, [ $hook_instance, $function_name ] );
 
 		/* Act. */
 		$instance->disable_legacy_emails();
 
 		/* Assert. */
-		$priority_after = has_action( $action_name, [ \Sensei()->emails, $function_name ] );
+		$priority_after = has_action( $action_name, [ $hook_instance, $function_name ] );
 		$this->assertNotEquals( $priority_before, $priority_after );
 	}
 
 	public function legacyHooksDataProvider() {
 		return [
-			'student_completes_course' => [ 'sensei_course_status_updated', 'teacher_completed_course' ],
-			'student_starts_course'    => [ 'sensei_user_course_start', 'teacher_started_course' ],
-			'student_quiz_submitted'   => [ 'sensei_user_quiz_submitted', 'teacher_quiz_submitted' ],
-			'course_completed'         => [ 'sensei_course_status_updated', 'learner_completed_course' ],
+			'student_completes_course' => [ 'sensei_course_status_updated', 'teacher_completed_course', \Sensei()->emails ],
+			'student_starts_course'    => [ 'sensei_user_course_start', 'teacher_started_course', \Sensei()->emails ],
+			'student_quiz_submitted'   => [ 'sensei_user_quiz_submitted', 'teacher_quiz_submitted', \Sensei()->emails ],
+			'course_completed'         => [ 'sensei_course_status_updated', 'learner_completed_course', \Sensei()->emails ],
+			'teacher_course_assigned'  => [ 'sensei_course_new_teacher_assigned', 'teacher_course_assigned_notification', \Sensei()->teacher ],
 		];
 	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-patterns.php
+++ b/tests/unit-tests/internal/emails/test-class-email-patterns.php
@@ -35,6 +35,9 @@ class Email_Patterns_Test extends \WP_UnitTestCase {
 		$pattern_items = [
 			'sensei-lms/student-completes-course',
 			'sensei-lms/student-starts-course',
+			'sensei-lms/student-submits-quiz',
+			'sensei-lms/course-completed',
+			'sensei-lms/new-course-assigned',
 		];
 
 		/* Act. */
@@ -57,6 +60,9 @@ class Email_Patterns_Test extends \WP_UnitTestCase {
 		$pattern_items     = [
 			'sensei-lms/student-completes-course',
 			'sensei-lms/student-starts-course',
+			'sensei-lms/student-submits-quiz',
+			'sensei-lms/course-completed',
+			'sensei-lms/new-course-assigned',
 		];
 
 		/* Act. */


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6479

## Proposed Changes
- Fixed issue of Course edit page not allowing to set any Teacher
- Added email to be sent to teacher when a course is assigned to that teacher

## Testing Instructions

- Enable the email post type
- Do not forget to run the tool (Sensei LMS -> Tools -> Re Create Emails). Run this again even if you've run it before
- Create a course
- Assign the course to a different teacher other than yourself (other than the user who you are logged in as and editing the course)
- Make sure the assigning worked
- Make sure that the assigned teacher has received an email

## Hooks

### Added
`sensei_course_new_teacher_assigned` - Fires when a new teacher is assigned to a course

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
