### PR TITLE
Disable "welcome" and "no progress" emails

### DIFF
--- a/changelog/change-disable-no-progress-and-welcome-emails
+++ b/changelog/change-disable-no-progress-and-welcome-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disable the "welcome" and "no progress" emails by default

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -145,7 +145,7 @@ class Email_List_Table extends Sensei_List_Table {
 		$last_modified = sprintf(
 			/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */
 			__( '%s ago', 'sensei-lms' ),
-			human_time_diff( strtotime( $post->post_modified_gmt ) )
+			human_time_diff( strtotime( get_gmt_from_date( $post->post_modified ) ) )
 		);
 
 		$row_data = [

--- a/includes/internal/emails/class-email-repository.php
+++ b/includes/internal/emails/class-email-repository.php
@@ -88,16 +88,17 @@ class Email_Repository {
 	 * @param string $description Email description.
 	 * @param string $content     Email content.
 	 * @param bool   $is_pro      Is pro email.
+	 * @param bool   $disabled    Is the email disabled.
 	 *
 	 * @return int|false Email post ID. Returns false if email already exists. Returns WP_Error on failure.
 	 */
-	public function create( string $identifier, array $types, string $subject, string $description, string $content, bool $is_pro = false ) {
+	public function create( string $identifier, array $types, string $subject, string $description, string $content, bool $is_pro = false, bool $disabled = false ) {
 		if ( $this->has( $identifier ) ) {
 			return false;
 		}
 
 		$email_data = [
-			'post_status'  => 'publish',
+			'post_status'  => $disabled ? 'draft' : 'publish',
 			'post_type'    => Email_Post_Type::POST_TYPE,
 			'post_title'   => $subject,
 			'post_content' => $content,

--- a/includes/internal/emails/class-email-seeder-data.php
+++ b/includes/internal/emails/class-email-seeder-data.php
@@ -53,6 +53,7 @@ class Email_Seeder_Data {
 				'subject'     => __( 'Welcome to [course:name]', 'sensei-lms' ),
 				'description' => __( 'Welcome to Course', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/course-welcome"} /-->',
+				'disabled'    => true,
 			],
 			'quiz_graded'                 => [
 				'types'       => [ 'student' ],
@@ -127,6 +128,7 @@ class Email_Seeder_Data {
 				'description' => __( 'No Progress Reminder - 3 days', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/student-no-progress-3-days"} /-->',
 				'is_pro'      => true,
+				'disabled'    => true,
 			],
 			'student_no_progress_7_days'  => [
 				'types'       => [ 'student' ],
@@ -134,6 +136,7 @@ class Email_Seeder_Data {
 				'description' => __( 'No Progress Reminder - 7 days', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/student-no-progress-7-days"} /-->',
 				'is_pro'      => true,
+				'disabled'    => true,
 			],
 			'student_no_progress_28_days' => [
 				'types'       => [ 'student' ],
@@ -141,6 +144,7 @@ class Email_Seeder_Data {
 				'description' => __( 'No Progress Reminder - 28 days', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/student-no-progress-28-days"} /-->',
 				'is_pro'      => true,
+				'disabled'    => true,
 			],
 			'course_expiration_today'     => [
 				'types'       => [ 'student' ],

--- a/includes/internal/emails/class-email-seeder.php
+++ b/includes/internal/emails/class-email-seeder.php
@@ -118,9 +118,10 @@ class Email_Seeder {
 
 		$description = $email_data['description'] ?? '';
 
-		$is_pro = $email_data['is_pro'] ?? false;
+		$is_pro   = $email_data['is_pro'] ?? false;
+		$disabled = $email_data['disabled'] ?? false;
 
-		$email_id = $this->email_repository->create( $identifier, $types, $subject, $description, $content, $is_pro );
+		$email_id = $this->email_repository->create( $identifier, $types, $subject, $description, $content, $is_pro, $disabled );
 
 		return is_int( $email_id ) && $email_id > 0;
 	}

--- a/tests/unit-tests/internal/emails/test-class-email-repository.php
+++ b/tests/unit-tests/internal/emails/test-class-email-repository.php
@@ -47,6 +47,18 @@ class Email_Repository_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function testCreate_DisabledEmail_CreatesPostAsDraft() {
+		/* Arrange. */
+		$repository = new Email_Repository();
+
+		/* Act. */
+		$post_id = $repository->create( 'a', [ 'b' ], 'c', 'd', 'e', false, true );
+		$post    = get_post( $post_id );
+
+		/* Assert. */
+		$this->assertEquals( 'draft', $post->post_status );
+	}
+
 	public function testGet_EmailNotInRepository_ReturnsNull() {
 		/* Arrange. */
 		$repository = new Email_Repository();
@@ -85,6 +97,18 @@ class Email_Repository_Test extends \WP_UnitTestCase {
 		$this->assertEquals( '', get_post_meta( $result1->ID, '_sensei_email_is_pro', true ) );
 		$this->assertEquals( 'y', $result2->post_title );
 		$this->assertEquals( 1, get_post_meta( $result2->ID, '_sensei_email_is_pro', true ) );
+	}
+
+	public function testGet_EmailCreatedWithDisabledParam_ReturnsNull() {
+		/* Arrange. */
+		$repository = new Email_Repository();
+		$repository->create( 'a', [ 'b' ], 'c', 'd', 'e', false, true );
+
+		/* Act. */
+		$result = $repository->get( 'a' );
+
+		/* Assert. */
+		$this->assertNull( $result );
 	}
 
 	public function testHasEmails_EmailsNotInRepository_ReturnsFalse() {


### PR DESCRIPTION
Some users have complained that we're sending too many emails, so this PR disables some of them.

The change will affect only new installs. Existing emails won't be affected.

p1680838870076219-slack-C02P7FHLVR9

## Proposed Changes
* Disable the "Welcome to Course" email.
* Disable the "No Progress" emails.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei LMS -> Tools and run the "Recreate Emails" action.
2. Go to Sensei LMS -> Settings -> Emails.
3. Make sure the "Welcome to Course" email is disabled.
4. Make sure the 3 "No Progress" emails are disabled.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues