### PR TITLE
Fix duplicate comment section under lesson in FSE themes

### DIFF
--- a/changelog/fix-duplicate-comment-section-in-fse-themes
+++ b/changelog/fix-duplicate-comment-section-in-fse-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix duplicate comment sections under lesson in FSE themes

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4990,7 +4990,8 @@ class Sensei_Lesson {
 		$user_can_view_lesson  = sensei_can_user_view_lesson();
 		$lesson_allow_comments = $allow_comments && $user_can_view_lesson;
 
-		if ( $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
+		if ( ( $lesson_allow_comments && ! Sensei_Utils::is_fse_theme() ) || is_singular( 'sensei_message' ) ) {
+
 			// Borrowed solution from https://github.com/WordPress/gutenberg/pull/28128.
 			add_filter( 'deprecated_file_trigger_error', '__return_false' );
 			comments_template( '', true );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2816,6 +2816,8 @@ class Sensei_Utils {
 	/**
 	 * Check if the current theme supports Full Site Editing (FSE).
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return bool True if FSE is supported, false otherwise.
 	 */
 	public static function is_fse_theme() {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2812,6 +2812,15 @@ class Sensei_Utils {
 		}
 		return $course_id;
 	}
+
+	/**
+	 * Check if the current theme supports Full Site Editing (FSE).
+	 *
+	 * @return bool True if FSE is supported, false otherwise.
+	 */
+	public static function is_fse_theme() {
+		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
 }
 
 /**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -75,8 +75,10 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		add_filter( 'the_content', array( $this, 'cpt_page_content_filter' ) );
 		add_filter( 'template_include', array( $this, 'force_page_template' ) );
 
-		// Disable comments.
-		Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
+		// Disable comments if not block theme and post type is not lesson.
+		if ( ! $this->is_lesson_cpt_in_block_fse_theme() ) {
+			Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
+		}
 
 		// Handle some type-specific items.
 		if ( 'sensei_message' === $this->post_type ) {
@@ -119,7 +121,9 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		$content  = $renderer->render();
 
 		// Disable theme comments.
-		Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
+		if ( ! $this->is_lesson_cpt_in_block_fse_theme() ) {
+			Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
+		}
 
 		// Disable pagination.
 		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
@@ -229,4 +233,13 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		return $template;
 	}
 
+	/**
+	 * Check if current theme is a FSE block one and if the current post type is a lesson.
+	 *
+	 * @return bool
+	 * @access private
+	 */
+	public function is_lesson_cpt_in_block_fse_theme() {
+		return 'lesson' === $this->post_type && Sensei_Utils::is_fse_theme();
+	}
 }

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -236,10 +236,11 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	/**
 	 * Check if current theme is a FSE block one and if the current post type is a lesson.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return bool
-	 * @access private
 	 */
-	public function is_lesson_cpt_in_block_fse_theme() {
+	private function is_lesson_cpt_in_block_fse_theme() {
 		return 'lesson' === $this->post_type && Sensei_Utils::is_fse_theme();
 	}
 }

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -519,4 +519,77 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertEquals( $course_id, $result );
 	}
+
+	public function testIsFseThemeSupported_WhenCalled_WorksIfBlockTemplatesIndexAvailable() {
+		/* Arrange */
+		$theme_directory = get_template_directory() . '/block-templates';
+		$index_file      = $theme_directory . '/index.html';
+
+		// Remove the 'block-templates/index.html' file if it exists.
+		if ( file_exists( $index_file ) ) {
+			unlink( $index_file );
+		}
+
+		// Create the 'block-templates' directory if it doesn't exist.
+		if ( ! is_dir( $theme_directory ) ) {
+			mkdir( $theme_directory );
+		}
+
+		$this->create_file( $index_file );
+
+		/* Assert */
+		// Call the function and assert the result.
+		$this->assertTrue( Sensei_Utils::is_fse_theme() );
+
+		unlink( $index_file );
+		rmdir( $theme_directory );
+	}
+
+	public function testIsFseThemeSupported_WhenCalled_WorksIfIndexHtmlAvailable() {
+		/* Arrange */
+		$theme_directory = get_template_directory() . '/templates';
+		$index_file      = $theme_directory . '/index.html';
+
+		// Remove the 'templates/index.html' file if it exists.
+		if ( file_exists( $index_file ) ) {
+			unlink( $index_file );
+		}
+
+		// Create the 'templates' directory if it doesn't exist.
+		if ( ! is_dir( $theme_directory ) ) {
+			mkdir( $theme_directory );
+		}
+
+		$this->create_file( $index_file );
+
+		/* Assert */
+		// Call the function and assert the result.
+		$this->assertTrue( Sensei_Utils::is_fse_theme() );
+
+		unlink( $index_file );
+		rmdir( $theme_directory );
+	}
+
+	/**
+	 * Create the 'index.html' file to mimic a theme with FSE support.
+	 */
+	private function create_file( $index_file ) {
+		// Initialize the WP_Filesystem.
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		WP_Filesystem();
+
+		global $wp_filesystem;
+
+		// Check if WP_Filesystem is initialized properly.
+		if ( ! $wp_filesystem ) {
+			return; // Or handle the error accordingly.
+		}
+
+		$file_contents = "Silence is golden\n";
+
+		// Use WP_Filesystem's method to create and write to the file.
+		$wp_filesystem->put_contents( $index_file, $file_contents, FS_CHMOD_FILE );
+	}
 }

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -520,7 +520,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $course_id, $result );
 	}
 
-	public function testIsFseThemeSupported_WhenCalled_WorksIfBlockTemplatesIndexAvailable() {
+	public function testIsFseTheme_WhenBlockTemplatesIndexAvailable_ReturnsTrue() {
 		/* Arrange */
 		$theme_directory = get_template_directory() . '/block-templates';
 		$index_file      = $theme_directory . '/index.html';
@@ -537,15 +537,17 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 
 		$this->create_file( $index_file );
 
+		/* Act */
+		$result = Sensei_Utils::is_fse_theme();
+
 		/* Assert */
-		// Call the function and assert the result.
-		$this->assertTrue( Sensei_Utils::is_fse_theme() );
+		$this->assertTrue( $result );
 
 		unlink( $index_file );
 		rmdir( $theme_directory );
 	}
 
-	public function testIsFseThemeSupported_WhenCalled_WorksIfIndexHtmlAvailable() {
+	public function testIsFseTheme_WhenIndexHtmlAvailable_ReturnsTrue() {
 		/* Arrange */
 		$theme_directory = get_template_directory() . '/templates';
 		$index_file      = $theme_directory . '/index.html';
@@ -562,9 +564,11 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 
 		$this->create_file( $index_file );
 
+		/* Act */
+		$result = Sensei_Utils::is_fse_theme();
+
 		/* Assert */
-		// Call the function and assert the result.
-		$this->assertTrue( Sensei_Utils::is_fse_theme() );
+		$this->assertTrue( $result );
 
 		unlink( $index_file );
 		rmdir( $theme_directory );


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7037

## Proposed Changes
In FSE themes, like Course, Twenty Twenty Three etc, we were seeing two comment sections. After some investigation, we understood that one of them (the one at the bottom) was coming from the `page` template of those themes (It also turned out it's not using the right template, so we created [another issue](https://github.com/Automattic/sensei/issues/7041) for it). So this was the expected one, but the top one was unexpected.

We found that there are some custom processes in place for lesson post type, there we manually call the comments_template [function on a hook](https://github.com/Automattic/sensei/blob/29c898bb726aadb6559d06dd224b4ceac7189932/includes/class-sensei-lesson.php#L4995-L4997). But as the deprecation hook messages suggest in linked code, that there is no comments.php template available for the theme, which is expected. But it was still echoing comments. Looking deeper, we found out that it uses a [fallback default template](https://github.com/WordPress/wordpress-develop/blob/bea4307daa21a3f97d159898b0ac676332e0e7de/src/wp-includes/comment-template.php#L1595) from the compat folder in core even if it doesn't find any template in the theme, as it comes from core, they don't follow any design from our block theme's comment section. So we made calling the function conditional for non FSE themes.

Doing the above was rendering single comment section only from the FSE theme's page template as expected, but the comment reply form was still not loading. Digging into that, we found that for all unsupported themes (every block theme), we're disabling comments using a hook [here](https://github.com/Automattic/sensei/blob/29c898bb726aadb6559d06dd224b4ceac7189932/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php#L79) and [here](https://github.com/Automattic/sensei/blob/29c898bb726aadb6559d06dd224b4ceac7189932/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php#L122). So we made them conditional for FSE as well.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

0. Disable Learning Mode in `Sensei LMS -> Settings -> Appearance`.
1. Create a lesson
2. In that lesson's setting section from the right side, enable comments
3. Take the lesson as a student
4. Try commenting and replying to comments.
5. Make sure you see only one comment section and that it's working as expected.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
