### PR TITLE
Fix global typography in the Course theme's default variation

### DIFF
--- a/assets/course-theme/blocks/lesson-blocks/exit-course-button/exit-course-edit.js
+++ b/assets/course-theme/blocks/lesson-blocks/exit-course-button/exit-course-edit.js
@@ -8,12 +8,14 @@ export const ExitCourseEdit = () => {
 	const blockProps = useBlockProps();
 
 	return (
-		<a
-			{ ...blockProps }
-			href="#exit-course-button-pseudo-link"
-			onClick={ ( event ) => event.preventDefault() }
-		>
-			{ __( 'Exit Course', 'sensei-lms' ) }
-		</a>
+		<div className="sensei-course-theme__exit-course-wrapper">
+			<a
+				{ ...blockProps }
+				href="#exit-course-button-pseudo-link"
+				onClick={ ( event ) => event.preventDefault() }
+			>
+				{ __( 'Exit Course', 'sensei-lms' ) }
+			</a>
+		</div>
 	);
 };

--- a/assets/course-theme/blocks/lesson-blocks/exit-course-button/exit-course-edit.js
+++ b/assets/course-theme/blocks/lesson-blocks/exit-course-button/exit-course-edit.js
@@ -8,9 +8,8 @@ export const ExitCourseEdit = () => {
 	const blockProps = useBlockProps();
 
 	return (
-		<div className="sensei-course-theme__exit-course-wrapper">
+		<div { ...blockProps }>
 			<a
-				{ ...blockProps }
 				href="#exit-course-button-pseudo-link"
 				onClick={ ( event ) => event.preventDefault() }
 			>

--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -217,7 +217,9 @@ export default [
 			return (
 				<div { ...blockProps }>
 					<span className="post-page-numbers current">1</span>
-					<span className="post-page-numbers">2</span>
+					<a href="#pseudo-link" className="post-page-numbers">
+						2
+					</a>
 				</div>
 			);
 		},

--- a/assets/css/3rd-party/themes/course/learning-mode.scss
+++ b/assets/css/3rd-party/themes/course/learning-mode.scss
@@ -32,11 +32,7 @@ body {
 }
 
 .sensei-lms-course-navigation-module__title {
-	font-family: var(--wp--preset--font-family--heading);
 	font-size: 1.75rem;
-	font-weight: 400;
-	line-height: 100%;
-	letter-spacing: 0.01em;
 	text-transform: uppercase;
 }
 
@@ -58,14 +54,7 @@ body {
 	align-items: baseline;
 }
 
-.sensei-lms-course-navigation-lesson__title {
-	font-family: var(--wp--preset--font-family--system);
-}
-
 .sensei-lms-course-navigation-lesson__extra {
-	font-family: var(--wp--preset--font-family--system);
-	line-height: 1.23;
-	font-weight: normal;
 	opacity: 1;
 	letter-spacing: 0.02em;
 }
@@ -76,8 +65,6 @@ body {
 }
 
 .sensei-course-theme-lesson-actions__next-lesson {
-	font-family: var(--wp--preset--font-family--heading);
-	font-size: var(--wp--custom--typography--font-sizes--button);
 	letter-spacing: 0.05em;
 	text-transform: uppercase;
 }
@@ -192,7 +179,6 @@ body {
 	border-radius: 4px;
 }
 
-/* Modern Template */
 .sensei-course-theme.sensei-modern .sensei-course-theme__header,
 .sensei-course-theme.sensei-modern .sensei-course-theme__sidebar {
 	background-color: var(--sensei-background-color);
@@ -201,8 +187,4 @@ body {
 
 .learning-mode-full-width .wp-block-sensei-lms-course-theme-course-progress-counter {
 	opacity: 1;
-}
-
-.wp-block-sensei-lms-exit-course:hover {
-	text-decoration: none;
 }

--- a/assets/css/3rd-party/themes/course/learning-mode.scss
+++ b/assets/css/3rd-party/themes/course/learning-mode.scss
@@ -31,9 +31,9 @@ body {
 	padding-top: 0;
 }
 
+.editor-styles-wrapper .sensei-lms-course-navigation-module__title,
 .sensei-lms-course-navigation-module__title {
 	font-size: 1.75rem;
-	text-transform: uppercase;
 }
 
 .sensei-lms-course-navigation-module__summary {

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -33,6 +33,7 @@
 .wp-block-sensei-lms-exit-course {
 	color: var(--sensei-primary-color);
 	font-size: 1rem;
+	line-height: 1.1875;
 }
 
 .editor-styles-wrapper .sensei-course-theme__sidebar,
@@ -83,6 +84,7 @@
 .wp-block-sensei-lms-page-actions .post-page-numbers {
 	color: var(--sensei-pagination-color);
 	line-height: 3.1111111111;
+	text-decoration: none;
 }
 
 .sensei-course-theme-lesson-actions {
@@ -94,6 +96,8 @@
 .editor-styles-wrapper .sensei-lms-course-navigation-module__title,
 .sensei-lms-course-navigation-module__title {
 	color: var(--sensei-primary-color);
+	font-weight: 600;
+	line-height: 1.33;
 
 	@media screen and (max-width: (782px)) {
 		font-size: 1.3125rem;

--- a/assets/css/sensei-course-theme/blocks/course-navigation.scss
+++ b/assets/css/sensei-course-theme/blocks/course-navigation.scss
@@ -55,8 +55,6 @@
 	&__title {
 		flex: 1;
 		font-size: 1.125rem;
-		font-weight: 600;
-		line-height: 1.33;
 		margin: 0;
 		text-align: left;
 	}
@@ -85,7 +83,11 @@
 
 .sensei-lms-course-navigation-lesson {
 	display: flex;
+	font-size: 0.875rem;
+	line-height: 1.214285714285714;
 	margin-top: 24px;
+	padding: 10px 1px;
+	text-decoration: none;
 
 	&__link {
 		display: flex;
@@ -97,12 +99,11 @@
 		flex: 1;
 		font-size: 0.875rem;
 		font-weight: 300;
-		padding: 0 8px;
 		line-height: 1.214;
+		padding: 0 8px;
 	}
 
 	&__extra {
-		font-size: 0.8125rem;
 		margin-top: 1px; // Needed to compensate the font-size difference.
 		padding-left: 6px;
 	}

--- a/assets/css/sensei-course-theme/blocks/course-navigation.scss
+++ b/assets/css/sensei-course-theme/blocks/course-navigation.scss
@@ -97,9 +97,6 @@
 
 	&__title {
 		flex: 1;
-		font-size: 0.875rem;
-		font-weight: 300;
-		line-height: 1.214;
 		padding: 0 8px;
 	}
 

--- a/assets/css/sensei-course-theme/blocks/exit-course.scss
+++ b/assets/css/sensei-course-theme/blocks/exit-course.scss
@@ -1,5 +1,4 @@
 .editor-styles-wrapper .wp-block .wp-block-sensei-lms-exit-course,
 .wp-block-sensei-lms-exit-course {
-	line-height: 1.1875;
 	text-decoration: underline;
 }

--- a/assets/css/sensei-course-theme/blocks/lesson-actions.scss
+++ b/assets/css/sensei-course-theme/blocks/lesson-actions.scss
@@ -41,7 +41,6 @@ body .is-layout-flow > * + .sensei-course-theme__actions-wrapper {
 	display: flex;
 	.post-page-numbers {
 		opacity: 0.6;
-		text-decoration: none;
 
 		&.current {
 			opacity: 1;

--- a/includes/blocks/course-theme/class-exit-course.php
+++ b/includes/blocks/course-theme/class-exit-course.php
@@ -58,6 +58,15 @@ class Exit_Course {
 
 		$label = $attributes['label'] ?? __( 'Exit Course', 'sensei-lms' );
 
-		return sprintf( '<div class="sensei-course-theme__exit-course-wrapper"><a href="%1$s" %2$s>%3$s</a></div>', get_the_permalink( $course_id ), $wrapper_attributes, $label );
+		return sprintf(
+			'<div %1$s>
+				<a href="%2$s">
+					%3$s
+				</a>
+			</div>',
+			$wrapper_attributes,
+			get_the_permalink( $course_id ),
+			$label
+		);
 	}
 }

--- a/includes/blocks/course-theme/class-exit-course.php
+++ b/includes/blocks/course-theme/class-exit-course.php
@@ -58,6 +58,6 @@ class Exit_Course {
 
 		$label = $attributes['label'] ?? __( 'Exit Course', 'sensei-lms' );
 
-		return sprintf( '<a href="%1$s" %2$s>%3$s</a>', get_the_permalink( $course_id ), $wrapper_attributes, $label );
+		return sprintf( '<div class="sensei-course-theme__exit-course-wrapper"><a href="%1$s" %2$s>%3$s</a></div>', get_the_permalink( $course_id ), $wrapper_attributes, $label );
 	}
 }

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -109,7 +109,7 @@ class Lesson_Actions {
 		$label = __( 'Next Lesson', 'sensei-lms' );
 		$icon  = \Sensei()->assets->get_icon( 'arrow-right' );
 
-		return ( "<a class='sensei-course-theme-lesson-actions__next-lesson sensei-course-theme__button is-link has-icon' href='{$url}'><span>{$label}</span>{$icon}</a>" );
+		return ( "<a class='wp-block-button__link wp-element-button sensei-course-theme__button sensei-course-theme-lesson-actions__next-lesson has-icon' href='{$url}'><span>{$label}</span>{$icon}</a>" );
 
 	}
 


### PR DESCRIPTION
Resolves #6862.

## Proposed Changes
Fixes global typography for the default Course variation when using the default Learning Mode template. I did this using one of two approaches:

- Move the block level typography settings to element level settings instead. This only worked in cases where all elements of that type have the same default styles.
- Add a wrapper element around the element to be styled, and leverage CSS inheritance to apply the appropriate styles to the child element.

## Testing Instructions

1. Switch to [this PR](https://github.com/Automattic/themes/pull/7068).
2. Activate the Course theme and the default Learning Mode template. Ensure you're using the default theme variation.
3. In Global Styles > Typography, change all the properties and ensure they update in the editor and on the frontend, except for the following exceptions.

## Exceptions
### Links
- Decoration doesn't work correctly for the Exit Course link or for links contained within the content.

### Headings
- Course Title: All global typography settings work except for font size.
- Modules in sidebar: All global typography settings work except for font size.
- Modules in lesson: All global typography settings work except for font size.

### Text
- Meta in header (e.g. "2 of 12 lessons complete (16%)"): No global typography settings work.
- Meta in sidebar (e.g. "2 lessons, 1 quiz"): No global typography settings work.

### Pagination
I opted not to have global typography affect pagination, given that the currently selected page is a `span` tag and the other pages are links. It introduced inconsistencies to use the Text style for the current page and the Link style for links, and it would also be trickey to have them all use the same setting.

Please see p6rkRX-6hi-p2 for more context.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues