### PR TITLE
Fix wp core deprecation messages for strpos and str_replace

### DIFF
--- a/changelog/fix-wp-core-deprecation-messages
+++ b/changelog/fix-wp-core-deprecation-messages
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-strpos and str_replace deprecation messages in PHP 8.2 and 8.2
+Fix `strpos`and `str_replace` deprecation messages in PHP 8.1 and 8.2

--- a/changelog/fix-wp-core-deprecation-messages
+++ b/changelog/fix-wp-core-deprecation-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+strpos and str_replace deprecation messages in PHP 8.2 and 8.2

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -130,7 +130,7 @@ class Sensei_Admin {
 	 */
 	public function add_course_order() {
 		add_submenu_page(
-			null, // Hide in menu.
+			'', // Hide in menu.
 			__( 'Order Courses', 'sensei-lms' ),
 			__( 'Order Courses', 'sensei-lms' ),
 			'manage_sensei',
@@ -147,7 +147,7 @@ class Sensei_Admin {
 	 */
 	public function add_lesson_order() {
 		add_submenu_page(
-			null,
+			'',
 			__( 'Order Lessons', 'sensei-lms' ),
 			__( 'Order Lessons', 'sensei-lms' ),
 			'edit_published_lessons',

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -210,7 +210,7 @@ class Sensei_Course {
 	 */
 	public function add_showcase_courses_upsell() {
 		add_submenu_page(
-			null,
+			'',
 			__( 'Showcase Courses', 'sensei-lms' ),
 			__( 'Showcase Courses', 'sensei-lms' ),
 			'edit_courses',

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1231,7 +1231,7 @@ class Sensei_Core_Modules {
 	 */
 	public function add_submenus() {
 		add_submenu_page(
-			null, // Hide the submenu.
+			'', // Hide the submenu.
 			__( 'Order Modules', 'sensei-lms' ),
 			__( 'Order Modules', 'sensei-lms' ),
 			'edit_lessons',


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7016

## Proposed Changes
* Multiple deprecation messages are appearing in PHP 8.1 and 8.2. Among those messages, 6 were related to strpos and str_replace. This PR fixes those.

Though the error message shows that it's being thrown from the core (wp-includes/functions.php), these are actually due to some calls to the function `add_submenu_page` in Sensei core.

Among the parameters we use for calling `add_submenu_page`, the first one for the parent. If it's not set, the page is added but it's not listed under the visible menu. So use use empty string or null as the first parameter for some pages, like the course and lesson ordering pages.

Sending empty strings is alright, but sending null actually makes core wp throw a deprecation message because sending null to the haystack for strpos is no longer allowed, which is called internally by the `add_submenu_page` function. So we are changing the nulls to empty strings here. And in the future, we should not use null anymore in similar use case.

## Testing Instructions
- Use PHP 8.1 or 8.2 at least
- Set WP_DEBUG, WP_DEBUG_DISPLAY, WP_DEBUG_LOG to true
- Load the dashboard
- Make sure you see no deprecation messages visible in the rendered page or the log

### Note
For PHP 8.2, you'll still see some deprecation messages regarding dynamically created variables. Those will be fixed separately under this [issue](https://github.com/Automattic/sensei/issues/6814), because it's more specific to that deprecation message.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
