### PR TITLE
Replace course theme lesson actions block with generic one

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged

--- a/assets/blocks/shared.js
+++ b/assets/blocks/shared.js
@@ -10,6 +10,13 @@ import { subscribe, select } from '@wordpress/data';
 import registerSenseiBlocks from './register-sensei-blocks';
 import ContactTeacherBlock from './contact-teacher-block';
 import ConditionalContentBlock from './conditional-content-block';
+import {
+	LessonActionsBlock,
+	CompleteLessonBlock,
+	NextLessonBlock,
+	ResetLessonBlock,
+	ViewQuizBlock,
+} from './lesson-actions';
 import { registerCourseListBlock } from './course-list-block';
 
 // Post types where blocks should be loaded. Or null if it should be loaded for any post type.
@@ -18,7 +25,7 @@ const BLOCKS_PER_POST_TYPE = {
 	'sensei-lms/conditional-content': [ 'course', 'lesson' ],
 };
 
-registerSenseiBlocks( [ ContactTeacherBlock, ConditionalContentBlock ] );
+registerSenseiBlocks( [ ContactTeacherBlock, ConditionalContentBlock, LessonActionsBlock, CompleteLessonBlock, NextLessonBlock, ResetLessonBlock, ViewQuizBlock ] );
 
 registerCourseListBlock();
 

--- a/includes/blocks/class-sensei-lesson-actions-block.php
+++ b/includes/blocks/class-sensei-lesson-actions-block.php
@@ -46,8 +46,8 @@ class Sensei_Lesson_Actions_Block {
 		$course_id = Sensei()->lesson->get_course_id( $lesson->ID );
 
 		if (
-			Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id )
-			|| ! Sensei_Lesson::should_show_lesson_actions( $lesson->ID )
+			// Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id )
+			! Sensei_Lesson::should_show_lesson_actions( $lesson->ID )
 		) {
 			return '';
 		}

--- a/includes/blocks/course-theme/class-course-theme-blocks.php
+++ b/includes/blocks/course-theme/class-course-theme-blocks.php
@@ -58,7 +58,7 @@ class Course_Theme_Blocks extends Sensei_Blocks_Initializer {
 		new Blocks\Exit_Course();
 		new Blocks\Course_Progress_Counter();
 		new Blocks\Course_Progress_Bar();
-		new Blocks\Lesson_Actions();
+		// new Blocks\Lesson_Actions();
 		new Blocks\Quiz_Back_To_Lesson();
 		new Blocks\Sidebar_Toggle_Button();
 		new Blocks\Quiz_Actions();

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -237,7 +237,10 @@ class Sensei_Autoloader {
 			'Sensei\Blocks\Course_Theme\Site_Logo'         => 'blocks/course-theme/class-site-logo.php',
 			'Sensei\Blocks\Course_Theme\Focus_Mode'        => 'blocks/course-theme/class-focus-mode.php',
 			'Sensei\Blocks\Course_Theme\Notices'           => 'blocks/course-theme/class-notices.php',
-			'Sensei\Blocks\Course_Theme\Lesson_Actions'    => 'blocks/course-theme/class-lesson-actions.php',
+
+			'Sensei_Lesson_Actions_Block'                  => 'blocks/class-sensei-lesson-actions-block.php',
+
+			// 'Sensei\Blocks\Course_Theme\Lesson_Actions'    => 'blocks/course-theme/class-lesson-actions.php',
 			'Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson' => 'blocks/course-theme/class-quiz-back-to-lesson.php',
 			'Sensei\Blocks\Course_Theme\Course_Progress_Counter' => 'blocks/course-theme/class-course-progress-counter.php',
 			'Sensei\Blocks\Course_Theme\Course_Progress_Bar' => 'blocks/course-theme/class-course-progress-bar.php',

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -56,7 +56,24 @@
 
         <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
         <div class="wp-block-group"><!-- wp:sensei-lms/page-actions /-->
-            <!-- wp:sensei-lms/course-theme-lesson-actions {"options":{"nextLesson":true}} /--></div>
+        	<!-- wp:sensei-lms/lesson-actions -->
+			<div class="wp-block-sensei-lms-lesson-actions"><div class="sensei-buttons-container"><!-- wp:sensei-lms/button-view-quiz {"inContainer":true} -->
+			<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper"><div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link">View Quiz</button></div></div>
+			<!-- /wp:sensei-lms/button-view-quiz -->
+
+			<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true} -->
+			<div class="wp-block-sensei-lms-button-complete-lesson is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper"><div class="wp-block-sensei-lms-button-complete-lesson is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link sensei-stop-double-submission">Complete Lesson</button></div></div>
+			<!-- /wp:sensei-lms/button-complete-lesson -->
+
+			<!-- wp:sensei-lms/button-next-lesson {"inContainer":true} -->
+			<div class="wp-block-sensei-lms-button-next-lesson is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-next-lesson__wrapper"><div class="wp-block-sensei-lms-button-next-lesson is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link">Next Lesson</button></div></div>
+			<!-- /wp:sensei-lms/button-next-lesson -->
+
+			<!-- wp:sensei-lms/button-reset-lesson {"inContainer":true} -->
+			<div class="wp-block-sensei-lms-button-reset-lesson is-style-outline sensei-buttons-container__button-block wp-block-sensei-lms-button-reset-lesson__wrapper"><div class="wp-block-sensei-lms-button-reset-lesson is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link sensei-stop-double-submission">Reset Lesson</button></div></div>
+			<!-- /wp:sensei-lms/button-reset-lesson --></div></div>
+			<!-- /wp:sensei-lms/lesson-actions -->
+        </div>
         <!-- /wp:group --></div>
     <!-- /wp:sensei-lms/ui --></div>
 <!-- /wp:sensei-lms/ui -->


### PR DESCRIPTION
Quick and dirty attempt to replace the custom Learning Mode Lesson Actions block with the generic one.

#### Editor - What It Should Look Like
![Screenshot 2023-04-03 at 7 07 35 PM](https://user-images.githubusercontent.com/1190420/229645683-2f0173c2-e429-4cbd-9562-9b5d9c52ec2a.jpg)

#### What It Actually Looks Like
![Screenshot 2023-04-03 at 7 05 30 PM](https://user-images.githubusercontent.com/1190420/229645412-b371983b-df69-484a-a2ac-59c39d40f609.jpg)

#### Frontend - What It Should Look Like
![Screenshot 2023-04-03 at 7 08 52 PM](https://user-images.githubusercontent.com/1190420/229645826-c606b209-393c-4123-bc7d-9e61f4e246fb.jpg)

#### What It Actually Looks Like
![Screenshot 2023-04-03 at 7 06 01 PM](https://user-images.githubusercontent.com/1190420/229645458-f639f196-8d17-4f43-9f95-686e33e2485d.jpg)