### PR TITLE
Fix the home email notification settings link

### DIFF
--- a/changelog/fix-email-notificaiton-settings-link
+++ b/changelog/fix-email-notificaiton-settings-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the home email notification settings link

--- a/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
+++ b/includes/admin/home/quick-links/class-sensei-home-quick-links-provider.php
@@ -32,7 +32,7 @@ class Sensei_Home_Quick_Links_Provider {
 			$this->create_category(
 				__( 'Settings', 'sensei-lms' ),
 				[
-					$this->create_item( __( 'Email notifications', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#email-notification-settings' ) ),
+					$this->create_item( __( 'Email notifications', 'sensei-lms' ), admin_url( $this->get_email_notification_url() ) ),
 					$this->create_item( __( 'Learning mode', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#appearance-settings' ) ),
 					$this->create_item( __( 'WooCommerce', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#woocommerce-settings' ) ),
 					$this->create_item( __( 'Content drip', 'sensei-lms' ), admin_url( '/admin.php?page=sensei-settings#sensei-content-drip-settings' ) ),
@@ -48,6 +48,19 @@ class Sensei_Home_Quick_Links_Provider {
 				]
 			),
 		];
+	}
+
+	/**
+	 * Return the correct email notification settings based on the feature flag.
+	 *
+	 * @return array The magical link to create a demo course or the link to edit the demo course.
+	 */
+	private function get_email_notification_url() {
+		if ( Sensei()->feature_flags->is_enabled( 'email_customization' ) ) {
+			return 'admin.php?page=sensei-settings&tab=email-notification-settings';
+		}
+
+		return '/admin.php?page=sensei-settings#email-notification-settings';
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes
Update the email notification link on the Sensei > Home page.
<img width="599" alt="Screenshot 2023-04-05 at 18 47 44" src="https://user-images.githubusercontent.com/38718/230164068-46a88f6e-c17a-4366-b1fb-c00510cd729b.png">


## Testing Instructions
* Go To the Sensei > Home page.
* Click on the E-mail notification link
* Check if the link is correctly pointing to the new email notification settings page.


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes

