### PR TITLE
Disable pro emails by default, allow enabling from pro, show pro badge

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -56,3 +56,12 @@ $promo_highlight: #43af99;
 	color: #2c3338;
 	font-weight: 400;
 }
+
+.sensei-upsell-pro-badge {
+	background: #91E7C5;
+	color: #2c3338;
+	font-weight: 400;
+	border-radius: 12px;
+	padding: 2px 8px;
+	margin-left: 10px;
+}

--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -65,3 +65,7 @@ $promo_highlight: #43af99;
 	padding: 2px 8px;
 	margin-left: 10px;
 }
+
+sensei-wp-list-table-row--disabled .sensei-email-unavailable {
+	color: #999999;
+}

--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -51,21 +51,18 @@ body #toplevel_page_sensei {
 
 $promo_highlight: #43af99;
 
-#adminmenuwrap #adminmenu .sensei-promo-groups__badge {
+#adminmenuwrap #adminmenu .sensei-promo-groups__badge, .sensei-upsell-pro-badge {
 	background: $promo_highlight;
 	color: #2c3338;
 	font-weight: 400;
 }
 
 .sensei-upsell-pro-badge {
-	background: #91E7C5;
-	color: #2c3338;
-	font-weight: 400;
 	border-radius: 12px;
 	padding: 2px 8px;
 	margin-left: 10px;
 }
 
