### PR TITLE
Substitute theme cache to allow site editor for a non-block theme

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -171,10 +171,11 @@ class Sensei_Course_Theme_Editor {
 		}
 
 		$cache_hash = md5( $theme->theme_root . '/' . $theme->stylesheet );
-		wp_cache_delete( 'theme-' . $cache_hash, 'themes' );
+		$cache_key  = "theme-{$cache_hash}";
 
+		wp_cache_delete( $cache_key, 'themes' );
 		wp_cache_add(
-			'theme-' . $cache_hash,
+			$cache_key,
 			array(
 				'block_theme' => true,
 				'headers'     => $theme->headers,

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -153,6 +153,23 @@ class Sensei_Course_Theme_Editor {
 		add_action( 'admin_init', [ $this, 'add_editor_styles' ] );
 
 		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
+			$theme = wp_get_theme();
+			if ( $theme ) {
+				$cache_hash = md5( $theme->theme_root . '/' . $theme->stylesheet );
+				wp_cache_delete( 'theme-' . $cache_hash, 'themes' );
+				wp_cache_add(
+					'theme-' . $cache_hash,
+					array(
+						'block_theme' => true,
+						'headers'     => $theme->headers,
+						'errors'      => $theme->errors,
+						'stylesheet'  => $theme->stylesheet,
+						'template'    => $theme->template,
+					),
+					'themes',
+					0
+				);
+			}
 			add_filter( 'theme_file_path', [ $this, 'override_theme_block_template_file' ], 10, 2 );
 		}
 	}

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -153,25 +153,38 @@ class Sensei_Course_Theme_Editor {
 		add_action( 'admin_init', [ $this, 'add_editor_styles' ] );
 
 		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
-			$theme = wp_get_theme();
-			if ( $theme ) {
-				$cache_hash = md5( $theme->theme_root . '/' . $theme->stylesheet );
-				wp_cache_delete( 'theme-' . $cache_hash, 'themes' );
-				wp_cache_add(
-					'theme-' . $cache_hash,
-					array(
-						'block_theme' => true,
-						'headers'     => $theme->headers,
-						'errors'      => $theme->errors,
-						'stylesheet'  => $theme->stylesheet,
-						'template'    => $theme->template,
-					),
-					'themes',
-					0
-				);
-			}
+			$this->substitute_theme_cache();
 			add_filter( 'theme_file_path', [ $this, 'override_theme_block_template_file' ], 10, 2 );
 		}
+	}
+
+	/**
+	 * Substitute cache to enable site editor for non-block themes.
+	 *
+	 * This is a temporary workaround until the site editor is enabled for non-block themes.
+	 * Or there will be a way to override the value for the theme.
+	 */
+	private function substitute_theme_cache() {
+		$theme = wp_get_theme();
+		if ( ! $theme ) {
+			return;
+		}
+
+		$cache_hash = md5( $theme->theme_root . '/' . $theme->stylesheet );
+		wp_cache_delete( 'theme-' . $cache_hash, 'themes' );
+
+		wp_cache_add(
+			'theme-' . $cache_hash,
+			array(
+				'block_theme' => true,
+				'headers'     => $theme->headers,
+				'errors'      => $theme->errors,
+				'stylesheet'  => $theme->stylesheet,
+				'template'    => $theme->template,
+			),
+			'themes',
+			0
+		);
 	}
 
 	/**


### PR DESCRIPTION
Resolves #6277

Because of cache we can't normally use our filter to allow site editor for our Learning Mode templates.

We don't have hooks to filter this value earlier than we can do anything with it or substitute the theme object or something like that. It is getting filled . (Hopefully, I didn't miss anything.)

Also, I found we can't use WP_Theme::cache_delete as it instantiates the theme immediately and caches data. 

## Proposed Changes
* Delete cache and substitute it with our version which says the theme is a block theme.

## Testing Instructions
1. Activate a non-block theme (2021 or other).
2. Go to Site Editor.
3. No errors appear.

## Video

https://user-images.githubusercontent.com/329356/229989124-419e47e5-6e32-4bed-80fc-a65aabc362dd.mp4



## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
