### PR TITLE
Make the email post type private

### DIFF
--- a/changelog/fix-email-post-type-being-public
+++ b/changelog/fix-email-post-type-being-public
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make the email post type private

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -113,7 +113,7 @@ class Email_Post_Type {
 					'menu_name'          => __( 'Emails', 'sensei-lms' ),
 					'name_admin_bar'     => __( 'Email', 'sensei-lms' ),
 				],
-				'public'       => true,
+				'public'       => false,
 				'show_ui'      => true,
 				'show_in_menu' => false,
 				'show_in_rest' => true, // Enables the Gutenberg editor.


### PR DESCRIPTION
## Proposed Changes

Switch the email post type from public to private. This prevents the email posts from being publicly visible on the site and also hides them from being searched.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure the email posts are not visible on the front-end of the site. You can test that by a simple search.
2. Make sure the email feature is working as before.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
