### PR TITLE
Fix auto grading not working and also generating error when gap fill questions are present

### DIFF
--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -110,13 +110,19 @@ jQuery( document ).ready( function ( $ ) {
 
 				if ( $this.hasClass( 'gap-fill' ) ) {
 					user_answer = $this
-						.find( '.user-answer .highlight' )
+						.find( '.user-answer' )
+						.contents()
+						.find( '.highlight' )
 						.html();
 					correct_answer = $this
 						.find( '.correct-answer .highlight' )
 						.html();
 				} else {
-					user_answer = $this.find( '.user-answer' ).html();
+					user_answer = $this
+						.find( '.user-answer' )
+						.contents()
+						.find( 'body' )
+						.html();
 					correct_answer = $this.find( '.correct-answer' ).html();
 				}
 

--- a/changelog/fix-auto-grading-not-working
+++ b/changelog/fix-auto-grading-not-working
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix auto grading not working and additionally throwing error for fill gap questions

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -331,10 +331,11 @@ class Sensei_Grading_User_Quiz {
 							$html = wp_kses_post( apply_filters( 'sensei_answer_text', $_user_answer ) );
 							$html = '<html><head><title></title></head><body>' . $html . '</body></html>';
 							?>
-							<iframe class="user-answer" srcdoc="<?php echo esc_attr( $html ); ?>" sandbox="" height="auto"></iframe>
+							<iframe class="user-answer" srcdoc="<?php echo esc_attr( $html ); ?>" sandbox="allow-same-origin" height="auto"></iframe>
 							<?php
 						}
 						?>
+
 						<div class="right-answer">
 							<h5><?php esc_html_e( 'Correct answer', 'sensei-lms' ); ?></h5>
 							<span class="correct-answer">


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2264 (Could not move the issue here)

## Proposed Changes
* It was tricky to find, but as it turns out, the quiz grading page couldn't get any content from the inside of the sandboxed iframe, so the user's answer was always empty even for MCQs and for fill-gap type questions, it was undefined which generated console errors and broke the script. So we've added the "allow-same-origin" rule to the sandbox which is the minimum to access inner contents. Also fixed how the answer contents were read by jQuery to that they work as expected.

## Testing Instructions

1. Create a Quiz with multiple questions
2. Ideally have all types of questions to make sure it works for all of them (at least one fill in the gap should be there)
3. Enable auto-grading for the quiz
4. Now take the quiz as a student
5. To to Sensei LMS -> Grading -> [the taken quiz in the list]
6. Click on Grade Quiz
7. Make sure the scores shown on the top and the bottom are correct
8. Change the score of any of the graded answers
9. Click on 'Auto Grade'
10. Make sure it recalculates it as expected
11. Make sure there's no error printed in the console

https://user-images.githubusercontent.com/6820724/232736074-784a0918-05a2-44e5-8053-66d41008c36e.mov

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
