### PR TITLE
Fix lateral spacing on learning mode and Twenty Twenty-Three theme

### DIFF
--- a/assets/css/3rd-party/themes/course/learning-mode.scss
+++ b/assets/css/3rd-party/themes/course/learning-mode.scss
@@ -53,14 +53,6 @@ body {
 
 /* Course Navigation */
 
-.sensei-lms-course-navigation {
-	&__modules,
-	&__lessons {
-		padding-inline-start: 0;
-	}
-}
-
-
 .sensei-lms-course-navigation-module__header {
 	padding-top: 0;
 }
@@ -202,10 +194,6 @@ body {
 .sensei-course-theme__header+.sensei-course-theme__columns > div:first-child.sensei-course-theme__sidebar {
 	border-radius: 0px;
 	border-width: 0px 1px 0px 0px;
-}
-
-.sensei-lms-course-navigation__modules {
-	padding-inline-start: 0;
 }
 
 .wp-block-post-content :is(h2, h3, h4, h5, h6) {

--- a/assets/css/sensei-course-theme/blocks/course-navigation.scss
+++ b/assets/css/sensei-course-theme/blocks/course-navigation.scss
@@ -9,7 +9,9 @@
 			list-style: none;
 			padding: 0;
 		}
+		padding-inline-start: 0;
 	}
+
 	&__modules {
 		display: flex;
 		gap:  24px;

--- a/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
+++ b/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
@@ -31,13 +31,14 @@ $breakpoint: 783px;
 		background: none;
 	}
 }
-
+// Desktop
 @media screen and (min-width: ($breakpoint)) {
 	.sensei-course-theme__sidebar-toggle {
 		display: none;
 	}
 }
 
+// Mobile
 @media screen and (max-width: ($breakpoint - 1)) {
 	.sensei-course-theme {
 
@@ -70,7 +71,7 @@ $breakpoint: 783px;
 			overscroll-behavior: contain;
 			display: flex;
 			flex-direction: column;
-			padding: 32px var(--content-padding);
+			padding: 32px var(--content-padding) !important;
 			transition: opacity 300ms;
 			scrollbar-gutter: stable both-edges;
 			pointer-events: none;


### PR DESCRIPTION
Resolves #6912 

## Proposed Changes
* Enforce the lateral menu spacing reset
* Remove the same style from the course theme style,

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1.  Set Twenty Twenty-Three theme as the site theme.
2.  Go to a course with learning mode
3.  Use a mobile width screen size < 782px
4. Check if the menu is aligned with the progress bar(mobile and desktop)
5. Check the course theme 

### Screenshots

#### Before
<img width="191" alt="Screenshot 2023-05-26 at 16 13 55" src="https://github.com/Automattic/sensei/assets/38718/b38e3b65-7586-4242-9c0c-603f6b79295f">



#### After
<img width="597" alt="Screenshot 2023-05-26 at 15 49 16" src="https://github.com/Automattic/sensei/assets/38718/2e088e21-bac5-442a-9f15-7aea468915a6">
<img width="428" alt="Screenshot 2023-05-26 at 14 59 18" src="https://github.com/Automattic/sensei/assets/38718/1ca51cca-bc50-49b6-b960-755af15af3cd">


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes

