### PR TITLE
Add a "copy-changelog-to-readme" script

### DIFF
--- a/scripts/copy-changelog-to-readme.php
+++ b/scripts/copy-changelog-to-readme.php
@@ -1,0 +1,62 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Tool that will copy the latest changelog entries to the readme.
+ *
+ * @package Sensei
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals, WordPress.WP.AlternativeFunctions
+ */
+
+chdir( __DIR__ . '/../' );
+
+/**
+ * Get the latest changelog entries.
+ *
+ * @param int $num_entries Number of entries to get.
+ *
+ * @return array
+ */
+function get_latest_changelog_entries( int $num_entries ): array {
+	$changelog = file_get_contents( 'changelog.txt' );
+	$changelog = str_replace( "*** Changelog ***\n\n", '', $changelog );
+
+	$version_regex = '/(## [\d.\-a-z]+ - \d{4}-\d{2}-\d{2})/';
+	$matches       = preg_split( $version_regex, $changelog, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
+
+	$entries = [];
+	for ( $i = 0; $i < $num_entries; $i++ ) {
+		$version             = trim( array_shift( $matches ) );
+		$entries[ $version ] = trim( array_shift( $matches ) );
+	}
+
+	return $entries;
+}
+
+/**
+ * Replace the changelog section in the readme.
+ *
+ * @param array $changelog_entries Changelog entries.
+ */
+function replace_changelog_in_readme( $changelog_entries ): void {
+	$readme = file_get_contents( 'readme.txt' );
+	$readme = preg_replace( '/(== Changelog ==).*/s', '$1', $readme );
+
+	foreach ( $changelog_entries as $version => $entry ) {
+		$version = str_replace( '##', '###', $version );
+		$entry   = str_replace( '###', '####', $entry );
+
+		$readme .= "\n\n" . $version . "\n" . $entry;
+	}
+
+	file_put_contents( 'readme.txt', $readme );
+}
+
+$changelog_entries = get_latest_changelog_entries( 3 );
+
+if ( empty( $changelog_entries ) ) {
+	echo "No changelog entries found.\n";
+	exit( 1 );
+}
+
+replace_changelog_in_readme( $changelog_entries );


### PR DESCRIPTION
Part of #6661

## Proposed Changes
* Add a script that copies the latest 3 changelog entries to the readme.txt file.
* The script also makes sure the changelog headings in the readme.txt are correct.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the `readme.txt` and remove the changelog entries below `== Changelog ==` section.  
1. Run the script `./scripts/copy-changelog-to-readme.php`.
2. Open the `readme.txt` and make sure the last 3 changelog versions are there.
3. Make sure the changelog version heading uses `###` instead of `##`.
4. Make sure the changelog section heading uses `####` instead of `###`.

I wasn't able to figure out how to write proper tests. Let me know if you have any ideas.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
