### PR TITLE
Fix polyfill dependency causing issues

### DIFF
--- a/config/scoper.inc.php
+++ b/config/scoper.inc.php
@@ -22,6 +22,5 @@ return [
 		Finder::create()->files()->in( 'vendor/pelago/emogrifier' )->name( [ '*.php', 'LICENSE', 'composer.json' ] ),
 		Finder::create()->files()->in( 'vendor/sabberworm/php-css-parser' )->name( [ '*.php', 'LICENSE', 'composer.json' ] ),
 		Finder::create()->files()->in( 'vendor/symfony/css-selector' )->name( [ '*.php', 'LICENSE', 'composer.json' ] ),
-		Finder::create()->files()->in( 'vendor/symfony/polyfill-php80' )->name( [ '*.php', 'LICENSE', 'composer.json' ] ),
 	],
 ];


### PR DESCRIPTION
The `polyfill-php80` was causing the following SVN pre-commit hook error:

![image](https://user-images.githubusercontent.com/1612178/228676467-d7e7e169-9ee9-42a5-98f9-2cabd1575d31.png)

The `polyfill-php80` is required by `symfony/css-selector` which is required by `pelago/emogrifier` but It looks like the polyfill is not needed in our case.

## Proposed Changes
* Remove the `polyfill-php80` dependency.

## Testing Instructions

1. Download the build generated in this PR.
2. Unzip it and make sure the `third-party/symfony/polyfill-php80` dependency is missing.
3. Install the build on PHP 7.2 and 8.0 and make sure the new email features are working.
4. Make sure there are no errors generated.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
