### PR TITLE
Deprecate Extension layout call and handling

### DIFF
--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -279,7 +279,6 @@ const selectors = {
 	),
 	getEntities: ( { entities }, entity ) => entities[ entity ],
 	getConnectionStatus: ( { connected } ) => connected,
-	getLayout: ( { layout } ) => layout,
 	getNextProcess: ( { queue } ) => queue[ 0 ] || null,
 	getError: ( { error } ) => error,
 };
@@ -296,7 +295,6 @@ const resolvers = {
 			path: '/sensei-internal/v1/sensei-extensions?type=plugin',
 		} );
 
-		yield actions.setLayout( response.layout );
 		yield actions.setEntities( {
 			extensions: keyBy( response.extensions, 'product_slug' ),
 		} );

--- a/changelog/remove-layout-calls
+++ b/changelog/remove-layout-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removed unused calls to SenseiLMS.com for the old extensions page

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -226,37 +226,14 @@ final class Sensei_Extensions {
 	 * Get extensions page layout.
 	 *
 	 * @since 3.11.0
+	 * @deprecated $$next-version$$
 	 *
 	 * @return array
 	 */
 	public function get_layout() {
-		$transient_key = implode(
-			'_',
-			[
-				'sensei_extensions_layout',
-				determine_locale(),
-				md5( self::SENSEILMS_PRODUCTS_API_BASE_URL ),
-			]
-		);
+		_deprecated_function( __METHOD__, '$$next-version$$' );
 
-		$extension_layout = get_transient( $transient_key );
-
-		if ( false === $extension_layout ) {
-			$raw_layout = wp_safe_remote_get(
-				add_query_arg(
-					[ 'lang' => determine_locale() ],
-					self::SENSEILMS_PRODUCTS_API_BASE_URL . '/layout'
-				)
-			);
-
-			if ( ! is_wp_error( $raw_layout ) ) {
-				$json             = json_decode( wp_remote_retrieve_body( $raw_layout ) );
-				$extension_layout = isset( $json->layout ) ? $json->layout : [];
-				set_transient( $transient_key, $extension_layout, DAY_IN_SECONDS );
-			}
-		}
-
-		return $extension_layout;
+		return [];
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -203,7 +203,7 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			}
 		);
 
-		return $this->create_extensions_response( $filtered_plugins, 'extensions', true );
+		return $this->create_extensions_response( $filtered_plugins, 'extensions' );
 	}
 
 	/**
@@ -363,13 +363,12 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.8.0 It doesn't support WCCOM extensions anymore.
 	 *
-	 * @param array   $plugins        The plugins.
-	 * @param string  $extensions_key Response key for the extensions array.
-	 * @param boolean $full_response  Whether it's creating the response for the main fetch.
+	 * @param array  $plugins        The plugins.
+	 * @param string $extensions_key Response key for the extensions array.
 	 *
 	 * @return WP_REST_Response
 	 */
-	private function create_extensions_response( array $plugins, string $extensions_key, bool $full_response = false ): WP_REST_Response {
+	private function create_extensions_response( array $plugins, string $extensions_key ): WP_REST_Response {
 		$mapped_plugins = array_map(
 			function ( $plugin ) {
 				$plugin->price      = isset( $plugin->price ) ? html_entity_decode( $plugin->price ) : '';
@@ -381,13 +380,6 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 		);
 
 		$response_json = [];
-
-		if ( $full_response ) {
-			$response_json = [
-				'layout' => Sensei_Extensions::instance()->get_layout(),
-			];
-		}
-
 		$response_json[ $extensions_key ] = array_values( $mapped_plugins );
 
 		$response = new WP_REST_Response();
@@ -463,72 +455,6 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 						'has_update'      => [
 							'type'        => 'boolean',
 							'description' => 'Whether the extension has available updates.',
-						],
-					],
-				],
-			],
-			'layout'     => [ $this, 'get_layout_schema' ],
-		];
-	}
-
-	/**
-	 * Schema for the layout endpoint.
-	 *
-	 * @return array Schema object.
-	 */
-	private function get_layout_schema() : array {
-		return [
-			'type'  => 'array',
-			'items' => [
-				'type'       => 'object',
-				'properties' => [
-					'key'         => [
-						'type'        => 'string',
-						'description' => 'Section key.',
-					],
-					'columns'     => [
-						'type'        => 'integer',
-						'description' => 'Number of columns to use.',
-					],
-					'type'        => [
-						'type'        => 'string',
-						'description' => 'Type of content.',
-					],
-					'title'       => [
-						'type'        => 'string',
-						'description' => 'Section title.',
-					],
-					'description' => [
-						'type'        => 'string',
-						'description' => 'Description title.',
-					],
-					'items'       => [
-						'type'        => 'array',
-						'description' => 'Items to list.',
-						'items'       => [
-							'type'       => 'object',
-							'properties' => [
-								'key'           => [
-									'type'        => 'string',
-									'description' => 'Item key.',
-								],
-								'extensionSlug' => [
-									'type'        => 'string',
-									'description' => 'Extension slug.',
-								],
-								'itemProps'     => [
-									'type'        => 'object',
-									'description' => 'Props to add to the list item component.',
-								],
-								'wrapperProps'  => [
-									'type'        => 'object',
-									'description' => 'Props to add to the wrapper component.',
-								],
-								'cardProps'     => [
-									'type'        => 'object',
-									'description' => 'Props to add to the card component.',
-								],
-							],
 						],
 					],
 				],


### PR DESCRIPTION
We are making an unnecessary request to the `/layouts` endpoint whenever we get the list of extensions (onboarding wizard and Sensei Home). This used to be used in the separate Extensions page but is no longer in use and can be removed.

## Proposed Changes
* Remove the `layout` remote SenseiLMS.com call and handling on the backend and frontend.

## Testing Instructions
1. Clear transients.
2. Go through onboarding wizard.
3. Navigate to Sensei Home.
4. Ensure no errors appear.

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

* `Sensei_Extensions::get_layout`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
