### PR TITLE
Fix e2e test failure when creating a course

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@es-joy/jsdoccomment": "0.36.1",
         "@faker-js/faker": "8.0.2",
         "@lifeomic/attempt": "3.0.3",
-        "@playwright/test": "1.28.0",
+        "@playwright/test": "1.36.1",
         "@svgr/webpack": "6.1.2",
         "@testing-library/dom": "7.30.3",
         "@testing-library/jest-dom": "5.11.10",
@@ -6437,19 +6437,22 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.1.tgz",
+      "integrity": "sha512-YK7yGWK0N3C2QInPU6iaf/L3N95dlGdbsezLya4n0ZCh3IL7VgPGxC6Gnznh9ApWdOmkJeleT2kMTcWPRZvzqg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.28.0"
+        "playwright-core": "1.36.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@polka/url": {
@@ -31979,15 +31982,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.1.tgz",
+      "integrity": "sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==",
       "dev": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/please-upgrade-node": {
@@ -43952,13 +43955,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.1.tgz",
+      "integrity": "sha512-YK7yGWK0N3C2QInPU6iaf/L3N95dlGdbsezLya4n0ZCh3IL7VgPGxC6Gnznh9ApWdOmkJeleT2kMTcWPRZvzqg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.28.0"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.36.1"
       }
     },
     "@polka/url": {
@@ -62295,9 +62299,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.1.tgz",
+      "integrity": "sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==",
       "dev": true
     },
     "please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@es-joy/jsdoccomment": "0.36.1",
     "@faker-js/faker": "8.0.2",
     "@lifeomic/attempt": "3.0.3",
-    "@playwright/test": "1.28.0",
+    "@playwright/test": "1.36.1",
     "@svgr/webpack": "6.1.2",
     "@testing-library/dom": "7.30.3",
     "@testing-library/jest-dom": "5.11.10",

--- a/tests/e2e-playwright/pages/admin/post-type/index.ts
+++ b/tests/e2e-playwright/pages/admin/post-type/index.ts
@@ -79,6 +79,12 @@ export default class PostType {
 		return this.page;
 	}
 
+	async saveDraft(): Promise< void > {
+		await this.page
+			.locator( '[aria-label="Editor top bar"] >> text=Save draft' )
+			.click();
+	}
+
 	async publish(): Promise< void > {
 		await this.page
 			.locator( '[aria-label="Editor top bar"] >> text=Publish' )

--- a/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
+++ b/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
@@ -43,6 +43,7 @@ describe( 'Create Courses', () => {
 		await wizardModal.finishWithDefaultLayout();
 
 		await page.getByRole( 'button', { name: 'Start with blank' } ).click();
+		await coursesPage.saveDraft();
 
 		await coursesPage.addModuleWithLesson(
 			'Module 1',


### PR DESCRIPTION
## Proposed Changes
This PR fixes the `admin/teacher/course-creation.spec.ts:29:2 › Create Courses › it should create a course` [failure](https://github.com/Automattic/sensei/actions/runs/5613734346/job/15210396223).

While investigating the failure, I could see that the test was sometimes not successful at adding a module to the course outline block, causing subsequent checks to fail. Although I wasn't able to find a definitive reason for this, I wasn't able to reproduce it manually either. I suspect that either the editor's auto-save or the speed at which the tests execute were causing some sort of weird glitch. When I tried saving the course as draft before adding a module to the block, the tests went green. 🙌🏻 

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check that the E2E tests passed on this PR.
- Try rerunning `npm run test:e2e` a few times locally and ensure it doesn't fail when creating a course. (Note that it might still fail on other tests, but those will be handled separately.)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
