### PR TITLE
Fix editor elements don't obey global colors for Course theme

### DIFF
--- a/assets/css/3rd-party/themes/course/learning-mode.scss
+++ b/assets/css/3rd-party/themes/course/learning-mode.scss
@@ -179,11 +179,6 @@ body {
 	border-radius: 4px;
 }
 
-.sensei-course-theme.sensei-modern .sensei-course-theme__header,
-.sensei-course-theme.sensei-modern .sensei-course-theme__sidebar {
-	background-color: var(--sensei-background-color);
-	color: var(--sensei-text-color);
-}
 
 .learning-mode-full-width .wp-block-sensei-lms-course-theme-course-progress-counter {
 	opacity: 1;

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -1,7 +1,7 @@
 $breakpoint: 783px;
 
-body,
-.editor-styles-wrapper .wp-block {
+
+body, .editor-styles-wrapper {
 	// Try to pick up global styles, customizer or theme colors.
 	--sensei-background-color: var(--sensei-background-color-global, var(--sensei-course-theme-background-color, var(--wp--preset--color--background, #FFFFFF)));
 	--sensei-button-fill-hover-color: #FFFFFF;


### PR DESCRIPTION
Resolves #6835 

## Proposed Changes
*  Fix the header background color not obeying the global styles

We are previously setting CSS variables inside the  `.wp-block` as you can see [here](https://github.com/Automattic/sensei/pull/6887/commits/2867f679cb17f9f43871648fb85242bb38ceb653#diff-3ce848a738a931b14431516f745c6578e71cd8ec5229a994e7254f505fd54fbdL4).

So if an element tries to use that variable outside the first wp-block element, so if the user is using a theme that don't use the wp-block element (old themes) the variables will never be available. 

## Testing Instructions
*  Go to the learning mode template on "Appearance > Editor"
* Set a background color on the global style
* Check if the header background color is obeying the global styles.
*  Set a text color and a link color
* Check if the editor is obeying the global styles.
* Go to a course, and check if the frontend is rendering the same colors you set on the editor.


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented

