### PR TITLE
Fix tests failing on WP nightly

### DIFF
--- a/tests/unit-tests/test-class-sensei-feature-flags.php
+++ b/tests/unit-tests/test-class-sensei-feature-flags.php
@@ -62,7 +62,7 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 
 		/* Act. */
 		$flags->register_scripts();
-		$inline_script = wp_scripts()->print_inline_script( 'sensei-feature-flags', 'after', false );
+		$inline_script = wp_scripts()->get_data( 'sensei-feature-flags', 'after' )[1];
 
 		/* Assert. */
 		$expected = 'window.sensei = window.sensei || {}; window.sensei.featureFlags = {"foo_feature":false};';


### PR DESCRIPTION
## Proposed Changes

Tests were failing on WP nightly because `WP_Scripts::print_inline_script` got deprecated. This PR uses `WP_Scripts::get_data` instead.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The WP nightly tests should be passing in CI.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
