### PR TITLE
Fix tests not running after switching to Composer autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
 			"includes/"
 		],
         "files": [
-            "includes/sensei-functions.php",
-            "includes/3rd-party/3rd-party.php"
+            "includes/sensei-functions.php"
         ]
 	},
 	"autoload-dev": {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -350,6 +350,7 @@ class Sensei_Main {
 		$this->initialize_cache_groups();
 		$this->initialize_global_objects();
 		$this->initialize_cli();
+		$this->initialize_3rd_party_compatibility();
 	}
 
 	/**
@@ -602,6 +603,15 @@ class Sensei_Main {
 
 			new Sensei_CLI();
 		}
+	}
+
+	/**
+	 * Load the 3rd party compatibility tweaks.
+	 *
+	 * @since $$next-version$$
+	 */
+	private function initialize_3rd_party_compatibility(): void {
+		require_once $this->resolve_path( 'includes/3rd-party/3rd-party.php' );
 	}
 
 	/**

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -1,9 +1,4 @@
 <?php
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
 /**
  * Global Sensei functions
  */

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
         <server name="SERVER_NAME" value="http://foo.bar"/>
         <server name="SERVER_PORT" value="80"/>
         <server name="REMOTE_ADDR" value="127.1.2.3"/>
+        <const name="PHPUNIT_SENSEI_TESTSUITE" value="true"/>
     </php>
     <testsuites>
         <testsuite name="Sensei Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,7 +13,6 @@
         <server name="SERVER_NAME" value="http://foo.bar"/>
         <server name="SERVER_PORT" value="80"/>
         <server name="REMOTE_ADDR" value="127.1.2.3"/>
-        <const name="PHPUNIT_SENSEI_TESTSUITE" value="true"/>
     </php>
     <testsuites>
         <testsuite name="Sensei Test Suite">

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -47,7 +47,7 @@ if ( ! defined( 'SENSEI_LMS_PLUGIN_PATH' ) ) {
 	define( 'SENSEI_LMS_PLUGIN_PATH', plugin_dir_path( SENSEI_LMS_PLUGIN_FILE ) );
 }
 
-if ( class_exists( 'Sensei_Main' ) && ! defined( 'PHPUNIT_SENSEI_TESTSUITE' ) ) {
+if ( class_exists( 'Sensei_Main', false ) ) {
 	if ( ! function_exists( 'is_sensei_activating' ) ) {
 		/**
 		 * Checks if Sensei is being activated.

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -47,7 +47,7 @@ if ( ! defined( 'SENSEI_LMS_PLUGIN_PATH' ) ) {
 	define( 'SENSEI_LMS_PLUGIN_PATH', plugin_dir_path( SENSEI_LMS_PLUGIN_FILE ) );
 }
 
-if ( class_exists( 'Sensei_Main' ) ) {
+if ( class_exists( 'Sensei_Main' ) && ! defined( 'PHPUNIT_SENSEI_TESTSUITE' ) ) {
 	if ( ! function_exists( 'is_sensei_activating' ) ) {
 		/**
 		 * Checks if Sensei is being activated.


### PR DESCRIPTION
This PR fixes the tests [not running](https://github.com/Automattic/sensei/actions/runs/4619332514/jobs/8167945044) after switching to the [Composer autoloader](https://github.com/Automattic/sensei/pull/6755).

The linter looks broken in CI but I think that's another issue...

## Testing Instructions
1. Make sure the tests are running and passing.
2. Make sure the plugin is working as expected.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
