### PR TITLE
Add condition for notices to happen in a specific date range

### DIFF
--- a/changelog/add-notice-condition-date-range
+++ b/changelog/add-notice-condition-date-range
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Ability to set conditions on admin notices based on a date range

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -142,7 +142,6 @@ class Sensei_Admin_Notices {
 		$transient_key = implode( '_', [ 'sensei_notices', Sensei()->version, determine_locale() ] );
 		$data          = get_transient( $transient_key );
 		$notices       = false;
-
 		// If the data is too old, fetch it again.
 		if ( $max_age && is_array( $data ) ) {
 			$age = time() - ( $data['_fetched'] ?? 0 );
@@ -546,8 +545,7 @@ class Sensei_Admin_Notices {
 	 * @return bool
 	 */
 	private function condition_check_date_range( ?string $start_date_str, ?string $end_date_str ) : bool {
-		$condition_pass = true;
-		$now            = new DateTime();
+		$now = new DateTime();
 
 		// Defaults to WP timezone, but can be overridden by passing string that includes timezone.
 		$start_date = $start_date_str ? date_create( $start_date_str, wp_timezone() ) : null;
@@ -559,14 +557,14 @@ class Sensei_Admin_Notices {
 		}
 
 		if ( $start_date && $now < $start_date ) {
-			$condition_pass = false;
+			return false;
 		}
 
 		if ( $end_date && $now > $end_date ) {
-			$condition_pass = false;
+			return false;
 		}
 
-		return $condition_pass;
+		return true;
 	}
 
 	/**

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -413,6 +413,18 @@ class Sensei_Admin_Notices {
 						break 2;
 					}
 					break;
+
+				case 'date_range':
+					if ( ! isset( $condition['start_date'] ) && ! isset( $condition['end_date'] ) ) {
+						break;
+					}
+
+					if ( ! $this->condition_check_date_range( $condition['start_date'], $condition['end_date'] ) ) {
+						$can_see_notice = false;
+						break 2;
+					}
+
+					break;
 			}
 		}
 
@@ -506,6 +518,8 @@ class Sensei_Admin_Notices {
 	/**
 	 * Check an "installed since" condition
 	 *
+	 * @since 4.10.0
+	 *
 	 * @param int|string $installed_since Time to check the installation time for.
 	 *
 	 * @return bool
@@ -519,6 +533,40 @@ class Sensei_Admin_Notices {
 			return false;
 		}
 		return $installed_at <= $installed_since;
+	}
+
+	/**
+	 * Check a date range condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param ?string $start_date_str Start date.
+	 * @param ?string $end_date_str   End date.
+	 *
+	 * @return bool
+	 */
+	private function condition_check_date_range( ?string $start_date_str, ?string $end_date_str ) : bool {
+		$condition_pass = true;
+		$now            = new DateTime();
+
+		// Defaults to WP timezone, but can be overridden by passing string that includes timezone.
+		$start_date = $start_date_str ? date_create( $start_date_str, wp_timezone() ) : null;
+		$end_date   = $end_date_str ? date_create( $end_date_str, wp_timezone() ) : null;
+
+		// If the passed date strings are invalid, don't show the notice.
+		if ( false === $start_date || false === $end_date ) {
+			return false;
+		}
+
+		if ( $start_date && $now < $start_date ) {
+			$condition_pass = false;
+		}
+
+		if ( $end_date && $now > $end_date ) {
+			$condition_pass = false;
+		}
+
+		return $condition_pass;
 	}
 
 	/**

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -419,7 +419,7 @@ class Sensei_Admin_Notices {
 						break;
 					}
 
-					if ( ! $this->condition_check_date_range( $condition['start_date'], $condition['end_date'] ) ) {
+					if ( ! $this->condition_check_date_range( $condition['start_date'] ?? null, $condition['end_date'] ?? null ) ) {
 						$can_see_notice = false;
 						break 2;
 					}

--- a/tests/unit-tests/admin/test-class-sensei-admin-notices.php
+++ b/tests/unit-tests/admin/test-class-sensei-admin-notices.php
@@ -345,6 +345,102 @@ class Sensei_Admin_Notices_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'notice-with-date-range', $notices_to_display );
 	}
 
+	public function testGetNoticesToDisplay_WithPartialStartDateInFuture_HideNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'       => 'date_range',
+						'start_date' => ( new DateTime( '+1 hour' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
+	public function testGetNoticesToDisplay_WithPartialStartDateInPast_ShowNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'       => 'date_range',
+						'start_date' => ( new DateTime( '-1 hour' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
+	public function testGetNoticesToDisplay_WithPartialEndDateInPast_HideNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'     => 'date_range',
+						'end_date' => ( new DateTime( '-1 hour' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
+	public function testGetNoticesToDisplay_WithPartialEndDateInFuture_ShowNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'     => 'date_range',
+						'end_date' => ( new DateTime( '+1 hour' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
 	/**
 	 * Tests basic has/doesn't have plugins test.
 	 */

--- a/tests/unit-tests/admin/test-class-sensei-admin-notices.php
+++ b/tests/unit-tests/admin/test-class-sensei-admin-notices.php
@@ -220,6 +220,131 @@ class Sensei_Admin_Notices_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'on-sensei-pages', $notices_on_edit_course );
 	}
 
+	public function testGetNoticesToDisplay_WithDateRangeCondtionMet_ShowNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'       => 'date_range',
+						'start_date' => ( new DateTime( '-1 minute' ) )->format( 'c' ),
+						'end_date'   => ( new DateTime( '+1 minute' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
+	public function testGetNoticesToDisplay_WithDateRangeEndingMinuteAgo_HideNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'       => 'date_range',
+						'start_date' => ( new DateTime( '-2 minutes' ) )->format( 'c' ),
+						'end_date'   => ( new DateTime( '-1 minute' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
+	public function testGetNoticesToDisplay_WithDateRangeStartingInOneMinute_HideNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'       => 'date_range',
+						'start_date' => ( new DateTime( '+1 minute' ) )->format( 'c' ),
+						'end_date'   => ( new DateTime( '+1 year' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
+	public function testGetNoticesToDisplay_WithInvalidStartDateFormat_HideNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'       => 'date_range',
+						'start_date' => ( new DateTime( '-1 year' ) )->format( 'c' ) . ' MoonTime',
+						'end_date'   => ( new DateTime( '+1 year' ) )->format( 'c' ),
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
+	public function testGetNoticesToDisplay_WithInvalidEndDateFormat_HideNotice() {
+		// Arrange.
+		$this->login_as_admin();
+		$notices = [
+			'notice-with-date-range' => [
+				'message'    => 'Important message to show on sites during a specific date range.',
+				'conditions' => [
+					[
+						'type'       => 'date_range',
+						'start_date' => ( new DateTime( '-1 year' ) )->format( 'c' ),
+						'end_date'   => ( new DateTime( '+1 year' ) )->format( 'c' ) . ' MoonTime',
+					],
+				],
+			],
+		];
+
+		$instance = $this->getMockInstance( [ 'notices' => $notices ] );
+
+		// Act.
+		$notices_to_display = $instance->get_notices_to_display();
+
+		// Assert.
+		$this->assertArrayNotHasKey( 'notice-with-date-range', $notices_to_display );
+	}
+
 	/**
 	 * Tests basic has/doesn't have plugins test.
 	 */


### PR DESCRIPTION
Resolves #6774

## Proposed Changes
* Add condition for notices with date.

## Testing Instructions
1. Play with this snippet to show/hide notices based on date.
```php
add_filter(
	'sensei_admin_notices',
	function( $notices ) {
		$notices['test-in-future'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei FUTURE',
			'message'     => 'This message should NOT be shown.',
			'dismissible' => false,
			'conditions'  => [
				[
					'type' => 'date_range',
					'start_date' => '2023-06-20T00:00:00Z',
					'end_date' => '2023-06-23T00:00:00Z',
				]
			],
		];
		$notices['test-in-past'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei PAST',
			'message'     => 'This message should NOT be shown.',
			'dismissible' => false,
			'conditions'  => [
				[
					'type' => 'date_range',
					'start_date' => '2022-06-20T00:00:00Z',
					'end_date' => '2022-06-23T00:00:00Z',
				]
			],
		];
		$notices['test-now'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei NOW',
			'message'     => 'This message should be shown.',
			'dismissible' => false,
			'conditions'  => [
				[
					'type' => 'date_range',
					'start_date' => '2022-06-20T00:00:00Z',
					'end_date' => '2024-06-23T00:00:00Z',
				]
			],
		];
		$notices['test-start-in-past'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei START IN PAST',
			'message'     => 'This message should be shown.',
			'dismissible' => false,
			'conditions'  => [
				[
					'type' => 'date_range',
					'start_date' => '2022-06-20T00:00:00Z',
				]
			],
		];
		$notices['test-start-in-future'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei START IN FUTURE',
			'message'     => 'This message should NOT be shown.',
			'dismissible' => false,
			'conditions'  => [
				[
					'type' => 'date_range',
					'start_date' => '2025-06-20T00:00:00Z',
				]
			],
		];
		$notices['test-end-in-future'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei END IN FUTURE',
			'message'     => 'This message should be shown.',
			'dismissible' => false,
			'conditions'  => [
				[
					'type' => 'date_range',
					'end_date' => '2025-06-20T00:00:00Z',
				]
			],
		];
		$notices['test-end-in-past'] = [
			'type'        => 'site-wide',
			'icon'        => 'sensei',
			'style'       => 'error',
			'heading'     => 'Sensei END IN PAST',
			'message'     => 'This message should NOT be shown.',
			'dismissible' => false,
			'conditions'  => [
				[
					'type' => 'date_range',
					'end_date' => '2022-06-20T00:00:00Z',
				]
			],
		];
		return $notices;		
	}
);
```
- Should see 3 notices that should be shown. None should be shown that shouldn't be.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
