### PR TITLE
Fix courses page showing blank on astra theme

### DIFF
--- a/changelog/fix-courses-page-blank-on-astra-theme
+++ b/changelog/fix-courses-page-blank-on-astra-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Astra not loading the Courses page content

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4402,6 +4402,12 @@ class Sensei_Course {
 				)
 			);
 			remove_all_actions( 'sensei_pagination' );
+
+			// Running query loop block in do_blocks sets $wp_query->current_post to 0 which should be -1.
+			// This causes have_posts() to return false after rendering blocks. Which eventually causes
+			// Astra theme to not render the generated content.
+			global $wp_query;
+			$wp_query->current_post = -1;
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6807

## Proposed Changes
* In newer installations, we are showing the courses in the **Courses** page using the Query Loop block. Runing query loop changes the current_post of global query from -1 to 0. This causes the `have_posts` check in [Astra theme here](https://themes.trac.wordpress.org/browser/astra/4.1.3/inc/class-astra-loop.php#L190) return false, so the generated content does not load. We've fixed the issue here by reassigning the value to -1 after `do_blocks` is called. It's only assigned when we're on the archive page and using the Query Loop block, so won't affect anything else.

## Testing Instructions

1. Create a new installation of Sensei
2. Install and activate Astra theme
3. Have one or more courses published
4. Go to the Courses page in the frontend
5. Make sure you see the courses
6. Check with a couple other themes to make sure you see the courses there as well

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
