### PR TITLE
Fix email body rendered in the front-end in some cases

### DIFF
--- a/changelog/fix-rendering-the-email-body
+++ b/changelog/fix-rendering-the-email-body
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix email body rendered in the front-end in some cases

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -176,9 +176,8 @@ class Email_Sender {
 		);
 
 		the_post();
-
 		$templated_output = $this->get_templated_post_content( $placeholders );
-		wp_reset_postdata();
+		wp_reset_query(); // phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- We need to reset the global query object.
 
 		return CssInliner::fromHtml( $templated_output )
 			->inlineCss( $this->load_email_styles() )

--- a/tests/unit-tests/internal/emails/test-class-email-sender.php
+++ b/tests/unit-tests/internal/emails/test-class-email-sender.php
@@ -242,6 +242,24 @@ class Email_Sender_Test extends \WP_UnitTestCase {
 		self::assertStringContainsString( 'Welcome – John', $email_body );
 	}
 
+	public function testGetEmailBody_WhenCalled_ResetsTheGlobalWpQuery() {
+		$post = $this->factory->post->create_and_get(
+			[
+				'post_type'    => Email_Post_Type::POST_TYPE,
+				'post_title'   => 'My template',
+				'post_name'    => 'Welcome - [name]',
+				'post_content' => 'Welcome - [name]',
+			]
+		);
+
+		/* Act. */
+		$this->email_sender->get_email_body( $post, [ 'name' => 'John' ] );
+		global $wp_query, $wp_the_query;
+
+		/* Assert. */
+		self::assertEquals( $wp_query, $wp_the_query );
+	}
+
 	public function testSendEmail_WhenTheReplyToIsSet_SetReplyTo() {
 		/* Arrange. */
 		$this->settings->set( 'email_reply_to_address', 'address_to_be_replied@gmail.com' );


### PR DESCRIPTION
Resolves #6817

This PR fixes the global `wp_query` object not being reset after fetching the email content. This causes the email body to be rendered in the front-end in some cases.

Donna [suggested](https://github.com/Automattic/sensei/issues/6817#issuecomment-1554449030) using [this approach](https://github.com/Automattic/sensei/blob/4c6afab3f5456a4c347e75835625e7b6997834fd/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php#L66) but it does the same thing as calling `query_posts` + `wp_reset_query` which is to overwrite the global `wp_query` with a new WP_Query object and reset it using the `wp_the_query` global. So I've decided to stick with calling `query_posts` + `wp_reset_query`.

## Proposed Changes
* Reset the `wp_query` global object after calling `query_posts`.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions at https://github.com/Automattic/sensei/issues/6817#issuecomment-1553012517
* Make sure the email body is not replacing the post content.
* Use the `Preview as Student` feature and open a lesson.
* Make sure the email body is not replacing the lesson.
* Make sure the emails are working as before.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
