### PR TITLE
Fix warning message shown after grading

### DIFF
--- a/includes/internal/emails/class-email-blocks.php
+++ b/includes/internal/emails/class-email-blocks.php
@@ -130,7 +130,7 @@ class Email_Blocks {
 
 		$screen = get_current_screen();
 
-		if ( Email_Post_Type::POST_TYPE !== $screen->post_type || ! $screen->is_block_editor() ) {
+		if ( Email_Post_Type::POST_TYPE !== ( $screen->post_type ?? '' ) || ! $screen->is_block_editor() ) {
 			return $theme;
 		}
 

--- a/tests/unit-tests/internal/emails/test-class-email-blocks.php
+++ b/tests/unit-tests/internal/emails/test-class-email-blocks.php
@@ -139,4 +139,24 @@ class Email_Blocks_Test extends \WP_UnitTestCase {
 		/* Act. */
 		$this->assertSame( $theme_json, $blocks->set_email_css_units( $theme_json ) );
 	}
+
+	/**
+	 * Ran in separate process to not set WP_ADMIN for all tests.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testSetEmailCssUnits_WhenCalledWithoutACurrentScreen_DoesNotRaiseWarnings() {
+		/* Arrange. */
+		$blocks     = new Email_Blocks();
+		$theme_json = $this->createMock( 'WP_Theme_JSON_Data' );
+
+		define( 'WP_ADMIN', true );
+
+		/* Assert. */
+		$this->expectNotToPerformAssertions();
+
+		/* Act. */
+		$blocks->set_email_css_units( $theme_json );
+	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
@@ -100,7 +100,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 
 		/* Assert. */
 		$enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
-		$this->assertTrue( $enrolment->is_enrolled( $student_id ) );
+		$this->assertTrue( $enrolment->is_enrolled( $student_id, false ) );
 	}
 
 	public function testAddUsersToCourses_UserNotFoundGiven_ReturnsSuccessfulResponse() {


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6637

## Proposed Changes
* Added a null check so that it doesn't raise warnings if screen is null. Though small, it was tricky to find the exact reason for this because both '[is_admin()](https://developer.wordpress.org/reference/functions/is_admin/)' and '[get_current_screen()'](https://developer.wordpress.org/reference/functions/get_current_screen/) depends on the same global variable $current_screen. So it was not possible that is_admin will let the check pass to allow get_current_screen to return a null screen only unless WP_ADMIN gets defined to true somewhere. And as tests share any global constant that's declared, we could not just set WP_ADMIN because it'll impact all other tests where is_admin check is relevant. So we ran the test in a different process and with preservation disabled.

## Testing Instructions

1. Enable email customization
2. Create a course with a quiz
3. Take the course as a student and take the quiz
4. Grade the quiz
5. Make sure no warning is shown

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
