### PR TITLE
Don't re-create emails on plugin update

### DIFF
--- a/changelog/fix-email-template-creation
+++ b/changelog/fix-email-template-creation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't re-create emails on plugin update

--- a/includes/internal/emails/class-email-repository.php
+++ b/includes/internal/emails/class-email-repository.php
@@ -68,9 +68,10 @@ class Email_Repository {
 	public function has( string $identifier ): bool {
 		$query = new WP_Query(
 			[
-				'post_type'  => Email_Post_Type::POST_TYPE,
-				'meta_key'   => self::META_IDENTIFIER, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value' => $identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value,
+				'post_type'   => Email_Post_Type::POST_TYPE,
+				'post_status' => 'any',
+				'meta_key'    => self::META_IDENTIFIER, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'  => $identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value,
 			]
 		);
 
@@ -130,10 +131,11 @@ class Email_Repository {
 	public function delete( string $identifier ): bool {
 		$query = new WP_Query(
 			[
-				'select'     => 'ID',
-				'post_type'  => Email_Post_Type::POST_TYPE,
-				'meta_key'   => self::META_IDENTIFIER, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value' => $identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'select'      => 'ID',
+				'post_type'   => Email_Post_Type::POST_TYPE,
+				'post_status' => 'any',
+				'meta_key'    => self::META_IDENTIFIER, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'  => $identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			]
 		);
 
@@ -230,6 +232,7 @@ class Email_Repository {
 		$query = new WP_Query(
 			[
 				'post_type'      => Email_Post_Type::POST_TYPE,
+				'post_status'    => 'any',
 				'posts_per_page' => 1,
 			]
 		);

--- a/tests/unit-tests/internal/emails/test-class-email-repository.php
+++ b/tests/unit-tests/internal/emails/test-class-email-repository.php
@@ -22,6 +22,23 @@ class Email_Repository_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	/**
+	 * Tests that a disabled email is found in the repository.
+	 *
+	 * @covers Email_Repository::has
+	 */
+	public function testHas_DisabledEmailInRepository_ReturnsTrue() {
+		/* Arrange. */
+		$repository = new Email_Repository();
+		$repository->create( 'disabled', [ 'b' ], 'c', 'd', 'e', false, true );
+
+		/* Act. */
+		$result = $repository->has( 'disabled' );
+
+		/* Assert. */
+		$this->assertTrue( $result );
+	}
+
 	public function testHas_EmailCreated_ReturnsTrue() {
 		/* Arrange. */
 		$repository = new Email_Repository();
@@ -127,6 +144,24 @@ class Email_Repository_Test extends \WP_UnitTestCase {
 		$repository = new Email_Repository();
 		$repository->create( 'a', [ 'b' ], 'c', 'd', 'e' );
 		$repository->create( 'f', [ 'g' ], 'h', 'i', 'j' );
+
+		/* Act. */
+		$result = $repository->has_emails();
+
+		/* Assert. */
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that when only disabled emails are created, that they are still found in the repository.
+	 *
+	 * @covers Email_Repository::has_emails
+	 */
+	public function testHasEmails_AllEmailsDisabled_ReturnsTrue() {
+		/* Arrange. */
+		$repository = new Email_Repository();
+		$repository->create( 'a', [ 'b' ], 'c', 'd', 'e', false, true );
+		$repository->create( 'f', [ 'g' ], 'h', 'i', 'j', false, true );
 
 		/* Act. */
 		$result = $repository->has_emails();


### PR DESCRIPTION
Resolves #6879.

## Proposed Changes
Check for `any` `post_status` in the `Email_Repository` class' `has`, `delete` and `has_emails` functions:

- `has_emails` is called when the plugin is updated to determine whether to create the emails or not. It was only returning `true` if there were any emails with the `publish` status. If all emails had some other status (i.e. `draft`), it would return `false` and the emails would be regenerated, causing multiples to be created.
- `has` is also called when the plugin is updated. It's a bit of a redundant check since `has_emails` already checks `post_status`, but it seems safer to add the check here too.
- `delete` seemed to work fine without checking `post_status`, but for clarity's sake I opted to add it.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Disable all emails for teachers and students.
2. Run `wp option update sensei-version "4.12.0"` so we can simulate and trigger a plugin update.
3. Load a non-WP Admin page. 
4. Go to Sensei > Settings > Emails.
5. Ensure no emails are duplicated.
6. Try enabling an email and sending to ensure it still works.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
