### PR TITLE
Check if current theme is the Course theme in admin

### DIFF
--- a/includes/3rd-party/themes/course.php
+++ b/includes/3rd-party/themes/course.php
@@ -32,7 +32,9 @@ function sensei_load_learning_mode_style_for_course_theme() {
  * Enqueue Course theme-specific Learning Mode styles in the admin for the Site Editor and Lesson Editor.
  */
 function sensei_admin_load_learning_mode_style_for_course_theme() {
-	if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+	$is_course_theme = 'course' === wp_get_theme()->get_template();
+
+	if ( ! is_admin() || ! function_exists( 'get_current_screen' ) || ! $is_course_theme ) {
 		return;
 	}
 


### PR DESCRIPTION
We shouldn't apply Course theme-specific Learning Management CSS if Course theme is not activated.

## Proposed Changes
* Check if current theme is the Course theme in admin

## Testing Instructions

1. Activate Course theme, go to Site Editor.
2. Check if CSS loaded.
3. Activate another theme (2023, for example), go to Site Editor.
4. Check CSS not loaded

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes