### PR TITLE
Fix lessons not using set template in fse themes

### DIFF
--- a/changelog/fix-lesson-not-using-set-template-in-fse-themes
+++ b/changelog/fix-lesson-not-using-set-template-in-fse-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed issue of lessons not using the selected template in FSE themes

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -224,6 +224,10 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 * @return string The page.php template if possible, the original template * otherwise.
 	 */
 	public function force_page_template( $template ) {
+		if ( $this->is_lesson_cpt_in_block_fse_theme() ) {
+			return $template;
+		}
+
 		$path = get_query_template( 'page' );
 
 		if ( $path ) {

--- a/tests/framework/trait-sensei-file-system-helper.php
+++ b/tests/framework/trait-sensei-file-system-helper.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File with trait Sensei_File_System_Helper.
+ *
+ * @package sensei-tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait Sensei_File_System_Helper {
+	/**
+	 * Create the 'index.html' file to mimic a theme with FSE support.
+	 */
+	public function create_index_file( $index_file ) {
+		// Initialize the WP_Filesystem.
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		WP_Filesystem();
+
+		global $wp_filesystem;
+
+		// Check if WP_Filesystem is initialized properly.
+		if ( ! $wp_filesystem ) {
+			return; // Or handle the error accordingly.
+		}
+
+		$file_contents = "Silence is golden\n";
+
+		// Use WP_Filesystem's method to create and write to the file.
+		$wp_filesystem->put_contents( $index_file, $file_contents, FS_CHMOD_FILE );
+	}
+}

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -5,6 +5,8 @@ use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interfac
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface;
 
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-file-system-helper.php';
+
 /**
  * Class for testing Sensei_Utils class.
  *
@@ -13,7 +15,7 @@ use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repositor
  * phpcs:disable Generic.Commenting.DocComment.MissingShort
  */
 class Sensei_Class_Utils_Test extends WP_UnitTestCase {
-
+	use \Sensei_File_System_Helper;
 	/**
 	 * setup function
 	 *
@@ -535,7 +537,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 			mkdir( $theme_directory );
 		}
 
-		$this->create_file( $index_file );
+		$this->create_index_file( $index_file );
 
 		/* Assert */
 		// Call the function and assert the result.
@@ -560,7 +562,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 			mkdir( $theme_directory );
 		}
 
-		$this->create_file( $index_file );
+		$this->create_index_file( $index_file );
 
 		/* Assert */
 		// Call the function and assert the result.
@@ -568,28 +570,5 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 
 		unlink( $index_file );
 		rmdir( $theme_directory );
-	}
-
-	/**
-	 * Create the 'index.html' file to mimic a theme with FSE support.
-	 */
-	private function create_file( $index_file ) {
-		// Initialize the WP_Filesystem.
-		if ( ! function_exists( 'WP_Filesystem' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-		WP_Filesystem();
-
-		global $wp_filesystem;
-
-		// Check if WP_Filesystem is initialized properly.
-		if ( ! $wp_filesystem ) {
-			return; // Or handle the error accordingly.
-		}
-
-		$file_contents = "Silence is golden\n";
-
-		// Use WP_Filesystem's method to create and write to the file.
-		$wp_filesystem->put_contents( $index_file, $file_contents, FS_CHMOD_FILE );
 	}
 }

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -46,7 +46,7 @@
 
 		<!-- wp:sensei-lms/course-theme-notices /-->
 
-		<!-- wp:post-content /-->
+		<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 		<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="margin-top:40px">

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -46,7 +46,7 @@
 
 		<!-- wp:sensei-lms/course-theme-notices /-->
 
-		<!-- wp:post-content {"layout":{"inherit":true}} /-->
+		<!-- wp:post-content /-->
 
 		<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="margin-top:40px">


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7041

## Proposed Changes
* In FSE themes, we were forcing the page template to be used for Lesson, so if someone created a custom template and selected that instead, that was getting overridden. Now we are not forcing the page template if it's an FSE theme.

Point to be noted is, if there's no sensei bock, for example, the Lesson Actions block inside the lesson, we'll still override the template to inject the necessary blocks, but this is [expected and documented behavior](https://senseilms.com/documentation/course-page-blocks/), so we are not changing that.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use a block theme (Course, Twenty Twenty Three etc)
2. Create a course with a lesson
3. Make sure the lesson has Lesson Actions block in it
4. In the settings section in the right side of the editor, create a custom template for the lesson, do some distinct design change in there, save the template.
5. Reload the lesson editor and make sure your custom template is being shown in the editor as the lesson's selected template
6. Save and publish the course with the lesson
7. Take the lesson from the frontend
8. Make sure your custom template is being used
9. Use another FSE theme, try the same.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
