### PR TITLE
Avoid an error with getting future post URL

### DIFF
--- a/changelog/fix-frontend-error-when-schedule-email
+++ b/changelog/fix-frontend-error-when-schedule-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid an error with getting future post URL for a scheduled sensei_email post.

--- a/includes/internal/emails/class-email-post-type.php
+++ b/includes/internal/emails/class-email-post-type.php
@@ -123,7 +123,7 @@ class Email_Post_Type {
 		register_post_type(
 			self::POST_TYPE,
 			[
-				'labels'       => [
+				'labels'              => [
 					'name'               => __( 'Emails', 'sensei-lms' ),
 					'singular_name'      => __( 'Email', 'sensei-lms' ),
 					'add_new'            => __( 'Add New', 'sensei-lms' ),
@@ -138,13 +138,16 @@ class Email_Post_Type {
 					'menu_name'          => __( 'Emails', 'sensei-lms' ),
 					'name_admin_bar'     => __( 'Email', 'sensei-lms' ),
 				],
-				'public'       => false,
-				'show_ui'      => true,
-				'show_in_menu' => false,
-				'show_in_rest' => true, // Enables the Gutenberg editor.
-				'hierarchical' => false,
-				'rewrite'      => false,
-				'supports'     => [ 'title', 'editor', 'author', 'revisions' ],
+				'public'              => true,
+				'exclude_from_search' => true,
+				'publicly_queryable'  => false,
+				'show_in_nav_menus'   => false,
+				'show_ui'             => true,
+				'show_in_menu'        => false,
+				'show_in_rest'        => true, // Enables the Gutenberg editor.
+				'hierarchical'        => false,
+				'rewrite'             => false,
+				'supports'            => [ 'title', 'editor', 'author', 'revisions' ],
 			]
 		);
 	}


### PR DESCRIPTION
Resolves #6891 

The error appears, because it can't get the URL of the future post. It is related to the fact the CPT is registered as `public=false`.
The idea here is to register it as a public post type, but overwrite the derived properties to prevent appearing of emails on the front end.
Please share if you know a case that I missed here.

Unfortunately, I didn't find a way to prevent a post from being scheduled into the future.


## Proposed Changes
* Set public property to true, but additionally set [derived properties](https://developer.wordpress.org/reference/functions/register_post_type/#public).

## Testing Instructions

1. Try to reproduce the error:
2. Go to Sensei LMS -> Settings -> Emails
3. Switch an email to a draft.
4. Set a future publish date.
5. Click "Schedule"
6. No errors expected.
7. Go to the front end and try to find a post via search.
8. It is expected you can't find it.
9. Try to open emails on the front end by "querying" them, adding `?post_type=sensei_email` in the URL, like this: `https://sensei.test/?post_type=sensei_email`
10. It is expected you won't get the list of emails.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented (Described above, the discussion is expected in comments.)
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
