### PR TITLE
Set hideAnswerFeedback default value to string

### DIFF
--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -45,7 +45,7 @@
 			"type": "object",
 			"default": {
 				"grade": 1,
-				"hideAnswerFeedback": true
+				"hideAnswerFeedback": ""
 			}
 		},
 		"editable": {

--- a/changelog/fix-question-default-value
+++ b/changelog/fix-question-default-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix error on quiz update

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -779,7 +779,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 					'hideAnswerFeedback' => [
 						'type'        => 'string',
 						'description' => 'Hide/show answer feedback for the question',
-						'default'     => false,
+						'default'     => '',
 					],
 				],
 			],


### PR DESCRIPTION
There is an issue currently when creating new questions on a quiz. It is caused by setting the default value of `hideAnswerFeedback` to a boolean while it should be a string. To reproduce

### Steps
1. Go to a lesson
2. Add a new question to a quiz
3. Do not modify the question settings
4. Click update

### What I expected to happen
No error to occur

### What happened instead
There is an error returned that complains that question does not pass validation.


## Proposed Changes
* Set all default values to strings.