### PR TITLE
Tweaks to Learning Mode lesson template

### DIFF
--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -123,11 +123,11 @@ export default [
 		edit() {
 			return (
 				<div className="sensei-course-theme-lesson-actions">
+					<div className="sensei-course-theme__button is-secondary">
+						{ __( 'Complete Lesson', 'sensei-lms' ) }
+					</div>
 					<div className="sensei-course-theme__button is-primary">
 						{ __( 'Take Quiz', 'sensei-lms' ) }
-					</div>
-					<div className="sensei-course-theme__button is-secondary">
-						{ __( 'Complete Course', 'sensei-lms' ) }
 					</div>
 				</div>
 			);

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -167,17 +167,17 @@ class Lesson_Actions {
 			$is_quiz_submitted           = Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id );
 			$is_pass_required            = Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson_id );
 
-			// Quiz button.
-			if ( ! empty( $quiz_permalink ) && ! $is_quiz_submitted ) {
-				$take_quiz_button = $this->render_take_quiz( $quiz_permalink, $has_incomplete_prerequisite );
-				$actions[]        = $take_quiz_button;
-			}
-
 			// Complete button.
 			if ( ! $is_pass_required ) {
 				$complete_button_class  = isset( $take_quiz_button ) ? 'is-secondary' : 'is-primary';
 				$complete_lesson_button = $this->render_complete_lesson( $complete_button_class, $has_incomplete_prerequisite );
 				$actions[]              = $complete_lesson_button;
+			}
+
+			// Quiz button.
+			if ( ! empty( $quiz_permalink ) && ! $is_quiz_submitted ) {
+				$take_quiz_button = $this->render_take_quiz( $quiz_permalink, $has_incomplete_prerequisite );
+				$actions[]        = $take_quiz_button;
 			}
 		}
 

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -161,21 +161,26 @@ class Lesson_Actions {
 				$actions[] = $this->render_next_lesson();
 			}
 		} else {
-
+			$render_quiz_button          = false;
+			$complete_button_class       = 'is-primary';
 			$has_incomplete_prerequisite = ! Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
 			$quiz_permalink              = Sensei()->lesson->get_quiz_permalink( $lesson_id );
 			$is_quiz_submitted           = Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id );
 			$is_pass_required            = Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson_id );
 
+			if ( ! empty( $quiz_permalink ) && ! $is_quiz_submitted ) {
+				$render_quiz_button    = true;
+				$complete_button_class = 'is-secondary';
+			}
+
 			// Complete button.
 			if ( ! $is_pass_required ) {
-				$complete_button_class  = isset( $take_quiz_button ) ? 'is-secondary' : 'is-primary';
 				$complete_lesson_button = $this->render_complete_lesson( $complete_button_class, $has_incomplete_prerequisite );
 				$actions[]              = $complete_lesson_button;
 			}
 
 			// Quiz button.
-			if ( ! empty( $quiz_permalink ) && ! $is_quiz_submitted ) {
+			if ( $render_quiz_button ) {
 				$take_quiz_button = $this->render_take_quiz( $quiz_permalink, $has_incomplete_prerequisite );
 				$actions[]        = $take_quiz_button;
 			}

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -26,18 +26,7 @@
 	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":""} -->
 	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar">
 		<!-- wp:sensei-lms/course-navigation /-->
-
-		<!-- wp:sensei-lms/spacer-flex -->
-		<div class="wp-block-sensei-lms-spacer-flex sensei-course-theme__spacer-flex"></div>
-		<!-- /wp:sensei-lms/spacer-flex -->
-
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"12px","bottom":"12px"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-		<div class="wp-block-group" style="margin-top:12px;margin-bottom:12px"><!-- wp:sensei-lms/button-contact-teacher -->
-			<div
-				class="wp-block-sensei-lms-button-contact-teacher is-style-outline wp-block-sensei-button wp-block-button has-text-align-left">
-				<a class="wp-block-button__link">Contact Teacher</a></div>
-			<!-- /wp:sensei-lms/button-contact-teacher --></div>
-		<!-- /wp:group --></div>
+	</div>
 	<!-- /wp:sensei-lms/ui -->
 
 	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false}} -->
@@ -54,9 +43,13 @@
 		<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
-        <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-        <div class="wp-block-group"><!-- wp:sensei-lms/page-actions /-->
-            <!-- wp:sensei-lms/course-theme-lesson-actions {"options":{"nextLesson":true}} /--></div>
-        <!-- /wp:group --></div>
-    <!-- /wp:sensei-lms/ui --></div>
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+			<!-- wp:sensei-lms/course-theme-lesson-actions {"options":{"nextLesson":true}} /-->
+			<!-- wp:sensei-lms/page-actions /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:sensei-lms/ui -->
+</div>
 <!-- /wp:sensei-lms/ui -->


### PR DESCRIPTION
## Proposed Changes
Makes some UI changes that will be common to all Learning Mode templates:
- Remove spacer + Contact Teacher block.
- Switch positions of lesson actions and pagination.
- Left justify lesson actions and pagination.
- Swap positions of Complete Lesson and Take Quiz buttons.
- Rename Complete Course button to Complete Lesson button in editor.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run start`.
2. Open the lesson template in the site editor.
3. Check that the Contact Teacher button is no longer in the sidebar.
4. Check that the lesson actions and pagination look similar to the screenshot below.
5. Browse to a lesson on the frontend.
6. Check that it looks similar to the second screenshot below.

### Editor
![Screenshot 2023-04-05 at 4 23 18 PM](https://user-images.githubusercontent.com/1190420/230202734-30b767c7-a021-4cda-b913-9262561e6069.jpg)

### Frontend
![Screenshot 2023-04-05 at 4 44 06 PM](https://user-images.githubusercontent.com/1190420/230207231-4f4b687f-ba5f-409f-bdba-9efeb259ee9d.jpg)

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
