### PR TITLE
Fix email page template link  and layout issues

### DIFF
--- a/assets/css/email-notifications/email-editor-style.scss
+++ b/assets/css/email-notifications/email-editor-style.scss
@@ -1,21 +1,42 @@
 @import './email-style.scss';
 
-:root .editor-styles-wrapper {
-	--wp--preset--color--background: #f3f3f3;
-	background-color: var(--wp--preset--color--background);
+// Style applied only when the user is editing the Sensei Email content
+.post-type-sensei_email, .editor-styles-wrapper:has(.email__wrapper) {
 
-	.wp-block-post-content *, .block-editor-block-list__layout * {
+	.wp-block-post-content *,
+	.block-editor-block-list__layout * {
 		font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
+		color: #101517;
 	}
-	.wp-element-button, .editor-styles-wrapper .wp-block-button__link {
+	.wp-element-button,
+	.editor-styles-wrapper .wp-block-button__link {
 		text-transform: capitalize;
 		border-radius: 4px;
 	}
+
+	// Hides the post-title but retain the spacing.
+	.edit-post-visual-editor__post-title-wrapper,
+	.editor-post-title {
+		visibility: hidden;
+		font-size: 12px !important;
+		margin: 0;
+	}
 }
 
-.edit-post-visual-editor__post-title-wrapper, .editor-post-title {
-	visibility: hidden;
+
+// This style is applied only when the user is editing the page layout via site-editor
+:has(.email__wrapper) {
+	.editor-styles-wrapper {
+		background-color: #f3f3f3;
+
+		.email__wrapper {
+			padding: 40px 56px 48px 56px !important;
+		}
+	}
 }
 
-
-
+:root .editor-styles-wrapper:has(.email-notification__content) {
+	.email__wrapper {
+		padding: 0 !important;
+	}
+}

--- a/changelog/fix-email-template-editor
+++ b/changelog/fix-email-template-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Missing email page template link on the editor

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -218,6 +218,8 @@ class Sensei_Course_Theme_Editor {
 			Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-blocks', 'course-theme/blocks/index.js', [ 'sensei-shared-blocks' ] );
 			Sensei()->assets->enqueue_style( 'sensei-shared-blocks-editor-style' );
 			Sensei()->assets->enqueue_style( 'sensei-learning-mode-editor' );
+			Sensei()->assets->enqueue( 'sensei-email-editor-style', 'css/email-notifications/email-editor-style.css' );
+
 			Sensei_Course_Theme::instance()->enqueue_fonts();
 
 			Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-editor', 'course-theme/course-theme.editor.js' );

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -59,6 +59,31 @@ class Email_Post_Type {
 		add_action( 'init', [ $this, 'register_post_type' ] );
 		add_action( 'load-edit.php', [ $this, 'maybe_redirect_to_listing' ] );
 		add_action( 'map_meta_cap', [ $this, 'remove_cap_of_deleting_email' ], 10, 4 );
+
+		add_filter( 'is_post_type_viewable', [ $this, 'enable_email_template_editor' ], 10, 2 );
+	}
+
+	/**
+	 * Set sensei_email as viewable only on the admin interface.
+	 *
+	 * @param bool         $is_viewable    Original is_viewable value.
+	 * @param WP_Post_Type $post_type  Current post_type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @access private
+	 *
+	 * @internal
+	 *
+	 * @return bool
+	 */
+	public function enable_email_template_editor( $is_viewable, $post_type ) {
+
+		if ( is_admin() && self::POST_TYPE === $post_type->name ) {
+			return true;
+		}
+
+		return $is_viewable;
 	}
 
 	/**

--- a/tests/unit-tests/internal/emails/test-class-email-post-type.php
+++ b/tests/unit-tests/internal/emails/test-class-email-post-type.php
@@ -3,6 +3,7 @@
 namespace SenseiTest\Internal\Emails;
 
 use Sensei\Internal\Emails\Email_Post_Type;
+use WP_Post_Type;
 
 /**
  * Tests for the Email_Post_Type class.
@@ -49,6 +50,49 @@ class Email_Post_Type_Test extends \WP_UnitTestCase {
 		$this->assertSame( 10, $priority );
 	}
 
+
+	public function testEnableEmailTemplateEditor_WhenIsAdminAndPostTypeIsEmail_ReturnsTrue() {
+		/* Arrange. */
+		$original = false;
+		set_current_screen( 'edit-post' );
+		$current_post_type = new WP_Post_Type( Email_Post_Type::POST_TYPE );
+
+		$email_post_type = Email_Post_Type::instance();
+
+		/* Act. */
+		$result = $email_post_type->enable_email_template_editor( $original, $current_post_type );
+
+		/* Assert. */
+		$this->assertSame( true, $result );
+	}
+
+
+	public function testEnableEmailTemplateEditorWhenIsNotTheEmailPostType_ReturnsOriginal() {
+		/* Arrange. */
+		$original          = false;
+		$current_post_type = new WP_Post_Type( 'other-post-type' );
+		$email_post_type   = Email_Post_Type::instance();
+		set_current_screen( 'edit-post' );
+
+		/* Act. */
+		$result = $email_post_type->enable_email_template_editor( $original, $current_post_type );
+
+		/* Assert. */
+		$this->assertSame( $original, $result );
+	}
+
+	public function testEnableEmailTemplateEditorWhenIsNotTheAdminInterface_ReturnsOriginal() {
+		/* Arrange. */
+		$original          = false;
+		$current_post_type = new WP_Post_Type( Email_Post_Type::POST_TYPE );
+		$email_post_type   = Email_Post_Type::instance();
+
+		/* Act. */
+		$result = $email_post_type->enable_email_template_editor( $original, $current_post_type );
+
+		/* Assert. */
+		$this->assertSame( $original, $result );
+	}
 
 	public function testInit_WhenCalled_AddsHookForRemovingEmailDeletingCap() {
 		/* Arrange. */


### PR DESCRIPTION
## Proposed Changes
* Re-enable to edit the email layout template
* Small CSS tweaks to meet better the design e-mail editor requirements.

### Context
When we moved the email post type to private on this PR https://github.com/Automattic/sensei/pull/6778, it hides all links on WP_Admin to edit the email template. 
The correct way to enable it without exposing our internal sensei_email is using the[ is_post_type_viewable hook](https://developer.wordpress.org/reference/functions/is_post_type_viewable/) to enable it only when the user is using the editor.



## Testing Instructions
* Go to the Branch
* Run `npm run start` 
* Go to Sensei > Settings > Emails
* Choose any email
* Check if the email editor interface is using a white background
* Check if is possible to edit the email page template thought the "Sensei Email" link
* Click on the "Sensei Email" link
* Check if the editor background is gray.



<img width="279" alt="Screenshot 2023-05-01 at 18 19 18" src="https://user-images.githubusercontent.com/38718/235495655-c023fd65-6db0-4dec-aaee-d8dd46c5aa7f.png">

<img width="1127" alt="Screenshot 2023-05-01 at 18 21 07" src="https://user-images.githubusercontent.com/38718/235495951-4bc42bad-e117-4d2e-8a5f-89a9e7aa84eb.png">

<img width="1192" alt="Screenshot 2023-05-01 at 18 21 41" src="https://user-images.githubusercontent.com/38718/235496081-697e4f18-d636-457a-a136-18aa61ea0523.png">


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] New UIs match the designs
- [x] Code is tested on the minimum supported PHP and WordPress versions
