### PR TITLE
Add student progress migration

### DIFF
--- a/changelog/add-data-migrator
+++ b/changelog/add-data-migrator
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add student progress migration

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -18,6 +18,7 @@ use Sensei\Internal\Student_Progress\Services\Course_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\Lesson_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\Quiz_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\User_Deleted_Handler;
+use Sensei\Internal\Student_Progress\Tools\Migration_Tool;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -570,6 +571,11 @@ class Sensei_Main {
 		$this->course_progress_repository = ( new Course_Progress_Repository_Factory( $use_tables ) )->create();
 		$this->lesson_progress_repository = ( new Lesson_Progress_Repository_Factory( $use_tables ) )->create();
 		$this->quiz_progress_repository   = ( new Quiz_Progress_Repository_Factory( $use_tables ) )->create();
+
+		// Student progress migration.
+		if ( $use_tables ) {
+			( new Migration_Tool( \Sensei_Tools::instance() ) )->init();
+		}
 
 		// Quiz submission repositories.
 		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $use_tables ) )->create();

--- a/includes/internal/installer/class-migration.php
+++ b/includes/internal/installer/class-migration.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * File containing the interface \Sensei\Internal\Installer\Migration.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+
+namespace Sensei\Internal\Installer;
+
+/**
+ * Migration interface.
+ *
+ * @since $$next-version$$
+ */
+interface Migration {
+	/**
+	 * The targeted plugin version.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	public function target_version(): string;
+
+	/**
+	 * Run the migration.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $dry_run Whether to run the migration in dry-run mode.
+	 */
+	public function run( bool $dry_run = true );
+
+	/**
+	 * Get the migration errors.
+	 *
+	 * @return array
+	 */
+	public function get_errors(): array;
+}
+

