### PR TITLE
Provide notices to teachers on Sensei Home

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-home-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-home-controller.php
@@ -176,6 +176,7 @@ class Sensei_REST_API_Home_Controller extends \WP_REST_Controller {
 			'news'            => $this->news_provider->get(),
 			'guides'          => $this->guides_provider->get(),
 			'show_extensions' => $show_extensions,
+			'notices'         => $this->notices_provider->get(),
 		];
 
 		if ( $can_user_manage_sensei ) {
@@ -183,7 +184,6 @@ class Sensei_REST_API_Home_Controller extends \WP_REST_Controller {
 			$data['help']         = $this->help_provider->get();
 			$data['promo_banner'] = $this->promo_banner_provider->get();
 			$data['tasks']        = $this->tasks_provider->get();
-			$data['notices']      = $this->notices_provider->get();
 		}
 
 		return $data;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-home-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-home-controller.php
@@ -248,7 +248,7 @@ class Sensei_REST_API_Home_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( $mocked_response, $result['notices'] );
 	}
 
-	public function testGetData_GivenAMockedNoticesProviderAsTeacher_NotIncluded() {
+	public function testGetData_GivenAMockedNoticesProviderAsTeacher_Included() {
 		// Arrange
 		$this->login_as_teacher();
 
@@ -256,6 +256,6 @@ class Sensei_REST_API_Home_Controller_Test extends WP_UnitTestCase {
 		$result = $this->controller->get_data();
 
 		// Assert
-		$this->assertArrayNotHasKey( 'notices', $result );
+		$this->assertArrayHasKey( 'notices', $result );
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2235

## Proposed Changes
* Show notices to teachers from Sensei Home.
* Note: All notices I could find that we wouldn't want to show teachers (reviews, plugin updates, etc) have cap/role checks but we should double check.
 
## Testing Instructions
1. From the release branch on Sensei Pro and this branch, remove the Sensei license or otherwise make the site unavailable for Sensei Showcase.
2. Logged in as a teacher, go to Sensei LMS > Courses > Showcase Courses 
3. Verify you're redirected to Sensei Home and the notice is shown.