### PR TITLE
Update MailPoet link to Lists

### DIFF
--- a/changelog/burtrw-patch-1
+++ b/changelog/burtrw-patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update MailPoet link to point to Lists

--- a/includes/internal/emails/views/html-settings.php
+++ b/includes/internal/emails/views/html-settings.php
@@ -58,8 +58,8 @@ $options           = isset( $options ) ? $options : [];
 				</p>
 				<div class="sensei-link-navigation">
 					<?php if ( is_plugin_active( 'mailpoet/mailpoet.php' ) ) : ?>
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=mailpoet-settings' ) ); ?>" target="_blank">
-							<?php esc_html_e( 'MailPoet Settings', 'sensei-lms' ); ?>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=mailpoet-segments#/lists' ) ); ?>" target="_blank">
+							<?php esc_html_e( 'MailPoet Lists', 'sensei-lms' ); ?>
 						</a>
 					<?php else : ?>
 						<a href="<?php echo esc_url( admin_url( 'plugin-install.php?s=mailpoet&tab=search&type=term' ) ); ?>">

--- a/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
+++ b/tests/unit-tests/internal/emails/test-class-email-settings-tab.php
@@ -317,7 +317,7 @@ class Email_Settings_Tab_Test extends \WP_UnitTestCase {
 		$content = $email_settings_tab->get_content( 'email-notification-settings' );
 
 		/* Assert. */
-		self::assertStringContainsString( 'MailPoet Settings', $content );
+		self::assertStringContainsString( 'MailPoet Lists', $content );
 	}
 
 	public function testTabContent_WhenInSettingsSubtabAndMailPoetIsNotActive_HasInstallMailPoetLink() {


### PR DESCRIPTION


## Proposed Changes

For sites with MailPoet already activated, we're changing the MailPoet Settings link to go to the MailPoet Lists instead.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
