### PR TITLE
Fix performance issue with alloptions filter

### DIFF
--- a/changelog/fix-alloptions-call
+++ b/changelog/fix-alloptions-call
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+Fixing performance issue when filtering on alloptions
+

--- a/changelog/fix-alloptions-call
+++ b/changelog/fix-alloptions-call
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
 
-Fixing performance issue when filtering on alloptions
+Remove fallback to legacy options
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -285,8 +285,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'20' => '20',
 		);
 
-		$alloptions = wp_load_alloptions();
-
 		$complete_settings    = array(
 			'passed'   => __( 'Once all the course lessons have been completed', 'sensei-lms' ),
 			'complete' => __( 'At any time (by clicking the \'Complete Course\' button)', 'sensei-lms' ),
@@ -320,7 +318,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'        => __( 'Course Archive Page', 'sensei-lms' ),
 			'description' => __( 'The page to use to display courses. If you leave this blank the default custom post type archive will apply.', 'sensei-lms' ),
 			'type'        => 'select',
-			'default'     => $alloptions['woothemes-sensei_courses_page_id'] ?? 0,
+			'default'     => 0,
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,
@@ -330,7 +328,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'        => __( 'My Courses Page', 'sensei-lms' ),
 			'description' => __( 'The page to use to display the courses that a user is currently taking as well as the courses a user has complete.', 'sensei-lms' ),
 			'type'        => 'select',
-			'default'     => $alloptions['woothemes-sensei_user_dashboard_page_id'] ?? 0,
+			'default'     => 0,
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,
@@ -340,7 +338,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'        => __( 'Course Completed Page', 'sensei-lms' ),
 			'description' => __( 'The page that is displayed after a student completes a course.', 'sensei-lms' ),
 			'type'        => 'select',
-			'default'     => $alloptions['woothemes-sensei_course_completed_page_id'] ?? 0,
+			'default'     => 0,
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -45,7 +45,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
 
 		// Make sure we don't trigger queries if legacy options aren't loaded in pre-loaded options.
-		add_filter( 'alloptions', [ $this, 'no_special_query_for_legacy_options' ] );
+		add_filter( 'pre_cache_alloptions', [ $this, 'no_special_query_for_legacy_options' ] );
 
 		// Mark settings section as visited on ajax action received.
 		add_action( 'wp_ajax_sensei_settings_section_visited', [ $this, 'mark_section_as_visited' ] );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -300,7 +300,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'19' => '19',
 			'20' => '20',
 		);
-
 		$complete_settings    = array(
 			'passed'   => __( 'Once all the course lessons have been completed', 'sensei-lms' ),
 			'complete' => __( 'At any time (by clicking the \'Complete Course\' button)', 'sensei-lms' ),

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -44,9 +44,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Log when settings are updated by the user.
 		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
 
-		// Make sure we don't trigger queries if legacy options aren't loaded in pre-loaded options.
-		add_filter( 'pre_cache_alloptions', [ $this, 'no_special_query_for_legacy_options' ] );
-
 		// Mark settings section as visited on ajax action received.
 		add_action( 'wp_ajax_sensei_settings_section_visited', [ $this, 'mark_section_as_visited' ] );
 	}
