### PR TITLE
Fix email branch all tests

### DIFF
--- a/tests/unit-tests/internal/emails/test-class-email-customization.php
+++ b/tests/unit-tests/internal/emails/test-class-email-customization.php
@@ -38,7 +38,7 @@ class Email_Customization_Test extends \WP_UnitTestCase {
 		$this->assertInstanceOf( Email_Customization::class, $result );
 	}
 
-	public function testInstace_WhenInitiated_AddsHookForRemovingLegacyEmail() {
+	public function testInstance_WhenInitiated_AddsHookForRemovingLegacyEmail() {
 		/* Arrange. */
 		$settings                   = $this->createMock( Sensei_Settings::class );
 		$assets                     = $this->createMock( Sensei_Assets::class );
@@ -84,12 +84,13 @@ class Email_Customization_Test extends \WP_UnitTestCase {
 		$assets                     = $this->createMock( Sensei_Assets::class );
 		$lesson_progress_repository = $this->createMock( Lesson_Progress_Repository_Interface::class );
 		$instance                   = Email_Customization::instance( $settings, $assets, $lesson_progress_repository );
+		$count_before               = did_action( 'sensei_disable_legacy_emails' );
 
 		/* Act. */
 		$instance->disable_legacy_emails();
 
 		/* Assert. */
-		$this->assertEquals( 1, did_action( 'sensei_disable_legacy_emails' ) );
+		$this->assertEquals( $count_before + 1, did_action( 'sensei_disable_legacy_emails' ) );
 	}
 
 	public function legacyHooksDataProvider() {

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
@@ -304,14 +304,16 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	 * @return int The user ID.
 	 */
 	private function createUserWithActivity( string $activity_date, array $user_args = [] ): int {
-		$user_id = $this->factory->user->create( $user_args );
+		$user_id   = $this->factory->user->create( $user_args );
+		$course_id = $this->factory->course->create();
 
 		$lesson_id = $this->factory->lesson->create(
 			[
-				'meta_input' => [ '_lesson_course' => $this->factory->course->create() ],
+				'meta_input' => [ '_lesson_course' => $course_id ],
 			]
 		);
 
+		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
 		$activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id, true );
 
 		wp_update_comment(


### PR DESCRIPTION
Fixes the tests failing for reports and email customization

## Proposed Changes
* The test for student data provider for reports overview created lesson activity, but the students were not enrolled in the course, so the tests would already fail. But it didn't happen earlier because the function to send mail to teacher here https://github.com/Automattic/sensei/blob/456ed706bbbfab21457eaa0d4734bfd1276deaf2/includes/emails/class-sensei-email-teacher-completed-course.php#L48 calls the function `is_user_enrolled` which, while checking covers the issue [here](https://github.com/Automattic/sensei/blob/456ed706bbbfab21457eaa0d4734bfd1276deaf2/includes/enrolment/class-sensei-course-enrolment.php#L105-L156). So when the legacy teacher mail wasn't called, the enrollment issue caused the test failure.
* Fixed the customization check.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the PHP tests.
2. Make sure no tests are failing

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Data is [sanitized](https://developer.wordpress.org/apis/security/sanitizing/) / [escaped](https://developer.wordpress.org/apis/security/escaping/)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Test cases are written and passing (including feature flags)
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] We are generally happy with it and don’t feel like it immediately needs to be rewritten
- [ ] Application performance has not degraded
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
- [ ] Continuous Integration build is passing
