### PR TITLE
Fix site editor not working for non-block themes

### DIFF
--- a/changelog/fix-site-edit-not-working-for-non-block-themes
+++ b/changelog/fix-site-edit-not-working-for-non-block-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix site editor not working for non-block themes

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-editor.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-editor.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This file contains the Sensei_Course_Theme_Editor_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Course_Theme_Test class.
+ *
+ * @covers Sensei_Course_Theme_Editor
+ * @group course-theme
+ */
+class Sensei_Course_Theme_Editor_Test extends WP_UnitTestCase {
+	/**
+	 * Setup method. Run first on every test execution.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$_SERVER['REQUEST_URI'] = '';
+	}
+
+	/**
+	 * @dataProvider providerInit_WhenCalled_AddsHooks
+	 */
+	public function testInit_WhenCalled_AddsHooks( $hook_name, $method_name, $priority ) {
+		/* Act. */
+		$this->resetCourseThemeEditorInstance();
+
+		Sensei_Course_Theme_Editor::instance()->init();
+
+		/* Assert */
+		$this->assertSame(
+			$priority,
+			has_action(
+				$hook_name,
+				[ Sensei_Course_Theme_Editor::instance(), $method_name ]
+			)
+		);
+	}
+
+	public function providerInit_WhenCalled_AddsHooks() {
+		return [
+			[ 'setup_theme', 'override_site_editor_theme_for_non_block_themes', 1 ],
+			[ 'setup_theme', 'maybe_add_site_editor_hooks', 1 ],
+			[ 'setup_theme', 'maybe_override_lesson_theme', 1 ],
+			[ 'rest_api_init', 'maybe_add_site_editor_hooks', 10 ],
+			[ 'enqueue_block_editor_assets', 'enqueue_site_editor_assets', 10 ],
+			[ 'admin_menu', 'add_admin_menu_site_editor_item', 20 ],
+		];
+	}
+
+	public function testOverrideSiteEditorThemeForNonBlockThemes_WhenCalledForNonBlockTheme_OverridesTheme() {
+		/* Arrange. */
+		$this->resetCourseThemeEditorInstance();
+
+		$course_theme_mock = $this->createMock( Sensei_Course_Theme::class );
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/site-editor.php';
+
+		/* Assert. */
+		$course_theme_mock
+			->expects( $this->once() )
+			->method( 'override_theme' );
+
+		/* Act. */
+		Sensei_Course_Theme_Editor::instance( $course_theme_mock )->override_site_editor_theme_for_non_block_themes();
+	}
+
+	public function testOverrideSiteEditorThemeForNonBlockThemes_WhenCalledForBlockTheme_DoesNothing() {
+		/* Arrange. */
+		$this->resetCourseThemeEditorInstance();
+
+		$course_theme_mock = $this->createMock( Sensei_Course_Theme::class );
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/site-editor.php';
+
+		switch_theme( 'block-theme' );
+
+		/* Assert. */
+		$course_theme_mock
+			->expects( $this->never() )
+			->method( 'override_theme' );
+
+		/* Act. */
+		Sensei_Course_Theme_Editor::instance( $course_theme_mock )->override_site_editor_theme_for_non_block_themes();
+	}
+
+	public function testOverrideSiteEditorThemeForNonBlockThemes_WhenCalledNoInTheSiteEditor_DoesNothing() {
+		/* Arrange. */
+		$this->resetCourseThemeEditorInstance();
+
+		$course_theme_mock = $this->createMock( Sensei_Course_Theme::class );
+
+		/* Assert. */
+		$course_theme_mock
+			->expects( $this->never() )
+			->method( 'override_theme' );
+
+		/* Act. */
+		Sensei_Course_Theme_Editor::instance( $course_theme_mock )->override_site_editor_theme_for_non_block_themes();
+	}
+
+	private function resetCourseThemeEditorInstance() {
+		$instance = new ReflectionProperty( Sensei_Course_Theme_Editor::class, 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null );
+	}
+}
+

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-editor.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-editor.php
@@ -3,6 +3,8 @@
  * This file contains the Sensei_Course_Theme_Editor_Test class.
  *
  * @package sensei
+ *
+ * phpcs:disable Generic.Commenting.DocComment.MissingShort
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Resolves #6277

This PR fixes the site editor not working for non-block themes. This is because of a [recently added check](https://github.com/WordPress/wordpress-develop/blob/6.1.1/src/wp-includes/class-wp-theme-json-resolver.php#L423) in WP core. Because there are no hooks to bypass this, I'm overwriting the currently active non-block theme with the Learning Mode theme when accessing the site editor.

The issue is present in the following WP versions:

- WP 6.1.1 - The site editor shows a blank page.
- WP 6.2-RC2 - The site editor shows the following error: `The theme you are currently using is not compatible with the Site Editor.`

## Proposed Changes

* When accessing the site editor, replace the active non-block theme with the Learning Mode theme.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Repeat the next steps for WP 6.0.3, 6.1.1, and 6.2-RC2.
1. Activate a non-block theme like Twenty Twenty.
1. Go to Appearance -> Editor -> Templates -> Lesson.
1. Make sure the editor loads.


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Test cases are written and passing (including feature flags)
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
- [x] Continuous Integration build is passing
