### PR TITLE
Fix wp_mail still working for temporary users

### DIFF
--- a/changelog/fix-wpmail-temporary-users
+++ b/changelog/fix-wpmail-temporary-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block triggering wp_mail for temporary users even on non-frontend context.

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -487,7 +487,7 @@ class Sensei_Guest_User {
 	 * @param array     $atts   Email attributes.
 	 * @return bool|null Null if we should send the email, a boolean if not.
 	 */
-	public function skip_wp_mail( $return, $atts ) {
+	public static function skip_wp_mail( $return, $atts ) {
 		if ( self::is_current_user_guest() ) {
 			// If this e-mail is being dispatched while the current user is a guest, just... don't send it.
 			return false;

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -147,7 +147,6 @@ class Sensei_Guest_User {
 		add_action( 'sensei_can_access_course_content', [ $this, 'open_course_enable_course_access' ], 10, 2 );
 		add_action( 'sensei_can_user_manually_enrol', [ $this, 'open_course_user_can_manualy_enroll' ], 10, 2 );
 		add_filter( 'sensei_send_emails', [ $this, 'skip_sensei_email' ] );
-		add_filter( 'pre_wp_mail', [ $this, 'skip_wp_mail' ], 10, 2 );
 
 		$this->create_guest_student_role_if_not_exists();
 

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -307,7 +307,7 @@ class Sensei_Guest_User {
 	 * @since 4.11.0
 	 * @access private
 	 */
-	private function is_current_user_guest() {
+	private static function is_current_user_guest() {
 		$user = wp_get_current_user();
 		return self::is_guest_user( $user );
 	}
@@ -475,7 +475,7 @@ class Sensei_Guest_User {
 	 * @return boolean Whether to send the email.
 	 */
 	public function skip_sensei_email( $send_email ) {
-		return $this->is_current_user_guest() ? false : $send_email;
+		return self::is_current_user_guest() ? false : $send_email;
 	}
 
 	/**
@@ -489,7 +489,7 @@ class Sensei_Guest_User {
 	 * @return bool|null Null if we should send the email, a boolean if not.
 	 */
 	public function skip_wp_mail( $return, $atts ) {
-		if ( $this->is_current_user_guest() ) {
+		if ( self::is_current_user_guest() ) {
 			// If this e-mail is being dispatched while the current user is a guest, just... don't send it.
 			return false;
 		}

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -92,7 +92,6 @@ class Sensei_Preview_User {
 		add_action( 'show_admin_bar', [ $this, 'show_admin_bar_to_preview_user' ], 90 );
 		add_action( 'admin_bar_menu', [ $this, 'add_user_switch_to_admin_bar' ], 90 );
 		add_filter( 'sensei_is_enrolled', [ $this, 'preview_user_always_enrolled' ], 90, 3 );
-		add_filter( 'pre_wp_mail', [ $this, 'skip_wp_mail' ], 10, 2 );
 
 		$this->create_role();
 	}

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -263,7 +263,7 @@ class Sensei_Preview_User {
 	 * @param array     $atts   Email attributes.
 	 * @return bool|null Null if we should send the email, a boolean if not.
 	 */
-	public function skip_wp_mail( $return, $atts ) {
+	public static function skip_wp_mail( $return, $atts ) {
 		if ( self::is_preview_user_active() ) {
 			// If this e-mail is being dispatched while the current user is a previwe user, just... don't send it.
 			return false;

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -103,7 +103,7 @@ class Sensei_Preview_User {
 	 * @access private
 	 */
 	public function add_preview_user_filters() {
-		if ( $this->is_preview_user_active() ) {
+		if ( self::is_preview_user_active() ) {
 			add_filter( 'map_meta_cap', [ $this, 'allow_post_preview' ], 10, 4 );
 			add_filter( 'pre_get_posts', [ $this, 'count_unpublished_lessons' ], 10 );
 			add_filter( 'sensei_notice', [ $this, 'hide_notices' ], 10, 1 );
@@ -195,7 +195,7 @@ class Sensei_Preview_User {
 			return;
 		}
 
-		if ( $this->can_switch_to_preview_user( $course_id ) && ! $this->is_preview_user_active() ) {
+		if ( $this->can_switch_to_preview_user( $course_id ) && ! self::is_preview_user_active() ) {
 			$wp_admin_bar->add_node(
 				[
 					'id'     => self::SWITCH_ON_ACTION,
@@ -209,7 +209,7 @@ class Sensei_Preview_User {
 			);
 		}
 
-		if ( $this->is_preview_user_active() ) {
+		if ( self::is_preview_user_active() ) {
 			$wp_admin_bar->add_node(
 				[
 					'id'     => self::SWITCH_OFF_ACTION,
@@ -236,7 +236,7 @@ class Sensei_Preview_User {
 	 * @return bool
 	 */
 	public function show_admin_bar_to_preview_user( $show ) {
-		if ( $this->is_preview_user_active() ) {
+		if ( self::is_preview_user_active() ) {
 			return true;
 		}
 
@@ -265,7 +265,7 @@ class Sensei_Preview_User {
 	 * @return bool|null Null if we should send the email, a boolean if not.
 	 */
 	public function skip_wp_mail( $return, $atts ) {
-		if ( $this->is_preview_user_active() ) {
+		if ( self::is_preview_user_active() ) {
 			// If this e-mail is being dispatched while the current user is a previwe user, just... don't send it.
 			return false;
 		}
@@ -481,7 +481,7 @@ class Sensei_Preview_User {
 	 *
 	 * @return bool
 	 */
-	private function is_preview_user_active() {
+	private static function is_preview_user_active() {
 		$user = wp_get_current_user();
 		return self::is_preview_user( $user );
 	}

--- a/includes/class-sensei-temporary-user.php
+++ b/includes/class-sensei-temporary-user.php
@@ -35,6 +35,8 @@ class Sensei_Temporary_User {
 		add_filter( 'sensei_learners_query', [ static::class, 'filter_learners_query' ] );
 		add_filter( 'sensei_count_statuses_args', [ static::class, 'filter_count_statuses' ] );
 		add_filter( 'sensei_check_for_activity', [ static::class, 'filter_sensei_activity' ], 10, 2 );
+		add_filter( 'pre_wp_mail', [ Sensei_Guest_User::class, 'skip_wp_mail' ], 10, 2 );
+		add_filter( 'pre_wp_mail', [ Sensei_Preview_User::class, 'skip_wp_mail' ], 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
Fix a situation that #6855 didn't cover: Blocking `wp_mail` when the e-mail isn't dispatched from the frontend of the site.

## Proposed Changes
* Block `wp_mail` calls related to temporary users even on non-frontend context;

## Testing Instructions

The test for this is pretty simple, on WP-CLI, run the following commands, line by line:

```
remove_all_filters('wp_mail'); // To make sure that no other filter will change the data informed
wp_mail( 'user1@guest.senseilms', 'Test email', 'Hello, this is a test email.', [    'From: My Site Name <noreply@example.com>']); // Should return false on this branch, true on trunk
wp_mail( 'user1@preview.senseilms', 'Test email', 'Hello, this is a test email.', [    'From: My Site Name <noreply@example.com>']); // Should return false on this branch, true on trunk
wp_mail( 'user1@example.com', 'Test email', 'Hello, this is a test email.', [    'From: My Site Name <noreply@example.com>']); // Should return true in any scenario
```

Here's the code running on this branch:

![image](https://github.com/Automattic/sensei/assets/529864/697e87d9-3e9f-40c8-9878-3bcb564fdf8d)

This is the code running on the `trunk` branch:

![image](https://github.com/Automattic/sensei/assets/529864/d1257868-6093-46f9-891e-d3bc91e44d5c)


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
