### PR TITLE
Fix flaky MailPoet test 🎉

### DIFF
--- a/tests/framework/class-sensei-mailpoet-api-factory.php
+++ b/tests/framework/class-sensei-mailpoet-api-factory.php
@@ -125,6 +125,7 @@ class Sensei_MailPoetMockAPI_Test {
 			'subscribers' => array(),
 		);
 		$this->lists[] = $new_list;
+
 		return $new_list;
 	}
 
@@ -138,7 +139,7 @@ class Sensei_MailPoetMockAPI_Test {
 			}
 		}
 
-		$id                       = wp_rand( 10, 50 );
+		$id                       = intval( wp_unique_id() );
 		$subscriber               = array(
 			'id'         => $id,
 			'email'      => $email,
@@ -147,6 +148,7 @@ class Sensei_MailPoetMockAPI_Test {
 			'list_ids'   => array(),
 		);
 		$this->subscribers[ $id ] = $subscriber;
+
 		return $subscriber;
 	}
 
@@ -155,9 +157,11 @@ class Sensei_MailPoetMockAPI_Test {
 	 */
 	public function subscribeToList( $id, $list_id, $options ) {
 		$list_index = $this->getListIndex( $list_id );
+
 		if ( ! in_array( $id, $this->lists[ $list_index ]['subscribers'], true ) ) {
 			$this->lists[ $list_index ]['subscribers'][] = $id;
 		}
+
 		return true;
 	}
 
@@ -181,6 +185,7 @@ class Sensei_MailPoetMockAPI_Test {
 	public function getSubscribers( $args ) {
 		$list_id    = $args['listId'];
 		$list_index = $this->getListIndex( $list_id );
+
 		return $this->lists[ $list_index ]['subscribers'];
 	}
 


### PR DESCRIPTION
## Proposed Changes
This PR fixes the [intermittent MailPoet test failure](https://github.com/Automattic/sensei/actions/runs/5527157160/jobs/10082635866). The use of the `wp_rand` function ☠️ would sometimes generate the same ID as in a previous call, thereby causing the failure. I was able to get the test to fail every time by changing the line to `wp_rand( 10, 10 );`.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check that the PHP unit tests passed on this PR.
2. Try running `npm run test-php -- --filter Main_Test` locally a few times and ensure there are no failures.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues