### PR TITLE
Update `sensei_results_links` filter to include the learner's user ID

### DIFF
--- a/changelog/add-profile-links-filter
+++ b/changelog/add-profile-links-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add `sensei_results_completed_links` filter

--- a/changelog/add-profile-links-filter
+++ b/changelog/add-profile-links-filter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Add `sensei_results_completed_links` filter
+Updates the `sensei_results_links` filter to include the learner's user ID when displaying public profiles and to display results links publicly.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2093,7 +2093,7 @@ class Sensei_Course {
 					/**
 					 * Publicly displays links related to the completed course
 					 *
-					 * @since 4.16.0
+					 * @since 4.16.1
 					 * @hook sensei_results_completed_links
 					 *
 					 * @param {int} $course_id The ID of the course.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2090,6 +2090,17 @@ class Sensei_Course {
 
 					}
 				}
+					/**
+					 * Publicly displays links related to the completed course
+					 *
+					 * @since 4.16.0
+					 * @hook sensei_results_completed_links
+					 *
+					 * @param {int} $course_id The ID of the course.
+					 * @param {int} $user_id The user ID of the learner.
+					 *
+					 * @return {string} HTML output of the links.
+					 */
 					$complete_html .= apply_filters( 'sensei_results_completed_links', '', $course_item->ID, $user->ID );
 
 					$complete_html .= '</section>';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2067,42 +2067,23 @@ class Sensei_Course {
 
 						$complete_html .= $this->get_progress_meter( 100 );
 
-				if ( $manage ) {
-					$has_quizzes = Sensei()->course->course_quizzes( $course_item->ID, true );
+                               $results_link = '';
+                               if ( $manage && Sensei()->course->course_quizzes( $course_item->ID, true ) ) {
+                                       $results_link = '<a class="button view-results" href="'
+                                               . esc_url( self::get_view_results_link( $course_item->ID ) )
+                                               . '">' . esc_html__( 'View Results', 'sensei-lms' )
+                                               . '</a>';
+                               }
 
-					// Output only if there is content to display
-					if ( self::has_results_links( $course_item->ID ) || $has_quizzes ) {
-						$complete_html .= '<p class="sensei-results-links">';
-						$results_link   = '';
-
-						if ( $has_quizzes ) {
-							$results_link = '<a class="button view-results" href="'
-								. esc_url( self::get_view_results_link( $course_item->ID ) )
-								. '">' . esc_html__( 'View Results', 'sensei-lms' )
-								. '</a>';
-						}
-
-						/**
-						 * Filter documented in Sensei_Course::the_course_action_buttons
-						 */
-						$complete_html .= apply_filters( 'sensei_results_links', $results_link, $course_item->ID );
-						$complete_html .= '</p>';
-
-					}
-				}
-					/**
-					 * Publicly displays links related to the completed course
-					 *
-					 * @since 4.16.1
-					 * @hook sensei_results_completed_links
-					 *
-					 * @param {int} $course_id The ID of the course.
-					 * @param {int} $user_id The user ID of the learner.
-					 *
-					 * @return {string} HTML output of the links.
-					 */
-					$complete_html .= apply_filters( 'sensei_results_completed_links', '', $course_item->ID, $user->ID );
-
+                               /**
+                                * Filter documented in Sensei_Course::the_course_action_buttons
+                                */
+								$results_links = apply_filters( 'sensei_results_links', $results_link, $course_item->ID, $user->ID );
+								if ( $results_links ) {
+										$complete_html .= '<p class="sensei-results-links">';
+										$complete_html .= $results_links;
+										$complete_html .= '</p>';
+				 }
 					$complete_html .= '</section>';
 
 				$complete_html .= '</article>';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2083,7 +2083,7 @@ class Sensei_Course {
 						$complete_html .= '<p class="sensei-results-links">';
 						$complete_html .= $results_links;
 						$complete_html .= '</p>';
-				 }
+				}
 					$complete_html .= '</section>';
 
 				$complete_html .= '</article>';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2090,6 +2090,7 @@ class Sensei_Course {
 
 					}
 				}
