### PR TITLE
Fix title alignment on patterns

### DIFF
--- a/includes/block-patterns/course/templates/life-coach.php
+++ b/includes/block-patterns/course/templates/life-coach.php
@@ -36,13 +36,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div style="height:28px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading -->
-<h2><?php esc_html_e( 'Make your dream a reality', 'sensei-lms' ); ?></h2>
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"9px","bottom":"9px"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide" style="margin-top:9px;margin-bottom:9px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:heading -->
+<h2 class="wp-block-heading"><?php esc_html_e( 'Make your dream a reality', 'sensei-lms' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
 <p><?php esc_html_e( "Hellen's classes offer 1:1 sessions so that she gets to know each of their students. It's not just a group chat, it's you and Hellen, at a personal level. That way you can figure out exactly how to apply her teachings to your personality.", 'sensei-lms' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
 
 <!-- wp:spacer {"height":16} -->
 <div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/includes/block-patterns/course/templates/long-sales-page.php
+++ b/includes/block-patterns/course/templates/long-sales-page.php
@@ -75,8 +75,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:spacer -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"120px","top":"120px","right":"90px","left":"90px"}},"color":{"background":"#121c1c","text":"#ffffff"}},"className":"sensei-pattern-group","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull sensei-pattern-group has-text-color has-background" style="background-color:#121c1c;color:#ffffff;padding-top:120px;padding-right:90px;padding-bottom:120px;padding-left:90px"><!-- wp:heading -->
-<h2><?php esc_html_e( 'What you will learn to master', 'sensei-lms' ); ?></h2>
+<div class="wp-block-group alignfull sensei-pattern-group has-text-color has-background" style="background-color:#121c1c;color:#ffffff;padding-top:120px;padding-right:90px;padding-bottom:120px;padding-left:90px">
+<!-- wp:heading {"align":"wide"} -->
+<h2 class="wp-block-heading alignwide"><?php esc_html_e( 'What you will learn to master', 'sensei-lms' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":16} -->

--- a/includes/block-patterns/course/templates/video-hero.php
+++ b/includes/block-patterns/course/templates/video-hero.php
@@ -186,8 +186,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="wp-block-sensei-lms-button-contact-teacher is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link has-text-color" style="color:#ffffff"><?php esc_html_e( 'Contact Teacher', 'sensei-lms' ); ?></a></div>
 <!-- /wp:sensei-lms/button-contact-teacher --></div>
 <!-- /wp:group -->
-
-<!-- wp:spacer {"height":24} -->
-<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
+</div>
 <!-- /wp:group -->

--- a/includes/block-patterns/course/templates/video-hero.php
+++ b/includes/block-patterns/course/templates/video-hero.php
@@ -155,10 +155,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 <h2><?php esc_html_e( "Let's get started", 'sensei-lms' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:spacer {"height":24} -->
-<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
 <!-- wp:sensei-lms/course-progress /-->
 
 <!-- wp:sensei-lms/course-outline -->

--- a/includes/block-patterns/course/templates/video-hero.php
+++ b/includes/block-patterns/course/templates/video-hero.php
@@ -16,10 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 <h1 class="alignwide sensei-content-title" style="font-size:clamp(3rem, 6vw, 4.5rem);line-height:1.15"><?php esc_html_e( 'Welcome to the Film Direction Course', 'sensei-lms' ); ?></h1>
 <!-- /wp:heading -->
 
-<!-- wp:spacer {"height":32} -->
-<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
 <!-- wp:video {"align":"wide"} -->
 <figure class="wp-block-video alignwide"><video controls src="<?php echo esc_url( Sensei()->assets->get_image( 'patterns-video.mp4' ) ); ?>"></video></figure>
 <!-- /wp:video -->


### PR DESCRIPTION
Related to https://github.com/Automattic/themes/issues/7121

## Proposed Changes
* Align titles by the left
* Remove extra spacing

### Screenshots
**Life Coat pattern (Before/After)**
![image](https://github.com/Automattic/sensei/assets/38718/4ade0aa4-2a1e-46b3-815f-3f79dd315abf)
![image](https://github.com/Automattic/sensei/assets/38718/beeed8e8-c729-4d01-b4d4-759c19117675)
----

**Long Sales pattern (Before/After)**
![image](https://github.com/Automattic/sensei/assets/38718/2b23b02c-5694-4aee-b899-06ea0bd1779b)
![image](https://github.com/Automattic/sensei/assets/38718/5704cc3b-e205-41be-b191-75a24d78fa71)

**Video Hero Before/After**
![image](https://github.com/Automattic/sensei/assets/38718/adc5dcd0-51a6-4625-8dbc-483fedf23869)
![image](https://github.com/Automattic/sensei/assets/38718/973300a0-b06e-42cd-ad15-b67f24a4e03d)


## Testing instructions
- Go to this branch
- Create a new course
- Use the pattern described above
- Check if they are equal to the **after** screenshots


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->

- [x] Decisions are publicly documented
- [x] All strings are translatable (without concatenation, handles plurals)
