### PR TITLE
Add Sensei Pro updater fallback

### DIFF
--- a/assets/css/senseilms-licensing.scss
+++ b/assets/css/senseilms-licensing.scss
@@ -1,0 +1,8 @@
+#section-changelog {
+	h2 {
+		clear: none;
+	}
+	h3 {
+		margin: 0;
+	}
+}

--- a/includes/admin/class-senseilms-plugin-updater.php
+++ b/includes/admin/class-senseilms-plugin-updater.php
@@ -132,8 +132,7 @@ class SenseiLMS_Plugin_Updater {
 			'high' => $remote->banners->{'2x'},
 		];
 
-		// TODO: ADD CSS.
-		wp_enqueue_style( 'sensei-updater-styles', plugin_dir_url( $this->plugin_full_name ) . 'assets/dist/senseilms-licensing/styles.css', [], $this->version );
+		Sensei()->assets->enqueue( 'sensei-updater-styles', 'css/senseilms-licensing.css' );
 
 		return $res;
 	}

--- a/includes/admin/class-senseilms-plugin-updater.php
+++ b/includes/admin/class-senseilms-plugin-updater.php
@@ -190,13 +190,16 @@ class SenseiLMS_Plugin_Updater {
 		$remote    = get_transient( $cache_key );
 
 		if ( false === $remote ) {
+			// @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			$api_url = apply_filters( 'senseilms_licensing_api', 'https://senseilms.com/wp-json' );
+
 			$remote = wp_remote_get(
 				add_query_arg(
 					[
 						'plugin_slug' => $this->plugin_slug,
 						'ts'          => time(), // Adding some timestamp to workaround cache issues.
 					],
-					'https://senseilms.com/wp-json/plugin-updater/v1/info'
+					$api_url . '/plugin-updater/v1/info'
 				),
 				[
 					'timeout' => 10,

--- a/includes/admin/class-senseilms-plugin-updater.php
+++ b/includes/admin/class-senseilms-plugin-updater.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Manages plugin updates by hooking into WordPress's plugins update system and querying SenseiLMS Store's API.
  *
  * It's a fallback to SenseiLMS_Licensing\SenseiLMS_Plugin_Updater from Sensei Pro. So it works when
- * Sensei Pro is in a legacy version without this class.
+ * Sensei Pro is in a legacy version that depends on the activated license.
  *
  * @since $$next-version$$
  */

--- a/includes/admin/class-senseilms-plugin-updater.php
+++ b/includes/admin/class-senseilms-plugin-updater.php
@@ -150,7 +150,7 @@ class SenseiLMS_Plugin_Updater {
 	public function maybe_inject_custom_update_to_update_plugins_transient( $transient ) {
 
 		// Skip empty transients or if it was already set by Sensei Pro.
-		if ( empty( $transient ) || isset( $response[ $this->plugin_full_name ] ) ) {
+		if ( empty( $transient ) || isset( $transient->response[ $this->plugin_full_name ] ) ) {
 			return $transient;
 		}
 

--- a/includes/admin/class-senseilms-plugin-updater.php
+++ b/includes/admin/class-senseilms-plugin-updater.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * File containing SenseiLMS_Plugin_Updater class.
+ *
+ * @package Sensei\Admin
+ * @since   $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Manages plugin updates by hooking into WordPress's plugins update system and querying SenseiLMS Store's API.
+ *
+ * It's a fallback to SenseiLMS_Licensing\SenseiLMS_Plugin_Updater from Sensei Pro. So it works when
+ * Sensei Pro is in a legacy version without this class.
+ *
+ * @since $$next-version$$
+ */
+class SenseiLMS_Plugin_Updater {
+
+	const CACHE_KEY_PREFIX = 'senseilms_plugin_updater_info__';
+	const CACHE_TTL        = 3600;
+
+	/**
+	 * Full qualified name for the plugin. Relative path from plugins directory. Example: 'akismet/akismet.php'.
+	 *
+	 * @var string
+	 */
+	private $plugin_full_name;
+
+	/**
+	 * Plugin slug name. Example: 'akismet'.
+	 *
+	 * @var string
+	 */
+	private $plugin_slug;
+
+	/**
+	 * Current version for the plugin. Example: '1.0.0'.
+	 *
+	 * @var string
+	 */
+	private $version;
+
+	/**
+	 * Private constructor.
+	 *
+	 * @param string $main_plugin_file_absolute_path Plugin's main file path.
+	 * @param string $version                        Plugin version.
+	 */
+	private function __construct( $main_plugin_file_absolute_path, $version ) {
+		$this->plugin_full_name = plugin_basename( $main_plugin_file_absolute_path );
+		$this->plugin_slug      = basename( $main_plugin_file_absolute_path, '.php' );
+		$this->version          = $version;
+	}
+
+	/**
+	 * Initialize the plugin updater.
+	 */
+	public static function init() {
+		add_action( 'plugins_loaded', [ __CLASS__, 'plugins_loaded' ] );
+	}
+
+	/**
+	 * Add hooks after the `plugins_loaded`, so we make sure Sensei Pro was
+	 * already loaded.
+	 */
+	public static function plugins_loaded() {
+		// Early return if license and updates are managed by WooCommerce.
+		if ( defined( 'SENSEI_COMPAT_PLUGIN' ) && SENSEI_COMPAT_PLUGIN ) {
+			return;
+		}
+
+		if ( class_exists( '\Sensei_Pro_Interactive_Blocks\Setup_Context' ) ) {
+			$instance = new self( SENSEI_IB_PLUGIN_FILE, SENSEI_IB_VERSION );
+		} elseif ( class_exists( '\Sensei_Pro\Setup_Context' ) ) {
+			$instance = new self( SENSEI_PRO_PLUGIN_FILE, SENSEI_PRO_VERSION );
+		} else {
+			return;
+		}
+
+		add_filter( 'plugins_api', [ $instance, 'get_plugin_info' ], 15, 3 );
+		add_filter( 'site_transient_update_plugins', [ $instance, 'maybe_inject_custom_update_to_update_plugins_transient' ], 15 );
+	}
+
+	/**
+	 * Get plugin information as expected by the `plugins_api` hook.
+	 * This will be called to display the details for the updated in the detailed view.
+	 *
+	 * @param false|object|array $res    Result. As defined per the `plugins_api` hook.
+	 * @param string             $action The action being executed. As defined per the `plugins_api` hook.
+	 * @param object             $args   The arguments. As defined per the `plugins_api` hook.
+	 *
+	 * @hooked plugins_api
+	 *
+	 * @return false|object If other than false is returned the actual call to wordpress.org is not done.
+	 */
+	public function get_plugin_info( $res, $action, $args ) {
+		if (
+			'plugin_information' !== $action
+			|| $this->plugin_slug !== $args->slug
+			|| false !== $res
+		) {
+			return $res;
+		}
+
+		$remote = $this->request_info();
+		if ( is_wp_error( $remote ) ) {
+			// Early return in case request to SenseiLMS.com failed.
+			return $res;
+		}
+
+		$res                = new stdClass();
+		$res->name          = $remote->name;
+		$res->slug          = $remote->slug;
+		$res->author        = $remote->author;
+		$res->version       = $remote->version;
+		$res->requires      = $remote->requires;
+		$res->tested        = $remote->tested;
+		$res->requires_php  = $remote->requires_php;
+		$res->last_updated  = $remote->last_updated;
+		$res->sections      = [
+			'description'  => $remote->sections->description,
+			'installation' => $remote->sections->installation,
+			'changelog'    => $remote->sections->changelog,
+		];
+		$res->download_link = $remote->download_url;
+		$res->banners       = [
+			'low'  => $remote->banners->{'1x'},
+			'high' => $remote->banners->{'2x'},
+		];
+
+		// TODO: ADD CSS.
+		wp_enqueue_style( 'sensei-updater-styles', plugin_dir_url( $this->plugin_full_name ) . 'assets/dist/senseilms-licensing/styles.css', [], $this->version );
+
+		return $res;
+	}
+
+	/**
+	 * Potentially injects the details for a new plugin version by checking against the remote server.
+	 * This is done by hooking into the `update_plugins` transient by using the `site_transient_update_plugins` hook.
+	 *
+	 * @param mixed $transient The plugin_update transient.
+	 *
+	 * @hooked site_transient_update_plugins See reference for `site_transient_transient`.
+	 *
+	 * @return mixed
+	 */
+	public function maybe_inject_custom_update_to_update_plugins_transient( $transient ) {
+
+		// Skip empty transients or if it was already set by Sensei Pro.
+		if ( empty( $transient ) || isset( $response[ $this->plugin_full_name ] ) ) {
+			return $transient;
+		}
+
+		$remote = $this->request_info();
+		if ( is_wp_error( $remote ) ) {
+			// Request failed so do not inject anything into the transient.
+			return $transient;
+		}
+
+		if (
+			$remote
+			&& version_compare( $this->version, $remote->version, '<' )
+			&& version_compare( get_bloginfo( 'version' ), $remote->requires, '>=' )
+			&& version_compare( PHP_VERSION, $remote->requires_php, '>=' )
+		) {
+
+			$res                                 = new stdClass();
+			$res->slug                           = $remote->slug;
+			$res->plugin                         = $this->plugin_full_name;
+			$res->new_version                    = $remote->version;
+			$res->tested                         = $remote->tested;
+			$res->package                        = $remote->download_url;
+			$res->icons                          = (array) $remote->icons;
+			$transient->response[ $res->plugin ] = $res;
+		}
+		return $transient;
+	}
+
+	/**
+	 * Helper function that retrieves the latest version information from the remote server if there is a valid license in the system.
+	 * This function caches remote response by using transients.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function request_info() {
+		$cache_key = self::CACHE_KEY_PREFIX . $this->plugin_slug;
+		$remote    = get_transient( $cache_key );
+
+		if ( false === $remote ) {
+			$remote = wp_remote_get(
+				add_query_arg(
+					[
+						'plugin_slug' => $this->plugin_slug,
+						'ts'          => time(), // Adding some timestamp to workaround cache issues.
+					],
+					'https://senseilms.com/wp-json/plugin-updater/v1/info'
+				),
+				[
+					'timeout' => 10,
+					'headers' => [
+						'Accept'        => 'application/json',
+						'Cache-Control' => 'no-cache',
+					],
+				]
+			);
+
+			// Caching any response.
+			set_transient( $cache_key, $remote, self::CACHE_TTL );
+		}
+
+		// Check response for errors.
+		if (
+			is_wp_error( $remote )
+			|| 200 !== wp_remote_retrieve_response_code( $remote )
+			|| empty( wp_remote_retrieve_body( $remote ) )
+		) {
+			return new WP_Error( 'remote-error', __( 'Remote answered with an error.', 'sensei-lms' ) );
+		}
+
+		// Check response for valid json.
+		$response = json_decode( wp_remote_retrieve_body( $remote ) );
+		if ( is_null( $response ) ) {
+			return new WP_Error( 'invalid-remote-response', __( 'Remote answered with an invalid response.', 'sensei-lms' ) );
+		}
+
+		return $response;
+	}
+}

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -140,6 +140,7 @@ class Sensei_Autoloader {
 			'Sensei_Admin_Notices'                         => 'admin/class-sensei-admin-notices.php',
 			'Sensei_Editor_Wizard'                         => 'admin/class-sensei-editor-wizard.php',
 			'Sensei_No_Users_Table_Relationship'           => 'reports/class-sensei-no-users-table-relationship.php',
+			'SenseiLMS_Plugin_Updater'                     => 'admin/class-senseilms-plugin-updater.php',
 
 			/**
 			 * Admin Tools

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -526,6 +526,7 @@ class Sensei_Main {
 			new Sensei_Exit_Survey();
 
 			Sensei_No_Users_Table_Relationship::instance()->init();
+			SenseiLMS_Plugin_Updater::init();
 
 		} else {
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,7 @@ const files = [
 	'css/sensei-theme-blocks.scss',
 	'css/sensei-course-theme/sidebar-mobile-menu.scss',
 	'css/showcase-upsell.scss',
+	'css/senseilms-licensing.scss',
 	'course-theme/learning-mode.js',
 	'course-theme/course-theme.editor.js',
 	'course-theme/blocks/index.js',


### PR DESCRIPTION
Resolves #6667

## Proposed Changes

* It includes a fallback to the Sensei Pro updater.
  * Basically, it works in installations with Sensei Pro in a legacy version that doesn't check for updates when the license is not activated. New versions of Sensei Pro will handle it, so this code is just useful for the older versions.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure your requests to senseilms.com are pointing to your dev env, in the branch `feature/reengaging-customers`. The following snipped can be useful if you didn't do it yet.
   ```php
	add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
		$host = parse_url( $url, PHP_URL_HOST );

		if ( 'senseilms.com' === $host ) {
			$scheme  = parse_url( $url, PHP_URL_SCHEME );
			$http    = _wp_http_get_object();
			$new_url = str_replace(
				$scheme . '://' . $host,
				'http://senseilms-com.local',
				$url
			);

			error_log( 'Redirect from: ' . $url );
			error_log( 'To: ' . $new_url );

			return $http->request( $new_url, $r );
		}
		return $preempt;
	}, 10, 3 );
   ```
3. Make sure you don't have a Sensei license activated.
4. Activate Sensei Pro plugin in an old version `git checkout version/sensei-pro-1.11.1`.
5. Navigate to the plugins page, and make sure it displays the message "There is a new version of Sensei Pro available".
6. Activate Sensei Pro.
7. Make sure the message is still there (now it's handled by Sensei Pro - I think the best way to test it is by debugging the code to see that it skips in Sensei LMS).
8. Checkout `feature/reengaging-customers` in Sensei Pro (it contains the version that already handles it).
9. Update the Sensei Pro versions in `sensei-pro.php` to simulate an older version.
10. Debug the code, and make sure everything is handled by Sensei Pro, and it's skipped in Sensei LMS.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
