### PR TITLE
Update colors & typography for "Lesson (Learning Mode - Default)" template in the editor

### DIFF
--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -27,6 +27,13 @@
 	}
 }
 
+/* Header */
+.editor-styles-wrapper .wp-block .wp-block-sensei-lms-exit-course,
+.wp-block-sensei-lms-exit-course {
+	color: var(--sensei-primary-color);
+	font-size: 1rem;
+}
+
 .editor-styles-wrapper .sensei-course-theme__sidebar,
 .sensei-course-theme__sidebar {
 	a, [class*='sensei-'] a, a[class*='sensei-'] {
@@ -41,8 +48,20 @@
 .editor-styles-wrapper .wp-block-sensei-lms-course-title,
 .wp-block-sensei-lms-course-title {
 	color: var(--sensei-text-color);
+	font-size: clamp(0.875rem, 0.696rem + 0.476vw, 1.125rem);
+	font-weight: 600;
+	line-height: 1.167;
 	margin: 0;
 	padding: 1px 2px;
+}
+
+.editor-styles-wrapper .sensei-course-theme-course-progress-bar,
+.sensei-course-theme-course-progress-bar {
+	background-color: var(--sensei-course-progress-bar-color);
+}
+
+.sensei-course-theme-course-progress-bar-inner {
+	background-color: var(--sensei-course-progress-bar-inner-color);
 }
 
 .editor-styles-wrapper .wp-block .wp-block-sensei-lms-course-theme-course-progress-counter,

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -11,6 +11,7 @@
 	font-size: 100%;
 }
 
+.editor-styles-wrapper .sensei-course-theme__main-content,
 .sensei-course-theme {
 	--wp--preset--font-family--body-font: -apple-system, BlinkMacSystemFont, Inter, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-family: var(--wp--preset--font-family--body-font);
@@ -25,6 +26,7 @@
 	}
 }
 
+.editor-styles-wrapper .sensei-course-theme__sidebar,
 .sensei-course-theme__sidebar {
 	a, [class*='sensei-'] a, a[class*='sensei-'] {
 		text-decoration: none;
@@ -60,6 +62,7 @@
 }
 
 /* Course Navigation */
+.editor-styles-wrapper .sensei-lms-course-navigation-module__title,
 .sensei-lms-course-navigation-module__title {
 	color: var(--sensei-primary-color);
 
@@ -72,10 +75,16 @@
 	color: var(--sensei-lesson-meta-color);
 }
 
+.editor-styles-wrapper .sensei-lms-course-navigation-lesson__link,
 .sensei-lms-course-navigation-lesson__link {
 	color: var(--sensei-module-lesson-color);
 }
 
+.status-locked .sensei-lms-course-navigation-lesson__link {
+	color: var(--sensei-locked-lesson-color);
+}
+
+.editor-styles-wrapper .sensei-lms-course-navigation-lesson__extra,
 .sensei-lms-course-navigation-lesson__extra {
 	color: var(--sensei-lesson-meta-color);
 }

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -52,6 +52,13 @@
 	line-height: 1.1875;
 }
 
+/* Content */
+.editor-styles-wrapper .wp-block .wp-block-sensei-lms-course-theme-lesson-module,
+.wp-block-sensei-lms-course-theme-lesson-module {
+	border-color: var(--sensei-module-lesson-color);
+	color: var(--sensei-module-lesson-color);
+}
+
 /* Lesson Actions & Pagination */
 .wp-block-sensei-lms-page-actions .post-page-numbers {
 	color: var(--sensei-pagination-color);

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -11,7 +11,7 @@
 	font-size: 100%;
 }
 
-.editor-styles-wrapper .sensei-course-theme__main-content,
+.editor-styles-wrapper .wp-block,
 .sensei-course-theme {
 	--wp--preset--font-family--body-font: -apple-system, BlinkMacSystemFont, Inter, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-family: var(--wp--preset--font-family--body-font);
@@ -44,7 +44,7 @@
 	padding: 1px 2px;
 }
 
-.editor-styles-wrapper .wp-block-sensei-lms-course-theme-course-progress-counter,
+.editor-styles-wrapper .wp-block .wp-block-sensei-lms-course-theme-course-progress-counter,
 .wp-block-sensei-lms-course-theme-course-progress-counter {
 	color: var(--sensei-lesson-meta-color);
 	font-size: 1rem;

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -23,6 +23,7 @@
 		color: var(--sensei-text-color);
 		font-weight: 300;
 		font-size: clamp(2.25rem, 1.536rem + 1.905vw, 3.25rem);
+		line-height: 1.23;
 	}
 }
 
@@ -54,6 +55,7 @@
 /* Lesson Actions & Pagination */
 .wp-block-sensei-lms-page-actions .post-page-numbers {
 	color: var(--sensei-pagination-color);
+	line-height: 2.667;
 }
 
 .sensei-course-theme-lesson-actions {

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -5,6 +5,7 @@ body {
 	--sensei-background-color: var(--sensei-background-color-global, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #FFFFFF)));
 	--sensei-button-hover-color: #F0F0F0;
 	--sensei-lesson-meta-color: #787C82;
+	--sensei-locked-lesson-color: #646970;
 	--sensei-module-lesson-color: #101517;
 	--sensei-pagination-color: #191E23;
 	--sensei-primary-color: var(--sensei-primary-color-global, var(--sensei-course-theme-primary-color, var(--wp--preset--color--primary, #155E65)));
@@ -13,6 +14,7 @@ body {
 	--sensei-text-color: var(--sensei-text-color-global, var(--sensei-course-theme-foreground-color, var(--wp--preset--color--text, var(--wp--preset--color--foreground, #1E1E1E))));
 
 	--border-color: rgba(125, 125, 125, 0.3);
+
 	background-color: var(--sensei-background-color);
 	color: var(--sensei-text-color);
 }

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -7,6 +7,8 @@ body,
 	--sensei-button-fill-hover-color: #FFFFFF;
 	--sensei-button-outline-hover-color: #F0F0F0;
 	--sensei-button-text-color: #26212E;
+	--sensei-course-progress-bar-color: #DCDCDE;
+	--sensei-course-progress-bar-inner-color: #30968B;
 	--sensei-lesson-meta-color: #787C82;
 	--sensei-locked-lesson-color: #646970;
 	--sensei-module-lesson-color: #101517;
@@ -19,9 +21,6 @@ body,
 	--border-color: rgba(125, 125, 125, 0.3);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-
-	background-color: var(--sensei-background-color);
-	color: var(--sensei-text-color);
 }
 
 .sensei-course-theme__frame {

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -4,7 +4,8 @@ body,
 .editor-styles-wrapper .wp-block {
 	// Try to pick up global styles, customizer or theme colors.
 	--sensei-background-color: var(--sensei-background-color-global, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #FFFFFF)));
-	--sensei-button-hover-color: #F0F0F0;
+	--sensei-button-fill-hover-color: #FFFFFF;
+	--sensei-button-outline-hover-color: #F0F0F0;
 	--sensei-button-text-color: #26212E;
 	--sensei-lesson-meta-color: #787C82;
 	--sensei-locked-lesson-color: #646970;

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -1,9 +1,11 @@
 $breakpoint: 783px;
 
-body {
+body,
+.editor-styles-wrapper .wp-block {
 	// Try to pick up global styles, customizer or theme colors.
 	--sensei-background-color: var(--sensei-background-color-global, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #FFFFFF)));
 	--sensei-button-hover-color: #F0F0F0;
+	--sensei-button-text-color: #26212E;
 	--sensei-lesson-meta-color: #787C82;
 	--sensei-locked-lesson-color: #646970;
 	--sensei-module-lesson-color: #101517;
@@ -14,6 +16,8 @@ body {
 	--sensei-text-color: var(--sensei-text-color-global, var(--sensei-course-theme-foreground-color, var(--wp--preset--color--text, var(--wp--preset--color--foreground, #1E1E1E))));
 
 	--border-color: rgba(125, 125, 125, 0.3);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 
 	background-color: var(--sensei-background-color);
 	color: var(--sensei-text-color);

--- a/assets/css/sensei-course-theme/blocks/course-navigation.scss
+++ b/assets/css/sensei-course-theme/blocks/course-navigation.scss
@@ -19,6 +19,7 @@
 	}
 }
 
+.editor-styles-wrapper .sensei-lms-course-navigation-module,
 .sensei-lms-course-navigation-module {
 	.sensei-collapsible__toggle {
 		align-items: flex-start;

--- a/assets/css/sensei-course-theme/blocks/course-navigation.scss
+++ b/assets/css/sensei-course-theme/blocks/course-navigation.scss
@@ -88,6 +88,7 @@
 		flex: 1;
 		font-size: 0.875rem;
 		font-weight: 300;
+		line-height: 1.214;
 		padding: 0 12px;
 	}
 

--- a/assets/css/sensei-course-theme/blocks/course-progress-bar.scss
+++ b/assets/css/sensei-course-theme/blocks/course-progress-bar.scss
@@ -1,15 +1,9 @@
 .sensei-course-theme-course-progress-bar {
 	height: var(--header-progress-bar-height, 4px);
-	background-color: var(--border-color);
 	margin: 0 !important;
 	width: 100%;
 
 	&-inner {
-		background-color: #30968B;
 		height: var(--header-progress-bar-height, 4px);
-	}
-
-	&.wp-block:not(.has-background) {
-		background-color: var(--border-color);
 	}
 }

--- a/assets/css/sensei-course-theme/blocks/course-title.scss
+++ b/assets/css/sensei-course-theme/blocks/course-title.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-sensei-lms-course-title,
+.editor-styles-wrapper .wp-block .wp-block-sensei-lms-course-title,
 .wp-block-sensei-lms-course-title {
 	font-size: clamp(0.875rem, 0.696rem + 0.476vw, 1.125rem);
 	font-weight: 600;

--- a/assets/css/sensei-course-theme/blocks/course-title.scss
+++ b/assets/css/sensei-course-theme/blocks/course-title.scss
@@ -1,8 +1,5 @@
 .editor-styles-wrapper .wp-block .wp-block-sensei-lms-course-title,
 .wp-block-sensei-lms-course-title {
-	font-size: clamp(0.875rem, 0.696rem + 0.476vw, 1.125rem);
-	font-weight: 600;
-	line-height: 1.167;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/assets/css/sensei-course-theme/blocks/exit-course.scss
+++ b/assets/css/sensei-course-theme/blocks/exit-course.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-sensei-lms-exit-course,
+.editor-styles-wrapper .wp-block .wp-block-sensei-lms-exit-course,
 .wp-block-sensei-lms-exit-course {
 	color: var(--sensei-primary-color);
 	font-size: 1rem;

--- a/assets/css/sensei-course-theme/blocks/exit-course.scss
+++ b/assets/css/sensei-course-theme/blocks/exit-course.scss
@@ -2,5 +2,6 @@
 .wp-block-sensei-lms-exit-course {
 	color: var(--sensei-primary-color);
 	font-size: 1rem;
+	line-height: 1.1875;
 	text-decoration: underline;
 }

--- a/assets/css/sensei-course-theme/blocks/exit-course.scss
+++ b/assets/css/sensei-course-theme/blocks/exit-course.scss
@@ -1,7 +1,5 @@
 .editor-styles-wrapper .wp-block .wp-block-sensei-lms-exit-course,
 .wp-block-sensei-lms-exit-course {
-	color: var(--sensei-primary-color);
-	font-size: 1rem;
 	line-height: 1.1875;
 	text-decoration: underline;
 }

--- a/assets/css/sensei-course-theme/blocks/lesson-module.scss
+++ b/assets/css/sensei-course-theme/blocks/lesson-module.scss
@@ -1,7 +1,6 @@
 .editor-styles-wrapper .wp-block .wp-block-sensei-lms-course-theme-lesson-module,
 .wp-block-sensei-lms-course-theme-lesson-module {
-	border-left: solid 2px var(--sensei-module-lesson-color);
-	color: var(--sensei-module-lesson-color);
+	border-left: solid 2px;
 	font-size: 0.875rem;
 	line-height: 1.2;
 	padding-left: 0.5em;

--- a/assets/css/sensei-course-theme/blocks/lesson-module.scss
+++ b/assets/css/sensei-course-theme/blocks/lesson-module.scss
@@ -1,3 +1,4 @@
+.editor-styles-wrapper .wp-block-sensei-lms-course-theme-lesson-module,
 .wp-block-sensei-lms-course-theme-lesson-module {
 	border-left: solid 2px var(--sensei-text-color);
 	color: var(--sensei-text-color);

--- a/assets/css/sensei-course-theme/blocks/lesson-module.scss
+++ b/assets/css/sensei-course-theme/blocks/lesson-module.scss
@@ -1,7 +1,7 @@
-.editor-styles-wrapper .wp-block-sensei-lms-course-theme-lesson-module,
+.editor-styles-wrapper .wp-block .wp-block-sensei-lms-course-theme-lesson-module,
 .wp-block-sensei-lms-course-theme-lesson-module {
-	border-left: solid 2px var(--sensei-text-color);
-	color: var(--sensei-text-color);
+	border-left: solid 2px var(--sensei-module-lesson-color);
+	color: var(--sensei-module-lesson-color);
 	font-size: 0.875rem;
 	line-height: 1.2;
 	padding-left: 0.5em;

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -76,13 +76,13 @@
 		color: var(--sensei-button-text-color);
 
 		&:hover {
-			color: #FFFFFF;
+			color: var(--sensei-button-fill-hover-color);
 			background-color: var(--sensei-primary-color);
 			border-color: var(--sensei-primary-color);
 		}
 
 		&:focus {
-			border: 1px solid #FFFFFF;
+			border: 1px solid var(--sensei-button-fill-hover-color);
 			box-shadow: 0px 0px 0px 1.5px var(--sensei-secondary-color);
 		}
 	}
@@ -94,7 +94,7 @@
 		flex-shrink: 0;
 
 		&:hover {
-			background-color: var(--sensei-button-hover-color);
+			background-color: var(--sensei-button-outline-hover-color);
 			color: var(--sensei-primary-color);
 
 			.wp-block-button__link {
@@ -114,7 +114,7 @@
 		padding: 0.83em 1.11em;
 
 		&:hover {
-			background-color: var(--sensei-button-hover-color);
+			background-color: var(--sensei-button-outline-hover-color);
 			color: var(--sensei-primary-color) !important;
 		}
 

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -11,7 +11,7 @@
 	}
 }
 
-.editor-styles-wrapper .wp-block-button .wp-block-button__link.sensei-course-theme__button,
+.editor-styles-wrapper .sensei-course-theme__main-content .wp-block-button,
 .sensei-course-theme .wp-block-button,
 .sensei-course-theme__button,
 .sensei-course-theme__button[type=submit],

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -73,7 +73,7 @@
 	&.is-primary,
 	&.wp-block-button:not(.is-style-outline, .is-style-link) {
 		background-color: var(--sensei-secondary-color);
-		color: #26212E;
+		color: var(--sensei-button-text-color);
 
 		&:hover {
 			color: #FFFFFF;

--- a/assets/css/sensei-course-theme/editor.scss
+++ b/assets/css/sensei-course-theme/editor.scss
@@ -51,10 +51,6 @@ body {
 	padding: 12px 0;
 }
 
-.wp-block-post-title {
-	font-size: 48px !important;
-}
-
 input, textarea {
 	border: none;
 	padding: 0;

--- a/assets/css/sensei-course-theme/fixed-sidebar.scss
+++ b/assets/css/sensei-course-theme/fixed-sidebar.scss
@@ -19,7 +19,6 @@ $breakpoint: 783px;
 			left: 0;
 			width: var(--sensei-lm-sidebar-width, 300px);
 			border-right: 1px solid var(--border-color);
-			background-color: var(--sensei-background-color);
 			overflow: auto;
 			overscroll-behavior: contain;
 			display: flex;

--- a/assets/css/sensei-course-theme/notices.scss
+++ b/assets/css/sensei-course-theme/notices.scss
@@ -9,10 +9,10 @@
 
 .sensei-course-theme-lesson-quiz-notice {
 	display: flex;
-	justify-content: space-between;
 	flex-flow: wrap;
+	font-size: 1.125rem;
 	gap: 15px;
-	font-size: 14px;
+	justify-content: space-between;
 
 	&__content {
 		display: flex;

--- a/assets/css/sensei-course-theme/theme-fixes.scss
+++ b/assets/css/sensei-course-theme/theme-fixes.scss
@@ -47,11 +47,6 @@
 	}
 }
 
-// Astra
-.wp-block:not(.has-background) {
-	background-color: unset;
-}
-
 // Twenty Fifteen
 .sensei-course-theme::before {
 	width: 0px;

--- a/assets/css/sensei-course-theme/ui-blocks.scss
+++ b/assets/css/sensei-course-theme/ui-blocks.scss
@@ -35,7 +35,6 @@ body.sensei-course-theme {
 		right: 0;
 		height: var(--sensei-lm-header-height);
 		top: var(--top-offset);
-		background-color: var(--sensei-background-color);
 		z-index: 100;
 		display: flex;
 		flex-direction: column;

--- a/assets/css/sensei-course-theme/ui-blocks.scss
+++ b/assets/css/sensei-course-theme/ui-blocks.scss
@@ -33,6 +33,7 @@ body.sensei-course-theme {
 		position: fixed;
 		left: 0;
 		right: 0;
+		background-color: var(--sensei-background-color);
 		height: var(--sensei-lm-header-height);
 		top: var(--top-offset);
 		z-index: 100;


### PR DESCRIPTION
Resolves #6786.

## Proposed Changes
Updates the CSS to ensure that the "Lesson (Learning Mode - Default)" template looks good in the editor for Divi, Astra and the Course theme's default variation. I also adjusted some line heights that were missed the first time around.

## Testing Instructions
1. Ensure you're on [this branch](https://github.com/Automattic/themes/pull/7033) of the Course theme.
2. Switch to the Divi theme.
3. Go to the site editor and select the "Lesson (Learning Mode - Default)" template.
4. Ensure the colors & typography of the template in the editor match the design - 8mY8ui4zYK1Ylw2yIFi9Lx-fi-20020527_41973.
5. Repeat steps 2 - 4 for the Astra and Course theme (default variation).
6. Switch to the Course theme if it's not already activated.
7. Set global colors for all elements.
8. Ensure the colors of the template in the editor update to match the global colors that you set (see below for some exceptions).

## Exceptions
Due to what looks like a bug with Sensei-specific CSS color variables not populating in the editor, the following elements do not currently work with global colors in the editor. I've opened a [separate issue](https://github.com/Automattic/sensei/issues/6835) to address this:
- Header background color
- Progress bar color

![Screenshot 2023-04-21 at 2 56 02 PM](https://user-images.githubusercontent.com/1190420/233716336-24cf7945-d354-4e6d-a8fd-8b5ee4e94bd9.jpg)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues