### PR TITLE
Standardize notice levels

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -64,19 +64,19 @@ $sensei-notice-icon-width: 30px;
 		position: static;
 	}
 
-	&__error {
+	&--error {
 		border-left-color: $notice-error;
 	}
 
-	&__warning {
+	&--warning {
 		border-left-color: $notice-warning;
 	}
 
-	&__info {
+	&--info {
 		border-left-color: $notice-info;
 	}
 
-	&__success {
+	&--success {
 		border-left-color: $notice-success;
 	}
 }

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -64,19 +64,19 @@ $sensei-notice-icon-width: 30px;
 		position: static;
 	}
 
-	&.sensei-notice-error {
+	&__error {
 		border-left-color: $notice-error;
 	}
 
-	&.sensei-notice-warning {
+	&__warning {
 		border-left-color: $notice-warning;
 	}
 
-	&.sensei-notice-info {
+	&__info {
 		border-left-color: $notice-info;
 	}
 
-	&.sensei-notice-success {
+	&__success {
 		border-left-color: $notice-success;
 	}
 }

--- a/assets/home/notices.js
+++ b/assets/home/notices.js
@@ -103,7 +103,7 @@ const NoticeInfoLink = ( { infoLink } ) => {
 const Notice = ( { noticeId, notice, dismissNonce } ) => {
 	let noticeClass = '';
 	if ( !! notice.level ) {
-		noticeClass = 'sensei-notice__' + notice.level;
+		noticeClass = 'sensei-notice--' + notice.level;
 	}
 
 	const isDismissible = notice.dismissible && dismissNonce;

--- a/assets/home/notices.js
+++ b/assets/home/notices.js
@@ -103,7 +103,7 @@ const NoticeInfoLink = ( { infoLink } ) => {
 const Notice = ( { noticeId, notice, dismissNonce } ) => {
 	let noticeClass = '';
 	if ( !! notice.level ) {
-		noticeClass = 'sensei-notice-' + notice.level;
+		noticeClass = 'sensei-notice__' + notice.level;
 	}
 
 	const isDismissible = notice.dismissible && dismissNonce;

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -235,20 +235,18 @@ class Sensei_Admin_Notices {
 			$notice['actions'] = [];
 		}
 
-		$notice_class = '';
-		if ( ! empty( $notice['style'] ) ) {
-			$notice_class = 'sensei-notice-' . $notice['style'];
-		}
+		$notice_classes   = [];
+		$notice_classes[] = 'sensei-notice__' . $notice['level'];
 
 		$is_dismissible       = $notice['dismissible'];
 		$notice_wrapper_extra = '';
 		if ( $is_dismissible ) {
 			wp_enqueue_script( 'sensei-dismiss-notices' );
-			$notice_class        .= ' is-dismissible';
+			$notice_classes[]     = 'is-dismissible';
 			$notice_wrapper_extra = sprintf( ' data-dismiss-action="sensei_dismiss_notice" data-dismiss-notice="%1$s" data-dismiss-nonce="%2$s"', esc_attr( $notice_id ), esc_attr( wp_create_nonce( self::DISMISS_NOTICE_NONCE_ACTION ) ) );
 		}
 		?>
-		<div class="notice sensei-notice <?php echo esc_attr( $notice_class ); ?>"
+		<div class="notice sensei-notice <?php echo esc_attr( implode( ' ', $notice_classes ) ); ?>"
 			<?php
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
 			echo $notice_wrapper_extra;

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -660,6 +660,11 @@ class Sensei_Admin_Notices {
 			];
 		}
 
+		$notice_levels = [ 'error', 'warning', 'success', 'info' ];
+		if ( ! isset( $notice['level'] ) || ! in_array( $notice['level'], $notice_levels, true ) ) {
+			$notice['level'] = 'info';
+		}
+
 		if ( ! isset( $notice['dismissible'] ) ) {
 			$notice['dismissible'] = true;
 		}

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -236,7 +236,7 @@ class Sensei_Admin_Notices {
 		}
 
 		$notice_classes   = [];
-		$notice_classes[] = 'sensei-notice__' . $notice['level'];
+		$notice_classes[] = 'sensei-notice--' . $notice['level'];
 
 		$is_dismissible       = $notice['dismissible'];
 		$notice_wrapper_extra = '';

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -96,14 +96,8 @@ class Sensei_Home_Notices_Provider {
 	 * @return array
 	 */
 	private function format_item( $notice ) {
-		$level = 'info';
-		if ( array_key_exists( 'level', $notice ) ) {
-			$level = $notice['level'];
-		} elseif ( array_key_exists( 'style', $notice ) ) {
-			$level = $notice['style'];
-		}
 		return [
-			'level'       => $level,
+			'level'       => $notice['level'] ?? 'info',
 			'heading'     => $notice['heading'] ?? null,
 			'message'     => $notice['message'],
 			'info_link'   => $notice['info_link'] ?? null,

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -307,7 +307,7 @@ class Sensei_Home_Notices {
 		$is_dismissible = class_exists( 'Sensei_Admin_Notices' );
 
 		return [
-			'level'       => 'info',
+			'level'       => 'warning',
 			'type'        => 'site-wide',
 			'info_link'   => $info_link,
 			'conditions'  => [

--- a/includes/admin/views/html-admin-page-home.php
+++ b/includes/admin/views/html-admin-page-home.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div id="sensei-home-page" class="sensei-home-page">
 	<noscript>
 		<h1><?php esc_html_e( 'Sensei Home', 'sensei-lms' ); ?></h1>
-		<div class="notice sensei-notice sensei-notice-error">
+		<div class="notice sensei-notice sensei-notice__error">
 			<div class="sensei-notice__wrapper">
 				<div class="sensei-notice__content">
 					<div class="sensei-notice__heading">

--- a/includes/admin/views/html-admin-page-home.php
+++ b/includes/admin/views/html-admin-page-home.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div id="sensei-home-page" class="sensei-home-page">
 	<noscript>
 		<h1><?php esc_html_e( 'Sensei Home', 'sensei-lms' ); ?></h1>
-		<div class="notice sensei-notice sensei-notice__error">
+		<div class="notice sensei-notice sensei-notice--error">
 			<div class="sensei-notice__wrapper">
 				<div class="sensei-notice__content">
 					<div class="sensei-notice__heading">


### PR DESCRIPTION
## Proposed Changes
* Standardizes notice `level` (gets rid of `style`).
* Uses more standard class naming of notice levels.
* Sets default level of `info`. Context here: p1681737541525079-slack-C04URKMQHA9
* Paired with https://github.com/Automattic/senseilms-com-plugins/pull/199 for schema change.

<img width="1257" alt="Screenshot 2023-04-17 at 3 28 44 pm" src="https://user-images.githubusercontent.com/68693/232516987-8b9a8f6f-5e31-41df-950b-e7f8302fdc34.png">

## Testing Instructions
1. Manually set the Sensei plugin version (in header and constant) to be a lower version.
2. Go to Sensei Home.
3. Ensure the update notice shows a `warning` level with yellow side.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues