### PR TITLE
Fix bulk actions not getting applied on emails

### DIFF
--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -109,6 +109,10 @@ class Email_Post_Type {
 			return;
 		}
 
+		if ( isset( $_GET['action'] ) && '-1' !== $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
 		wp_safe_redirect( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ), 301 );
 		exit;
 	}

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -70,7 +70,7 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		$this->assertSame( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ), $redirect_location );
 	}
 
-	public function testMaybeRedirectToListing_WhenCalledWithNonEmailPostType_RedirectsToEmailsPage() {
+	public function testMaybeRedirectToListing_WhenCalledWithNonEmailPostType_DoesNotRedirectToEmailsPage() {
 		/* Arrange. */
 		$email_post_type   = new Email_Post_Type();
 		$_GET['post_type'] = 'non_sensei_email';

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -176,4 +176,48 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertTrue( current_user_can( 'delete_post', $post_id ) );
 	}
+
+	public function testMaybeRedirectToListing_WhenCalledWithEmailPostTypeAndInvalidBulkAction_RedirectsToEmailsPage() {
+		/* Arrange. */
+		$email_post_type   = new Email_Post_Type();
+		$_GET['post_type'] = 'sensei_email';
+		$_GET['action']    = '-1';
+		$this->prevent_wp_redirect();
+
+		/* Act. */
+		$redirect_status   = 0;
+		$redirect_location = '';
+		try {
+			$email_post_type->maybe_redirect_to_listing();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status   = $e->getCode();
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert. */
+		$this->assertSame( 301, $redirect_status );
+		$this->assertSame( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ), $redirect_location );
+	}
+
+	public function testMaybeRedirectToListing_WhenCalledWithEmailPostTypeAndValidBulkAction_DoesNotRedirectToEmailsPage() {
+		/* Arrange. */
+		$email_post_type   = new Email_Post_Type();
+		$_GET['post_type'] = 'sensei_email';
+		$_GET['action']    = 'disable-bulk-action';
+		$this->prevent_wp_redirect();
+
+		/* Act. */
+		$redirect_status   = 0;
+		$redirect_location = '';
+		try {
+			$email_post_type->maybe_redirect_to_listing();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status   = $e->getCode();
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert. */
+		$this->assertSame( 0, $redirect_status );
+		$this->assertSame( '', $redirect_location );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6646

## Proposed Changes
* The bulk action request was getting redirected before being executed. Added a check to prevent that from happening.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable Email customization
2. Go to Sensei LMS -> Settings -> Emails
3. Select one or more Emails using the checkbox on the left
4. Apply enable or disable action from top left dropdown
5. Make sure the selected emails are enabled/disabled

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [x] Continuous Integration build is passing
