### PR TITLE
Fix Exit Course block: don't pass raw attributes to the wrapping function

### DIFF
--- a/includes/blocks/course-theme/class-exit-course.php
+++ b/includes/blocks/course-theme/class-exit-course.php
@@ -53,7 +53,7 @@ class Exit_Course {
 
 		$wrapper_attributes = '';
 		if ( function_exists( 'get_block_wrapper_attributes' ) ) {
-			$wrapper_attributes = get_block_wrapper_attributes( $attributes );
+			$wrapper_attributes = get_block_wrapper_attributes();
 		}
 
 		$label = $attributes['label'] ?? __( 'Exit Course', 'sensei-lms' );

--- a/includes/blocks/course-theme/class-focus-mode.php
+++ b/includes/blocks/course-theme/class-focus-mode.php
@@ -50,7 +50,7 @@ class Focus_Mode {
 
 		$wrapper_attributes = '';
 		if ( function_exists( 'get_block_wrapper_attributes' ) ) {
-			$wrapper_attributes = get_block_wrapper_attributes( $attributes );
+			$wrapper_attributes = get_block_wrapper_attributes();
 		}
 
 		$title_toggle = __( 'Toggle focus mode', 'sensei-lms' );


### PR DESCRIPTION
Resolves #6734

`get_block_wrapper_attributes` expects array of strings, at least for the following keys: style, class, id.

Found the same issue for the Focus Mode block.

## Proposed Changes
* Don't pass raw attributes to [get_block_wrapper_attributes](https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/).

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Site Editor, select 'Lesson (Learning Mode - Default)' template.
2. Set margin and padding for Exit Course block, save.
3. Open a lesson in LM.
4. See no errors on the screen/in console/logs.

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Code is tested on the minimum supported PHP and WordPress versions
