### PR TITLE
Pass tables based submission to delete all related grades

### DIFF
--- a/changelog/fix-grades-duplicates
+++ b/changelog/fix-grades-duplicates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Part of progress storage feature which is not publicly released.
+
+

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -737,13 +737,14 @@ class Sensei_Grading {
 		if ( in_array( $lesson_status, [ 'passed', 'graded' ], true ) ) {
 
 			/**
-			 * Summary.
+			 * Fires when a user completes a lesson.
 			 *
-			 * Description.
+			 * This hook is fired when a user passes a quiz or their quiz submission was graded.
+			 * Therefore the corresponding lesson is marked as complete.
 			 *
 			 * @since 1.7.0
 			 *
-			 * @param int  $user_id
+			 * @param int $user_id
 			 * @param int $quiz_lesson_id
 			 */
 			do_action( 'sensei_user_lesson_end', $user_id, $quiz_lesson_id );

--- a/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
@@ -197,7 +197,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 		if ( $this->use_tables ) {
 			$tables_based_submission = $this->tables_based_submission_repository->get( $submission->get_quiz_id(), $submission->get_user_id() );
 			if ( $tables_based_submission ) {
-				$this->tables_based_repository->delete_all( $submission );
+				$this->tables_based_repository->delete_all( $tables_based_submission );
 			}
 		}
 	}

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
@@ -37,7 +37,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$comments_based_repository
 			->expects( $this->once() )
 			->method( 'create' )
-			->with( $submission, 2, 3, 4, 'feedback' );
+			->with( $this->identicalTo( $submission ), 2, 3, 4, 'feedback' );
 		$repository->create( $submission, 2, 3, 4, 'feedback' );
 	}
 
@@ -129,7 +129,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$comments_based_repository
 			->expects( $this->once() )
 			->method( 'delete_all' )
-			->with( $submission );
+			->with( $this->identicalTo( $submission ) );
 		$repository->delete_all( $submission );
 	}
 
@@ -187,7 +187,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$tables_based_repository
 			->expects( $this->once() )
 			->method( 'delete_all' )
-			->with( $tables_based_submission );
+			->with( $this->identicalTo( $tables_based_submission ) );
 		$repository->delete_all( $submission );
 	}
 
@@ -212,7 +212,10 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$comments_based_repository
 			->expects( $this->once() )
 			->method( 'save_many' )
-			->with( $submission, $grades );
+			->with(
+				$this->identicalTo( $submission ),
+				$this->identicalTo( $grades )
+			);
 		$repository->save_many( $submission, $grades );
 	}
 
@@ -281,7 +284,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'save_many' )
 			->with(
-				$tables_based_submission,
+				$this->identicalTo( $tables_based_submission ),
 				$this->callback(
 					function ( array $grades ) {
 						$this->assertSame( 1, count( $grades ) );


### PR DESCRIPTION
Resolves #7024 

I want to remind one more time of my initial proposal to use different classes for comments based and for tables based models. That approach makes this kind of errors visible.

What's interesting, we have a test that was supposed to catch this error. But it didn't fail, because `with()` doesn't check if the parameter is identical.

## Proposed Changes
* Pass proper version of submission to tables based repository. 

## Testing Instructions

1. Enable tables_based_progress: `add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );`
2. Submit a quiz for grading.
3. Grade the quiz for the first time. There are no errors at this point.
4. Grade the quiz again.
3. No errors in logs.


## New/Updated Hooks

* Updated description for `sensei_user_lesson_end`.


## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
