### PR TITLE
Enable to generate the course outline with blank lessons or using ai assistance

### DIFF
--- a/assets/blocks/course-outline/outline-block/elements/deprecated-placeholder.js
+++ b/assets/blocks/course-outline/outline-block/elements/deprecated-placeholder.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockIcon } from '@wordpress/block-editor';
+import { Button, Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import settings from '../index';
+
+export const DeprecatedPlaceholder = ( { addBlock } ) => (
+	<Placeholder
+		className="wp-block-sensei-lms-course-outline__placeholder"
+		label={ __( 'Course Outline', 'sensei-lms' ) }
+		icon={ <BlockIcon icon={ settings.icon } showColors /> }
+		instructions={ __(
+			'Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together.',
+			'sensei-lms'
+		) }
+	>
+		<Button
+			isDefault
+			onClick={ () => addBlock( 'module' ) }
+			className="is-large"
+		>
+			{ __( 'Create a module', 'sensei-lms' ) }
+		</Button>
+		<Button
+			isDefault
+			onClick={ () => addBlock( 'lesson' ) }
+			className="is-large"
+		>
+			{ __( 'Create a lesson', 'sensei-lms' ) }
+		</Button>
+	</Placeholder>
+);

--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -19,6 +19,9 @@ import { COURSE_STORE } from '../course-outline-store';
 import { useBlocksCreator } from '../use-block-creator';
 import OutlineAppender from './outline-appender';
 import OutlinePlaceholder from './outline-placeholder';
+import useSenseiProSettings from './use-sensei-pro-settings';
+
+const SENSEI_PRO_LINK = 'https://senseilms.com/sensei-pro/';
 
 const ALLOWED_BLOCKS = [
 	'sensei-lms/course-outline-module',
@@ -44,6 +47,8 @@ const OutlineEdit = ( props ) => {
 
 	const { loadStructure } = useDispatch( COURSE_STORE );
 
+	const { isActivated: isSenseiProActivated } = useSenseiProSettings();
+
 	useEffect( () => {
 		if ( ! attributes.isPreview ) {
 			loadStructure();
@@ -67,8 +72,12 @@ const OutlineEdit = ( props ) => {
 	);
 
 	const openTailoredModal = useCallback( () => {
-		window.location.hash = 'generate-course-outline-using-ai';
-	}, [] );
+		if ( isSenseiProActivated ) {
+			window.location.hash = 'generate-course-outline-using-ai';
+		} else {
+			window.location.href = SENSEI_PRO_LINK;
+		}
+	}, [ isSenseiProActivated ] );
 
 	return isEmpty ? (
 		<OutlinePlaceholder

--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -66,9 +66,15 @@ const OutlineEdit = ( props ) => {
 		[ clientId ]
 	);
 
+	const openTailoredModal = useCallback( () => {
+		window.location.hash = 'generate-course-outline-using-ai';
+	}, [] );
+
 	return isEmpty ? (
 		<OutlinePlaceholder
 			addBlock={ ( type ) => setBlocks( [ { type } ], true ) }
+			addBlocks={ setBlocks }
+			openTailoredModal={ openTailoredModal }
 		/>
 	) : (
 		<OutlineAttributesContext.Provider

--- a/assets/blocks/course-outline/outline-block/outline-placeholder.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { BlockIcon } from '@wordpress/block-editor';
-import { Button, Placeholder } from '@wordpress/components';
+import { Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -13,103 +13,134 @@ import AiIcon from '../../../shared/components/ai-icon';
 import AiLessonsImage from './ai-lessons-image';
 import CheckIcon from '../../../icons/checked.svg';
 import SenseiProBadge from '../../../shared/components/sensei-pro-badge';
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import { DeprecatedPlaceholder } from './elements/deprecated-placeholder';
 
 /**
  * Placeholder for empty Course Outline block.
  *
  * @param {Function} addBlock Add block
  */
-const OutlinePlaceholder = ( { addBlock } ) => {
-	const instructions = window.sensei.featureFlags.course_outline_ai
-		? __( 'Build and display a course outline.', 'sensei-lms' )
-		: __(
-				'Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together.',
-				'sensei-lms'
-		  );
 
-	const content = window.sensei.featureFlags.course_outline_ai ? (
-		<div className="wp-block-sensei-lms-course-outline__placeholder-items">
-			<figure className="wp-block-sensei-lms-course-outline__placeholder-item is-blank">
-				<p className="wp-block-sensei-lms-course-outline__placeholder-item-intro">
-					{ __(
-						'Start with a blank canvas and create your own course outline.',
-						'sensei-lms'
-					) }
-				</p>
-				<ul className="wp-block-sensei-lms-course-outline__placeholder-item-details">
-					<li>{ __( 'Add Lessons and Modules', 'sensei-lms' ) }</li>
-					<li>{ __( 'Reorder and edit anytime', 'sensei-lms' ) }</li>
-				</ul>
-				<ul className="wp-block-sensei-lms-course-outline__placeholder-item-lessons">
-					<li>{ __( 'Lesson 1', 'sensei-lms' ) }</li>
-					<li>{ __( 'Lesson 2', 'sensei-lms' ) }</li>
-				</ul>
-				<figcaption className="wp-block-sensei-lms-course-outline__placeholder-item-caption">
-					{ __( 'Start with blank', 'sensei-lms' ) }
-				</figcaption>
-			</figure>
+const EditPlaceholder = ( { addBlocks, openTailoredModal = noop } ) => {
+	const createBlankLessons = () => {
+		addBlocks( [
+			{
+				type: 'lesson',
+				title: 'Lesson 1',
+			},
+			{
+				type: 'lesson',
+				title: 'Lesson 2',
+			},
+			{
+				type: 'lesson',
+				title: 'Lesson 3',
+			},
+		] );
+	};
 
-			<figure className="wp-block-sensei-lms-course-outline__placeholder-item is-ai">
-				<div>
-					<p className="wp-block-sensei-lms-course-outline__placeholder-item-intro">
-						{ __(
-							"Get AI's help to start with a tailored course outline.",
-							'sensei-lms'
-						) }
-					</p>
-					<AiIcon className="wp-block-sensei-lms-course-outline__placeholder-item-icon" />
-				</div>
-				<ul className="wp-block-sensei-lms-course-outline__placeholder-item-details">
-					<li>
-						<CheckIcon className="wp-block-sensei-lms-course-outline__placeholder-item-icon" />
-						{ __(
-							'AI tailored outline based on your content',
-							'sensei-lms'
-						) }
-					</li>
-					<li>
-						<CheckIcon className="wp-block-sensei-lms-course-outline__placeholder-item-icon" />
-						{ __(
-							'Access to all Sensei Pro features',
-							'sensei-lms'
-						) }
-					</li>
-				</ul>
-				<AiLessonsImage />
-				<figcaption className="wp-block-sensei-lms-course-outline__placeholder-item-caption">
-					{ __( 'Generate with AI', 'sensei-lms' ) }
-					<SenseiProBadge />
-				</figcaption>
-			</figure>
-		</div>
-	) : (
-		<>
-			<Button
-				isDefault
-				onClick={ () => addBlock( 'module' ) }
-				className="is-large"
-			>
-				{ __( 'Create a module', 'sensei-lms' ) }
-			</Button>
-			<Button
-				isDefault
-				onClick={ () => addBlock( 'lesson' ) }
-				className="is-large"
-			>
-				{ __( 'Create a lesson', 'sensei-lms' ) }
-			</Button>
-		</>
-	);
+	const onGenerateWithAIClick = () => {
+		openTailoredModal();
+	};
 
 	return (
 		<Placeholder
 			className="wp-block-sensei-lms-course-outline__placeholder"
 			label={ __( 'Course Outline', 'sensei-lms' ) }
 			icon={ <BlockIcon icon={ settings.icon } showColors /> }
-			instructions={ instructions }
+			instructions={ __(
+				'Build and display a course outline.',
+				'sensei-lms'
+			) }
 		>
-			{ content }
+			<div className="wp-block-sensei-lms-course-outline__placeholder-items">
+				<button
+					className="wp-block-sensei-lms-course-outline__placeholder-item is-blank"
+					onClick={ createBlankLessons }
+					aria-labelledby="generate-blank"
+				>
+					<p className="wp-block-sensei-lms-course-outline__placeholder-item-intro">
+						{ __(
+							'Start with a blank canvas and create your own course outline.',
+							'sensei-lms'
+						) }
+					</p>
+					<ul className="wp-block-sensei-lms-course-outline__placeholder-item-details">
+						<li>
+							{ __( 'Add Lessons and Modules', 'sensei-lms' ) }
+						</li>
+						<li>
+							{ __( 'Reorder and edit anytime', 'sensei-lms' ) }
+						</li>
+					</ul>
+					<ul className="wp-block-sensei-lms-course-outline__placeholder-item-lessons">
+						<li>{ __( 'Lesson 1', 'sensei-lms' ) }</li>
+						<li>{ __( 'Lesson 2', 'sensei-lms' ) }</li>
+					</ul>
+					<figcaption
+						className="wp-block-sensei-lms-course-outline__placeholder-item-caption"
+						id="generate-blank"
+					>
+						{ __( 'Start with blank', 'sensei-lms' ) }
+					</figcaption>
+				</button>
+
+				<button
+					className="wp-block-sensei-lms-course-outline__placeholder-item is-ai"
+					aria-labelledby="generate-with-ai"
+					onClick={ onGenerateWithAIClick }
+				>
+					<div>
+						<p className="wp-block-sensei-lms-course-outline__placeholder-item-intro">
+							{ __(
+								"Get AI's help to start with a tailored course outline.",
+								'sensei-lms'
+							) }
+						</p>
+						<AiIcon className="wp-block-sensei-lms-course-outline__placeholder-item-icon" />
+					</div>
+					<ul className="wp-block-sensei-lms-course-outline__placeholder-item-details">
+						<li>
+							<CheckIcon className="wp-block-sensei-lms-course-outline__placeholder-item-icon" />
+							{ __(
+								'AI tailored outline based on your content',
+								'sensei-lms'
+							) }
+						</li>
+						<li>
+							<CheckIcon className="wp-block-sensei-lms-course-outline__placeholder-item-icon" />
+							{ __(
+								'Access to all Sensei Pro features',
+								'sensei-lms'
+							) }
+						</li>
+					</ul>
+					<AiLessonsImage />
+					<figcaption
+						className="wp-block-sensei-lms-course-outline__placeholder-item-caption"
+						id="generate-with-ai"
+					>
+						{ __( 'Generate with AI', 'sensei-lms' ) }
+						<SenseiProBadge />
+					</figcaption>
+				</button>
+			</div>
 		</Placeholder>
+	);
+};
+
+const OutlinePlaceholder = ( { addBlock, addBlocks, openTailoredModal } ) => {
+	return window.sensei.featureFlags.course_outline_ai ? (
+		<EditPlaceholder
+			addBlocks={ addBlocks }
+			openTailoredModal={ openTailoredModal }
+		/>
+	) : (
+		<DeprecatedPlaceholder addBlock={ addBlock } />
 	);
 };
 

--- a/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
+++ b/assets/blocks/course-outline/outline-block/outline-placeholder.test.js
@@ -7,19 +7,19 @@ import { render } from '@testing-library/react';
  * Internal dependencies
  */
 import OutlinePlaceholder from './outline-placeholder';
+import userEvent from '@testing-library/user-event';
 
 describe( '<OutlinePlaceholder />', () => {
-	const addBlockMock = jest.fn();
+	const addBlocksMock = jest.fn();
 
 	beforeAll( () => {
 		window.sensei = { featureFlags: {} };
+		window.sensei.featureFlags.course_outline_ai = true;
 	} );
 
 	it( 'Should render the outline placeholder correctly when feature flag is enabled', () => {
-		window.sensei.featureFlags.course_outline_ai = true;
-
 		const { container, getByText } = render(
-			<OutlinePlaceholder addBlock={ addBlockMock } />
+			<OutlinePlaceholder addBlocksMock={ addBlocksMock } />
 		);
 
 		expect(
@@ -29,20 +29,51 @@ describe( '<OutlinePlaceholder />', () => {
 		expect( container.querySelector( '.is-ai' ) ).toBeTruthy();
 	} );
 
-	it( 'Should render the outline placeholder correctly when feature flag is disabled', () => {
-		window.sensei.featureFlags.course_outline_ai = false;
-
-		const { getByText } = render(
-			<OutlinePlaceholder addBlock={ addBlockMock } />
+	it( 'Should create empty lessons', () => {
+		const { getByRole } = render(
+			<OutlinePlaceholder addBlocks={ addBlocksMock } />
 		);
 
-		expect(
-			getByText(
-				'You can use modules to group related lessons together.',
-				{ exact: false }
-			)
-		).toBeTruthy();
-		expect( getByText( 'Create a module' ) ).toBeTruthy();
-		expect( getByText( 'Create a lesson' ) ).toBeTruthy();
+		userEvent.click( getByRole( 'button', { name: 'Start with blank' } ) );
+
+		expect( addBlocksMock ).toHaveBeenCalled();
+	} );
+
+	it( 'Should open the tailored modal', () => {
+		const openTailoredModalMock = jest.fn();
+
+		const { getByRole } = render(
+			<OutlinePlaceholder
+				addBlocks={ addBlocksMock }
+				openTailoredModal={ openTailoredModalMock }
+			/>
+		);
+
+		userEvent.click(
+			getByRole( 'button', { name: 'Generate with AI Pro' } )
+		);
+
+		expect( openTailoredModalMock ).toHaveBeenCalled();
+	} );
+
+	describe( 'when the course_outline_ai is off', () => {
+		it( 'Should render the outline placeholder correctly when feature flag is disabled', () => {
+			const addBlockMock = jest.fn();
+
+			window.sensei.featureFlags.course_outline_ai = false;
+
+			const { getByText } = render(
+				<OutlinePlaceholder addBlock={ addBlockMock } />
+			);
+
+			expect(
+				getByText(
+					'You can use modules to group related lessons together.',
+					{ exact: false }
+				)
+			).toBeTruthy();
+			expect( getByText( 'Create a module' ) ).toBeTruthy();
+			expect( getByText( 'Create a lesson' ) ).toBeTruthy();
+		} );
 	} );
 } );

--- a/assets/blocks/course-outline/outline-block/use-sensei-pro-settings.js
+++ b/assets/blocks/course-outline/outline-block/use-sensei-pro-settings.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { EXTENSIONS_STORE } from '../../../extensions/store';
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+
+const useSenseiProSettings = () => {
+	const extension = select( EXTENSIONS_STORE ).getSenseiProExtension();
+
+	return useMemo(
+		() => ( {
+			isActivated: Boolean( extension?.is_activated ),
+		} ),
+		[ extension?.is_activated ]
+	);
+};
+export default useSenseiProSettings;

--- a/assets/blocks/course-outline/outline-block/use-sensei-pro-settings.test.js
+++ b/assets/blocks/course-outline/outline-block/use-sensei-pro-settings.test.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import useSenseiProSettings from './use-sensei-pro-settings';
+
+const mockGetSenseiProExtension = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( {
+		getSenseiProExtension: mockGetSenseiProExtension,
+	} ),
+	createRegistrySelector: jest.fn(),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+} ) );
+
+const DEFAULT_EXTENSION_VALUES = {
+	title: 'Sensei Pro',
+	image: null,
+	image_large: null,
+	is_featured: false,
+	product_slug: 'sensei-pro',
+	hosted_location: 'internal',
+	type: 'plugin',
+	plugin_file: 'sensei-pro/sensei-pro.php',
+	version: '',
+	is_installed: true,
+	is_activated: false,
+	installed_version: '1.15.1',
+	has_update: false,
+	can_update: false,
+};
+
+describe( 'useSenseiProSettings', () => {
+	describe( '#isActivated', () => {
+		it( 'should return false when sensei-pro is not installed', () => {
+			const { result } = renderHook( () => useSenseiProSettings() );
+
+			expect( result.current.isActivated ).toBe( false );
+		} );
+
+		it( 'should return true when sensei-pro is installed', () => {
+			mockGetSenseiProExtension.mockReturnValueOnce( {
+				...DEFAULT_EXTENSION_VALUES,
+				is_activated: true,
+			} );
+
+			const { result } = renderHook( () => useSenseiProSettings() );
+
+			expect( result.current.isActivated ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
Related to #7000

## Proposed Changes
* Move the deprecated course outline placeholder to another file.
* Implement the "Start with Blank" button to create lessons
* Implement the *Generate with AI* button
** If sensei-pro is installed, it will open the modal
** if sensei-pro is not installed, it will open the sensei-pro page.


## Testing Instructions
Requires use of the sensei-pro branch created on  https://github.com/Automattic/sensei-pro/pull/2327"

Note: For now, we are redirecting the to regular senseilms.com page, in the future, we want to implement a more smooth upgrade process (if possible). 

**Sensei with an active Sensei Pro installation**
* Create a course
* Delete all lessons
* Click on  "Start with Blank" button
* Check if it created 3 lessons
* Delete all lessons
* Click on *Generate with AI*
* Check if the modal is opened

**Sensei without an active Sensei Pro installation**
* Create a course
* Delete all lessons
* Click on  "Start with Blank" button
* Check if it created 3 lessons
* Delete all lessons
* Click on *Generate with AI*
* Check if you were redirected to the senseilms.com page


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] New UIs match the designs
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] Known issues are created as new GitHub issues
