### PR TITLE
Fix Email post type test

### DIFF
--- a/includes/internal/emails/class-email-customization.php
+++ b/includes/internal/emails/class-email-customization.php
@@ -129,7 +129,7 @@ class Email_Customization {
 		$this->repository           = new Email_Repository();
 		$template_repository        = new Email_Page_Template_Repository();
 		$this->patterns             = new Email_Patterns();
-		$this->post_type            = new Email_Post_Type();
+		$this->post_type            = Email_Post_Type::instance();
 		$this->settings_menu        = new Settings_Menu();
 		$this->settings_tab         = new Email_Settings_Tab( $settings );
 		$this->blocks               = new Email_Blocks();

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -20,6 +20,32 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Email_Post_Type {
 	/**
+	 * Class instance.
+	 *
+	 * @var self
+	 */
+	static private $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Email_Post_Type constructor.
+	 */
+	private function __construct() {}
+
+	
+	/**
 	 * Post type name.
 	 */
 	public const POST_TYPE = 'sensei_email';

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -24,7 +24,7 @@ class Email_Post_Type {
 	 *
 	 * @var self
 	 */
-	static private $instance = null;
+	private static $instance = null;
 
 	/**
 	 * Get class instance.
@@ -44,7 +44,7 @@ class Email_Post_Type {
 	 */
 	private function __construct() {}
 
-	
+
 	/**
 	 * Post type name.
 	 */

--- a/tests/unit-tests/internal/emails/test-class-email-customization.php
+++ b/tests/unit-tests/internal/emails/test-class-email-customization.php
@@ -38,7 +38,7 @@ class Email_Customization_Test extends \WP_UnitTestCase {
 		$this->assertInstanceOf( Email_Customization::class, $result );
 	}
 
-	public function testInstace_WhenInitiated_AddsHookForRemovingLegacyEmail() {
+	public function testInstance_WhenInitiated_AddsHookForRemovingLegacyEmail() {
 		/* Arrange. */
 		$settings                   = $this->createMock( Sensei_Settings::class );
 		$assets                     = $this->createMock( Sensei_Assets::class );
@@ -84,12 +84,13 @@ class Email_Customization_Test extends \WP_UnitTestCase {
 		$assets                     = $this->createMock( Sensei_Assets::class );
 		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
 		$instance                   = Email_Customization::instance( $settings, $assets, $lesson_progress_repository );
+		$count_before               = did_action( 'sensei_disable_legacy_emails' );
 
 		/* Act. */
 		$instance->disable_legacy_emails();
 
 		/* Assert. */
-		$this->assertEquals( 1, did_action( 'sensei_disable_legacy_emails' ) );
+		$this->assertEquals( $count_before + 1, did_action( 'sensei_disable_legacy_emails' ) );
 	}
 
 	public function legacyHooksDataProvider() {

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -100,6 +100,8 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the `remove_cap_of_deleting_email` method returns the expected caps.
+	 *
 	 * @dataProvider providerRemoveCapOfDeletingEmail_ArgumentsGiven_ReturnsMatchingCaps
 	 */
 	public function testRemoveCapOfDeletingEmail_ArgumentsGiven_ReturnsMatchingCaps( $caps, $cap, $post_type, $expected_caps ) {

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -16,7 +16,7 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 
 	public function testRegisterPostType_WhenCalled_RegistersEmailPostType() {
 		/* Arrange. */
-		$email_post_type = new Email_Post_Type();
+		$email_post_type = Email_Post_Type::instance();
 
 		/* Act. */
 		$email_post_type->register_post_type();
@@ -27,7 +27,7 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 
 	public function testInit_WhenCalled_AddsInitAction() {
 		/* Arrange. */
-		$email_post_type = new Email_Post_Type();
+		$email_post_type = Email_Post_Type::instance();
 
 		/* Act. */
 		$email_post_type->init();
@@ -39,7 +39,7 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 
 	public function testInit_WhenCalled_AddsLoadEditAction() {
 		/* Arrange. */
-		$email_post_type = new Email_Post_Type();
+		$email_post_type = Email_Post_Type::instance();
 
 		/* Act. */
 		$email_post_type->init();
@@ -49,51 +49,10 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		$this->assertSame( 10, $priority );
 	}
 
-	public function testMaybeRedirectToListing_WhenCalledWithEmailPostType_RedirectsToEmailsPage() {
-		/* Arrange. */
-		$email_post_type   = new Email_Post_Type();
-		$_GET['post_type'] = 'sensei_email';
-		$this->prevent_wp_redirect();
-
-		/* Act. */
-		$redirect_status   = 0;
-		$redirect_location = '';
-		try {
-			$email_post_type->maybe_redirect_to_listing();
-		} catch ( \Sensei_WP_Redirect_Exception $e ) {
-			$redirect_status   = $e->getCode();
-			$redirect_location = $e->getMessage();
-		}
-
-		/* Assert. */
-		$this->assertSame( 301, $redirect_status );
-		$this->assertSame( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ), $redirect_location );
-	}
-
-	public function testMaybeRedirectToListing_WhenCalledWithNonEmailPostType_DoesNotRedirectToEmailsPage() {
-		/* Arrange. */
-		$email_post_type   = new Email_Post_Type();
-		$_GET['post_type'] = 'non_sensei_email';
-		$this->prevent_wp_redirect();
-
-		/* Act. */
-		$redirect_status   = 0;
-		$redirect_location = '';
-		try {
-			$email_post_type->maybe_redirect_to_listing();
-		} catch ( \Sensei_WP_Redirect_Exception $e ) {
-			$redirect_status   = $e->getCode();
-			$redirect_location = $e->getMessage();
-		}
-
-		/* Assert. */
-		$this->assertSame( 0, $redirect_status );
-		$this->assertSame( '', $redirect_location );
-	}
 
 	public function testInit_WhenCalled_AddsHookForRemovingEmailDeletingCap() {
 		/* Arrange. */
-		$email_post_type = new Email_Post_Type();
+		$email_post_type = Email_Post_Type::instance();
 
 		/* Act. */
 		$email_post_type->init();
@@ -105,7 +64,7 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 	public function testUserCap_WhenCalledForAdminUserForEmailPost_DoesNotAllowToDelete() {
 		/* Arrange. */
 		$this->login_as_admin();
-		$email_post_type = new Email_Post_Type();
+		$email_post_type = Email_Post_Type::instance();
 		$email_post_type->register_post_type();
 		$email_id = $this->factory->post->create(
 			[
@@ -124,7 +83,7 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 	public function testUserCap_WhenCalledForEditorUser_DoesNotAllowToDelete() {
 		/* Arrange. */
 		$this->login_as_editor();
-		$email_post_type = new Email_Post_Type();
+		$email_post_type = Email_Post_Type::instance();
 		$email_post_type->register_post_type();
 		$email_id = $this->factory->post->create(
 			[
@@ -140,11 +99,64 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		$this->assertFalse( current_user_can( 'delete_post', $email_id ) );
 	}
 
-	public function testUserCap_WhenCalled_AllowsDeletingUnlessHookIsAttached() {
+	/**
+	 * @dataProvider providerRemoveCapOfDeletingEmail_ArgumentsGiven_ReturnsMatchingCaps
+	 */
+	public function testRemoveCapOfDeletingEmail_ArgumentsGiven_ReturnsMatchingCaps( $caps, $cap, $post_type, $expected_caps ) {
 		/* Arrange. */
 		$this->login_as_admin();
-		$email_post_type = new Email_Post_Type();
-		$email_post_type->register_post_type();
+		$user_id = $this->get_user_by_role( 'admin' );
+
+		$email_post_type = Email_Post_Type::instance();
+		$email_post_type->init();
+
+		$email_id = $this->factory->post->create(
+			[
+				'post_type'   => $post_type,
+				'post_status' => 'publish',
+			]
+		);
+
+		/* Act. */
+		$actual_caps = $email_post_type->remove_cap_of_deleting_email( $caps, $cap, $user_id, array( $email_id ) );
+
+		/* Assert. */
+		self::assertSame( $expected_caps, $actual_caps );
+	}
+
+	public function providerRemoveCapOfDeletingEmail_ArgumentsGiven_ReturnsMatchingCaps(): array {
+		return array(
+			'delete_post cap for email post type' => array(
+				array( 'delete_published_posts' ),
+				'delete_post',
+				'sensei_email',
+				array(
+					'delete_published_posts',
+					'do_not_allow',
+				),
+			),
+			'other cap'                           => array(
+				array( 'delete_published_posts' ),
+				'edit_post',
+				'sensei_email',
+				array( 'delete_published_posts' ),
+			),
+			'delete_post cap for other post type' => array(
+				array( 'delete_published_posts' ),
+				'delete_post',
+				'post',
+				array( 'delete_published_posts' ),
+			),
+		);
+	}
+
+	public function testCurrentUserCan_HookNotAttachedAndEmailProvided_AllowsDeleting() {
+		/* Arrange. */
+		$this->login_as_admin();
+
+		$email_post_type = Email_Post_Type::instance();
+		$email_post_type->init();
+
 		$email_id = $this->factory->post->create(
 			[
 				'post_type'   => 'sensei_email',
@@ -152,17 +164,19 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 			]
 		);
 
+		remove_action( 'map_meta_cap', [ $email_post_type, 'remove_cap_of_deleting_email' ], 10 );
+
 		/* Act. */
-		remove_action( 'map_meta_cap', [ $email_post_type, 'map_meta_cap' ], 10 );
+		$actual = current_user_can( 'delete_post', $email_id );
 
 		/* Assert. */
-		$this->assertTrue( current_user_can( 'delete_post', $email_id ) );
+		$this->assertTrue( $actual );
 	}
 
 	public function testEmailDeleteCapHook_WhenCalled_DoesNotAffectOtherPostTypes() {
 		/* Arrange. */
 		$this->login_as_admin();
-		$email_post_type = new Email_Post_Type();
+		$email_post_type = Email_Post_Type::instance();
 		$email_post_type->register_post_type();
 		$post_id = $this->factory->post->create(
 			[
@@ -177,47 +191,67 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		$this->assertTrue( current_user_can( 'delete_post', $post_id ) );
 	}
 
+	public function testMaybeRedirectToListing_WhenCalledWithEmailPostType_RedirectsToEmailsPage() {
+		/* Arrange. */
+		$email_post_type   = Email_Post_Type::instance();
+		$_GET['post_type'] = 'sensei_email';
+		$this->prevent_wp_redirect();
+
+		/* Expect & Act. */
+		self::expectException( \Sensei_WP_Redirect_Exception::class );
+		self::expectExceptionCode( 301 );
+		self::getExpectedExceptionMessage( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ) );
+		$email_post_type->maybe_redirect_to_listing();
+	}
+
+	public function testMaybeRedirectToListing_WhenCalledWithNonEmailPostType_DoesNotRedirectToEmailsPage() {
+		/* Arrange. */
+		$email_post_type   = Email_Post_Type::instance();
+		$_GET['post_type'] = 'non_sensei_email';
+		$this->prevent_wp_redirect();
+
+		/* Act. */
+		$redirect_happened = false;
+		try {
+			$email_post_type->maybe_redirect_to_listing();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			$redirect_happened = true;
+		}
+
+		/* Assert. */
+		$this->assertFalse( $redirect_happened );
+	}
+
 	public function testMaybeRedirectToListing_WhenCalledWithEmailPostTypeAndInvalidBulkAction_RedirectsToEmailsPage() {
 		/* Arrange. */
-		$email_post_type   = new Email_Post_Type();
+		$email_post_type   = Email_Post_Type::instance();
 		$_GET['post_type'] = 'sensei_email';
 		$_GET['action']    = '-1';
 		$this->prevent_wp_redirect();
 
-		/* Act. */
-		$redirect_status   = 0;
-		$redirect_location = '';
-		try {
-			$email_post_type->maybe_redirect_to_listing();
-		} catch ( \Sensei_WP_Redirect_Exception $e ) {
-			$redirect_status   = $e->getCode();
-			$redirect_location = $e->getMessage();
-		}
-
-		/* Assert. */
-		$this->assertSame( 301, $redirect_status );
-		$this->assertSame( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ), $redirect_location );
+		/* Expect & Act. */
+		self::expectException( \Sensei_WP_Redirect_Exception::class );
+		self::expectExceptionCode( 301 );
+		self::getExpectedExceptionMessage( admin_url( 'admin.php?page=sensei-settings&tab=email-notification-settings' ) );
+		$email_post_type->maybe_redirect_to_listing();
 	}
 
 	public function testMaybeRedirectToListing_WhenCalledWithEmailPostTypeAndValidBulkAction_DoesNotRedirectToEmailsPage() {
 		/* Arrange. */
-		$email_post_type   = new Email_Post_Type();
+		$email_post_type   = Email_Post_Type::instance();
 		$_GET['post_type'] = 'sensei_email';
 		$_GET['action']    = 'disable-bulk-action';
 		$this->prevent_wp_redirect();
 
 		/* Act. */
-		$redirect_status   = 0;
-		$redirect_location = '';
+		$redirect_happened = false;
 		try {
 			$email_post_type->maybe_redirect_to_listing();
 		} catch ( \Sensei_WP_Redirect_Exception $e ) {
-			$redirect_status   = $e->getCode();
-			$redirect_location = $e->getMessage();
+			$redirect_happened = true;
 		}
 
 		/* Assert. */
-		$this->assertSame( 0, $redirect_status );
-		$this->assertSame( '', $redirect_location );
+		$this->assertFalse( $redirect_happened );
 	}
 }

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
@@ -304,14 +304,16 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	 * @return int The user ID.
 	 */
 	private function createUserWithActivity( string $activity_date, array $user_args = [] ): int {
-		$user_id = $this->factory->user->create( $user_args );
+		$user_id   = $this->factory->user->create( $user_args );
+		$course_id = $this->factory->course->create();
 
 		$lesson_id = $this->factory->lesson->create(
 			[
-				'meta_input' => [ '_lesson_course' => $this->factory->course->create() ],
+				'meta_input' => [ '_lesson_course' => $course_id ],
 			]
 		);
 
+		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
 		$activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id, true );
 
 		wp_update_comment(


### PR DESCRIPTION
Resolves #

## Proposed Changes
* Use singleton to avoid several instances of email post type during tests.

## Testing Instructions

1. Run `npm run test-php`.
2. Make sure there are no failures for `Email_Post_Type_Test`.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
