### PR TITLE
Downgrade symfony/polyfill due to incompatibility with SVN

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"sirbrillig/phpcs-no-get-current-user": "1.1.0",
 		"sirbrillig/phpcs-variable-analysis": "2.11.16",
 		"squizlabs/php_codesniffer": "3.7.2",
-		"symfony/polyfill-php80": "1.27.0",
+		"symfony/polyfill-php80": "1.16.0",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"yoast/phpunit-polyfills": "2.0.0"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57e93b8390ee51f6de5440743548a5bc",
+    "content-hash": "271a1c6440fc20adcd38c25f24d3eefe",
     "packages": [],
     "packages-dev": [
         {
@@ -3160,29 +3160,25 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+                "reference": "c4bdcb0490a6c0e12c51e9d771fda5867e908fd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/c4bdcb0490a6c0e12c51e9d771fda5867e908fd2",
+                "reference": "c4bdcb0490a6c0e12c51e9d771fda5867e908fd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "dev-master": "1.16-dev"
                 }
             },
             "autoload": {
@@ -3223,7 +3219,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.16.0"
             },
             "funding": [
                 {
@@ -3239,7 +3235,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2020-05-08T16:50:20+00:00"
         },
         {
             "name": "symfony/process",


### PR DESCRIPTION
Same solution we have #6723

> The `polyfill-php80` was causing the following SVN pre-commit hook error:
> 
> ![image](https://user-images.githubusercontent.com/1612178/228676467-d7e7e169-9ee9-42a5-98f9-2cabd1575d31.png)
> 
> The `polyfill-php80` is required by `symfony/css-selector` which is required by `pelago/emogrifier` the version 1.16 is not 
> adding the files that are causing issues.
> 
> ## Proposed Changes
> * Remove the `polyfill-php80` dependency.
> 
> ## Testing Instructions
> 
> 1. Download the build generated in this PR.
> 2. Unzip it and make sure the `third-party/symfony/polyfill-php80` dependency is missing.
> 3. Install the build on PHP 7.2 and 8.0 and make sure the new email features are working.
> 4. Make sure there are no errors generated.

