### PR TITLE
Skip Lesson complete screen

### DIFF
--- a/assets/course-theme/complete-lesson-button.js
+++ b/assets/course-theme/complete-lesson-button.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Initializes complete lesson transition.
@@ -18,9 +17,6 @@ export const initCompleteLessonTransition = () => {
 		const progressBars = document.querySelectorAll(
 			'.sensei-course-theme-course-progress-bar-inner'
 		);
-		const mainContent =
-			document.querySelector( '.sensei-course-theme__main-content' ) ??
-			document.body;
 
 		/**
 		 * Disable complete buttons.
@@ -70,16 +66,6 @@ export const initCompleteLessonTransition = () => {
 
 			delayFormSubmit( e, form );
 			runProgressBarAnimation();
-
-			mainContent.insertAdjacentHTML(
-				'afterbegin',
-				`<div class="sensei-course-theme-lesson-completion-notice">
-					${ window.sensei.checkCircleIcon }
-					<p role="alert" class="sensei-course-theme-lesson-completion-notice__text">
-						${ __( 'Lesson complete', 'sensei-lms' ) }
-					</p>
-				</div>`
-			);
 		};
 
 		completeForms.forEach( ( form ) => {

--- a/changelog/change-remove-lesson-complete-screen
+++ b/changelog/change-remove-lesson-complete-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Redirect to the next lesson without showing Lesson complete message


### PR DESCRIPTION
Resolves #6752 

## Proposed Changes
* Remove lesson complete.

## Testing Instructions
0. Run `npm start` (or `npm run build:assets`).
1. Create a course with 2+ lessons.
2. Take the course. Start and complete a lesson.
3. Make sure "Lesson complete" message doesn't appear.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes

## Video
https://user-images.githubusercontent.com/329356/230830070-52569245-e784-40fe-8221-91760e098da5.mp4



