### PR TITLE
Update the future minimum PHP version

### DIFF
--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Dependency_Checker {
 	const MINIMUM_PHP_VERSION        = '7.2';
-	const FUTURE_MINIMUM_PHP_VERSION = '7.2';
+	const FUTURE_MINIMUM_PHP_VERSION = '7.3';
 
 	/**
 	 * Checks for our PHP version requirement.


### PR DESCRIPTION
## Proposed Changes

This PR updates the future minimum PHP version. This enables a notice informing the users of the required PHP version for the future release.

## Testing Instructions

1. Open the admin panel using PHP 7.2.
2. Go to the Dashboard or the Plugins screen.
3. There should be a notice that says: `Sensei LMS will require, in the next release, a minimum PHP version of 7.3, but you are running 7.2.34.`

<img width="644" alt="image" src="https://github.com/Automattic/sensei/assets/1612178/47cc209c-e83d-448b-a35d-c18bffea0a21">

## Context

p1685125683441429-slack-C07418EJ0