### PR TITLE
Remove "New" status when a new issue is created

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "[Status] New, [Type] Bug"
+labels: "[Type] Bug"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: "[Status] New, [Type] Enhancement"
+labels: "[Type] Enhancement"
 assignees: ''
 
 ---


### PR DESCRIPTION
Adding the "New" status was meant to make it easier to triage user-submitted issues, but it actually seems to be more work because we're forgetting to remove it for issues that we create as well. This status seems unnecessary anyway, as we can tell if an issue has been triaged by checking whether it's been added to the Sensei Janitorial board.