### PR TITLE
Fix learning mode premium template mobile lateral spacing in mobile view

### DIFF
--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -28,9 +28,11 @@ body {
 	color: var(--sensei-background-color);
 }
 
-.sensei-course-theme__main-content {
-	padding: 0 24px;
+.wp-site-blocks {
+	padding: 0 var(--content-padding);
+}
 
+.sensei-course-theme__main-content {
 	> * {
 		max-width: var(--content-size) !important;
 		margin-left: auto;

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -10,7 +10,7 @@ $breakpoint: 783px;
 	}
 
 
-	@at-root :root:has(.admin-bar) {
+	@at-root :root:has(.admin-bar) .sensei-course-theme__sidebar {
 		// When the admin bar is present, something is applying and extra spacing that is messing the padding calculate, so it require cut the padding by half.
 		--content-padding: 12px;
 	}


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6897

## Proposed Changes
* Restores spacing target class to previous one

## Testing Instructions

1. Make sure you are on latest trunk of pro
2. Create a course with lesson
3. Make sure Learning mode is enabled
4. Take a lesson as a student in mobile view
5. Make sure you see spacings on the left and right for all the LM templates

Before:
![image](https://github.com/Automattic/sensei/assets/6820724/82df6b42-3d7c-4267-9dde-e35da069454d)

After:
![image](https://github.com/Automattic/sensei/assets/6820724/432ffd92-b1bb-4de9-b5d6-24e167bd689c)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
