### PR TITLE
Trash emails on plugin uninstall

### DIFF
--- a/changelog/add-delete-emails-on-uninstall
+++ b/changelog/add-delete-emails-on-uninstall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Trash emails on plugin uninstall

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -31,6 +31,7 @@ class Sensei_Data_Cleaner {
 		'question',
 		'multiple_question',
 		'sensei_message',
+		'sensei_email',
 	);
 
 	/**

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -11,6 +11,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	private $biography_ids;
 	private $course_ids;
 	private $lesson_ids;
+	private $email_ids;
 
 	// Pages.
 	private $regular_page_ids;
@@ -79,6 +80,15 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'lesson',
+			)
+		);
+
+		// Create some Sensei emails.
+		$this->email_ids = $this->factory->post->create_many(
+			16,
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'sensei_email',
 			)
 		);
 	}
@@ -266,7 +276,8 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	public function testSenseiPostsTrashed() {
 		Sensei_Data_Cleaner::cleanup_all();
 
-		$ids = array_merge( $this->course_ids, $this->lesson_ids );
+		$ids = array_merge( $this->course_ids, $this->lesson_ids, $this->email_ids );
+
 		foreach ( $ids as $id ) {
 			$post = get_post( $id );
 			$this->assertEquals( 'trash', $post->post_status, 'Sensei post should be trashed' );


### PR DESCRIPTION
Resolves #6576.

## Proposed Changes
Trashes Sensei's emails when the plugin is deleted.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You may want to perform these steps on a new site to prevent your data from being lost.

1. In Sensei's settings, check the _Delete data on uninstall_ box.
2. Deactivate and then delete the plugin.
3. Verify in the database that the emails were trashed (`select * from wp_posts where post_status = 'trash'`) OR
4. Comment out [this line](https://github.com/Automattic/sensei/blob/trunk/includes/internal/emails/class-email-post-type.php#L34).
5. Install and activate Sensei.
6. Navigate to the Emails page WP Admin (i.e. `/wp-admin/edit.php?post_type=sensei_email`).
7. Verify that the emails were moved to the trash. You'll also see 16 published emails because reactivating the plugin triggered the emails to be recreated.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [x] Continuous Integration build is passing
