### PR TITLE
Show Sensei Pro pricing dynamically and consistently

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1078,6 +1078,11 @@ $promo_highlight: #43af99;
 		margin: 0;
 	}
 
+	&__price-period {
+		display: block;
+		font-size: 14px;
+	}
+
 	&__actions {
 		display: flex;
 		gap: 14px;

--- a/changelog/update-use-dynamic-pricing
+++ b/changelog/update-use-dynamic-pricing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use dynamic pricing for Sensei Pro upsells

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Sensei_Extensions {
 	const SENSEILMS_PRODUCTS_API_BASE_URL = 'https://senseilms.com/wp-json/senseilms-products/1.0';
+	const PRODUCT_SENSEI_PRO_SLUG = 'sensei-pro';
 
 	/**
 	 * Instance of class.

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Sensei_Extensions {
 	const SENSEILMS_PRODUCTS_API_BASE_URL = 'https://senseilms.com/wp-json/senseilms-products/1.0';
-	const PRODUCT_SENSEI_PRO_SLUG = 'sensei-pro';
+	const PRODUCT_SENSEI_PRO_SLUG         = 'sensei-pro';
 
 	/**
 	 * Instance of class.

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -108,6 +108,32 @@ final class Sensei_Extensions {
 	}
 
 	/**
+	 * Fetch a specific Sensei extension.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $slug Extension slug.
+	 *
+	 * @return object|null
+	 */
+	public function get_extension( $slug ) {
+		$extensions = $this->get_extensions( 'plugin' );
+
+		$extensions = array_filter(
+			$extensions,
+			function( $extension ) use ( $slug ) {
+				return $slug === $extension->product_slug;
+			}
+		);
+
+		if ( empty( $extensions ) ) {
+			return null;
+		}
+
+		return array_shift( $extensions );
+	}
+
+	/**
 	 * Get Sensei extensions and WooCommerce.
 	 *
 	 * @since 4.8.0

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -224,6 +224,14 @@ class Sensei_Course {
 	 * @internal
 	 */
 	public function showcase_courses_screen() {
+		// Get the price of Pro. Return if it's not available.
+		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( 'sensei-pro' );
+		if ( ! $sensei_pro_product ) {
+			return;
+		}
+
+		$sensei_pro_price = str_replace( '.00', '', $sensei_pro_product->price );
+
 		// Enqueue styles.
 		Sensei()->assets->enqueue( 'sensei-showcase-upsell', 'css/showcase-upsell.css' );
 
@@ -250,8 +258,13 @@ class Sensei_Course {
 					</ul>
 
 					<div class="sensei-showcase-upsell__price-wrapper">
-						<span class="sensei-showcase-upsell__price"><?php esc_html_e( '$13 USD', 'sensei-lms' ); ?></span>
-						<span class="sensei-showcase-upsell__price-period"><?php esc_html_e( 'per month, billed yearly', 'sensei-lms' ); ?></span>
+						<span class="sensei-showcase-upsell__price">
+							<?php
+							// translators: Placeholder is the price of Sensei Pro.
+							echo esc_html( sprintf( __( '%s USD', 'sensei-lms' ), $sensei_pro_price ) );
+							?>
+						</span>
+						<span class="sensei-showcase-upsell__price-period"><?php esc_html_e( 'per year, 1 site', 'sensei-lms' ); ?></span>
 					</div>
 
 					<ul class="sensei-showcase-upsell__buttons">

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -225,7 +225,7 @@ class Sensei_Course {
 	 */
 	public function showcase_courses_screen() {
 		// Get the price of Pro. Return if it's not available.
-		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( 'sensei-pro' );
+		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( Sensei_Extensions::PRODUCT_SENSEI_PRO_SLUG );
 		$sensei_pro_price   = $sensei_pro_product ? str_replace( '.00', '', $sensei_pro_product->price ) : '-';
 
 		// Enqueue styles.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -226,11 +226,7 @@ class Sensei_Course {
 	public function showcase_courses_screen() {
 		// Get the price of Pro. Return if it's not available.
 		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( 'sensei-pro' );
-		if ( ! $sensei_pro_product ) {
-			return;
-		}
-
-		$sensei_pro_price = str_replace( '.00', '', $sensei_pro_product->price );
+		$sensei_pro_price   = $sensei_pro_product ? str_replace( '.00', '', $sensei_pro_product->price ) : '-';
 
 		// Enqueue styles.
 		Sensei()->assets->enqueue( 'sensei-showcase-upsell', 'css/showcase-upsell.css' );

--- a/includes/class-sensei-groups-landing-page.php
+++ b/includes/class-sensei-groups-landing-page.php
@@ -50,11 +50,7 @@ class Sensei_Groups_Landing_Page {
 	public function display_student_groups_landing_page() {
 		// Get the price of Pro. Return if it's not available.
 		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( 'sensei-pro' );
-		if ( ! $sensei_pro_product ) {
-			return;
-		}
-
-		$sensei_pro_price = str_replace( '.00', '', $sensei_pro_product->price );
+		$sensei_pro_price   = $sensei_pro_product ? str_replace( '.00', '', $sensei_pro_product->price ) : '-';
 
 		// Enqueue styles.
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css' );

--- a/includes/class-sensei-groups-landing-page.php
+++ b/includes/class-sensei-groups-landing-page.php
@@ -49,7 +49,7 @@ class Sensei_Groups_Landing_Page {
 	 */
 	public function display_student_groups_landing_page() {
 		// Get the price of Pro. Return if it's not available.
-		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( 'sensei-pro' );
+		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( Sensei_Extensions::PRODUCT_SENSEI_PRO_SLUG );
 		$sensei_pro_price   = $sensei_pro_product ? str_replace( '.00', '', $sensei_pro_product->price ) : '-';
 
 		// Enqueue styles.

--- a/includes/class-sensei-groups-landing-page.php
+++ b/includes/class-sensei-groups-landing-page.php
@@ -48,6 +48,13 @@ class Sensei_Groups_Landing_Page {
 	 * @since 4.5.2
 	 */
 	public function display_student_groups_landing_page() {
+		// Get the price of Pro. Return if it's not available.
+		$sensei_pro_product = Sensei_Extensions::instance()->get_extension( 'sensei-pro' );
+		if ( ! $sensei_pro_product ) {
+			return;
+		}
+
+		$sensei_pro_price = str_replace( '.00', '', $sensei_pro_product->price );
 
 		// Enqueue styles.
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css' );
@@ -90,7 +97,11 @@ class Sensei_Groups_Landing_Page {
 				</li>
 			</ul>
 			<h3 class="sensei-promo-groups__important-info">
-					<?php echo esc_html( __( '$149.00 USD / year (1 site)', 'sensei-lms' ) ); ?>
+			<?php
+				// translators: Placeholder is the price of Sensei Pro.
+				echo esc_html( sprintf( __( '%s USD', 'sensei-lms' ), $sensei_pro_price ) );
+			?>
+			<span class="sensei-promo-groups__price-period"><?php esc_html_e( 'per year, 1 site', 'sensei-lms' ); ?></span>
 			</h3>
 			<div class="sensei-promo-groups__actions">
 				<a


### PR DESCRIPTION
Fixes #6658 

## Proposed Changes
* Pulls the price for Sensei Pro from the extensions endpoint and use it throughout the site for all upsells.
* Displays the price the same throughout (based on the Sensei Home upsell):
```
{price} USD
per year, 1 site
```
  * Specifically: Groups upsell, Sensei Showcase upsell
* **Note**: This PR does not make the specific designs consistent (notice coloring and other differences) but instead focuses on the priority around what information is displayed and where it comes from.

## Testing Instructions
* Deactivate Sensei Pro.
* Go to Sensei LMS > Groups and observe the price is displayed correctly:
<img width="1397" alt="Screenshot 2023-03-20 at 10 48 55 pm" src="https://user-images.githubusercontent.com/68693/226482586-94ed049a-c8ac-4254-b4a7-295a3762f7af.png">
* Go to Sensei LMS > Courses > Showcase Courses and observe the price is displayed correctly:
<img width="2089" alt="Screenshot 2023-03-20 at 10 50 41 pm" src="https://user-images.githubusercontent.com/68693/226482797-31b56fbc-773a-4ca0-9a17-d0966a54af51.png">

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