-sensei-wp-list-table-row--disabled .sensei-email-unavailable {
+.sensei-wp-list-table-row--disabled .sensei-email-unavailable {
 	color: #999999;
 }

--- a/changelog/add-disable-pro-emails-and-upsell
+++ b/changelog/add-disable-pro-emails-and-upsell
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Disable pro emails by default and allow enabling from pro

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -289,12 +289,9 @@ class Email_List_Table extends Sensei_List_Table {
 	 *
 	 * @param \WP_Post $post The email post.
 	 *
-	 * @internal
-	 * @access private
-	 *
 	 * @return boolean True if the email is available, false otherwise.
 	 */
-	public function is_email_available( $post ) {
+	private function is_email_available( $post ) {
 		$available = ! get_post_meta( $post->ID, '_sensei_email_is_pro', true );
 
 		/**

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -134,7 +134,7 @@ class Email_List_Table extends Sensei_List_Table {
 				get_post_meta( $post->ID, '_sensei_email_description', true ),
 				$this->row_actions( $actions )
 			) : sprintf(
-				'<strong>%1$s</strong><span class="awaiting-mod sensei-upsell-pro-badge">%2$s</span>%3$s',
+				'<strong class="sensei-email-unavailable">%1$s</strong><span class="awaiting-mod sensei-upsell-pro-badge">%2$s</span>%3$s',
 				get_post_meta( $post->ID, '_sensei_email_description', true ),
 				__( 'Pro', 'sensei-lms' ),
 				$this->row_actions( $actions )

--- a/includes/internal/emails/class-email-repository.php
+++ b/includes/internal/emails/class-email-repository.php
@@ -42,6 +42,13 @@ class Email_Repository {
 	private const META_DESCRIPTION = '_sensei_email_description';
 
 	/**
+	 * Email pro meta key.
+	 *
+	 * @param string
+	 */
+	private const META_IS_PRO = '_sensei_email_is_pro';
+
+	/**
 	 * Check if email exists for identifier.
 	 *
 	 * @internal
@@ -71,10 +78,11 @@ class Email_Repository {
 	 * @param string $subject     Email subject.
 	 * @param string $description Email description.
 	 * @param string $content     Email content.
+	 * @param bool   $is_pro      Is pro email.
 	 *
 	 * @return int|false Email post ID. Returns false if email already exists. Returns WP_Error on failure.
 	 */
-	public function create( string $identifier, array $types, string $subject, string $description, string $content ) {
+	public function create( string $identifier, array $types, string $subject, string $description, string $content, bool $is_pro = false ) {
 		if ( $this->has( $identifier ) ) {
 			return false;
 		}
@@ -87,6 +95,7 @@ class Email_Repository {
 			'meta_input'   => [
 				self::META_IDENTIFIER  => $identifier,
 				self::META_DESCRIPTION => $description,
+				self::META_IS_PRO      => $is_pro,
 			],
 		];
 

--- a/includes/internal/emails/class-email-seeder-data.php
+++ b/includes/internal/emails/class-email-seeder-data.php
@@ -119,24 +119,28 @@ class Email_Seeder_Data {
 				'subject'     => __( 'Get ready - [lesson:name] - starts [date:dtext]!', 'sensei-lms' ),
 				'description' => __( 'Lessons Available (Content Drip)', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/content-drip"} /-->',
+				'is_pro'      => true,
 			],
 			'course_expiration_today'  => [
 				'types'       => [ 'student' ],
 				'subject'     => __( '[course:name] expires today!', 'sensei-lms' ),
 				'description' => __( 'Course Expiration - Today', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/course-expiration-today"} /-->',
+				'is_pro'      => true,
 			],
 			'course_expiration_3_days' => [
 				'types'       => [ 'student' ],
 				'subject'     => __( '[course:name] expires in 3 days!', 'sensei-lms' ),
 				'description' => __( 'Course Expiration - in 3 days', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/course-expiration-x-days"} /-->',
+				'is_pro'      => true,
 			],
 			'course_expiration_7_days' => [
 				'types'       => [ 'student' ],
 				'subject'     => __( '[course:name] expires in 7 days!', 'sensei-lms' ),
 				'description' => __( 'Course Expiration - in 7 days', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/course-expiration-x-days"} /-->',
+				'is_pro'      => true,
 			],
 		];
 

--- a/includes/internal/emails/class-email-seeder.php
+++ b/includes/internal/emails/class-email-seeder.php
@@ -116,7 +116,9 @@ class Email_Seeder {
 
 		$description = $email_data['description'] ?? '';
 
-		$email_id = $this->email_repository->create( $identifier, $types, $subject, $description, $content );
+		$is_pro = $email_data['is_pro'] ?? false;
+
+		$email_id = $this->email_repository->create( $identifier, $types, $subject, $description, $content, $is_pro );
 
 		return is_int( $email_id ) && $email_id > 0;
 	}

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -282,7 +282,7 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		$expected = sprintf(
 			'<tr class="sensei-wp-list-table-row--disabled">' .
 			'<th class=\'cb column-cb check-column\'  ><label class="screen-reader-text">Select %2$s</label><input id="cb-select-%1$s" type="checkbox" name="email[]" value="%1$s" /></th>' .
-			'<td class=\'description column-description column-primary\' data-colname="Email" ><strong>description</strong><span class="awaiting-mod sensei-upsell-pro-badge">Pro</span><div class="row-actions"><span class=\'upgrade-to-pro\'><a href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&#038;utm_medium=upsell&#038;utm_campaign=email_customization_pro" aria-label="Upgrade to Sensei Pro">Upgrade to Sensei Pro</a></span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td>' .
+			'<td class=\'description column-description column-primary\' data-colname="Email" ><strong class="sensei-email-unavailable">description</strong><span class="awaiting-mod sensei-upsell-pro-badge">Pro</span><div class="row-actions"><span class=\'upgrade-to-pro\'><a href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&#038;utm_medium=upsell&#038;utm_campaign=email_customization_pro" aria-label="Upgrade to Sensei Pro">Upgrade to Sensei Pro</a></span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td>' .
 			'<td class=\'subject column-subject\' data-colname="Subject" >%2$s</td>' .
 			'<td class=\'last_modified column-last_modified\' data-colname="Last Modified" >1 second ago</td>' .
 			'</tr>',

--- a/tests/unit-tests/internal/emails/test-class-email-list-table.php
+++ b/tests/unit-tests/internal/emails/test-class-email-list-table.php
@@ -262,4 +262,37 @@ class Email_List_Table_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 'sensei-wp-list-table-row--disabled', $result );
 	}
+
+	public function testGetRowData_WhenHasProItem_ReturnsDataWithDisabledProEmailStructure() {
+		/* Arrange. */
+		$list_table = new Email_List_Table( new Email_Repository() );
+		$post       = $this->factory->email->create_and_get();
+
+		update_post_meta( $post->ID, '_sensei_email_description', 'description' );
+		update_post_meta( $post->ID, '_sensei_email_is_pro', true );
+
+		/* Act. */
+		$list_table->prepare_items();
+
+		ob_start();
+		$list_table->display_rows();
+		$result = ob_get_clean();
+
+		/* Assert. */
+		$expected = sprintf(
+			'<tr class="sensei-wp-list-table-row--disabled">' .
+			'<th class=\'cb column-cb check-column\'  ><label class="screen-reader-text">Select %2$s</label><input id="cb-select-%1$s" type="checkbox" name="email[]" value="%1$s" /></th>' .
+			'<td class=\'description column-description column-primary\' data-colname="Email" ><strong>description</strong><span class="awaiting-mod sensei-upsell-pro-badge">Pro</span><div class="row-actions"><span class=\'upgrade-to-pro\'><a href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&#038;utm_medium=upsell&#038;utm_campaign=email_customization_pro" aria-label="Upgrade to Sensei Pro">Upgrade to Sensei Pro</a></span></div><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td>' .
+			'<td class=\'subject column-subject\' data-colname="Subject" >%2$s</td>' .
+			'<td class=\'last_modified column-last_modified\' data-colname="Last Modified" >1 second ago</td>' .
+			'</tr>',
+			$post->ID,
+			$post->post_title,
+			wp_nonce_url( "post.php?action=disable-email&amp;post=$post->ID", 'disable-email-post_' . $post->ID ),
+			Email_Preview::get_preview_link( $post->ID ),
+			'description'
+		);
+
+		$this->assertStringContainsString( $expected, $result );
+	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-repository.php
+++ b/tests/unit-tests/internal/emails/test-class-email-repository.php
@@ -70,6 +70,23 @@ class Email_Repository_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 'c', $result->post_title );
 	}
 
+	public function testGet_EmailCreatedWithIsProParam_SavesIsProMetaAsExpected() {
+		/* Arrange. */
+		$repository = new Email_Repository();
+		$repository->create( 'a', [ 'b' ], 'c', 'd', 'e' );
+		$repository->create( 'x', [ 'b' ], 'y', 'd', 'e', true );
+
+		/* Act. */
+		$result1 = $repository->get( 'a' );
+		$result2 = $repository->get( 'x' );
+
+		/* Assert. */
+		$this->assertEquals( 'c', $result1->post_title );
+		$this->assertEquals( '', get_post_meta( $result1->ID, '_sensei_email_is_pro', true ) );
+		$this->assertEquals( 'y', $result2->post_title );
+		$this->assertEquals( 1, get_post_meta( $result2->ID, '_sensei_email_is_pro', true ) );
+	}
+
 	public function testHasEmails_EmailsNotInRepository_ReturnsFalse() {
 		/* Arrange. */
 		$repository = new Email_Repository();

--- a/tests/unit-tests/internal/emails/test-class-email-seeder-data.php
+++ b/tests/unit-tests/internal/emails/test-class-email-seeder-data.php
@@ -10,6 +10,27 @@ use Sensei\Internal\Emails\Email_Seeder_Data;
  * @covers \Sensei\Internal\Emails\Email_Seeder_Data
  */
 class Email_Seeder_Data_Test extends \WP_UnitTestCase {
+
+
+	private $email_keys = [
+		'course_created',
+		'course_welcome',
+		'quiz_graded',
+		'course_completed',
+		'student_starts_course',
+		'student_completes_course',
+		'student_completes_lesson',
+		'student_submits_quiz',
+		'student_sends_message',
+		'new_course_assigned',
+		'student_message_reply',
+		'teacher_message_reply',
+		'content_drip',
+		'course_expiration_today',
+		'course_expiration_3_days',
+		'course_expiration_7_days',
+	];
+
 	public function testGetEmailData_Always_ReturnsEmailData() {
 		/* Arrange. */
 		$email_seeder_data = new Email_Seeder_Data();
@@ -29,24 +50,26 @@ class Email_Seeder_Data_Test extends \WP_UnitTestCase {
 		$email_data = $email_seeder_data->get_email_data();
 
 		/* Assert. */
-		$expected_keys = [
-			'course_created',
-			'course_welcome',
-			'quiz_graded',
-			'course_completed',
-			'student_starts_course',
-			'student_completes_course',
-			'student_completes_lesson',
-			'student_submits_quiz',
-			'student_sends_message',
-			'new_course_assigned',
-			'student_message_reply',
-			'teacher_message_reply',
+		self::assertSame( $this->email_keys, array_keys( $email_data ) );
+	}
+
+	public function testGetEmailData_Always_ReturnsArrayWithExpectedProValues() {
+		/* Arrange. */
+		$email_seeder_data = new Email_Seeder_Data();
+		$pro_email_keys    = [
 			'content_drip',
 			'course_expiration_today',
 			'course_expiration_3_days',
 			'course_expiration_7_days',
 		];
-		self::assertSame( $expected_keys, array_keys( $email_data ) );
+
+		/* Act. */
+		$email_data = $email_seeder_data->get_email_data();
+
+		/* Assert. */
+		foreach ( $this->email_keys as $email_key ) {
+			$is_pro = in_array( $email_key, $pro_email_keys, true );
+			$this->assertSame( $is_pro, $email_data[ $email_key ]['is_pro'] ?? false );
+		}
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6615

## Proposed Changes
* Disable pro emails by default
* Allow enabling those emails from pro using hook
* Show pro badge with pro emails
* Show pro upgrade link below pro emails
* Hide Other actions from pro emails
* Don't allow clicking on Disabled pro email titles

## Testing Instructions

1. Enable email customization feature
2. Disable the sensei-pro plugin
3. Re-Run the email regeneration tool from Sensei LMS -> Tools -> Re-Create emails
4. Go to Sensei LMS -> Settings -> Emails -> Student Emails
5. Make sure the pro emails are disabled and are showing the pro badge
6. Checkout this branch from pro https://github.com/Automattic/sensei-pro/tree/add/enable-pro-emails
7. Now go to Sensei LMS -> Settings -> Emails -> Student Emails again
8. Make sure all the emails are showing normally without any disabled pro email

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* `sensei_email_is_available` - Hook for making specific email unavailable


When Pro is not installed
![image](https://user-images.githubusercontent.com/6820724/226301218-cfba2156-377a-47c9-bcde-c4f53befdebe.png)

When Pro is installed
![image](https://user-images.githubusercontent.com/6820724/226301452-1bd88833-8841-48c0-b721-331cca086e07.png)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
