### PR TITLE
Fix warning when no author found for module and add a final fallback as author

### DIFF
--- a/changelog/fix-warning-when-no-author-found-for-module
+++ b/changelog/fix-warning-when-no-author-found-for-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Warning when admin email does not match any existing user and module has no author

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2279,6 +2279,15 @@ class Sensei_Core_Modules {
 
 		$term_owner = get_user_by( 'email', get_bloginfo( 'admin_email' ) );
 
+		// Fallaback in case the admin email does not match a user, otherwise it shows warnings.
+		if ( ! $term_owner ) {
+			$site_admins = get_super_admins();
+
+			if ( ! empty( $site_admins ) && is_array( $site_admins ) ) {
+				$term_owner = get_user_by( 'login', $site_admins[0] );
+			}
+		}
+
 		if ( empty( $slug ) ) {
 
 			return $term_owner;
@@ -2292,7 +2301,7 @@ class Sensei_Core_Modules {
 				return get_user_by( 'id', $author_meta );
 			}
 		}
-		// look for the author in the slug
+		// look for the author in the slug.
 		$slug_parts = explode( '-', $slug );
 
 		if (


### PR DESCRIPTION
Resolves the issue of showing warnings when a module has no author (admin-authored module) and the site admin email does not match any user.

## Proposed Changes
* Add a last fallback to return the first admin user as an author if there's no other author found.

## Testing Instructions

1. Create a module as an admin
2. Now change the site admin email to an email you don't have a user with
3. Add that module to a course with a lesson inside it
4. Now go to that course from frontend
5. Make sure you see no warnings

![image](https://user-images.githubusercontent.com/6820724/231624725-fa8638c0-f8ff-41b7-94fc-63cdfa9ca66b.png)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
