### PR TITLE
Load Learning Mode Course theme styles in Editor

### DIFF
--- a/includes/3rd-party/themes/course.php
+++ b/includes/3rd-party/themes/course.php
@@ -28,5 +28,29 @@ function sensei_load_learning_mode_style_for_course_theme() {
 	}
 }
 
+/**
+ * Enqueue Course theme-specific Learning Mode styles in the admin for the Site Editor and Lesson Editor.
+ */
+function sensei_admin_load_learning_mode_style_for_course_theme() {
+	if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+		return;
+	}
+
+	$screen           = get_current_screen();
+	$is_lesson_editor = 'lesson' === $screen->post_type && 'post' === $screen->base;
+	$is_site_editor   = 'site-editor' === $screen->id;
+
+	if ( $is_lesson_editor || $is_site_editor ) {
+		Sensei()->assets->enqueue(
+			'course-learning-mode',
+			'css/3rd-party/themes/course/learning-mode.css',
+			[],
+			'screen'
+		);
+	}
+
+}
+
 add_action( 'wp', 'sensei_disable_learning_mode_style_for_course_theme' );
 add_action( 'wp_enqueue_scripts', 'sensei_load_learning_mode_style_for_course_theme' );
+add_action( 'admin_enqueue_scripts', 'sensei_admin_load_learning_mode_style_for_course_theme' );


### PR DESCRIPTION
Resolves #6872 

Load compatibility CSS for the Course theme in the editor.

## Proposed Changes
* Load Course theme Learning Mode styles for the Site Editor and for a lesson in the editor.

## Testing Instructions

1. Open site editor.
2. Open page source code and search for "course-learning-mode-css".
3. It is expected to find the `<link` tag with the corresponding CSS file.
4. Check if it is loaded when you open a lesson in the editor.
5. Check if it is not loaded for a course (or other post types).



## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