--- a/includes/internal/installer/migrations/class-student-progress-migration.php
+++ b/includes/internal/installer/migrations/class-student-progress-migration.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * File containing the class Student_Progress_Migration.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Installer\Migrations;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+use Sensei\Internal\Installer\Migration;
+use Sensei\Internal\Student_Progress\Course_Progress\Models\Course_Progress;
+use Sensei\Internal\Student_Progress\Lesson_Progress\Models\Lesson_Progress;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress;
+
+/**
+ * Class Student_Progress_Migration.
+ *
+ * @since $$next-version$$
+ */
+class Student_Progress_Migration implements Migration {
+
+	/**
+	 * The errors that occurred during the migration.
+	 *
+	 * @var array
+	 */
+	private $errors = array();
+
+	/**
+	 * The course progress data to insert.
+	 *
+	 * @var array
+	 */
+	private $progress_inserts = array();
+
+	/**
+	 * The size of a batch.
+	 *
+	 * @var int
+	 */
+	private $batch_size;
+
+	/**
+	 * The number of batches to insert in a single run.
+	 *
+	 * @var int
+	 */
+	private $batch_count;
+
+	/**
+	 * Constructs a new instance of the migration.
+	 *
+	 * @param int $batch_size The size of a batch (how many rows to insert in one insert query).
+	 * @param int $batch_count The number of batches to insert in a single run.
+	 */
+	public function __construct( int $batch_size = 100, int $batch_count = 10 ) {
+		$this->batch_size  = $batch_size;
+		$this->batch_count = $batch_count;
+	}
+
+	/**
+	 * Return the errors that occurred during the migration.
+	 *
+	 * @return array
+	 */
+	public function get_errors(): array {
+		return $this->errors;
+	}
+
+	/**
+	 * The targeted plugin version.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	public function target_version(): string {
+		return '1.0.0';
+	}
+
+	/**
+	 * Run the migration.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $dry_run Whether to run the migration in dry-run mode.
+	 * @return int The number of rows inserted.
+	 */
+	public function run( bool $dry_run = true ) {
+		$since_comment_id = get_option( 'sensei_migrated_progress_last_comment_id', 0 );
+		list( $progress_comments, $mapped_meta, $last_comment_id ) = $this->get_comments_and_meta( $since_comment_id, $dry_run );
+
+		if ( empty( $progress_comments ) ) {
+			return 0;
+		}
+
+		if ( false === $last_comment_id && ! empty( $progress_comments ) ) {
+			$this->errors[] = __( 'Could not find the last comment ID migrating data.', 'sensei-lms' );
+			return 0;
+		}
+
+		$this->prepare_progress_to_insert( $progress_comments, $mapped_meta );
+		$inserted_rows = $this->insert_with_batches( $dry_run );
+
+		update_option( 'sensei_migrated_progress_last_comment_id', $last_comment_id );
+
+		return $inserted_rows;
+	}
+
+	/**
+	 * Get the comments and comment meta to migrate.
+	 *
+	 * @param int  $after_comment_id The last comment ID that was migrated.
+	 * @param bool $dry_run Whether to run the migration in dry-run mode.
+	 * @return array The comments and comment meta to migrate.
+	 */
+	private function get_comments_and_meta( int $after_comment_id, bool $dry_run ): array {
+		global $wpdb;
+
+		$limit = $this->batch_size * $this->batch_count;
+
+		$comments_query = $wpdb->prepare(
+			"SELECT * FROM {$wpdb->comments} " .
+				'WHERE comment_type IN (%s, %s) AND comment_ID > %d ' .
+				'ORDER BY comment_ID ASC ' .
+				'LIMIT %d',
+			'sensei_course_status',
+			'sensei_lesson_status',
+			$after_comment_id,
+			$limit
+		);
+
+		if ( $dry_run ) {
+			echo esc_html( $comments_query . "\n" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$progress_comments = $wpdb->get_results( $comments_query );
+
+		$comment_ids = array();
+		$post_ids    = array();
+		foreach ( $progress_comments as $progress_comment ) {
+			$comment_ids[] = $progress_comment->comment_ID;
+
+			// At the moment we don't care about post meta for course progress.
+			if ( 'sensei_lesson_status' === $progress_comment->comment_type ) {
+				// Map the post ID to the comment ID. Is used later to map post meta to the comment ID.
+				$post_ids[ $progress_comment->comment_post_ID ] = $progress_comment->comment_ID;
+			}
+		}
+
+		$progress_comment_meta = array();
+		if ( ! empty( $comment_ids ) ) {
+			$placeholders = implode( ',', array_fill( 0, count( $comment_ids ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			$comment_meta_query = $wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT * FROM {$wpdb->commentmeta} WHERE meta_key IN ( %s ) AND comment_id IN ( {$placeholders} )",
+				'start',
+				...$comment_ids
+			);
+
+			if ( $dry_run ) {
+				echo esc_html( $comment_meta_query . "\n" );
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+			$progress_comment_meta = $wpdb->get_results( $comment_meta_query );
+		}
+
+		$post_meta = array();
+		if ( ! empty( $post_ids ) ) {
+			$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
+			$ids          = array_keys( $post_ids );
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			$post_meta_query = $wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT * FROM {$wpdb->postmeta} WHERE  meta_key IN ( %s ) AND post_id IN ( {$placeholders} )",
+				'_lesson_quiz',
+				...$ids
+			);
+			if ( $dry_run ) {
+				echo esc_html( $post_meta_query . "\n" );
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+			$post_meta = $wpdb->get_results( $post_meta_query );
+		}
+
+		// Map different meta keys to the comment ID.
+		$mapped_meta = [];
+
+		// Map comment meta to the comment ID.
+		foreach ( $progress_comment_meta as $meta ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$mapped_meta[ $meta->comment_id ][ $meta->meta_key ] = $meta->meta_value;
+		}
+
+		// Map post meta to the comment ID.
+		foreach ( $post_meta as $meta ) {
+			$comment_id = $post_ids[ $meta->post_id ];
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$mapped_meta[ $comment_id ][ $meta->meta_key ] = $meta->meta_value;
+		}
+
+		$last_comment_id = end( $comment_ids );
+
+		return array( $progress_comments, $mapped_meta, $last_comment_id );
+	}
+
+
+	/**
+	 * Prepare the course progress data to be inserted.
+	 *
+	 * @param array $progress_comments The comments to migrate.
+	 * @param array $mapped_meta The comment meta to migrate.
+	 */
+	private function prepare_progress_to_insert( $progress_comments, $mapped_meta ): void {
+		$this->progress_inserts = array();
+		foreach ( $progress_comments as $progress_comment ) {
+			switch ( $progress_comment->comment_type ) {
+				case 'sensei_course_status':
+					$this->prepare_course_progress_to_insert( $progress_comment, $mapped_meta );
+					break;
+				case 'sensei_lesson_status':
+					$this->prepare_lesson_progress_to_insert( $progress_comment, $mapped_meta );
+					break;
+				default:
+					$this->errors[] = sprintf(
+						/* translators: %s: comment type */
+						__( 'Unknown comment (id %1$d) type: %2$s', 'sensei-lms' ),
+						$progress_comment->comment_ID,
+						$progress_comment->comment_type
+					);
+
+			}
+		}
+	}
+
+	/**
+	 * Prepare the course progress data to be inserted.
+	 *
+	 * @param object $comment The comment to migrate.
+	 * @param array  $meta The comment meta to migrate.
+	 */
+	private function prepare_course_progress_to_insert( $comment, $meta ): void {
+		$course_status = 'in-progress';
+		if ( Course_Progress::STATUS_COMPLETE === $comment->comment_approved ) {
+			$course_status = 'complete';
+		}
+
+		if ( Course_Progress::STATUS_COMPLETE === $comment->comment_approved ) {
+			$completed_at = $comment->comment_date;
+		} else {
+			$completed_at = null;
+		}
+
+		$started_at = 0;
+		if ( isset( $meta[ $comment->comment_ID ]['start'] ) ) {
+			$started_at = $meta[ $comment->comment_ID ]['start'];
+		}
+
+		$this->progress_inserts[] = [
+			'post_id'        => (int) $comment->comment_post_ID,
+			'user_id'        => (int) $comment->user_id,
+			'parent_post_id' => null,
+			'type'           => 'course',
+			'status'         => $course_status,
+			'started_at'     => $started_at,
+			'completed_at'   => $completed_at,
+			'created_at'     => $comment->comment_date,
+			'updated_at'     => $comment->comment_date,
+		];
+	}
+
+	/**
+	 * Prepare the lesson progress data to be inserted.
+	 *
+	 * @param object $comment The comment to migrate.
+	 * @param array  $meta The comment meta to migrate.
+	 */
+	private function prepare_lesson_progress_to_insert( $comment, $meta ): void {
+		$lesson_status = 'in-progress';
+		$completed_at  = null;
+		if ( in_array( $comment->comment_approved, [ 'complete', 'passed', 'graded' ], true ) ) {
+			$completed_at  = $comment->comment_date;
+			$lesson_status = 'complete';
+		}
+
+		$started_at = 0;
+		if ( isset( $meta[ $comment->comment_ID ]['start'] ) ) {
+			$started_at = $meta[ $comment->comment_ID ]['start'];
+		}
+
+		$this->progress_inserts[] = [
+			'post_id'        => (int) $comment->comment_post_ID,
+			'user_id'        => (int) $comment->user_id,
+			'parent_post_id' => null,
+			'type'           => 'lesson',
+			'status'         => $lesson_status,
+			'started_at'     => $started_at,
+			'completed_at'   => $completed_at,
+			'created_at'     => $comment->comment_date,
+			'updated_at'     => $comment->comment_date,
+		];
+
+		// In case there is a quiz associated with the lesson,
+		// we create a quiz progress entry as well.
+		// We are able to determine a few non-initial statuses for the quiz.
+		// Because of that, by default we set the status to in-progress.
+		if ( isset( $meta[ $comment->comment_ID ]['_lesson_quiz'] ) ) {
+			$quiz_id            = $meta[ $comment->comment_ID ]['_lesson_quiz'];
+			$supported_statuses = [
+				Quiz_Progress::STATUS_IN_PROGRESS,
+				Quiz_Progress::STATUS_FAILED,
+				Quiz_Progress::STATUS_GRADED,
+				Quiz_Progress::STATUS_PASSED,
+				Quiz_Progress::STATUS_UNGRADED,
+				// We need to map lesson statuses to quiz' passed status.
+				Lesson_Progress::STATUS_COMPLETE,
+			];
+			$quiz_status        = in_array( $comment->comment_approved, $supported_statuses, true )
+				? $comment->comment_approved
+				: Quiz_Progress::STATUS_IN_PROGRESS;
+			$quiz_completed_at  = $completed_at;
+			if ( Quiz_Progress::STATUS_IN_PROGRESS === $quiz_status ) {
+				$quiz_completed_at = null;
+			}
+			if ( Lesson_Progress::STATUS_COMPLETE === $quiz_status ) {
+				$quiz_status = Quiz_Progress::STATUS_PASSED;
+			}
+
+			$this->progress_inserts[] = [
+				'post_id'        => (int) $quiz_id,
+				'user_id'        => (int) $comment->user_id,
+				'parent_post_id' => null,
+				'type'           => 'quiz',
+				'status'         => $quiz_status,
+				'started_at'     => $started_at,
+				'completed_at'   => $quiz_completed_at,
+				'created_at'     => $comment->comment_date,
+				'updated_at'     => $comment->comment_date,
+			];
+		}
+	}
+
+	/**
+	 * Insert the progress data in batches.
+	 *
+	 * @param bool $dry_run Whether to run the migration in dry-run mode.
+	 */
+	private function insert_with_batches( bool $dry_run ): int {
+		$progress_count = count( $this->progress_inserts );
+		$inserted_rows  = 0;
+		for ( $i = 0; $i < $progress_count; $i += $this->batch_size ) {
+			$batch        = array_slice( $this->progress_inserts, $i, $this->batch_size );
+			$insert_query = $this->generate_insert_sql_for_batch( $batch );
+
+			if ( $dry_run ) {
+				echo esc_html( $insert_query . "\n" );
+				continue;
+			}
+
+			$inserted_rows += $this->db_query( $insert_query );
+		}
+
+		return $inserted_rows;
+	}
+
+	/**
+	 * Execute a database query.
+	 *
+	 * @param string $query The query to execute.
+	 * @return int Number of rows affected.
+	 */
+	private function db_query( string $query ): int {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->query( $query );
+
+		if ( '' !== $wpdb->last_error ) {
+			$this->add_error( $wpdb->last_error );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Add an error message to the errors list unless it's there already.
+	 *
+	 * @param string $error The error message to add.
+	 */
+	protected function add_error( string $error ): void {
+		if ( is_null( $this->errors ) ) {
+			$this->errors = array();
+		}
+
+		if ( ! in_array( $error, $this->errors, true ) ) {
+			$this->errors[] = $error;
+		}
+	}
+
+	/**
+	 * Generate SQL for data insertion.
+	 *
+	 * @param array $batch Data to generate queries for. Will be 'data' array returned by `$this->fetch_data_for_migration_for_ids()` method.
+	 *
+	 * @return string Generated queries for insertion for this batch, would be of the form:
+	 * INSERT IGNORE INTO $table_name ($columns) values
+	 *  ($value for row 1)
+	 *  ($value for row 2)
+	 * ...
+	 */
+	private function generate_insert_sql_for_batch( array $batch ): string {
+		global $wpdb;
+		$table      = $wpdb->prefix . 'sensei_lms_progress';
+		$column_sql = '`post_id`,`user_id`,`parent_post_id`,`type`,`status`,`started_at`,`completed_at`,`created_at`,`updated_at`';
+		$value_sql  = $this->generate_column_clauses( $batch );
+		return "INSERT IGNORE INTO $table ($column_sql) VALUES $value_sql;"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, -- $insert_query is hardcoded, $value_sql is already escaped.
+	}
+
+	/**
+	 * Generate values clauses to be used in INSERT statements.
+	 *
+	 * @param array $batch Actual data to migrate.
+	 * @return strng SQL clause for values.
+	 */
+	private function generate_column_clauses( array $batch ): string {
+		global $wpdb;
+
+		$column_placeholders = [
+			'post_id'        => '%d',
+			'user_id'        => '%d',
+			'parent_post_id' => '%d',
+			'type'           => '%s',
+			'status'         => '%s',
+			'started_at'     => '%s',
+			'completed_at'   => '%s',
+			'created_at'     => '%s',
+			'updated_at'     => '%s',
+		];
+
+		$values = array();
+		foreach ( array_values( $batch ) as $row ) {
+			$row_values = array();
+			foreach ( $column_placeholders as $column => $placeholder ) {
+				if ( ! isset( $row[ $column ] ) || is_null( $row[ $column ] ) ) {
+					$row_values[] = 'NULL';
+				} else {
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- $placeholder is a placeholder.
+					$row_values[] = $wpdb->prepare( $placeholder, $row[ $column ] );
+				}
+			}
+
+			$value_string = '(' . implode( ',', $row_values ) . ')';
+			$values[]     = $value_string;
+		}
+
+		return implode( ',', $values );
+	}
+}

--- a/includes/internal/student-progress/tools/class-migration-tool.php
+++ b/includes/internal/student-progress/tools/class-migration-tool.php
@@ -62,7 +62,7 @@ class Migration_Tool implements \Sensei_Tool_Interface {
 	 * @return string
 	 */
 	public function get_id() {
-		return 'progress-migration';
+		return 'student-progress-migration';
 	}
 
 	/**
@@ -71,7 +71,7 @@ class Migration_Tool implements \Sensei_Tool_Interface {
 	 * @return string
 	 */
 	public function get_name() {
-		return __( 'Migrate comment-based progress', 'sensei-lms' );
+		return __( 'Migrate comment-based student progress', 'sensei-lms' );
 	}
 
 	/**
@@ -103,6 +103,7 @@ class Migration_Tool implements \Sensei_Tool_Interface {
 				$message .= ' ' . $error;
 			}
 		}
+
 		$this->tools->add_user_message( $message, ! $result );
 	}
 

--- a/includes/internal/student-progress/tools/class-migration-tool.php
+++ b/includes/internal/student-progress/tools/class-migration-tool.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * File containing Migration_Tool class.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+
+namespace Sensei\Internal\Student_Progress\Tools;
+
+use Sensei\Internal\Installer\Migrations\Student_Progress_Migration;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Migration_Tool class.
+ *
+ * @since $$next-version$$
+ */
+class Migration_Tool implements \Sensei_Tool_Interface {
+
+	/**
+	 * Sensei_Tools instance.
+	 *
+	 * @var \Sensei_Tools
+	 */
+	private $tools;
+
+	/**
+	 * Migration_Tool constructor.
+	 *
+	 * @param \Sensei_Tools $tools Sensei_Tools instance.
+	 */
+	public function __construct( \Sensei_Tools $tools ) {
+		$this->tools = $tools;
+	}
+
+	/**
+	 * Initialize the tool.
+	 */
+	public function init() {
+		add_filter( 'sensei_tools', [ $this, 'register_tool' ] );
+	}
+
+	/**
+	 * Register the tool.
+	 *
+	 * @param array $tools List of tools.
+	 *
+	 * @return array
+	 */
+	public function register_tool( $tools ) {
+		$tools[] = $this;
+		return $tools;
+	}
+
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'progress-migration';
+	}
+
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Migrate comment-based progress', 'sensei-lms' );
+	}
+
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return __(
+			'Migrate comment-based progress to the new table-based progress system.',
+			'sensei-lms'
+		);
+	}
+
+	/**
+	 * Run the tool.
+	 */
+	public function process() {
+		$migration     = new Student_Progress_Migration();
+		$rows_migrated = $migration->run( false );
+		$errors        = $migration->get_errors();
+		$result        = empty( $errors );
+
+		// translators: %d: number of statuses migrated.
+		$message = sprintf( __( 'Progress entries created based on comments: %d.', 'sensei-lms' ), $rows_migrated );
+		if ( ! $result ) {
+			$message .= ' ' . __( 'Errors:', 'sensei-lms' );
+			foreach ( $errors as $error ) {
+				$message .= ' ' . $error;
+			}
+		}
+		$this->tools->add_user_message( $message, ! $result );
+	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
+}

--- a/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SenseiTest\Internal\Installer\Migrations;
+
+use Sensei\Internal\Installer\Migrations\Student_Progress_Migration;
+use Sensei_Factory;
+
+/**
+ * Class Student_Progress_Migration_Test
+ *
+ * @covers \Sensei\Internal\Installer\Migrations\Student_Progress_Migration
+ */
+class Student_Progress_Migration_Test extends \WP_UnitTestCase {
+
+	/**
+	 * @var \Sensei\Internal\Installer\Migrations\Student_Progress_Migration
+	 */
+	private $migration;
+
+	protected $factory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->migration = new Student_Progress_Migration();
+		$this->factory   = new Sensei_Factory();
+
+		global $wpdb;
+		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . 'sensei_lms_progress' );
+	}
+
+	public function testTargetVersion_Always_ReturnsMathcingValue(): void {
+		/* Act. */
+		$actual = $this->migration->target_version();
+
+		/* Assert. */
+		$this->assertEquals( '1.0.0', $actual );
+	}
+
+	public function testGetErrors_MigrationDidntRun_ReturnsEmptyArray(): void {
+		/* Act. */
+		$actual = $this->migration->get_errors();
+
+		/* Assert. */
+		$this->assertEmpty( $actual );
+	}
+
+	public function testRun_NoCommentsExist_ReturnsZero(): void {
+		/* Arrange. */
+		$expected = 0;
+
+		/* Act. */
+		$actual = $this->migration->run( $dry_run = false );
+
+		/* Assert. */
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function testRun_CommentsExist_ReturnsMatchingNumberOfInserts(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
+		$lesson_id = $this->factory->lesson->create( array( 'post_title' => 'Lesson 1', 'post_parent' => $course_id ) );
+
+		\Sensei_Utils::start_user_on_course( 1, $course_id );
+		\Sensei_Utils::user_start_lesson( 1, $lesson_id, true );
+
+		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
+
+		/* Act. */
+		$this->migration->run( $dry_run = false );
+
+		/* Assert. */
+		global $wpdb;
+		$actual_rows = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}sensei_lms_progress" );
+		$this->assertEquals( 2, $actual_rows );
+	}
+}

--- a/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
@@ -83,4 +83,77 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$actual_rows = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}sensei_lms_progress" );
 		$this->assertEquals( 2, $actual_rows );
 	}
+
+
+	public function testRun_CommentsExist_CreatesProgressMatchingEntriesInCustomTables(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
+		$quiz_id   = $this->factory->quiz->create(
+			array(
+				'post_title'  => 'Quiz 1',
+			)
+		);
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'post_title'  => 'Lesson 1',
+				'post_parent' => $course_id,
+				'meta_input'  => array(
+					'_lesson_quiz' => $quiz_id,
+				),
+			)
+		);
+		update_post_meta( $quiz_id, '_quiz_lesson', $lesson_id );
+
+
+		\Sensei_Utils::start_user_on_course( 1, $course_id );
+		\Sensei_Utils::user_start_lesson( 1, $lesson_id, true );
+		\Sensei_Utils::user_passed_quiz( $quiz_id, 1 );
+
+		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
+
+		/* Act. */
+		$this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+
+		/* Assert. */
+		$actual_rows = $this->get_table_based_progress();
+		$expected    = array(
+			array(
+				'user_id' => 1,
+				'post_id' => $course_id,
+				'status'  => 'in-progress',
+				'type'    => 'course',
+			),
+			array(
+				'user_id' => 1,
+				'post_id' => $lesson_id,
+				'status'  => 'complete',
+				'type'    => 'lesson',
+			),
+			array(
+				'user_id' => 1,
+				'post_id' => $quiz_id,
+				'status'  => 'passed',
+				'type'    => 'quiz',
+			),
+		);
+		$this->assertSame( $expected, $actual_rows );
+	}
+
+	private function get_table_based_progress(): array {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}sensei_lms_progress" );
+
+		$result = array();
+		foreach ( $rows as $row ) {
+			$result[] = array(
+				'user_id' => (int) $row->user_id,
+				'post_id' => (int) $row->post_id,
+				'status'  => $row->status,
+				'type'    => $row->type,
+			);
+		}
+
+		return $result;
+	}
 }

--- a/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
@@ -13,6 +13,8 @@ use Sensei_Factory;
 class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 
 	/**
+	 * Migration instance.
+	 *
 	 * @var \Sensei\Internal\Installer\Migrations\Student_Progress_Migration
 	 */
 	private $migration;
@@ -26,6 +28,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->factory   = new Sensei_Factory();
 
 		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . 'sensei_lms_progress' );
 	}
 
@@ -50,7 +53,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$expected = 0;
 
 		/* Act. */
-		$actual = $this->migration->run( $dry_run = false );
+		$actual = $this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 
 		/* Assert. */
 		$this->assertEquals( $expected, $actual );
@@ -59,7 +62,12 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 	public function testRun_CommentsExist_ReturnsMatchingNumberOfInserts(): void {
 		/* Arrange. */
 		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
-		$lesson_id = $this->factory->lesson->create( array( 'post_title' => 'Lesson 1', 'post_parent' => $course_id ) );
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'post_title'  => 'Lesson 1',
+				'post_parent' => $course_id,
+			)
+		);
 
 		\Sensei_Utils::start_user_on_course( 1, $course_id );
 		\Sensei_Utils::user_start_lesson( 1, $lesson_id, true );
@@ -67,10 +75,11 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
 
 		/* Act. */
-		$this->migration->run( $dry_run = false );
+		$this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 
 		/* Assert. */
 		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$actual_rows = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}sensei_lms_progress" );
 		$this->assertEquals( 2, $actual_rows );
 	}

--- a/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/installer/migrations/test-class-student-progress-migration.php
@@ -90,7 +90,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
 		$quiz_id   = $this->factory->quiz->create(
 			array(
-				'post_title'  => 'Quiz 1',
+				'post_title' => 'Quiz 1',
 			)
 		);
 		$lesson_id = $this->factory->lesson->create(
@@ -103,7 +103,6 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 			)
 		);
 		update_post_meta( $quiz_id, '_quiz_lesson', $lesson_id );
-
 
 		\Sensei_Utils::start_user_on_course( 1, $course_id );
 		\Sensei_Utils::user_start_lesson( 1, $lesson_id, true );

--- a/tests/unit-tests/internal/student-progress/tools/test-class-migration-tool.php
+++ b/tests/unit-tests/internal/student-progress/tools/test-class-migration-tool.php
@@ -1,0 +1,59 @@
+<?php
+namespace SenseiTest\Internal\Student_Progress\Tools;
+
+use Sensei\Internal\Student_Progress\Tools\Migration_Tool;
+
+/**
+ * Class Migration_Tool_Test
+ *
+ * @covers \SenseiTest\Internal\Student_Progress\Tools\Migration_Tool
+ */
+class Migration_Tool_Test extends \WP_UnitTestCase {
+	public function testGetId_Always_ReturnsMatchingValue(): void {
+		/* Arrange. */
+		$tools = $this->createMock( \Sensei_Tools::class );
+		$tool = new Migration_Tool( $tools );
+
+		/* Act. */
+		$actual = $tool->get_id();
+
+		/* Assert. */
+		$this->assertSame( 'student-progress-migration', $actual );
+	}
+
+	public function testInit_Always_AddsFilter(): void {
+		/* Arrange. */
+		$tools = $this->createMock( \Sensei_Tools::class );
+		$tool = new Migration_Tool( $tools );
+
+		/* Act. */
+		$before_init = has_filter( 'sensei_tools', [ $tool, 'register_tool' ] );
+		$tool->init();
+		$after_init = 10 === has_filter( 'sensei_tools', [ $tool, 'register_tool' ] );
+
+		$actual = array(
+			'before' => $before_init,
+			'after'  => $after_init,
+		);
+
+		/* Assert. */
+		$expected = array(
+			'before' => false,
+			'after'  => true,
+		);
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function testRegisterTool_Always_AddsItselfToTools(): void {
+		/* Arrange. */
+		$tools = $this->createMock( \Sensei_Tools::class );
+		$tool = new Migration_Tool( $tools );
+
+		/* Act. */
+		$actual = $tool->register_tool( array() );
+
+		/* Assert. */
+		$expected = array( $tool );
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/unit-tests/internal/student-progress/tools/test-class-migration-tool.php
+++ b/tests/unit-tests/internal/student-progress/tools/test-class-migration-tool.php
@@ -12,7 +12,7 @@ class Migration_Tool_Test extends \WP_UnitTestCase {
 	public function testGetId_Always_ReturnsMatchingValue(): void {
 		/* Arrange. */
 		$tools = $this->createMock( \Sensei_Tools::class );
-		$tool = new Migration_Tool( $tools );
+		$tool  = new Migration_Tool( $tools );
 
 		/* Act. */
 		$actual = $tool->get_id();
@@ -24,7 +24,7 @@ class Migration_Tool_Test extends \WP_UnitTestCase {
 	public function testInit_Always_AddsFilter(): void {
 		/* Arrange. */
 		$tools = $this->createMock( \Sensei_Tools::class );
-		$tool = new Migration_Tool( $tools );
+		$tool  = new Migration_Tool( $tools );
 
 		/* Act. */
 		$before_init = has_filter( 'sensei_tools', [ $tool, 'register_tool' ] );
@@ -47,7 +47,7 @@ class Migration_Tool_Test extends \WP_UnitTestCase {
 	public function testRegisterTool_Always_AddsItselfToTools(): void {
 		/* Arrange. */
 		$tools = $this->createMock( \Sensei_Tools::class );
-		$tool = new Migration_Tool( $tools );
+		$tool  = new Migration_Tool( $tools );
 
 		/* Act. */
 		$actual = $tool->register_tool( array() );


### PR DESCRIPTION
Resolves #5437 

- This PR doesn't introduce a data migration mechanism. Only an interface for migrations and the migration for student progress comments.
- It doesn't work with transactions at this moment. We decided to consider them later.
- Only a very basic test added for the migration. Tests are WIP.

## Proposed Changes
* Add a migration to copy status comments into custom tables.
* Add a tool to run migration manually.

## Testing Instructions

1. Enable the feature: `add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );`.
2. Go to `Sensei LMS -> Tools`.
3. Run `Migrate comment-based progress`.
4. You can run it several times. It processes 1000 comments per run.
5. If you see the message "Progress entries created based on comments: 0." it means there is nothing to migrate already.
6. To run it from the beginning you need to clean at least the option: `DELETE FROM `wp_options` where option_name = 'sensei_migrated_progress_last_comment_id';`
7. However, it won't insert duplicates, so you need to delete progress rows as well: `TRUNCATE TABLE `wp_sensei_lms_progress`;`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
