### PR TITLE
Don't translate Sensei custom post types

### DIFF
--- a/changelog/fix-wpml-save-course-lesson-bug
+++ b/changelog/fix-wpml-save-course-lesson-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disable translation of Sensei post types, taxonomies and fields to temporary fix compatibilty issue.

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -67,6 +67,7 @@
 		<custom-field action="ignore">_sensei_email_is_pro</custom-field>
 		<custom-field action="ignore">_sensei_email_type</custom-field>
 		<custom-field action="ignore">_course_woocommerce_product</custom-field>
+		<custom-field action="ignore">_lesson_video_embed</custom-field>
 	</custom-fields>
 	<admin-texts>
 		<key name="sensei-settings">

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,25 +1,73 @@
 <wpml-config>
-	<custom-fields>
-		<custom-field action="copy">_lesson_complexity</custom-field>
-		<custom-field action="copy">_lesson_length</custom-field>
-		<custom-field action="translate">_lesson_prerequisite</custom-field>
-		<custom-field action="translate">_lesson_course</custom-field>
-		<custom-field action="translate">_course_prerequisite</custom-field>
-		<custom-field action="translate">_course_woocommerce_product</custom-field>
-	</custom-fields>
 	<custom-types>
+		<custom-type translate="0">sensei_email</custom-type>
 		<custom-type translate="0">course</custom-type>
 		<custom-type translate="0">lesson</custom-type>
-		<custom-type translate="0">multiple_question</custom-type>
-		<custom-type translate="0">question</custom-type>
 		<custom-type translate="0">quiz</custom-type>
+		<custom-type translate="0">question</custom-type>
+		<custom-type translate="0">multiple_question</custom-type>
+		<custom-type translate="0">sensei_message</custom-type>
 	</custom-types>
 	<taxonomies>
-		<taxonomy translate="0">course-category</taxonomy>
-		<taxonomy translate="0">lesson-tag</taxonomy>
 		<taxonomy translate="0">module</taxonomy>
+		<taxonomy translate="0">sensei_learner</taxonomy>
+		<taxonomy translate="0">course-category</taxonomy>
+		<taxonomy translate="0">quiz-type</taxonomy>
+		<taxonomy translate="0">question-type</taxonomy>
 		<taxonomy translate="0">question-category</taxonomy>
+		<taxonomy translate="0">lesson-tag</taxonomy>
 	</taxonomies>
+	<custom-fields>
+		<custom-field action="ignore">_course_prerequisite</custom-field>
+		<custom-field action="ignore">_course_featured</custom-field>
+		<custom-field action="ignore">_open_access</custom-field>
+		<custom-field action="ignore">sensei_course_video_autocomplete</custom-field>
+		<custom-field action="ignore">sensei_course_video_autopause</custom-field>
+		<custom-field action="ignore">sensei_course_video_required</custom-field>
+		<custom-field action="ignore">_course_expiration_length</custom-field>
+		<custom-field action="ignore">_course_expires_on_date</custom-field>
+		<custom-field action="ignore">_course_starts_on_date</custom-field>
+		<custom-field action="ignore">_course_video_embed</custom-field>
+		<custom-field action="ignore">_lesson_course</custom-field>
+		<custom-field action="ignore">_quiz_lesson</custom-field>
+		<custom-field action="ignore">_lesson_quiz</custom-field>
+		<custom-field action="ignore">_lesson_order</custom-field>
+		<custom-field action="ignore">_lesson_length</custom-field>
+		<custom-field action="ignore">_lesson_preview</custom-field>
+		<custom-field action="ignore">_lesson_prerequisite</custom-field>
+		<custom-field action="ignore">_lesson_complexity</custom-field>
+		<custom-field action="ignore">_sensei_already_published</custom-field>
+		<custom-field action="ignore">_course_enrolment_version</custom-field>
+		<custom-field action="ignore">_module_order</custom-field>
+		<custom-field action="ignore">_pass_required</custom-field>
+		<custom-field action="ignore">_quiz_passmark</custom-field>
+		<custom-field action="ignore">_quiz_grade_type</custom-field>
+		<custom-field action="ignore">_enable_quiz_reset</custom-field>
+		<custom-field action="ignore">_show_questions</custom-field>
+		<custom-field action="ignore">_random_question_order</custom-field>
+		<custom-field action="ignore">_failed_indicate_incorrect</custom-field>
+		<custom-field action="ignore">_failed_show_correct_answers</custom-field>
+		<custom-field action="ignore">_failed_show_answer_feedback</custom-field>
+		<custom-field action="ignore">_question_grade</custom-field>
+		<custom-field action="ignore">_hide_answer_feedback</custom-field>
+		<custom-field action="ignore">_random_order</custom-field>
+		<custom-field action="ignore">_question_right_answer</custom-field>
+		<custom-field action="ignore">_question_wrong_answers</custom-field>
+		<custom-field action="ignore">_answer_order</custom-field>
+		<custom-field action="ignore">_right_answer_count</custom-field>
+		<custom-field action="ignore">_wrong_answer_count</custom-field>
+		<custom-field action="ignore">_quiz_id</custom-field>
+		<custom-field action="ignore">_question_order</custom-field>
+		<custom-field action="ignore">_enable_quiz_timer</custom-field>
+		<custom-field action="ignore">_quiz_timer</custom-field>
+		<custom-field action="ignore">_course_expiration_type</custom-field>
+		<custom-field action="ignore">_sensei_content_drip_type</custom-field>
+		<custom-field action="ignore">_sensei_email_identifier</custom-field>
+		<custom-field action="ignore">_sensei_email_description</custom-field>
+		<custom-field action="ignore">_sensei_email_is_pro</custom-field>
+		<custom-field action="ignore">_sensei_email_type</custom-field>
+		<custom-field action="ignore">_course_woocommerce_product</custom-field>
+	</custom-fields>
 	<admin-texts>
 		<key name="sensei-settings">
 			<key name="course_archive_more_link_text" />

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -8,17 +8,17 @@
 		<custom-field action="translate">_course_woocommerce_product</custom-field>
 	</custom-fields>
 	<custom-types>
