### PR TITLE
Fix Continue Course block not redirecting to first lesson when only one lesson

### DIFF
--- a/changelog/fix-continue-course-block-redirect
+++ b/changelog/fix-continue-course-block-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Continue Course block not redirecting to first lesson in some cases

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2786,7 +2786,7 @@ class Sensei_Utils {
 			$completed_lessons     = Sensei()->course->get_completed_lesson_ids( $course_id, $user_id );
 			$not_completed_lessons = array_diff( $course_lessons, $completed_lessons );
 
-			if ( count( $course_lessons ) !== count( $not_completed_lessons ) && ! empty( $not_completed_lessons ) ) {
+			if ( $not_completed_lessons ) {
 				return current( $not_completed_lessons );
 			}
 		}

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -382,7 +382,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $course_lessons['lesson_ids'][0], $result );
 	}
 
-	public function testGetTargetPagePostIdForContinueUrl_WhenCalled_ReturnsFirstLessonIdIfNoLessonIsCompleted() {
+	public function testGetTargetPagePostIdForContinueUrl_WhenNoLessonIsCompleted_ReturnsFirstLessonId() {
 		/* Arrange */
 		$course_lessons = $this->factory->get_course_with_lessons(
 			array(

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -382,7 +382,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $course_lessons['lesson_ids'][0], $result );
 	}
 
-	public function testGetTargetResumeId_WhenCalled_ReturnsCourseIdIfNoLessonIsCompleted() {
+	public function testGetTargetPagePostIdForContinueUrl_WhenCalled_ReturnsFirstLessonIdIfNoLessonIsCompleted() {
 		/* Arrange */
 		$course_lessons = $this->factory->get_course_with_lessons(
 			array(
@@ -395,7 +395,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$result = Sensei_Utils::get_target_page_post_id_for_continue_url( $course_lessons['course_id'], $user_id );
 
 		/* Assert */
-		$this->assertEquals( $course_lessons['course_id'], $result );
+		$this->assertEquals( $course_lessons['lesson_ids'][0], $result );
 	}
 
 	public function testGetTargetResumeId_WhenCalled_ReturnsCourseIdIfAllLessonsAreCompleted() {


### PR DESCRIPTION
Resolves #6996

## Proposed Changes

* Fix the Continue Course block not redirecting to the first lesson when the course contains only one non-complete lesson.

## Testing Instructions

1. Create a course with one lesson.
1. The course should have the Continue Course block (part of the Course Actions Block).
1. Visit the course in the front-end and click "Take Course".
1. Don't visit the Lesson otherwise you won't see the bug.
1. Click the "Continue" button.
1. You should be redirected to the lesson.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
