### PR TITLE
Remove trailing <br> in the user answer and in the correct answer before comparing

### DIFF
--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -153,6 +153,9 @@ jQuery( document ).ready( function ( $ ) {
 						) {
 							all_correct = false;
 						}
+					} else {
+						user_answer = user_answer.split( '<br>' )[ 0 ];
+						correct_answer = correct_answer.split( '<br>' )[ 0 ];
 					}
 
 					if ( all_correct || user_answer === correct_answer ) {

--- a/changelog/fix-auto-grading-non-multiple
+++ b/changelog/fix-auto-grading-non-multiple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix auto grading for non-multiple choice questions.


### PR DESCRIPTION
Resolves #6970

I managed to reproduce the scenario from the issue.
I noticed a problem for questions that are not multiple choice questions.
During debugging I found there is `<br>` tag that comes from html in the correct answer. We use this string when we handle the multiple choice question, but it spoils the result for others.
I added code that removes that trailing `<br>` from the correct answer. 
I also added the same removal from the user answer for consistency, even though it doesn't contain that string.

## Proposed Changes
* Remove `<br>` from the user answer and from the correct answer before comparing them.

## Testing Instructions

1. Add a quiz with two questions: first of type "true/false" (not a "multiple choice with answers "true" and "false"!), another of type "multiple choice".
2. Go to the front end as a student and do the quiz: answer correctly on both questions.
3. Go to Sensei LMS -> Grading and click Auto grading. Make sure it marked both answers as correct.

## Video
https://github.com/Automattic/sensei/assets/329356/4cbfcc58-efb5-4d93-ad10-6a335f295559


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [X] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [X] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [X] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
