### PR TITLE
Take user to login page if tries to access course completion page when logged out

### DIFF
--- a/changelog/add-redirect-to-login-from-course-completion-logged-out
+++ b/changelog/add-redirect-to-login-from-course-completion-logged-out
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Logged out users are redirected to login page if tries to access course completion page

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4217,7 +4217,7 @@ class Sensei_Course {
 
 		$completed_page_id = intval( $settings['course_completed_page'] ?? 0 );
 
-		if ( $completed_page_id < 1 || $completed_page_id !== get_the_ID() ) {
+		if ( $completed_page_id < 1 || get_the_ID() !== $completed_page_id ) {
 			return;
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4204,8 +4204,6 @@ class Sensei_Course {
 	 * @since $$next-version$$
 	 *
 	 * @access private
-	 *
-	 * @return void
 	 */
 	public function maybe_redirect_to_login_from_course_completion() {
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4199,7 +4199,7 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Take the user to login page if trying to access course results page without being logged in.
+	 * Take the user to login page if trying to access course completion page without being logged in.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -155,6 +155,8 @@ class Sensei_Course {
 
 		// Add custom navigation.
 		add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
+
+		add_action( 'template_redirect', array( $this, 'maybe_redirect_to_login_from_course_completion' ) );
 	}
 
 	/**
@@ -4194,6 +4196,45 @@ class Sensei_Course {
 			);
 			remove_all_actions( 'sensei_pagination' );
 		}
+	}
+
+	/**
+	 * Take the user to login page if trying to access course results page without being logged in.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @access private
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_to_login_from_course_completion() {
+
+		if ( is_user_logged_in() ) {
+			return;
+		}
+
+		$settings = Sensei()->settings->get_settings();
+
+		$completed_page_id = intval( $settings['course_completed_page'] ?? 0 );
+
+		if ( $completed_page_id < 1 || $completed_page_id !== get_the_ID() ) {
+			return;
+		}
+
+		$my_courses_url = null;
+
+		if ( isset( $settings['my_course_page'] ) && 0 < intval( $settings['my_course_page'] ) ) {
+			$my_courses_url = get_permalink( $settings['my_course_page'] );
+		}
+
+		$redirect_to_url = $my_courses_url ?? home_url( '/wp-login.php' );
+
+		$redirect_after_login_url = remove_query_arg(
+			array( '_wp_http_referer', '_wpnonce' ),
+			isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : ''
+		);
+
+		wp_safe_redirect( add_query_arg( 'redirect_to', $redirect_after_login_url, $redirect_to_url ), 303 );
 	}
 }
 

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -609,4 +609,36 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertFalse( isset( $redirect_status ) );
 	}
+
+	public function testCompletionRedirect_WhenCalledForAnotherPage_DoesNotRedirectEvenIfCompletionPageExists() {
+		/* Arrange. */
+		$this->prevent_wp_redirect();
+
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			]
+		);
+		Sensei()->settings->set( 'course_completed_page', $page_id );
+
+		$normal_page_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Random Page',
+			)
+		);
+
+		$this->go_to( get_permalink( $normal_page_id ) );
+
+		/* Act. */
+		try {
+			Sensei()->course->maybe_redirect_to_login_from_course_completion();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status = $e->getCode();
+		}
+
+		/* Assert. */
+		$this->assertFalse( isset( $redirect_status ) );
+	}
 }

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -665,4 +665,38 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertTrue( isset( $redirect_status ) );
 	}
+
+	public function testCompletionRedirect_WhenMyCoursesIsThere_PerformsRedirectionToMyCoursesPage() {
+		/* Arrange. */
+		$this->prevent_wp_redirect();
+		$completion_page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			]
+		);
+
+		$my_courses_page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'My Courses',
+			]
+		);
+		Sensei()->settings->set( 'course_completed_page', $completion_page_id );
+		Sensei()->settings->set( 'my_course_page', $my_courses_page_id );
+
+		$this->go_to( get_permalink( Sensei()->settings->get( 'course_completed_page' ) ) );
+
+		/* Act. */
+		try {
+			Sensei()->course->maybe_redirect_to_login_from_course_completion();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status   = $e->getCode();
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert. */
+		$this->assertTrue( isset( $redirect_status ) );
+		$this->assertStringContainsString( get_permalink( $my_courses_page_id ), $redirect_location );
+	}
 }

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -583,4 +583,30 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertFalse( isset( $redirect_status ) );
 	}
+
+	public function testCompletionRedirect_WhenCalled_DoesNotRedirectIfCompletionPageIsNotThere() {
+		/* Arrange. */
+		$this->prevent_wp_redirect();
+
+		Sensei()->settings->set( 'course_completed_page', null );
+
+		$normal_page_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Random Page',
+			)
+		);
+
+		$this->go_to( get_permalink( $normal_page_id ) );
+
+		/* Act. */
+		try {
+			Sensei()->course->maybe_redirect_to_login_from_course_completion();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status = $e->getCode();
+		}
+
+		/* Assert. */
+		$this->assertFalse( isset( $redirect_status ) );
+	}
 }

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -641,4 +641,28 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertFalse( isset( $redirect_status ) );
 	}
+
+	public function testCompletionRedirect_WhenCompletionPageExistsLoggedOut_PerformsRedirection() {
+		/* Arrange. */
+		$this->prevent_wp_redirect();
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			]
+		);
+		Sensei()->settings->set( 'course_completed_page', $page_id );
+
+		$this->go_to( get_permalink( Sensei()->settings->get( 'course_completed_page' ) ) );
+
+		/* Act. */
+		try {
+			Sensei()->course->maybe_redirect_to_login_from_course_completion();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status = $e->getCode();
+		}
+
+		/* Assert. */
+		$this->assertTrue( isset( $redirect_status ) );
+	}
 }

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -699,4 +699,31 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$this->assertTrue( isset( $redirect_status ) );
 		$this->assertStringContainsString( get_permalink( $my_courses_page_id ), $redirect_location );
 	}
+
+	public function testCompletionRedirect_WhenMyCoursesPageNotThere_PerformsRedirectionToWpLoginPage() {
+		/* Arrange. */
+		$this->prevent_wp_redirect();
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			]
+		);
+		Sensei()->settings->set( 'course_completed_page', $page_id );
+		Sensei()->settings->set( 'my_course_page', null );
+
+		$this->go_to( get_permalink( Sensei()->settings->get( 'course_completed_page' ) ) );
+
+		/* Act. */
+		try {
+			Sensei()->course->maybe_redirect_to_login_from_course_completion();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_status   = $e->getCode();
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert. */
+		$this->assertTrue( isset( $redirect_status ) );
+		$this->assertStringContainsString( home_url( '/wp-login.php' ), $redirect_location );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6636

## Proposed Changes
* Added redirection to take the user to the login page when a user tries to access the course completion page without logging in.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course
2. Complete the course
3. When you are taken to the course completion page, copy the URL of that page from browser navbar
4. Now log out
5. Directly hit the copied URL when you are logged out
6. Make sure you are taken to the login page
7. Log in
8. Make sure you are taken to the course completion page automatically after logging in

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
