### PR TITLE
Fix Sensei notice styles

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -5,12 +5,17 @@ $sensei-notice-icon-width: 30px;
 .sensei-notice {
 	@import '../shared/styles/wp-admin';
 
-	align-items: center;
 	border-left-color: $primary;
 	display: flex;
-	gap: 10px;
+	flex-direction: column;
+	gap: 18px;
 	min-height: 40px;
 	padding: 18px 24px;
+
+	@media ( min-width: 961px ) {
+		flex-direction: row;
+		align-items: center;
+	}
 
 	&__content {
 		flex: 1;
@@ -42,8 +47,11 @@ $sensei-notice-icon-width: 30px;
 		white-space: nowrap;
 
 		.button {
-			margin-left: 18px;
 			padding: 3px 12px;
+
+			&:not(:first-child) {
+				margin-left: 18px;
+			}
 		}
 	}
 

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -54,9 +54,8 @@ $sensei-notice-icon-width: 30px;
 	}
 
 	.notice-dismiss {
-		align-self: center;
-		padding: 0;
-		position: static;
+		top: 50%;
+		transform: translateY(-50%);
 	}
 
 	&.sensei-notice-error {

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -10,11 +10,12 @@ $sensei-notice-icon-width: 30px;
 	display: flex;
 	gap: 10px;
 	min-height: 40px;
-	padding: 10px 16px;
+	padding: 18px 24px;
 
 	&__content {
+		flex: 1;
 		display: flex;
-		gap: 10px;
+		gap: 18px;
 		align-items: center;
 		color: #101517;
 		font-size: 14px;
@@ -33,17 +34,15 @@ $sensei-notice-icon-width: 30px;
 	}
 
 	&__heading {
-		margin: 5px 0;
+		margin-bottom: 5px;
 		font-weight: bold;
 	}
 
 	&__actions {
-		margin: 0.5em 0 0.5em auto;
-		align-self: center;
 		white-space: nowrap;
 
 		.button {
-			margin-left: 20px;
+			margin-left: 18px;
 			padding: 3px 12px;
 		}
 	}

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -12,31 +12,24 @@ $sensei-notice-icon-width: 30px;
 	min-height: 40px;
 	padding: 10px 16px;
 
-	&__icon {
-		color: #26212E;
-		flex: 0 0 auto;
-		margin-top: 0.5em;
-		width: $sensei-notice-icon-width;
-		height: $sensei-notice-icon-height;
-	}
-
-	&__wrapper {
-		padding: 0;
-		font-size: 14px;
-
-		@media (min-width: 500px) {
-			display: flex;
-			flex: 1 1 auto;
-			gap: 10px;
-		}
-	}
-
 	&__content {
+		display: flex;
+		gap: 10px;
+		align-items: center;
 		color: #101517;
+		font-size: 14px;
 	}
 
 	&__content a {
 		color: #000;
+	}
+
+	&__icon {
+		color: #26212E;
+		flex: 0 0 auto;
+		margin-top: 0;
+		width: $sensei-notice-icon-width;
+		height: $sensei-notice-icon-height;
 	}
 
 	&__heading {
@@ -47,8 +40,10 @@ $sensei-notice-icon-width: 30px;
 	&__actions {
 		margin: 0.5em 0 0.5em auto;
 		align-self: center;
+		white-space: nowrap;
 
 		.button {
+			margin-left: 20px;
 			padding: 3px 12px;
 		}
 	}

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -24,10 +24,10 @@ $sensei-notice-icon-width: 30px;
 		align-items: center;
 		color: #101517;
 		font-size: 14px;
-	}
 
-	&__content a {
-		color: #000;
+		a {
+			color: #000;
+		}
 	}
 
 	&__icon {

--- a/assets/home/notices.js
+++ b/assets/home/notices.js
@@ -130,11 +130,9 @@ const Notice = ( { noticeId, notice, dismissNonce } ) => {
 
 	return (
 		<div { ...containerProps }>
-			<SenseiCircleLogo className="sensei-notice__icon" />
-			<div className="sensei-notice__wrapper">
-				<div className="sensei-notice__content">
-					<RawHTML>{ message }</RawHTML>
-				</div>
+			<div className="sensei-notice__content">
+				<SenseiCircleLogo className="sensei-notice__icon" />
+				<RawHTML>{ message }</RawHTML>
 			</div>
 			<NoticeInfoLink infoLink={ notice.info_link } />
 			<NoticeActions actions={ notice.actions } />

--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -5,7 +5,6 @@
 
 		.sensei-notice {
 			margin: 0 0 12px;
-			padding: 18px 24px;
 
 			&:last-child {
 				margin-bottom: 0;
@@ -15,40 +14,12 @@
 				display: none;
 			}
 
-			&__icon {
-				margin-top: 0;
-				align-self: center;
-			}
-
-			&__wrapper {
-				height: 100%;
-			}
-
-			&__content {
-				display: flex;
-				align-items: center;
-			}
-
 			.sensei-home {
 				&__link {
-					display: flex;
-					align-items: center;
-					height: 100%;
+					flex: 1;
 					white-space: nowrap;
+					text-align: right;
 				}
-			}
-
-			.button-secondary {
-				color: #155E65;
-				border-color: #43AF99;
-			}
-
-			.button {
-				margin-left: 20px;
-			}
-
-			.notice-dismiss {
-				margin-left: 18px;
 			}
 		}
 	}

--- a/assets/home/notices.scss
+++ b/assets/home/notices.scss
@@ -1,4 +1,3 @@
-
 .sensei-home {
 	&__notices {
 		margin-bottom: 20px;
@@ -16,9 +15,7 @@
 
 			.sensei-home {
 				&__link {
-					flex: 1;
 					white-space: nowrap;
-					text-align: right;
 				}
 			}
 		}

--- a/changelog/change-sensei-notices-styles
+++ b/changelog/change-sensei-notices-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Sensei admin notice styles

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -255,12 +255,12 @@ class Sensei_Admin_Notices {
 			?>
 		>
 			<?php
+			echo '<div class="sensei-notice__content">';
 			if ( ! empty( $notice['icon'] ) ) {
 				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the function.
 				echo Sensei()->assets->get_icon( $notice['icon'], 'sensei-notice__icon' );
 			}
-			echo '<div class="sensei-notice__wrapper">';
-			echo '<div class="sensei-notice__content">';
+			echo '<div>';
 			if ( ! empty( $notice['heading'] ) ) {
 				echo '<div class="sensei-notice__heading">';
 				echo wp_kses( $notice['heading'], self::ALLOWED_HTML );


### PR DESCRIPTION
Resolves #6726

## Proposed Changes

* It unifies and simplifies the Sensei notice styles (Sensei Home and other admin pages).
* It makes the notice responsive based on the screen size.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add the following snippet to your site:
  ```php
  add_filter(
	  'sensei_admin_notices',
	  function( $notices ) {
		  $notices['test'] = [
			  'type'        => 'site-wide',
			  'message'     => __( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus tempus, ex ac consectetur tristique, odio sem consectetur purus, ut gravida felis dolor eu urna. Donec eros nisi, dictum vel erat sed, ultrices interdum lacus.', 'senseilms-com' ),
			  'actions'     => [
				  [
					  'label'   => esc_html__( "What's new?", 'senseilms-com' ),
					  'url'     => '#',
					  'target'  => '_blank',
					  'primary' => false,
				  ],
				  [
					  'label'  => esc_html__( 'Update', 'senseilms-com' ),
					  'url'    => '#',
					  'target' => '_blank',
				  ],
			  ],
		  ];
  
		  return $notices;
	  }
  );
  ```
2. Check the notice in Sensei Home and in other admin pages.
3. Test other types of notices too.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari

## Screeshots

<img width="482" alt="Screenshot 2023-05-08 at 17 18 19" src="https://user-images.githubusercontent.com/876340/236927311-93e7233d-8b37-4379-920a-c071bb49c7d7.png">

Maybe the "What's new?" (first notice) could be in the same line as the action buttons. But to avoid a bigger refactor, I left it separated.

<img width="1188" alt="Screenshot 2023-05-08 at 17 22 09" src="https://user-images.githubusercontent.com/876340/236927345-5d5ab935-d26b-42c6-b2da-2ec029b97829.png">
