### PR TITLE
Fix patterns layout preview style

### DIFF
--- a/assets/admin/editor-wizard/patterns-list.scss
+++ b/assets/admin/editor-wizard/patterns-list.scss
@@ -1,6 +1,6 @@
 $thumbnail-height: 235px;
 $preview-padding: 5px;
-$preview-max-height: $thumbnail-height - $preview-padding * 2;
+$preview-max-height: $thumbnail-height + 5px;
 
 .sensei-patterns-list {
 	@media ( min-width: 600px ) {
@@ -22,14 +22,12 @@ $preview-max-height: $thumbnail-height - $preview-padding * 2;
 			height: $thumbnail-height;
 			overflow: hidden;
 
-			display: flex;
-			justify-content: center;
-			align-items: center;
 			padding-top: $preview-padding;
 			padding-bottom: $preview-padding;
 
 			.block-editor-block-preview__container {
 				max-height: $preview-max-height;
+				margin-top: -17px;
 			}
 		}
 

--- a/changelog/fix-wizard-layouts-preview
+++ b/changelog/fix-wizard-layouts-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix patterns wizard preview style


### PR DESCRIPTION
This PR fixes the course/lesson layout select preview style.

p1680781058940189-slack-C02P7FHLVR9

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new course and to go the layout selection screen.
2. Make sure the layout previews look good on desktop and mobile.
3. Repeat for lessons.

## Screenshots

![image](https://user-images.githubusercontent.com/1612178/230467881-f67aa59b-641a-4081-9746-bc02b0a22bc4.png)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues