### PR TITLE
Add showcase documentation link to upsell and filter to allow documentation link in the courses navigation

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -256,7 +256,7 @@ class Sensei_Course {
 
 					<ul class="sensei-showcase-upsell__buttons">
 						<li><a href="https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=showcase" class="sensei-showcase-upsell__button sensei-showcase-upsell__button--primary" target="_blank" rel="noreferrer"><?php esc_html_e( 'Get Sensei Pro', 'sensei-lms' ); ?></a></li>
-						<li><a href="#" class="sensei-showcase-upsell__button sensei-showcase-upsell__button--secondary" target="_blank" rel="noreferrer"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a></li>
+						<li><a href="https://senseilms.com/documentation/showcase/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=showcase" class="sensei-showcase-upsell__button sensei-showcase-upsell__button--secondary" target="_blank" rel="noreferrer"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a></li>
 					</ul>
 				</div>
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -379,6 +379,19 @@ class Sensei_Course {
 	 * @param array     $tabs List of tabs to show.
 	 */
 	private function display_courses_navigation( WP_Screen $screen, array $tabs ) {
+		/**
+		 * Filter courses navigation sidebar content.
+		 *
+		 * @hook  sensei_courses_navigation_sidebar
+		 * @since $$next-version$$
+		 *
+		 * @param {string}    $content The content to be displayed in the sidebar.
+		 * @param {WP_Screen} $screen  The current screen.
+		 *
+		 * @return {string} The content to be displayed in the sidebar.
+		 */
+		$navigation_sidebar = apply_filters( 'sensei_courses_navigation_sidebar', '', $screen );
+
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
 			<div class="sensei-custom-navigation__heading">
@@ -406,6 +419,14 @@ class Sensei_Course {
 						?>
 					</a>
 					<?php
+				}
+				?>
+				<?php
+				if ( ! empty( $navigation_sidebar ) ) {
+					?>
+					<div class="sensei-custom-navigation__separator"></div>
+					<?php
+					echo $navigation_sidebar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content escaped in filter.
 				}
 				?>
 			</div>


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei-pro/issues/2202
Pair with https://github.com/Automattic/sensei-pro/pull/2210

## Proposed Changes
* It adds the showcase documentation link to the upsell.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. With Sensei pro deactivated, go to WP Admin > Sensei LMS > Courses > Showcase Courses.
2. Click on "Learn more" in the upsell.
3. Make sure you are redirected to the showcase documentation link.
4. Filter test in https://github.com/Automattic/sensei-pro/pull/2210

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* `sensei_courses_navigation_sidebar` - Filter courses navigation sidebar content, so we can add the documentation link in the showcase listing.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [x] Application performance has not degraded
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
