### PR TITLE
Enable customizing click handlers of course outline placeholder

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline-placeholder.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.js
@@ -3,6 +3,7 @@
  */
 import { BlockIcon } from '@wordpress/block-editor';
 import { Button, Placeholder } from '@wordpress/components';
+import { addAction, doAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,12 +11,16 @@ import { __ } from '@wordpress/i18n';
  */
 import settings from './index';
 
+const createCourseOutline = () => {
+	// eslint-disable-next-line no-console
+	console.log( 'Message from Sensei LMS' );
+};
+
 /**
  * Placeholder for empty Course Outline block.
  *
- * @param {Function} addBlock Add block
  */
-const OutlinePlaceholder = ( { addBlock } ) => (
+const OutlinePlaceholder = () => (
 	<Placeholder
 		className="wp-block-sensei-lms-course-outline__placeholder"
 		label={ __( 'Course Outline', 'sensei-lms' ) }
@@ -27,19 +32,25 @@ const OutlinePlaceholder = ( { addBlock } ) => (
 	>
 		<Button
 			isDefault
-			onClick={ () => addBlock( 'module' ) }
+			onClick={ () => doAction( 'sensei.courseOutline.blank' ) }
 			className="is-large"
 		>
-			{ __( 'Create a module', 'sensei-lms' ) }
+			{ __( 'Start with blank', 'sensei-lms' ) }
 		</Button>
 		<Button
 			isDefault
-			onClick={ () => addBlock( 'lesson' ) }
+			onClick={ () => doAction( 'sensei.courseOutline.ai' ) }
 			className="is-large"
 		>
-			{ __( 'Create a lesson', 'sensei-lms' ) }
+			{ __( 'Generate with AI', 'sensei-lms' ) }
 		</Button>
 	</Placeholder>
 );
 
 export default OutlinePlaceholder;
+
+addAction(
+	'sensei.courseOutline.blank',
+	'sensei-lms/course-outline',
+	createCourseOutline
+);


### PR DESCRIPTION
Resolves #6960.

## Proposed Changes
This is an experiment to show how we can intercept click events in the course outline block. The idea is that the placeholder UI will be created entirely in Sensei, and Sensei Pro will hook into a click event to display the modal.

Do Not Merge!

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out [this branch](https://github.com/Automattic/sensei-pro/pull/2317) and run `npm run build` for Sensei Pro.
2. Run `npm run start` or `npm run build` for Sensei LMS.
3. Create a new course.
4. Step through the wizard and select the default layout.
5. Remove all lessons from the course outline in order to see the placeholder.
6. Open the Console.
7. Click the _Start with blank_ button. You should see "Message from Sensei LMS".
8. Click the _Generate with AI_ button. You should see "Message from Sensei Pro".