### PR TITLE
Don't dispatch e-mails related to Temporary Users

### DIFF
--- a/changelog/fix-email-guest-users
+++ b/changelog/fix-email-guest-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't send e-mails to Guest/Preview users

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -167,16 +167,16 @@ class Sensei_Emails {
 		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		add_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );
 
-		// Send
-		$send_email = true;
-
 		/**
 		 * Filter Sensei's ability to send out emails.
 		 *
 		 * @since 1.8.0
-		 * @param bool $send_email default true
+		 * @param bool $send_email Whether to send the email or not.
+		 * @param mixed $to The email address(es) to send the email to.
+		 * @param mixed $subject The subject of the email.
+		 * @param mixed $message The message of the email.
 		 */
-		if ( apply_filters( 'sensei_send_emails', $send_email, $to, $subject, $message ) ) {
+		if ( apply_filters( 'sensei_send_emails', true, $to, $subject, $message ) ) {
 
 			wp_mail( $to, $subject, $message, $headers, $attachments );
 

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -484,9 +484,9 @@ class Sensei_Guest_User {
 	 * @access private
 	 * @since  $$next-version$$
 	 *
-	 * @param boolean|null $return Whether to send the email.
-	 * @param array        $atts   Email attributes.
-	 * @return boolean|null Whether to send the email.
+	 * @param bool|null $return Null if we should send the email, a boolean if not.
+	 * @param array     $atts   Email attributes.
+	 * @return bool|null Null if we should send the email, a boolean if not.
 	 */
 	public function skip_wp_mail( $return, $atts ) {
 		if ( $this->is_current_user_guest() ) {

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -475,9 +475,9 @@ class Sensei_Guest_User {
 	 * @access private
 	 * @since  $$next-version$$
 	 *
-	 * @param boolean $return Whether to send the email.
-	 * @param array   $atts   Email attributes.
-	 * @return boolean Whether to send the email.
+	 * @param boolean|null $return Whether to send the email.
+	 * @param array        $atts   Email attributes.
+	 * @return boolean|null Whether to send the email.
 	 */
 	public function skip_wp_mail( $return, $atts ) {
 		if ( $this->is_current_user_guest() ) {

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -522,10 +522,8 @@ class Sensei_Guest_User {
 			}
 		}
 		foreach ( $emails as $address ) {
-			if ( preg_match( '/(.*)<(.+)>/', $address, $matches ) ) {
-				if ( count( $matches ) === 3 ) {
-					$address = $matches[2];
-				}
+			if ( preg_match( '/(.*)<(.+)>/', $address, $matches ) && count( $matches ) === 3 ) {
+				$address = $matches[2];
 			}
 			if ( str_ends_with( $address, '@guest.senseilms' ) ) {
 				// If this is an e-mail address for a guest user, don't send it.

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -499,13 +499,10 @@ class Sensei_Guest_User {
 			}
 			// If it's actually got contents.
 			if ( ! empty( $temp_headers ) ) {
-				// Iterate through the raw headers.
-				foreach ( $temp_headers as $header ) {
-					if ( strpos( $header, ':' ) === false ) {
-						continue;
+				foreach ( $temp_headers as $name => $content ) {
+					if ( is_int( $name ) && str_contains( $content, ':' ) ) {
+						list ( $name, $content) = explode( ':', trim( $content ), 2 );
 					}
-					// Explode them out.
-					list( $name, $content ) = explode( ':', trim( $header ), 2 );
 
 					// Cleanup crew.
 					$name    = trim( $name );

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -480,10 +480,6 @@ class Sensei_Guest_User {
 	 * @return boolean Whether to send the email.
 	 */
 	public function skip_wp_mail( $return, $atts ) {
-		if ( null !== $return ) {
-			// If we already have a return value, don't do anything, just return it early.
-			return $return;
-		}
 		if ( $this->is_current_user_guest() ) {
 			// If this e-mail is being dispatched while the current user is a guest, just... don't send it.
 			return false;
@@ -530,7 +526,7 @@ class Sensei_Guest_User {
 				return false;
 			}
 		}
-		return null;
+		return $return;
 	}
 
 	/**

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -511,7 +511,7 @@ class Sensei_Guest_User {
 					$name    = trim( $name );
 					$content = trim( $content );
 
-					if ( in_array( strtolower( $name ), array( 'from', 'cc', 'bcc', 'reply-to' ), true ) ) {
+					if ( in_array( strtolower( $name ), [ 'from', 'cc', 'bcc', 'reply-to' ], true ) ) {
 						$emails = array_merge( (array) $emails, explode( ',', $content ) );
 					}
 				}

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -493,44 +493,9 @@ class Sensei_Guest_User {
 			// If this e-mail is being dispatched while the current user is a guest, just... don't send it.
 			return false;
 		}
-		$emails = $atts['to'];
-		if ( ! is_array( $emails ) ) {
-			$emails = explode( ',', $emails );
-		}
-		if ( ! empty( $atts['headers'] ) ) {
-			$headers = $atts['headers'];
-			if ( ! is_array( $headers ) ) {
-				// Explode the headers out, so this function can take
-				// both string headers and an array of headers.
-				$temp_headers = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
-			} else {
-				$temp_headers = $headers;
-			}
-			// If it's actually got contents.
-			if ( ! empty( $temp_headers ) ) {
-				foreach ( $temp_headers as $name => $content ) {
-					if ( is_int( $name ) && str_contains( $content, ':' ) ) {
-						list ( $name, $content) = explode( ':', trim( $content ), 2 );
-					}
-
-					// Cleanup crew.
-					$name    = trim( $name );
-					$content = trim( $content );
-
-					if ( in_array( strtolower( $name ), [ 'from', 'cc', 'bcc', 'reply-to' ], true ) ) {
-						$emails = array_merge( (array) $emails, explode( ',', $content ) );
-					}
-				}
-			}
-		}
-		foreach ( $emails as $address ) {
-			if ( preg_match( '/(.*)<(.+)>/', $address, $matches ) && count( $matches ) === 3 ) {
-				$address = $matches[2];
-			}
-			if ( str_ends_with( $address, '@guest.senseilms' ) ) {
-				// If this is an e-mail address for a guest user, don't send it.
-				return false;
-			}
+		if ( Sensei_Temporary_User::should_block_email( $atts, self::EMAIL_DOMAIN ) ) {
+			// If this e-mail is being dispatched to a guest user, don't send it.
+			return false;
 		}
 		return $return;
 	}

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -137,7 +137,7 @@ class Sensei_Guest_User {
 		add_action( 'sensei_is_enrolled', [ $this, 'open_course_always_enrolled' ], 10, 3 );
 		add_action( 'sensei_can_access_course_content', [ $this, 'open_course_enable_course_access' ], 10, 2 );
 		add_action( 'sensei_can_user_manually_enrol', [ $this, 'open_course_user_can_manualy_enroll' ], 10, 2 );
-		add_action( 'sensei_send_emails', [ $this, 'skip_sensei_email' ] );
+		add_filter( 'sensei_send_emails', [ $this, 'skip_sensei_email' ] );
 
 		$this->create_guest_student_role_if_not_exists();
 
@@ -466,7 +466,6 @@ class Sensei_Guest_User {
 	 */
 	public function skip_sensei_email( $send_email ) {
 		return $this->is_current_user_guest() ? false : $send_email;
-
 	}
 
 	/**

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -41,6 +41,15 @@ class Sensei_Guest_User {
 	const LOGIN_PREFIX = 'sensei_guest_';
 
 	/**
+	 * Email domain used for guest users.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const EMAIL_DOMAIN = 'guest.senseilms';
+
+	/**
 	 * Guest user id.
 	 *
 	 * @since 4.11.0
@@ -328,7 +337,7 @@ class Sensei_Guest_User {
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,
-				'user_email'   => $user_name . '@guest.senseilms',
+				'user_email'   => $user_name . '@' . self::EMAIL_DOMAIN,
 				'display_name' => 'Guest Student ' . str_pad( $user_count, 3, '0', STR_PAD_LEFT ),
 				'role'         => self::ROLE,
 			]

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -30,6 +30,15 @@ class Sensei_Preview_User {
 	const SWITCH_OFF_ACTION = 'sensei-exit-student-preview';
 
 	/**
+	 * Email domain used for preview users.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const EMAIL_DOMAIN = 'preview.senseilms';
+
+	/**
 	 * Meta key for the associated preview user ID.
 	 * Used to link the original teacher and the preview user, in both directions.
 	 */
@@ -272,7 +281,7 @@ class Sensei_Preview_User {
 			[
 				'user_pass'    => wp_generate_password(),
 				'user_login'   => $user_name,
-				'user_email'   => $user_name . '@preview.senseilms',
+				'user_email'   => $user_name . '@' . self::EMAIL_DOMAIN,
 				'display_name' => $display_name,
 				'last_name'    => $display_name,
 				'role'         => self::ROLE,

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -260,9 +260,9 @@ class Sensei_Preview_User {
 	 * @access private
 	 * @since  $$next-version$$
 	 *
-	 * @param boolean|null $return Whether to send the email.
-	 * @param array        $atts   Email attributes.
-	 * @return boolean|null Whether to send the email.
+	 * @param bool|null $return Null if we should send the email, a boolean if not.
+	 * @param array     $atts   Email attributes.
+	 * @return bool|null Null if we should send the email, a boolean if not.
 	 */
 	public function skip_wp_mail( $return, $atts ) {
 		if ( $this->is_preview_user_active() ) {

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -97,7 +97,7 @@ class Sensei_Preview_User {
 			add_filter( 'map_meta_cap', [ $this, 'allow_post_preview' ], 10, 4 );
 			add_filter( 'pre_get_posts', [ $this, 'count_unpublished_lessons' ], 10 );
 			add_filter( 'sensei_notice', [ $this, 'hide_notices' ], 10, 1 );
-			add_action( 'sensei_send_emails', '__return_false' );
+			add_filter( 'sensei_send_emails', '__return_false' );
 
 		}
 

--- a/includes/class-sensei-temporary-user.php
+++ b/includes/class-sensei-temporary-user.php
@@ -166,7 +166,7 @@ class Sensei_Temporary_User {
 				$address = $matches[2];
 			}
 			if ( str_ends_with( $address, '@' . $email_domain ) ) {
-				// If this is an e-mail address for a guest user, don't send it.
+				// If this is an e-mail address for a temporary user, don't send it.
 				return true;
 			}
 		}

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -116,14 +116,22 @@ class Email_Sender {
 		$replacements = apply_filters( 'sensei_email_replacements', $replacements, $email_name, $email_post, $this );
 
 		foreach ( $replacements as $recipient => $replacement ) {
-			wp_mail(
-				$recipient,
-				$this->get_email_subject( $email_post, $replacement ),
-				$this->get_email_body( $email_post, $replacement ),
-				$this->get_email_headers(),
-				null
-			);
-			sensei_log_event( 'email_send', [ 'type' => $usage_tracking_type ] );
+			$subject = $this->get_email_subject( $email_post, $replacement );
+			$message = $this->get_email_body( $email_post, $replacement );
+
+			/*
+			 * For documentation of the filter check class-sensei-emails.php file.
+			 */
+			if ( apply_filters( 'sensei_send_emails', true, $recipient, $subject, $message ) ) {
+				wp_mail(
+					$recipient,
+					$subject,
+					$message,
+					$this->get_email_headers(),
+					null
+				);
+				sensei_log_event( 'email_send', [ 'type' => $usage_tracking_type ] );
+			}
 		}
 	}
 

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -138,16 +138,16 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_ReturnIsTrueAndHasGuestUser_ReturnsFalse() {
 		// Arrange
-		$atts = array(
-			'to'      => array( 'user1@example.com', 'user2@guest.senseilms' ),
-			'headers' => array(
+		$atts = [
+			'to'      => [ 'user1@example.com', 'user2@guest.senseilms' ],
+			'headers' => [
 				'Cc'       => 'user3@example.com,user4@example.com',
 				'Bcc'      => 'user5@example.com,user6@example.com',
 				'Reply-To' => 'user7@example.com,user8@example.com',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( true, $atts );
@@ -158,11 +158,11 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasGuestUserInTo_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com,user2@guest.senseilms',
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -173,14 +173,14 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasGuestUserInCc_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'Cc' => 'user2@guest.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -192,14 +192,14 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasGuestUserInBcc_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'Bcc' => 'user2@guest.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -210,14 +210,14 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasGuestUserInReplyTo_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'Reply-To' => 'user2@guest.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -229,14 +229,14 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasGuestUserInFrom_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'From' => 'User 2 <user2@guest.senseilms>',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -248,12 +248,12 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HeadersPassedAsString_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
 			'headers' => "Cc: user3@example.com,user4@guest.senseilms\r\nBcc: user5@example.com,user6@example.com\r\nReply-To: user7@example.com,user8@example.com",
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -285,18 +285,18 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_ChecksOnlyCcBccReplyToAndFromHeaders_ReturnsNull() {
 		// Arrange
-		$atts = array(
-			'to'      => array( 'user1@example.com', 'user2@example.com' ),
-			'headers' => array(
+		$atts = [
+			'to'      => [ 'user1@example.com', 'user2@example.com' ],
+			'headers' => [
 				'Cc'         => 'User 3 <user3@example.com>,user4@example.com',
 				'Bcc'        => 'user5@example.com,User 6 <user6@example.com>',
 				'Reply-To'   => 'user7@example.com,user8@example.com',
 				'From'       => 'User 9 <user9@example.com>',
 				'X-Reply-To' => 'user10@guest.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -307,11 +307,11 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_SingleToWithGuestEmail_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'John Doe <user1@guest.senseilms>',
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );
@@ -322,11 +322,11 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_SingleToWithValidEmail_ReturnsNull() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'John Doe <user1@example.com>',
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->guest_user->skip_wp_mail( null, $atts );

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -136,4 +136,203 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 
 	}
 
+	public function testSkipWpMail_ReturnIsTrueAndHasGuestUser_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => array( 'user1@example.com', 'user2@guest.senseilms' ),
+			'headers' => array(
+				'Cc'       => 'user3@example.com,user4@example.com',
+				'Bcc'      => 'user5@example.com,user6@example.com',
+				'Reply-To' => 'user7@example.com,user8@example.com',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( true, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_HasGuestUserInTo_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com,user2@guest.senseilms',
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_HasGuestUserInCc_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'Cc' => 'user2@guest.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+
+	public function testSkipWpMail_HasGuestUserInBcc_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'Bcc' => 'user2@guest.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_HasGuestUserInReplyTo_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'Reply-To' => 'user2@guest.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+
+	public function testSkipWpMail_HasGuestUserInFrom_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'From' => 'User 2 <user2@guest.senseilms>',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+
+	public function testSkipWpMail_HeadersPassedAsString_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => "Cc: user3@example.com,user4@guest.senseilms\r\nBcc: user5@example.com,user6@example.com\r\nReply-To: user7@example.com,user8@example.com",
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_EmailsArentGuestUsers_ReturnsAtts() {
+		// Arrange
+		$atts = [
+			'to'      => [ 'user1@example.com', 'user2@example.com' ],
+			'headers' => [
+				'Cc'       => 'user3@example.com,user4@example.com',
+				'Bcc'      => 'user5@example.com,user6@example.com',
+				'Reply-To' => 'user7@example.com,user8@example.com',
+			],
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		];
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertNull( $result );
+	}
+
+
+	public function testSkipWpMail_ChecksOnlyCcBccReplyToAndFromHeaders_ReturnsNull() {
+		// Arrange
+		$atts = array(
+			'to'      => array( 'user1@example.com', 'user2@example.com' ),
+			'headers' => array(
+				'Cc'         => 'User 3 <user3@example.com>,user4@example.com',
+				'Bcc'        => 'user5@example.com,User 6 <user6@example.com>',
+				'Reply-To'   => 'user7@example.com,user8@example.com',
+				'From'       => 'User 9 <user9@example.com>',
+				'X-Reply-To' => 'user10@guest.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertNull( $result );
+	}
+
+	public function testSkipWpMail_SingleToWithGuestEmail_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'John Doe <user1@guest.senseilms>',
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_SingleToWithValidEmail_ReturnsNull() {
+		// Arrange
+		$atts = array(
+			'to'      => 'John Doe <user1@example.com>',
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->guest_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertNull( $result );
+	}
+
 }

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -182,4 +182,204 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	}
 
+	public function testSkipWpMail_ReturnIsTrueAndHasPreviewUser_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => array( 'user1@example.com', 'user2@preview.senseilms' ),
+			'headers' => array(
+				'Cc'       => 'user3@example.com,user4@example.com',
+				'Bcc'      => 'user5@example.com,user6@example.com',
+				'Reply-To' => 'user7@example.com,user8@example.com',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( true, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_HasPreviewUserInTo_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com,user2@preview.senseilms',
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_HasPreviewUserInCc_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'Cc' => 'user2@preview.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+
+	public function testSkipWpMail_HasPreviewUserInBcc_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'Bcc' => 'user2@preview.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_HasPreviewUserInReplyTo_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'Reply-To' => 'user2@preview.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+
+	public function testSkipWpMail_HasPreviewUserInFrom_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => array(
+				'From' => 'User 2 <user2@preview.senseilms>',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+
+	public function testSkipWpMail_HeadersPassedAsString_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'user1@example.com',
+			'headers' => "Cc: user3@example.com,user4@preview.senseilms\r\nBcc: user5@example.com,user6@example.com\r\nReply-To: user7@example.com,user8@example.com",
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_EmailsArentPreviewUsers_ReturnsAtts() {
+		// Arrange
+		$atts = [
+			'to'      => [ 'user1@example.com', 'user2@example.com' ],
+			'headers' => [
+				'Cc'       => 'user3@example.com,user4@example.com',
+				'Bcc'      => 'user5@example.com,user6@example.com',
+				'Reply-To' => 'user7@example.com,user8@example.com',
+			],
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		];
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertNull( $result );
+	}
+
+
+	public function testSkipWpMail_ChecksOnlyCcBccReplyToAndFromHeaders_ReturnsNull() {
+		// Arrange
+		$atts = array(
+			'to'      => array( 'user1@example.com', 'user2@example.com' ),
+			'headers' => array(
+				'Cc'         => 'User 3 <user3@example.com>,user4@example.com',
+				'Bcc'        => 'user5@example.com,User 6 <user6@example.com>',
+				'Reply-To'   => 'user7@example.com,user8@example.com',
+				'From'       => 'User 9 <user9@example.com>',
+				'X-Reply-To' => 'user10@preview.senseilms',
+			),
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertNull( $result );
+	}
+
+	public function testSkipWpMail_SingleToWithPreviewEmail_ReturnsFalse() {
+		// Arrange
+		$atts = array(
+			'to'      => 'John Doe <user1@preview.senseilms>',
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertFalse( $result );
+	}
+
+	public function testSkipWpMail_SingleToWithValidEmail_ReturnsNull() {
+		// Arrange
+		$atts = array(
+			'to'      => 'John Doe <user1@example.com>',
+			'message' => 'Hello world',
+			'subject' => 'Test email',
+		);
+
+		// Act
+		$result = $this->preview_user->skip_wp_mail( null, $atts );
+
+		// Assert
+		$this->assertNull( $result );
+	}
+
+
 }

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -184,16 +184,16 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_ReturnIsTrueAndHasPreviewUser_ReturnsFalse() {
 		// Arrange
-		$atts = array(
-			'to'      => array( 'user1@example.com', 'user2@preview.senseilms' ),
-			'headers' => array(
+		$atts = [
+			'to'      => [ 'user1@example.com', 'user2@preview.senseilms' ],
+			'headers' => [
 				'Cc'       => 'user3@example.com,user4@example.com',
 				'Bcc'      => 'user5@example.com,user6@example.com',
 				'Reply-To' => 'user7@example.com,user8@example.com',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( true, $atts );
@@ -204,11 +204,11 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasPreviewUserInTo_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com,user2@preview.senseilms',
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -219,14 +219,14 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasPreviewUserInCc_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'Cc' => 'user2@preview.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -238,14 +238,14 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasPreviewUserInBcc_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'Bcc' => 'user2@preview.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -256,14 +256,14 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasPreviewUserInReplyTo_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'Reply-To' => 'user2@preview.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -275,14 +275,14 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HasPreviewUserInFrom_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
-			'headers' => array(
+			'headers' => [
 				'From' => 'User 2 <user2@preview.senseilms>',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -294,12 +294,12 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_HeadersPassedAsString_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'user1@example.com',
 			'headers' => "Cc: user3@example.com,user4@preview.senseilms\r\nBcc: user5@example.com,user6@example.com\r\nReply-To: user7@example.com,user8@example.com",
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -331,18 +331,18 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_ChecksOnlyCcBccReplyToAndFromHeaders_ReturnsNull() {
 		// Arrange
-		$atts = array(
-			'to'      => array( 'user1@example.com', 'user2@example.com' ),
-			'headers' => array(
+		$atts = [
+			'to'      => [ 'user1@example.com', 'user2@example.com' ],
+			'headers' => [
 				'Cc'         => 'User 3 <user3@example.com>,user4@example.com',
 				'Bcc'        => 'user5@example.com,User 6 <user6@example.com>',
 				'Reply-To'   => 'user7@example.com,user8@example.com',
 				'From'       => 'User 9 <user9@example.com>',
 				'X-Reply-To' => 'user10@preview.senseilms',
-			),
+			],
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -353,11 +353,11 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_SingleToWithPreviewEmail_ReturnsFalse() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'John Doe <user1@preview.senseilms>',
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );
@@ -368,11 +368,11 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 
 	public function testSkipWpMail_SingleToWithValidEmail_ReturnsNull() {
 		// Arrange
-		$atts = array(
+		$atts = [
 			'to'      => 'John Doe <user1@example.com>',
 			'message' => 'Hello world',
 			'subject' => 'Test email',
-		);
+		];
 
 		// Act
 		$result = $this->preview_user->skip_wp_mail( null, $atts );


### PR DESCRIPTION
Fixes #6860 

## Proposed Changes
* Use `add_filter` instead of `add_action` for hooking on the `sensei_send_emails` hook;
* Check on the `sensei_send_emails` hook before dispatching e-mail for the new e-mail project;
* Block `wp_mail` from being triggered for any e-mail related to the guest/preview user or when the guest/preview user is logged in - The idea is to block third-party plugins from sending e-mails to these users;

## Testing Instructions

Using a plugin build based on this branch's code, and a plugin to log calls to wp_mail (I recommend the [email-log plugin](https://wordpress.org/plugins/email-log/)):

1. Create a course thas has the Open Access setting enabled; 
![image](https://user-images.githubusercontent.com/529864/236036638-2dd763a0-2769-4767-86b3-88ee18c25607.png)

2. As an anonymous user, visit that course's page and "Take the Course". Make sure you can take the course as usual with the guest user created for you;
3. Make sure welcome e-mails (and any other transactional e-mail, actually) isn't triggered for guest users;
4. Now, as an administrator/teacher, visit the page of the course you just created and click on "Preview as Student" on the admin bar:
![image](https://user-images.githubusercontent.com/529864/236037190-8babc98f-6c7c-4d92-92f9-8172e87c8a84.png)

5. Make sure that no welcome e-mails are triggered for these guest users;
6. Also make sure that the added unit tests run as expected

## Pre-Merge Checklist

- [X] PR title and description contain sufficient detail and accurately describe the changes
- [X] Acceptance criteria is met
- [X] Decisions are publicly documented
- [X] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [X] All strings are translatable (without concatenation, handles plurals)
- [X] Follows our naming conventions (P6rkRX-4oA-p2)
- [X] Hooks (p6rkRX-1uS-p2) and functions are documented
- [X] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [X] New UIs match the designs
- [X] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [X] Code is tested on the minimum supported PHP and WordPress versions
- [X] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [X] "Needs Documentation" label is added if this change requires updates to documentation
- [X] Known issues are created as new GitHub issues
