### PR TITLE
Fix php 8.1 autovivification of false to array deprecation message issue

### DIFF
--- a/changelog/fix-php-8-1-array-from-false-deprecate
+++ b/changelog/fix-php-8-1-array-from-false-deprecate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.1 autovivification of falsy value deprecation message

--- a/includes/admin/home/class-sensei-home-remote-data-api.php
+++ b/includes/admin/home/class-sensei-home-remote-data-api.php
@@ -92,7 +92,9 @@ class Sensei_Home_Remote_Data_API {
 				$data = false;
 			}
 
-			unset( $data['_fetched'] );
+			if ( is_array( $data ) ) {
+				unset( $data['_fetched'] );
+			}
 		}
 
 		if ( false === $data ) {


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6958

## Proposed Changes
* PHP 8.1 has deprecated the support of autoviving false value to array. So we put a check in place to make sure it is an array before doing an array operation

## Testing Instructions
* Follow the instructions of the issue
* Make sure there is no message in the log for this

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
