### PR TITLE
Show only view results button in the course complete email that's sent to student

### DIFF
--- a/includes/internal/emails/generators/class-course-completed.php
+++ b/includes/internal/emails/generators/class-course-completed.php
@@ -53,9 +53,8 @@ class Course_Completed extends Email_Generators_Abstract {
 			return;
 		}
 
-		$student    = new \WP_User( $student_id );
-		$recipient  = stripslashes( $student->user_email );
-		$result_url = \Sensei()->course_results->get_permalink( $course_id ) ?? '';
+		$student   = new \WP_User( $student_id );
+		$recipient = stripslashes( $student->user_email );
 
 		$this->send_email_action(
 			[
@@ -64,8 +63,9 @@ class Course_Completed extends Email_Generators_Abstract {
 					'student:displayname' => $student->display_name,
 					'course:id'           => $course_id,
 					'course:name'         => get_the_title( $course_id ),
-					'certificate:url'     => esc_url( \Sensei_Course::get_course_completed_page_url( $course_id ) ?? '' ),
-					'results:url'         => esc_url( $result_url ),
+					'completed:url'       => esc_url(
+						\Sensei_Course::get_course_completed_page_url( $course_id ) ?? get_permalink( $course_id )
+					),
 				],
 			]
 		);

--- a/includes/internal/emails/patterns/course-completed.php
+++ b/includes/internal/emails/patterns/course-completed.php
@@ -13,13 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <!-- wp:post-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"40px"},"color":{"text":"#020202"},"spacing":{"margin":{"bottom":"48px"}}}} /-->
 
-<!-- wp:group {"style":{"color":{"background":"#f6f7f7"},"spacing":{"padding":{"top":"32px","right":"32px","bottom":"32px","left":"32px"}}}} -->
-<div class="wp-block-group has-background" style="background-color:#f6f7f7;padding-top:32px;padding-right:32px;padding-bottom:32px;padding-left:32px"><!-- wp:paragraph {"style":{"typography":{"fontSize":"32px"},"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"color":{"text":"#010101"}}} -->
-	<p class="has-text-color" style="color:#010101;font-size:32px;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><strong>[student:displayname]</strong></p>
+<!-- wp:group {"style":{"color":{"background":"#f6f7f7"},"spacing":{"padding":{"top":"32px","right":"32px","bottom":"32px","left":"32px"},"blockGap":"0px"}}} -->
+<div class="wp-block-group has-background" style="background-color:#f6f7f7;padding-top:32px;padding-right:32px;padding-bottom:32px;padding-left:32px"><!-- wp:paragraph {"style":{"typography":{"fontSize":"32px","lineHeight":"1"},"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"color":{"text":"#010101"}}} -->
+	<p class="has-text-color" style="color:#010101;font-size:32px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><strong>[student:displayname]</strong></p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"10px"}}} -->
-	<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontSize":"16px","lineHeight":"2"},"spacing":{"margin":{"top":"24px","bottom":"0px"}},"color":{"text":"#020202"}}} -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"10px","padding":{"top":"0px","bottom":"20px"}}}} -->
+	<div class="wp-block-group" style="padding-top:0px;padding-bottom:20px"><!-- wp:paragraph {"style":{"typography":{"fontSize":"16px","lineHeight":"2"},"spacing":{"margin":{"top":"24px","bottom":"0px"}},"color":{"text":"#020202"}}} -->
 		<p class="has-text-color" style="color:#020202;font-size:16px;line-height:2;margin-top:24px;margin-bottom:0px"><strong>Course Name</strong></p>
 		<!-- /wp:paragraph -->
 
@@ -28,17 +28,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<!-- /wp:paragraph --></div>
 	<!-- /wp:group -->
 
-	<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"40px"},"blockGap":"0px"}}} -->
-	<div class="wp-block-buttons" style="margin-top:40px"><!-- wp:button {"style":{"spacing":{"padding":{"top":"16px","bottom":"16px","left":"20px","right":"20px"}},"color":{"background":"#020202","text":"#fefefe"},"border":{"radius":"4px"}},"className":"inline-block"} -->
-		<div class="wp-block-button inline-block"><a class="wp-block-button__link has-text-color has-background" href="[certificate:url]" style="border-radius:4px;background-color:#020202;color:#fefefe;padding-top:16px;padding-right:20px;padding-bottom:16px;padding-left:20px">View Certificate</a></div>
-		<!-- /wp:button -->
-
-		<!-- wp:button {"style":{"spacing":{"padding":{"top":"16px","bottom":"16px","left":"24px","right":"24px"}},"border":{"radius":"4px"},"color":{"background":"#f6f7f7","text":"#020202"},"typography":{"fontSize":"16px"}},"className":"is-style-fill inline-block"} -->
-		<div class="wp-block-button has-custom-font-size is-style-fill inline-block" style="font-size:16px"><a class="wp-block-button__link has-text-color has-background" href="[results:url]" style="border-radius:4px;background-color:#f6f7f7;color:#020202;padding-top:16px;padding-right:24px;padding-bottom:16px;padding-left:24px"><span style="text-decoration: underline;">View Results</span></a></div>
+	<!-- wp:buttons -->
+	<div class="wp-block-buttons"><!-- wp:button {"style":{"spacing":{"padding":{"top":"16px","bottom":"16px","left":"20px","right":"20px"}},"color":{"background":"#020202","text":"#fefefe"},"border":{"radius":"4px"},"typography":{"fontSize":"16px"}}} -->
+		<div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link has-text-color has-background" href="[completed:url]" style="border-radius:4px;background-color:#020202;color:#fefefe;padding-top:16px;padding-right:20px;padding-bottom:16px;padding-left:20px">View Results</a></div>
 		<!-- /wp:button --></div>
 	<!-- /wp:buttons --></div>
 <!-- /wp:group -->
