### PR TITLE
Show Update notice on every Sensei page

### DIFF
--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -289,10 +289,11 @@ class Sensei_Home_Notices {
 	 * Get the base settings for a plugin update notice.
 	 *
 	 * @param array $plugin_data The plugin update data.
+	 * @param array $screens    The screens to show the notice on.
 	 *
 	 * @return array
 	 */
-	private function get_base_plugin_notice( $plugin_data ) {
+	private function get_base_plugin_notice( $plugin_data, $screens = [] ) {
 		$changelog_url = $plugin_data['changelog'] ?? false;
 
 		$info_link = false;
@@ -301,6 +302,9 @@ class Sensei_Home_Notices {
 				'label' => __( 'What\'s new', 'sensei-lms' ),
 				'url'   => esc_url_raw( $changelog_url ),
 			];
+		}
+		if ( empty( $screens ) ) {
+			$screens = [ $this->screen_id ];
 		}
 
 		// We only want this to be dismissible if Sensei LMS is active and available because it can handle the dismiss requests.
@@ -313,7 +317,7 @@ class Sensei_Home_Notices {
 			'conditions'  => [
 				[
 					'type'    => 'screens',
-					'screens' => [ $this->screen_id ],
+					'screens' => $screens,
 				],
 			],
 			'dismissible' => $is_dismissible,

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -393,7 +393,7 @@ class Sensei_Home_Notices {
 		$plugin_file    = $plugin_data['plugin_basename'];
 		$latest_version = $plugin_data['latest_version'];
 
-		$notice            = $this->get_base_plugin_notice( $plugin_data );
+		$notice            = $this->get_base_plugin_notice( $plugin_data, [ 'sensei*' ] );
 		$notice['message'] = wp_kses(
 			sprintf(
 					// translators: First placeholder is the plugin name and second placeholder is the latest version available.


### PR DESCRIPTION
Part of https://github.com/Automattic/senseilms-com-plugins/issues/169 

## Proposed Changes

* Add support for passing the list of screens to `get_base_plugin_notice`;
* Show update notice on every Sensei page;

## Testing Instructions

1. Change your Sensei Pro OR Sensei LMS (if your plugin folder is called `sensei-lms`, that is) version to refer to an old version;
2. Make sure the update notice appears on every page;

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
