### PR TITLE
Create progress tables only if the feature is enabled

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,6 +40,9 @@ class Sensei_Unit_Tests_Bootstrap {
 		// Prevent requests from `WP_Http::request` while testing.
 		tests_add_filter( 'pre_http_request', [ $this, 'prevent_requests' ], 99 );
 
+		// Enable features.
+		tests_add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
+
 		/*
 		* Load PHPUnit Polyfills for the WP testing suite.
 		* @see https://github.com/WordPress/wordpress-develop/pull/1563/

--- a/tests/unit-tests/internal/installer/test-class-schema.php
+++ b/tests/unit-tests/internal/installer/test-class-schema.php
@@ -24,8 +24,6 @@ class Schema_Test extends \WP_UnitTestCase {
 		parent::setUp();
 
 		$this->schema = new Schema();
-
-		$this->reset_schema();
 	}
 
 	public function testCreateTables_WhenCalled_ShouldCreateTheTablesDefinedInGetTables(): void {
@@ -33,6 +31,8 @@ class Schema_Test extends \WP_UnitTestCase {
 		global $wpdb;
 
 		$expected_tables = $this->schema->get_tables();
+
+		$this->reset_schema();
 
 		/* Act. */
 		$this->schema->create_tables();
@@ -42,6 +42,46 @@ class Schema_Test extends \WP_UnitTestCase {
 		$created_tables = $wpdb->get_col( "SHOW TABLES LIKE '{$wpdb->prefix}sensei_lms%'" );
 		foreach ( $expected_tables as $table ) {
 			$this->assertContains( $table, $created_tables );
+		}
+	}
+
+	public function testGetTables_WhenTablesBasedProgressFeatureIsEnabled_ShouldReturnTheTablesBasedProgressTables(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		/* Act. */
+		$tables = $this->schema->get_tables();
+
+		/* Assert. */
+		$expected_tables = [
+			"{$wpdb->prefix}sensei_lms_progress",
+			"{$wpdb->prefix}sensei_lms_quiz_submissions",
+			"{$wpdb->prefix}sensei_lms_quiz_answers",
+			"{$wpdb->prefix}sensei_lms_quiz_grades",
+		];
+		foreach ( $expected_tables as $table ) {
+			$this->assertContains( $table, $tables );
+		}
+	}
+
+	public function testGetTables_WhenTablesBasedProgressFeatureIsDisabled_ShouldNotReturnTheTablesBasedProgressTables(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		add_filter( 'sensei_feature_flag_tables_based_progress', '__return_false' );
+
+		/* Act. */
+		$tables = $this->schema->get_tables();
+
+		/* Assert. */
+		$expected_tables = [
+			"{$wpdb->prefix}sensei_lms_progress",
+			"{$wpdb->prefix}sensei_lms_quiz_submissions",
+			"{$wpdb->prefix}sensei_lms_quiz_answers",
+			"{$wpdb->prefix}sensei_lms_quiz_grades",
+		];
+		foreach ( $expected_tables as $table ) {
+			$this->assertNotContains( $table, $tables );
 		}
 	}
 


### PR DESCRIPTION
Resolves #7027

## Proposed Changes

At the moment, the progress storage tables are always created. This PR changes the logic to create the tables only when the progress storage feature is on.

### Note

You may notice the following error when running the tests:

```
WordPress database error Duplicate entry '102-2659' for key 'question_answer' for query INSERT INTO `wptests_sensei_lms_quiz_grades`
```

This is because I've enabled the progress storage feature when running tests. The problem is related to https://github.com/Automattic/sensei/issues/7024. It doesn't cause the tests to fail so just ignore it for now.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Delete the [progress storage tables](https://github.com/Automattic/sensei/pull/7025/files#diff-145b4e6efa554e02eb53e7d93757433b5f09da014b38c286a2c177a9a7f6babfR156-R159) if you have them.
2. Delete the `sensei-version` option from the `wp_options` table.
3. Enable the feature: `add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );`
4. Refresh any page.
5. The tables should be created.
6. Repeat steps 1-4 but this time make sure the feature is disabled: `add_filter( 'sensei_feature_flag_tables_based_progress', '__return_false' );`
7. The tables should not be created.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