-
-<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->

--- a/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
@@ -47,17 +47,18 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 
 	public function testGenerateEmail_WhenCalledByStudentCompletedCourseEvent_CallsStudentEmailSendingActionWithRightData() {
 		/* Arrange. */
-		$student_id = $this->factory->user->create(
+		$student_id    = $this->factory->user->create(
 			[
 				'display_name' => 'Test Student',
 				'user_email'   => 'test@a.com',
 			]
 		);
-		$course     = $this->factory->course->create_and_get(
+		$course        = $this->factory->course->create_and_get(
 			[
 				'post_title' => 'Test Course',
 			]
 		);
+		$completed_url = \Sensei_Course::get_course_completed_page_url( $course->ID );
 
 		\Sensei_Setup_Wizard::instance()->pages->create_pages();
 		remove_action( 'sensei_course_status_updated', [ \Sensei()->frontend, 'redirect_to_course_completed_page' ], 1000 );
@@ -89,8 +90,8 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		self::assertArrayHasKey( 'test@a.com', $email_data['data'] );
 		self::assertEquals( 'Test Student', $email_data['data']['test@a.com']['student:displayname'] );
 		self::assertEquals( 'Test Course', $email_data['data']['test@a.com']['course:name'] );
-		self::assertNotEmpty( $email_data['data']['test@a.com']['certificate:url'] );
-		self::assertArrayHasKey( 'results:url', $email_data['data']['test@a.com'] );
+		self::assertArrayHasKey( 'completed:url', $email_data['data']['test@a.com'] );
+		self::assertNotEmpty( $email_data['data']['test@a.com']['completed:url'] );
 	}
 
 	public function testGenerateEmail_WhenCalledByStudentUpdatedCourseEvent_DoesNotCallStudentEmailIfCourseNotCompleted() {

--- a/tests/unit-tests/internal/emails/test-class-email-patterns.php
+++ b/tests/unit-tests/internal/emails/test-class-email-patterns.php
@@ -115,6 +115,19 @@ class Email_Patterns_Test extends \WP_UnitTestCase {
 		}
 	}
 
+	public function testRegisteredCourseCompletedEmail_WhenRetrieved_HasViewResultsButton() {
+		/* Arrange. */
+		$patterns = new Email_Patterns();
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+
+		/* Act. */
+		$patterns->register_email_block_patterns();
+
+		/* Assert. */
+		$this->assertStringContainsString( 'View Results', $registry->get_registered( 'sensei-lms/course-completed' )['content'] );
+		$this->assertStringNotContainsString( 'Certificate', $registry->get_registered( 'sensei-lms/course-completed' )['content'] );
+	}
+
 	private function get_pattern_items() {
 		return [
 			'sensei-lms/student-completes-course',


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6604

## Proposed Changes
* Removed the View Certificate button and added the View Results button as the only button

## Testing Instructions

* Enable email customization
* Create a course
* Take the course as a student
* Complete the course
* Make sure the email the student receives has the View Results button

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
