### PR TITLE
Removing Beta Label Tag from Editor Menu

### DIFF
--- a/changelog/remove-beta-label-from-editor-menu
+++ b/changelog/remove-beta-label-from-editor-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Removed Beta label from Editor Menu

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -75,11 +75,7 @@ class Sensei_Course_Theme_Editor {
 
 		add_theme_page(
 			__( 'Editor', 'sensei-lms' ),
-			sprintf(
-			/* translators: %s: "beta" label */
-				__( 'Editor %s', 'sensei-lms' ),
-				'<span class="awaiting-mod">' . __( 'beta', 'sensei-lms' ) . '</span>'
-			),
+			__( 'Editor', 'sensei-lms' ),
 			'edit_theme_options',
 			'site-editor.php?postType=wp_template'
 		);


### PR DESCRIPTION
Resolves #6934

## Testing Instructions
1. Go to the Admin section and activate the Astra Theme 
2. Check that the Beta Label has been removed

![image](https://github.com/Automattic/sensei/assets/5557433/2c82c298-9cd0-4884-9894-cb942369ab72)

Both the PR author and reviewer are responsible for ensuring the checklist is completed. 
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