-		<custom-type translate="1">course</custom-type>
-		<custom-type translate="1">lesson</custom-type>
-		<custom-type translate="1" display-as-translated="1">multiple_question</custom-type>
-		<custom-type translate="1">question</custom-type>
-		<custom-type translate="1" display-as-translated="1">quiz</custom-type>
+		<custom-type translate="0">course</custom-type>
+		<custom-type translate="0">lesson</custom-type>
+		<custom-type translate="0" display-as-translated="1">multiple_question</custom-type>
+		<custom-type translate="0">question</custom-type>
+		<custom-type translate="0" display-as-translated="1">quiz</custom-type>
 	</custom-types>
 	<taxonomies>
-		<taxonomy translate="1">course-category</taxonomy>
-		<taxonomy translate="1">lesson-tag</taxonomy>
-		<taxonomy translate="1">module</taxonomy>
-		<taxonomy translate="1">question-category</taxonomy>
+		<taxonomy translate="0">course-category</taxonomy>
+		<taxonomy translate="0">lesson-tag</taxonomy>
+		<taxonomy translate="0">module</taxonomy>
+		<taxonomy translate="0">question-category</taxonomy>
 	</taxonomies>
 	<admin-texts>
 		<key name="sensei-settings">

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -10,9 +10,9 @@
 	<custom-types>
 		<custom-type translate="0">course</custom-type>
 		<custom-type translate="0">lesson</custom-type>
-		<custom-type translate="0" display-as-translated="1">multiple_question</custom-type>
+		<custom-type translate="0">multiple_question</custom-type>
 		<custom-type translate="0">question</custom-type>
-		<custom-type translate="0" display-as-translated="1">quiz</custom-type>
+		<custom-type translate="0">quiz</custom-type>
 	</custom-types>
 	<taxonomies>
 		<taxonomy translate="0">course-category</taxonomy>


### PR DESCRIPTION
Resolves #6978 

Our post types like Course and Lesson store additional information about related entities.
We can't allow WPML try to translate them automatically.
Here I disable translation to fix the bug with saving courses and lessons.
Later, we need to address the problem in our ML project.

I updated the list of custom post types, taxonomies and custom fields. I hope it might help us in the future.
As for fields, the list is not complete as we have auto-generated fields like `_order_module_17`.

## Proposed Changes
* Disable automatic translation of Sensei custom post types in WPML.

## Testing Instructions

1. Install and activate the WPML Multilingual LMS plugin (check Secret Store for creds).
2. Create a new course using the default layout.
3. No infinite loops!
4. Look at an existing lesson. It should be in the Draft status.


## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

*

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented (PR description)
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
