### PR TITLE
Use href instead of xlink:href for loading SVG icons

### DIFF
--- a/changelog/change-svg-xlink-href-to-href
+++ b/changelog/change-svg-xlink-href-to-href
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use non-deprecated attribute to load SVG icons.

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -310,7 +310,7 @@ class Sensei_Assets {
 	public function get_icon( string $name, string $class_names = '' ) : string {
 		$href = $this->get_icon_href( $name );
 
-		return '<svg class="' . esc_attr( $class_names ) . '"><use xlink:href="' . esc_url( $href ) . '"></use></svg>';
+		return '<svg class="' . esc_attr( $class_names ) . '"><use href="' . esc_url( $href ) . '"></use></svg>';
 	}
 
 	/**


### PR DESCRIPTION
Resolves #6810 

## Proposed Changes

* Use `href` attribute instead of `xlink:href`

## Testing Instructions

Using a version of the plugin based on this branch, make sure all the SVG icons (including those on learning mode) still show correctly;

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
