### PR TITLE
Enable feature flags for the front-end

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline-placeholder.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.js
@@ -20,14 +20,14 @@ import SenseiProBadge from '../../../shared/components/sensei-pro-badge';
  * @param {Function} addBlock Add block
  */
 const OutlinePlaceholder = ( { addBlock } ) => {
-	const instructions = window.sensei.feature_flags.course_outline_ai
+	const instructions = window.sensei.featureFlags.course_outline_ai
 		? __( 'Build and display a course outline.', 'sensei-lms' )
 		: __(
 				'Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together.',
 				'sensei-lms'
 		  );
 
-	const content = window.sensei.feature_flags.course_outline_ai ? (
+	const content = window.sensei.featureFlags.course_outline_ai ? (
 		<div className="wp-block-sensei-lms-course-outline__placeholder-items">
 			<figure className="wp-block-sensei-lms-course-outline__placeholder-item is-blank">
 				<p className="wp-block-sensei-lms-course-outline__placeholder-item-intro">

--- a/assets/blocks/course-outline/outline-block/outline-placeholder.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.js
@@ -20,14 +20,14 @@ import SenseiProBadge from '../../../shared/components/sensei-pro-badge';
  * @param {Function} addBlock Add block
  */
 const OutlinePlaceholder = ( { addBlock } ) => {
-	const instructions = window.sensei.aiCourseOutline
+	const instructions = window.sensei.feature_flags.course_outline_ai
 		? __( 'Build and display a course outline.', 'sensei-lms' )
 		: __(
 				'Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together.',
 				'sensei-lms'
 		  );
 
-	const content = window.sensei.aiCourseOutline ? (
+	const content = window.sensei.feature_flags.course_outline_ai ? (
 		<div className="wp-block-sensei-lms-course-outline__placeholder-items">
 			<figure className="wp-block-sensei-lms-course-outline__placeholder-item is-blank">
 				<p className="wp-block-sensei-lms-course-outline__placeholder-item-intro">

--- a/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
@@ -16,7 +16,7 @@ describe( '<OutlinePlaceholder />', () => {
 	} );
 
 	it( 'Should render the outline placeholder correctly when feature flag is enabled', () => {
-		window.sensei.aiCourseOutline = true;
+		window.sensei.feature_flags.course_outline_ai = true;
 
 		const { container, getByText } = render(
 			<OutlinePlaceholder addBlock={ addBlockMock } />
@@ -30,7 +30,7 @@ describe( '<OutlinePlaceholder />', () => {
 	} );
 
 	it( 'Should render the outline placeholder correctly when feature flag is disabled', () => {
-		window.sensei.aiCourseOutline = false;
+		window.sensei.feature_flags.course_outline_ai = false;
 
 		const { getByText } = render(
 			<OutlinePlaceholder addBlock={ addBlockMock } />

--- a/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
@@ -12,11 +12,11 @@ describe( '<OutlinePlaceholder />', () => {
 	const addBlockMock = jest.fn();
 
 	beforeAll( () => {
-		window.sensei = { feature_flags: {} };
+		window.sensei = { featureFlags: {} };
 	} );
 
 	it( 'Should render the outline placeholder correctly when feature flag is enabled', () => {
-		window.sensei.feature_flags.course_outline_ai = true;
+		window.sensei.featureFlags.course_outline_ai = true;
 
 		const { container, getByText } = render(
 			<OutlinePlaceholder addBlock={ addBlockMock } />
@@ -30,7 +30,7 @@ describe( '<OutlinePlaceholder />', () => {
 	} );
 
 	it( 'Should render the outline placeholder correctly when feature flag is disabled', () => {
-		window.sensei.feature_flags.course_outline_ai = false;
+		window.sensei.featureFlags.course_outline_ai = false;
 
 		const { getByText } = render(
 			<OutlinePlaceholder addBlock={ addBlockMock } />

--- a/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
@@ -12,7 +12,7 @@ describe( '<OutlinePlaceholder />', () => {
 	const addBlockMock = jest.fn();
 
 	beforeAll( () => {
-		window.sensei = {};
+		window.sensei = { feature_flags: {} };
 	} );
 
 	it( 'Should render the outline placeholder correctly when feature flag is enabled', () => {

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -111,6 +111,8 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 	 */
 	public function enqueue_block_editor_assets() {
 
+		Sensei()->assets->enqueue_script( 'sensei-feature-flags' );
+
 		Sensei()->assets->enqueue(
 			'sensei-single-course-blocks',
 			'blocks/single-course.js',
@@ -121,13 +123,6 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 			'sensei-single-course-blocks-editor-style',
 			'blocks/single-course-style-editor.css',
 			[ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ]
-		);
-
-		wp_add_inline_script(
-			'sensei-single-course-blocks',
-			'window.sensei = window.sensei || {}; ' .
-			'window.sensei.aiCourseOutline = false;',
-			'before'
 		);
 
 		global $post;

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -25,21 +25,58 @@ class Sensei_Feature_Flags {
 	 *
 	 * @var array
 	 */
-	private $feature_flags;
+	private $feature_flags = [];
+
+	/**
+	 * Default feature flags constant.
+	 */
+	private const DEFAULT_FEATURE_FLAGS = [
+		'production'  => [
+			'enrolment_provider_tooltip' => false,
+			'email_customization'        => true,
+			'course_outline_ai'          => false,
+		],
+		'development' => [
+			'enrolment_provider_tooltip' => false,
+			'email_customization'        => true,
+			'course_outline_ai'          => true,
+		],
+	];
 
 	/**
 	 * Sensei_Feature_Flags constructor.
+	 *
+	 * @internal
 	 */
 	public function __construct() {
-		$this->feature_flags = [];
+		add_action( 'init', [ $this, 'register_scripts' ], 9 );
 	}
 
 	/**
-	 * Get default feature settings.
+	 * Register scripts.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 */
+	public function register_scripts() {
+		wp_register_script( 'sensei-feature-flags', '' ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters -- Intended, this is a placeholder script.
+
+		wp_add_inline_script(
+			'sensei-feature-flags',
+			'window.sensei = window.sensei || {}; ' .
+			'window.sensei.feature_flags = ' . wp_json_encode( $this->get_feature_flags() ) . ';'
+		);
+	}
+
+	/**
+	 * Get the default feature flag settings for the current environment.
 	 *
 	 * @return array Default feature settings.
 	 */
-	private function get_default_feature_settings() {
+	private function get_default_feature_flags() {
+		$env = wp_get_environment_type();
+
 		/**
 		 * Filters the default feature flag settings.
 		 *
@@ -52,11 +89,22 @@ class Sensei_Feature_Flags {
 		 */
 		return apply_filters(
 			'sensei_default_feature_flag_settings',
-			[
-				'enrolment_provider_tooltip' => false,
-				'email_customization'        => true,
-			]
+			self::DEFAULT_FEATURE_FLAGS[ $env ] ?? self::DEFAULT_FEATURE_FLAGS['production']
 		);
+	}
+
+	/**
+	 * Get the feature flags for the current environment.
+	 *
+	 * @return array
+	 */
+	private function get_feature_flags(): array {
+		$feature_flags = [];
+		foreach ( $this->get_default_feature_flags() as $feature => $default_state ) {
+			$feature_flags[ $feature ] = $this->is_enabled( $feature );
+		}
+
+		return $feature_flags;
 	}
 
 	/**
@@ -67,17 +115,17 @@ class Sensei_Feature_Flags {
 	 * @return bool
 	 */
 	public function is_enabled( $feature ) {
-		$feature                  = trim( strtolower( $feature ) );
-		$default_feature_settings = $this->get_default_feature_settings();
+		$feature               = trim( strtolower( $feature ) );
+		$default_feature_flags = $this->get_default_feature_flags();
 
-		if ( ! isset( $default_feature_settings[ $feature ] ) ) {
+		if ( ! isset( $default_feature_flags[ $feature ] ) ) {
 			return false;
 		}
 
 		$full_feature_name = 'sensei_feature_flag_' . $feature;
 		if ( ! isset( $this->feature_flags[ $feature ] ) ) {
 			$feature_define                  = strtoupper( $full_feature_name );
-			$value                           = defined( $feature_define ) ? (bool) constant( $feature_define ) : $default_feature_settings[ $feature ];
+			$value                           = defined( $feature_define ) ? (bool) constant( $feature_define ) : $default_feature_flags[ $feature ];
 			$this->feature_flags[ $feature ] = $value;
 		}
 

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -89,7 +89,7 @@ class Sensei_Feature_Flags {
 		 */
 		return apply_filters(
 			'sensei_default_feature_flag_settings',
-			self::DEFAULT_FEATURE_FLAGS[ $env ] ?? self::DEFAULT_FEATURE_FLAGS['production']
+			static::DEFAULT_FEATURE_FLAGS[ $env ] ?? static::DEFAULT_FEATURE_FLAGS['production']
 		);
 	}
 

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -65,7 +65,7 @@ class Sensei_Feature_Flags {
 		wp_add_inline_script(
 			'sensei-feature-flags',
 			'window.sensei = window.sensei || {}; ' .
-			'window.sensei.feature_flags = ' . wp_json_encode( $this->get_feature_flags() ) . ';'
+			'window.sensei.featureFlags = ' . wp_json_encode( $this->get_feature_flags() ) . ';'
 		);
 	}
 

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1465,7 +1465,8 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	public function testSetQuickEditAdminDefaults_WhenCalled_LocalizesScripts(): void {
 		/* Arrange */
 		global $wp_scripts;
-		$wp_scripts = $this->createMock( WP_Scripts::class );
+		$old_wp_scripts = $wp_scripts;
+		$wp_scripts     = $this->createMock( WP_Scripts::class );
 
 		$post = $this->factory->lesson->create_and_get();
 		$quiz = $this->factory->quiz->create_and_get();
@@ -1506,6 +1507,9 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 				]
 			);
 		$lesson->set_quick_edit_admin_defaults( 'lesson-course', $post->ID );
+
+		/* Reset */
+		$wp_scripts = $old_wp_scripts;
 	}
 
 	public function testMetaBoxSave_PostIdGiven_UpdatesPostMeta(): void {

--- a/tests/unit-tests/test-class-sensei-feature-flags.php
+++ b/tests/unit-tests/test-class-sensei-feature-flags.php
@@ -1,13 +1,11 @@
 <?php
 
+/**
+ * Tests for Sensei_Feature_Flags class.
+ *
+ * @covers Sensei_Feature_Flags
+ */
 class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
-
-	/**
-	 * Constructor function
-	 */
-	public function __construct() {
-		parent::__construct();
-	}
 
 	public function add_mock_flags( $arr ) {
 		return array(
@@ -16,7 +14,10 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test functionality
+	 * Ran in a separate process to avoid conflicts with other tests.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function testFlags() {
 		add_filter( 'sensei_default_feature_flag_settings', array( $this, 'add_mock_flags' ) );
@@ -33,6 +34,39 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 		add_filter( 'sensei_feature_flag_foo_feature', '__return_false' );
 
 		$this->assertFalse( $flags->is_enabled( 'foo_feature' ), 'overriden by filter' );
+	}
+
+	public function testConstruct_WhenCalled_AddsRegisterScriptsHook(): void {
+		/* Arrange & Act. */
+		$flags = new Sensei_Feature_Flags();
+
+		/* Assert. */
+		$priority = has_action( 'init', [ $flags, 'register_scripts' ] );
+		$this->assertSame( 9, $priority );
+	}
+
+	public function testRegisterScripts_WhenCalled_RegistersFeatureFlagsScript(): void {
+		/* Arrange & Act. */
+		$flags = new Sensei_Feature_Flags();
+
+		/* Assert. */
+		$this->assertTrue( wp_script_is( 'sensei-feature-flags', 'registered' ) );
+	}
+
+	public function testRegisterScripts_WhenCalled_AddsFeatureFlagsInlineScript(): void {
+		/* Arrange. */
+		$flags = new Sensei_Feature_Flags();
+
+		wp_deregister_script( 'sensei-feature-flags' );
+		add_filter( 'sensei_default_feature_flag_settings', array( $this, 'add_mock_flags' ) );
+
+		/* Act. */
+		$flags->register_scripts();
+		$inline_script = wp_scripts()->print_inline_script( 'sensei-feature-flags', 'after', false );
+
+		/* Assert. */
+		$expected = 'window.sensei = window.sensei || {}; window.sensei.featureFlags = {"foo_feature":false};';
+		$this->assertSame( $expected, $inline_script );
 	}
 
 	public function testIsEnabled_WhenEmailFeatureGivenAndFlagEnabled_ReturnsTrue(): void {
@@ -59,5 +93,83 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * Ran in a separate process to avoid conflicts with other tests.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testIsEnabled_WhenInDevelopmentEnvironmentAndFlagEnabled_ReturnsTrue(): void {
+		/* Arrange. */
+		$flags = new class() extends Sensei_Feature_Flags {
+			protected const DEFAULT_FEATURE_FLAGS = [
+				'production'  => [
+					'foo' => false,
+				],
+				'development' => [
+					'foo' => true,
+				],
+			];
+		};
+
+		define( 'WP_RUN_CORE_TESTS', true );
+		define( 'WP_ENVIRONMENT_TYPE', 'development' );
+
+		/* Act. */
+		$actual = $flags->is_enabled( 'foo' );
+
+		/* Assert. */
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Ran in a separate process to avoid conflicts with other tests.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testIsEnabled_WhenInProductionEnvironmentAndFlagDisabled_ReturnsFalse(): void {
+		/* Arrange. */
+		$flags = new class() extends Sensei_Feature_Flags {
+			protected const DEFAULT_FEATURE_FLAGS = [
+				'production'  => [
+					'foo' => false,
+				],
+				'development' => [
+					'foo' => true,
+				],
+			];
+		};
+
+		define( 'WP_RUN_CORE_TESTS', true );
+		define( 'WP_ENVIRONMENT_TYPE', 'production' );
+
+		/* Act. */
+		$actual = $flags->is_enabled( 'foo' );
+
+		/* Assert. */
+		$this->assertFalse( $actual );
+	}
+
+	public function testIsEnabled_WhenNoEnvironmentSet_ReturnProductionFlagValue(): void {
+		/* Arrange. */
+		$flags = new class() extends Sensei_Feature_Flags {
+			protected const DEFAULT_FEATURE_FLAGS = [
+				'production'  => [
+					'foo' => true,
+				],
+				'development' => [
+					'foo' => false,
+				],
+			];
+		};
+
+		/* Act. */
+		$actual = $flags->is_enabled( 'foo' );
+
+		/* Assert. */
+		$this->assertTrue( $actual );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-learners-main.php
+++ b/tests/unit-tests/test-class-sensei-learners-main.php
@@ -67,6 +67,8 @@ class Sensei_Learners_Main_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider enrolmentFilterTestCases
 	 * @covers       Sensei_Learners_Main::get_learners
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function testUsersAreFilteredByEnrolmentStatus( $enrolment_status, $expected_result ) {
 


### PR DESCRIPTION
Resolves #6969

## Proposed Changes
* Enables the feature flags to be loaded in the front-end as an inline script.
* Replace the temporary feature flag for the Course Block AI with the new one.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run build:assets`.
2. In your `wp-config.php`, set the environment to `development`:
```php
define( 'WP_ENVIRONMENT_TYPE', 'development' );
```
3. Go to Sensei LMS -> Courses -> New Course
4. Open the page source code and make sure you have the following feature flags. Note that `course_outline_ai` should be `true`.
```
window.sensei.feature_flags = {"enrolment_provider_tooltip":false,"email_customization":true,"course_outline_ai":true}
```
5. On the Add New Course screen, remove all the lessons from the Course Outline and make sure you see the new AI view (should be working as before).
6. Set the `WP_ENVIRONMENT_TYPE` constant to `production`.
7. Make sure the `course_outline_ai` feature flag has changed to `false`.
8. Remove the `WP_ENVIRONMENT_TYPE` constant from your `wp-config.php`.
9. Make sure the `course_outline_ai` feature flag is still `false`.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