+					$complete_html .= apply_filters( 'sensei_completed_course_links', '', $course_item->ID, $user->ID );
 
 					$complete_html .= '</section>';
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2067,22 +2067,22 @@ class Sensei_Course {
 
 						$complete_html .= $this->get_progress_meter( 100 );
 
-                               $results_link = '';
-                               if ( $manage && Sensei()->course->course_quizzes( $course_item->ID, true ) ) {
-                                       $results_link = '<a class="button view-results" href="'
-                                               . esc_url( self::get_view_results_link( $course_item->ID ) )
-                                               . '">' . esc_html__( 'View Results', 'sensei-lms' )
-                                               . '</a>';
-                               }
+				$results_link = '';
+				if ( $manage && Sensei()->course->course_quizzes( $course_item->ID, true ) ) {
+						$results_link = '<a class="button view-results" href="'
+								. esc_url( self::get_view_results_link( $course_item->ID ) )
+								. '">' . esc_html__( 'View Results', 'sensei-lms' )
+								. '</a>';
+				}
 
-                               /**
-                                * Filter documented in Sensei_Course::the_course_action_buttons
-                                */
-								$results_links = apply_filters( 'sensei_results_links', $results_link, $course_item->ID, $user->ID );
-								if ( $results_links ) {
-										$complete_html .= '<p class="sensei-results-links">';
-										$complete_html .= $results_links;
-										$complete_html .= '</p>';
+				/**
+				* Filter documented in Sensei_Course::the_course_action_buttons
+				*/
+				$results_links = apply_filters( 'sensei_results_links', $results_link, $course_item->ID, $user->ID );
+				if ( $results_links ) {
+						$complete_html .= '<p class="sensei-results-links">';
+						$complete_html .= $results_links;
+						$complete_html .= '</p>';
 				 }
 					$complete_html .= '</section>';
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2090,7 +2090,7 @@ class Sensei_Course {
 
 					}
 				}
-					$complete_html .= apply_filters( 'sensei_completed_course_links', '', $course_item->ID, $user->ID );
+					$complete_html .= apply_filters( 'sensei_results_completed_links', '', $course_item->ID, $user->ID );
 
 					$complete_html .= '</section>';
 


### PR DESCRIPTION
## Proposed Changes
* Updates the `sensei_results_links` filter to include the learner's user ID when displaying public profiles. This will be used to enable Sensei Certificates to publicly display the "View Certificate" button (Ref: https://github.com/woocommerce/sensei-certificates/pull/341 )
* Refactors `load_user_courses_content()` to display results links publicly

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install Sensei from this PR and the Sensei Certificates plugin from [the corresponding PR](https://github.com/woocommerce/sensei-certificates/pull/341).
2. In WP Admin, navigate to _Sensei LMS > Settings > Student Profiles_ and ensure _Public student profiles_ is checked.
3. In WP Admin, navigate to _Sensei LMS > Settings > Certificate Settings_ and ensure _Public Certificate_ is checked.
4. Ensure that there is a user who has completed at least one course that has a certificate.
5. As that user, navigate to their Learner profile (`<site-url>/learner/<login>`) and check `Allow my Certificates to be publicly viewed`. Save the setting.
6. Navigate to the _Completed Courses_ tab. Ensure the "View Certificate" button is visible.
7. Open the user's Learner profile in an incognito/private window.
8. Navigate to the _Completed Courses_ tab. Ensure the "View Certificate" button is visible.
9. As the original user, uncheck `Allow my Certificates to be publicly viewed`. Save the setting.
6. Navigate to the _Completed Courses_ tab. Ensure the "View Certificate" button is visible.
7. Open the user's Learner profile in an incognito/private window.
8. Navigate to the _Completed Courses_ tab. Ensure the "View Certificate" button is not visible.

**Screenshot of public profile before the update**

<img width="1137" alt="CleanShot 2023-07-28 at 12 58 18@2x" src="https://github.com/Automattic/sensei/assets/7596032/88e2653b-35ee-4c53-a261-fc3903ecf7a6">

**Screenshot of public profile after the update**

<img width="1077" alt="CleanShot 2023-07-28 at 12 57 06@2x" src="https://github.com/Automattic/sensei/assets/7596032/e8f115b5-f6e4-4a59-bf61-847faa2b32b1">

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* Updated application of hook `sensei_results_links` inside `load_user_courses_content()` to include a `$user_id` parameter

New parameter:
 * `$user_id`: The user ID of the learner being viewed

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [X] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [X] Decisions are publicly documented
- [X] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [X] All strings are translatable (without concatenation, handles plurals)
- [X] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
