### PR TITLE
Remove trash button from email editor

### DIFF
--- a/changelog/add-remove-trash-button-from-email-editor
+++ b/changelog/add-remove-trash-button-from-email-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Trash button from the editor of the posts of email type

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -32,6 +32,31 @@ class Email_Post_Type {
 	public function init(): void {
 		add_action( 'init', [ $this, 'register_post_type' ] );
 		add_action( 'load-edit.php', [ $this, 'maybe_redirect_to_listing' ] );
+		add_action( 'map_meta_cap', [ $this, 'remove_cap_of_deleting_email' ], 10, 4 );
+	}
+
+	/**
+	 * Remove the capability of deleting emails.
+	 *
+	 * @param string[] $caps    The user's actual capabilities.
+	 * @param string   $cap     Capability name.
+	 * @param int      $user_id The user ID.
+	 * @param array    $args    Adds the context to the cap. Typically the object ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @access private
+	 *
+	 * @internal
+	 *
+	 * @return string[]
+	 */
+	public function remove_cap_of_deleting_email( $caps, $cap, $user_id, $args ) {
+		if ( 'delete_post' === $cap && isset( $args[0] ) && self::POST_TYPE === get_post_type( $args[0] ) ) {
+			$caps[] = 'do_not_allow';
+		}
+
+		return $caps;
 	}
 
 	/**

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -12,6 +12,7 @@ use Sensei\Internal\Emails\Email_Post_Type;
 class Email_Post_Type_Test extends \WP_UnitTestCase {
 
 	use \Sensei_Test_Redirect_Helpers;
+	use \Sensei_Test_Login_Helpers;
 
 	public function testRegisterPostType_WhenCalled_RegistersEmailPostType() {
 		/* Arrange. */
@@ -156,5 +157,23 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertTrue( current_user_can( 'delete_post', $email_id ) );
+	}
+
+	public function testEmailDeleteCapHook_WhenCalled_DoesNotAffectOtherPostTypes() {
+		/* Arrange. */
+		$this->login_as_admin();
+		$email_post_type = new Email_Post_Type();
+		$email_post_type->register_post_type();
+		$post_id = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+			]
+		);
+
+		/* Act. */
+		$email_post_type->init();
+
+		/* Assert. */
+		$this->assertTrue( current_user_can( 'delete_post', $post_id ) );
 	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -119,4 +119,23 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertFalse( current_user_can( 'delete_post', $email_id ) );
 	}
+
+	public function testUserCap_WhenCalledForEditorUser_DoesNotAllowToDelete() {
+		/* Arrange. */
+		$this->login_as_editor();
+		$email_post_type = new Email_Post_Type();
+		$email_post_type->register_post_type();
+		$email_id = $this->factory->post->create(
+			[
+				'post_type'   => 'sensei_email',
+				'post_status' => 'publish',
+			]
+		);
+
+		/* Act. */
+		$email_post_type->init();
+
+		/* Assert. */
+		$this->assertFalse( current_user_can( 'delete_post', $email_id ) );
+	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -100,4 +100,23 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals( 10, has_action( 'map_meta_cap', [ $email_post_type, 'remove_cap_of_deleting_email' ] ) );
 	}
+
+	public function testUserCap_WhenCalledForAdminUserForEmailPost_DoesNotAllowToDelete() {
+		/* Arrange. */
+		$this->login_as_admin();
+		$email_post_type = new Email_Post_Type();
+		$email_post_type->register_post_type();
+		$email_id = $this->factory->post->create(
+			[
+				'post_type'   => 'sensei_email',
+				'post_status' => 'publish',
+			]
+		);
+
+		/* Act. */
+		$email_post_type->init();
+
+		/* Assert. */
+		$this->assertFalse( current_user_can( 'delete_post', $email_id ) );
+	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -138,4 +138,23 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertFalse( current_user_can( 'delete_post', $email_id ) );
 	}
+
+	public function testUserCap_WhenCalled_AllowsDeletingUnlessHookIsAttached() {
+		/* Arrange. */
+		$this->login_as_admin();
+		$email_post_type = new Email_Post_Type();
+		$email_post_type->register_post_type();
+		$email_id = $this->factory->post->create(
+			[
+				'post_type'   => 'sensei_email',
+				'post_status' => 'publish',
+			]
+		);
+
+		/* Act. */
+		remove_action( 'map_meta_cap', [ $email_post_type, 'map_meta_cap' ], 10 );
+
+		/* Assert. */
+		$this->assertTrue( current_user_can( 'delete_post', $email_id ) );
+	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -89,4 +89,15 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $redirect_status );
 		$this->assertSame( '', $redirect_location );
 	}
+
+	public function testInit_WhenCalled_AddsHookForRemovingEmailDeletingCap() {
+		/* Arrange. */
+		$email_post_type = new Email_Post_Type();
+
+		/* Act. */
+		$email_post_type->init();
+
+		/* Assert. */
+		$this->assertEquals( 10, has_action( 'map_meta_cap', [ $email_post_type, 'remove_cap_of_deleting_email' ] ) );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6628

## Proposed Changes
* Removes the capability of the users to trash email post type.

## Testing Instructions

1. Enable the sensei_email post type
2. Generate the emails using Sensei LMS -> Tools -> Re-Create Emails
3. Go to Sensei LMS -> Settings -> Emails. Click on the edit button of an email
4. In the editor, make sure the trash button isn't there
5. Now go the editor of any other post type, like a post or a page or a course
6. Make sure the trash button is there

**Before**
![image](https://user-images.githubusercontent.com/6820724/224952402-da05b79b-bfce-49c4-90f6-6beca4ef83a0.png)

**After**
![image](https://user-images.githubusercontent.com/6820724/224952791-220984f1-fa56-4373-913f-0a94a9aabbca.png)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
