### PR TITLE
Fix PHP 8.1 deprecation notice on Students page

### DIFF
--- a/changelog/fix-php81-deprecation-notice
+++ b/changelog/fix-php81-deprecation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.1 deprecation notice on Students page

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -354,19 +354,25 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	}
 
 	/**
-	 * Helper method to display the bulk action selector.
+	 * Gets the HTML for the bulk action dropdown.
+	 *
+	 * @return string HTML for the bulk action dropdown.
 	 */
-	private function render_bulk_action_select_box() {
-		?>
-		<select id="bulk-action-selector-top" name="sensei_bulk_action_select" class="sensei-student-bulk-actions__placeholder-dropdown sensei-bulk-action-select">
-			<option value="0"><?php echo esc_html( __( 'Select Bulk Actions', 'sensei-lms' ) ); ?></option>
-			<?php
-			foreach ( $this->controller->get_known_bulk_actions() as $value => $translation ) {
-				echo '<option value="' . esc_attr( $value ) . '">' . esc_html( $translation ) . '</option>';
-			}
-			?>
-		</select>
-		<?php
+	private function get_bulk_action_dropdown_html() {
+		$html = '';
+
+		$html .= '<select id="bulk-action-selector-top" name="sensei_bulk_action_select" class="sensei-student-bulk-actions__placeholder-dropdown sensei-bulk-action-select">';
+		$html .= '<option value="0">';
+		$html .= esc_html( __( 'Select Bulk Actions', 'sensei-lms' ) );
+		$html .= '</option>';
+
+		foreach ( $this->controller->get_known_bulk_actions() as $value => $translation ) {
+			$html .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $translation ) . '</option>';
+		}
+
+		$html .= '</select>';
+
+		return $html;
 	}
 
 	/**
@@ -388,14 +394,15 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 					<div class="sensei-student-bulk-actions__bulk_actions_container">
 						<?php
 						echo wp_kses(
-							$this->render_bulk_action_select_box(),
+							$this->get_bulk_action_dropdown_html(),
 							array(
 								'option' => array(
 									'value' => array(),
 								),
 								'select' => array(
-									'id'   => array(),
-									'name' => array(),
+									'id'    => array(),
+									'class' => array(),
+									'name'  => array(),
 								),
 							)
 						);


### PR DESCRIPTION
Resolves #7029.

## Proposed Changes
`wp_kses` was the culprit because `null` was being passed as the first parameter. This is because we were passing the result of the call to `render_bulk_action_select_box`, which has no return value, so `null` was used instead. The net result was that `wp_kses` had no effect.

This PR changes the implementation of `render_bulk_action_select_box` (and renames it) such that the HTML is returned. Now, `null` is no longer passed to `wp_kses` and the call actually works. This became apparent when I realized that the dropdown wasn't displaying correctly, because the `class` attribute was being stripped out. So I added `class` as part of the allowed HTML for `wp_kses`.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On a PHP 8.1 site, browse to the _Students_ page.
2. Ensure the deprecated notice isn't being logged / displayed.
3. Check that the bulk action dropdown looks good and is populated correctly.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
