### PR TITLE
Fix the squashed logo on learning mode

### DIFF
--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -35,7 +35,7 @@ body, .editor-styles-wrapper {
 	}
 }
 
-.wp-block-site-logo img {
+.sensei-course-theme .wp-block-site-logo img {
 	max-height: 24px;
 	width: auto;
 }

--- a/assets/css/sensei-course-theme/ui-blocks.scss
+++ b/assets/css/sensei-course-theme/ui-blocks.scss
@@ -43,10 +43,6 @@ body.sensei-course-theme {
 		& > :first-child {
 			flex: 1;
 		}
-
-		img {
-			max-height: var(--sensei-lm-header-height);
-		}
 	}
 
 	&__header + *:not(style) {


### PR DESCRIPTION
Resolves  #6914 

## Proposed Changes
* Fix the learning mode site logo squashed 

## Supported Themes
* Course
* Divi
* Astra

## Screenshots

### Before 
<img width="428" alt="Screenshot 2023-05-26 at 14 59 18" src="https://github.com/Automattic/sensei/assets/38718/947361d0-6c34-4d34-b794-d5f9c0c1d6eb">

### After
<img width="464" alt="Screenshot 2023-05-26 at 15 15 46" src="https://github.com/Automattic/sensei/assets/38718/78af57e1-6910-4083-a4ba-4c2a77fe4ded">


## Testing Instructions
* Use squared logo like this one and check if it squashed
![logo_template](https://github.com/Automattic/sensei/assets/38718/402e039e-d91e-4715-a747-671e1b38473d)
* Check the premium templates


Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria are met
