### PR TITLE
Only show the sensei email template when user is editing the sensei_email post_type

### DIFF
--- a/changelog/fix-hide_sensei_page_template
+++ b/changelog/fix-hide_sensei_page_template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only show the sensei_email template for the sensei emails.

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -121,6 +121,13 @@ class Email_Page_Template {
 		if ( 'wp_template' !== $template_type || ! empty( $query['theme'] ) ) {
 			return $original_templates;
 		}
+
+		$post_type = $query['post_type'] ?? get_post_type();
+
+		if ( ! empty( $post_type ) && Email_Post_Type::POST_TYPE !== $post_type ) {
+			return $original_templates;
+		}
+
 		$from_db = $this->repository->get( self::ID );
 
 		if ( ! empty( $from_db ) ) {

--- a/tests/unit-tests/internal/emails/test-class-email-page-template.php
+++ b/tests/unit-tests/internal/emails/test-class-email-page-template.php
@@ -117,9 +117,9 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 		$page_template        = new Email_Page_Template( $repository );
 		$default_list         = [ $this->createMock( \WP_Block_Template::class ) ];
 		$template_to_be_added = $this->createMock( \WP_Block_Template::class );
-		$post = $post = new \stdClass();
-		$post->post_type = 'page';
-		$GLOBALS['post'] = $post;
+		$post                 = $post = new \stdClass();
+		$post->post_type      = 'page';
+		$GLOBALS['post']      = $post;
 
 		$repository
 			->method( 'get' )
@@ -135,12 +135,12 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 	public function testAddEmailTemplate_GivenQuerySpecifPostType_ReturnsDefaultTemplate() {
 
 		/* Arrange. */
-		$repository           = $this->createMock( Email_Page_Template_Repository::class );
-		$page_template        = new Email_Page_Template( $repository );
-		$default_list         = [ $this->createMock( \WP_Block_Template::class ) ];
+		$repository    = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template = new Email_Page_Template( $repository );
+		$default_list  = [ $this->createMock( \WP_Block_Template::class ) ];
 
 		/* Act. */
-		$result = $page_template->add_email_template( $default_list, ['post_type' => 'page'], 'wp_template' );
+		$result = $page_template->add_email_template( $default_list, [ 'post_type' => 'page' ], 'wp_template' );
 
 		/* Assert. */
 		self::assertSame( $default_list, $result );

--- a/tests/unit-tests/internal/emails/test-class-email-page-template.php
+++ b/tests/unit-tests/internal/emails/test-class-email-page-template.php
@@ -117,7 +117,7 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 		$page_template        = new Email_Page_Template( $repository );
 		$default_list         = [ $this->createMock( \WP_Block_Template::class ) ];
 		$template_to_be_added = $this->createMock( \WP_Block_Template::class );
-		$post                 = $post = new \stdClass();
+		$post                 = new \stdClass();
 		$post->post_type      = 'page';
 		$GLOBALS['post']      = $post;
 

--- a/tests/unit-tests/internal/emails/test-class-email-page-template.php
+++ b/tests/unit-tests/internal/emails/test-class-email-page-template.php
@@ -4,6 +4,8 @@ namespace SenseiTest\Internal\Emails;
 
 use Sensei\Internal\Emails\Email_Page_Template;
 use Sensei\Internal\Emails\Email_Page_Template_Repository;
+use Sensei\Internal\Emails\Email_Post_Type;
+use WP_Post;
 
 /**
  * Tests for Sensei\Internal\Emails\Email_Page_Template class.
@@ -106,6 +108,42 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertSame( $template_to_be_added, $result[1] );
+	}
+
+	public function testAddEmailTemplate_WhenThePostTypeIsIncorrect_ReturnsDefaultTemplate() {
+
+		/* Arrange. */
+		$repository           = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template        = new Email_Page_Template( $repository );
+		$default_list         = [ $this->createMock( \WP_Block_Template::class ) ];
+		$template_to_be_added = $this->createMock( \WP_Block_Template::class );
+		$post = $post = new \stdClass();
+		$post->post_type = 'page';
+		$GLOBALS['post'] = $post;
+
+		$repository
+			->method( 'get' )
+			->willReturn( $template_to_be_added );
+
+		/* Act. */
+		$result = $page_template->add_email_template( $default_list, [], 'wp_template' );
+
+		/* Assert. */
+		self::assertSame( $default_list, $result );
+	}
+
+	public function testAddEmailTemplate_GivenQuerySpecifPostType_ReturnsDefaultTemplate() {
+
+		/* Arrange. */
+		$repository           = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template        = new Email_Page_Template( $repository );
+		$default_list         = [ $this->createMock( \WP_Block_Template::class ) ];
+
+		/* Act. */
+		$result = $page_template->add_email_template( $default_list, ['post_type' => 'page'], 'wp_template' );
+
+		/* Assert. */
+		self::assertSame( $default_list, $result );
 	}
 
 	public function testAddEmailTemplate_WhenPostTypeIsIncorrect_ReturnsDefaultList() {


### PR DESCRIPTION
Resolves #6686

## Proposed Changes
The hook `get_block_templates` is called multiple times, sometimes with the post, and sometimes with a query. 
This PR is checking both cases before injecting our page template

## Testing instructions
* Edit/Create a post_type=page (or any other post_type) using the interface
* Check if the Sensei Email template is not available. 
* Edit a sensei_template  (Settings > emails)
* Check if the sensei-email is available. 
* Check if the sensei email is available on the Appearance > Editor.
* 
<img width="400" alt="Screenshot 2023-03-31 at 13 08 12" src="https://user-images.githubusercontent.com/38718/229115965-6f1806e0-4469-4a06-9dbf-27b56f901010.png">


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
