### PR TITLE
Fix PHP 8 deprecated notices

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -130,7 +130,7 @@ class Sensei_Admin {
 	 */
 	public function add_course_order() {
 		add_submenu_page(
-			null, // Hide in menu.
+			'options.php', // Hide in menu.
 			__( 'Order Courses', 'sensei-lms' ),
 			__( 'Order Courses', 'sensei-lms' ),
 			'manage_sensei',
@@ -147,7 +147,7 @@ class Sensei_Admin {
 	 */
 	public function add_lesson_order() {
 		add_submenu_page(
-			null,
+			'options.php', // Hide in menu.
 			__( 'Order Lessons', 'sensei-lms' ),
 			__( 'Order Lessons', 'sensei-lms' ),
 			'edit_published_lessons',

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -210,7 +210,7 @@ class Sensei_Course {
 	 */
 	public function add_showcase_courses_upsell() {
 		add_submenu_page(
-			null,
+			'options.php', // Hide in menu.
 			__( 'Showcase Courses', 'sensei-lms' ),
 			__( 'Showcase Courses', 'sensei-lms' ),
 			'edit_courses',

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1231,7 +1231,7 @@ class Sensei_Core_Modules {
 	 */
 	public function add_submenus() {
 		add_submenu_page(
-			null, // Hide the submenu.
+			'options.php', // Hide the submenu.
 			__( 'Order Modules', 'sensei-lms' ),
 			__( 'Order Modules', 'sensei-lms' ),
 			'edit_lessons',


### PR DESCRIPTION
## Proposed Changes

* It changes the approach to add modules that we don't want in the WP Admin menu to avoid PHP 8 deprecated notices.
  * Passing `null` as the first argument, will give the following notice:
    ```
    PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /your-site/wp-includes/functions.php on line 7053
    ```

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to a page in the WP Admin.
2. Make sure you don't see deprecation notices anymore.
3. Also make sure the following pages continue working properly:
  3.1. Order Courses (WP Admin > Sensei LMS > Courses)
  3.2. Order Modules (WP Admin > Sensei LMS > Modules)
  3.3. Order Lessons (WP Admin > Sensei LMS > Lessons)
  3.4. Showcase Courses (WP Admin > Sensei LMS > Courses)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