@@ -177,27 +174,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 	}
 
 	/**
-	 * Add legacy options to alloptions if they don't exist.
-	 *
-	 * @since 3.0.1
-	 *
-	 * @param array $alloptions All options that are preloaded by WordPress.
-	 *
-	 * @return array
-	 */
-	public function no_special_query_for_legacy_options( $alloptions ) {
-		if ( ! isset( $alloptions['woothemes-sensei_user_dashboard_page_id'] ) ) {
-			$alloptions['woothemes-sensei_user_dashboard_page_id'] = 0;
-		}
-
-		if ( ! isset( $alloptions['woothemes-sensei_courses_page_id'] ) ) {
-			$alloptions['woothemes-sensei_courses_page_id'] = 0;
-		}
-
-		return $alloptions;
-	}
-
-	/**
 	 * Add settings sections.
 	 *
 	 * @access public
@@ -308,6 +284,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'19' => '19',
 			'20' => '20',
 		);
+
+		$alloptions = wp_load_alloptions();
+
 		$complete_settings    = array(
 			'passed'   => __( 'Once all the course lessons have been completed', 'sensei-lms' ),
 			'complete' => __( 'At any time (by clicking the \'Complete Course\' button)', 'sensei-lms' ),
@@ -341,7 +320,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'        => __( 'Course Archive Page', 'sensei-lms' ),
 			'description' => __( 'The page to use to display courses. If you leave this blank the default custom post type archive will apply.', 'sensei-lms' ),
 			'type'        => 'select',
-			'default'     => get_option( 'woothemes-sensei_courses_page_id', 0 ),
+			'default'     => $alloptions['woothemes-sensei_courses_page_id'] ?? 0,
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,
@@ -351,7 +330,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'        => __( 'My Courses Page', 'sensei-lms' ),
 			'description' => __( 'The page to use to display the courses that a user is currently taking as well as the courses a user has complete.', 'sensei-lms' ),
 			'type'        => 'select',
-			'default'     => get_option( 'woothemes-sensei_user_dashboard_page_id', 0 ),
+			'default'     => $alloptions['woothemes-sensei_user_dashboard_page_id'] ?? 0,
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,
@@ -361,7 +340,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'        => __( 'Course Completed Page', 'sensei-lms' ),
 			'description' => __( 'The page that is displayed after a student completes a course.', 'sensei-lms' ),
 			'type'        => 'select',
-			'default'     => get_option( 'woothemes-sensei_course_completed_page_id', 0 ),
+			'default'     => $alloptions['woothemes-sensei_course_completed_page_id'] ?? 0,
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -174,6 +174,22 @@ class Sensei_Settings extends Sensei_Settings_API {
 	}
 
 	/**
+	 * Add legacy options to alloptions if they don't exist.
+	 *
+	 * @since 3.0.1
+	 * @deprecated $$next-version$$
+	 *
+	 * @param array $alloptions All options that are preloaded by WordPress.
+	 *
+	 * @return array
+	 */
+	public function no_special_query_for_legacy_options( $alloptions ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
+		return $alloptions;
+	}
+
+	/**
 	 * Add settings sections.
 	 *
 	 * @access public

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -310,7 +310,7 @@ class Sensei_Main {
 		$this->version               = isset( $args['version'] ) ? $args['version'] : null;
 
 		// Only set the install version if it is included in alloptions. This prevents a query on every page load.
-		$alloptions = wp_load_alloptions();
+		$alloptions            = wp_load_alloptions();
 		$this->install_version = $alloptions['sensei-install-version'] ?? null;
 
 		// Initialize the core Sensei functionality

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -308,7 +308,10 @@ class Sensei_Main {
 		$this->plugin_path           = trailingslashit( dirname( $this->main_plugin_file_name ) );
 		$this->template_url          = apply_filters( 'sensei_template_url', 'sensei/' );
 		$this->version               = isset( $args['version'] ) ? $args['version'] : null;
-		$this->install_version       = get_option( 'sensei-install-version' );
+
+		// Only set the install version if it is included in alloptions. This prevents a query on every page load.
+		$alloptions = wp_load_alloptions();
+		$this->install_version = $alloptions['sensei-install-version'] ?? null;
 
 		// Initialize the core Sensei functionality
 		$this->init();


### PR DESCRIPTION
This fixes a pretty serious performance issue I introduced years ago that filters every options call on `alloptions`. I don't think these fallback options are needed. These legacy options go back to to [pre-1.0.9](https://github.com/Automattic/sensei/blob/version/1.0.9/classes/class-woothemes-sensei-settings.php). Removing this would only affect sites who haven't saved their Sensei settings in the last 10 years.  I think the `course_completed_page_id` was a copy-and-paste error from when that feature was added. 

## Proposed Changes
* I've removed the legacy fallback for these options and the `alloptions` filter.
* Use `wp_load_alloptions` strategy on `sensei-install-version` which was querying on every page load if not set (Sensei was installed before this was added)

Note: `sensei-data-port-jobs` is still queried, but that is more complicated because we don't autoload it. Filed https://github.com/Automattic/sensei/issues/6760 for that one.

## Deprecations
- `Sensei_Settings::no_special_query_for_legacy_options`

## Testing Instructions
1. Activate query monitor.
2. Remove the `sensei-install-version`
3. Ensure there isn't a `{prefix}options` query for `woothemes-sensei_user_dashboard_page_id`, `woothemes-sensei_courses_page_id`, or `sensei-install-version` when visiting Sensei and/or non-Sensei screens in WP Admin.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
