### PR TITLE
Fix visibility for the course navigation

### DIFF
--- a/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
+++ b/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
@@ -50,6 +50,9 @@ $breakpoint: 783px;
 				pointer-events: all;
 			}
 
+			.sensei-course-theme__secondary-sidebar {
+				top: unset;
+			}
 		}
 
 		&__sidebar {


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2286
Counterpart PR in Sensei Pro: https://github.com/Automattic/sensei-pro/pull/2289

In case course navigation was inside secondary sidebar, it didn't appear on mobile.

## Proposed Changes
* Fix visibility for the course navigation in a secondary sidebar on mobile.

## Testing Instructions

0. Checkout corresponding branches in sensei and sensei-pro and run `npm run build:assests` for both.
1. Install and activate Sensei Pro, activate Video layout.
2. Open a lesson on mobile and open menu.
3. It is expected you can see course outline.


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes

