### PR TITLE
Fix lesson styles when Gutenberg is enabled

### DIFF
--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -1,4 +1,3 @@
-
 $breakpoint: 782px;
 
 .sensei-course-theme .wp-block-buttons {
@@ -8,18 +7,16 @@ $breakpoint: 782px;
 }
 
 .sensei-course-theme__button,
-.wp-block-button.is-style-outline > .wp-block-button__link,
 .sensei-course-theme__link {
 	align-items: center;
-	white-space: nowrap;
-	width: 100%;
 	height: 100%;
 	justify-content: center;
+	white-space: nowrap;
+	width: 100%;
 
 	@media screen and (max-width: $breakpoint) {
 		padding: .625rem;
 	}
-
 
 	&.has-icon {
 		display: flex;

--- a/changelog/fix-learning-mode-template-on-wpcom
+++ b/changelog/fix-learning-mode-template-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix some lesson styling issues when Gutenberg is enabled

--- a/changelog/fix-learning-mode-template-on-wpcom
+++ b/changelog/fix-learning-mode-template-on-wpcom
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix some lesson styling issues when Gutenberg is enabled
+Fix lesson styling in editor on WordPress 6.3 or when Gutenberg enabled

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -46,7 +46,7 @@
 
 		<!-- wp:sensei-lms/course-theme-notices /-->
 
-		<!-- wp:post-content /-->
+		<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 		<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="margin-top:40px">


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7055.

## Proposed Changes
- Updates the Learning Mode default template to use a constrained layout for post content. Note that we shouldn't have used the `layout type` setting because it wasn't introduced until WordPress 6.1, and we currently support WordPress 6.0.
- Removes 100% width for outline link buttons. It had no effect on the frontend and was only impacting the editor. Perhaps we could consider making the Contact Teacher button 100% width on mobile as part of https://github.com/Automattic/sensei/issues/7134?

Note that I was no longer able to reproduce the typography issues reported in the original issue.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please ensure that you are able to reproduce the original issue before following these steps. I had a bit of difficulty reproducing locally, so tested on a live WP.com atomic site.

- Create a WordPress.com test site (if you don't already have one). Let me know if you need help with this.
- Install and activate Gutenberg.
- Upload and activate built versions of this branch and [this Sensei Pro one](https://github.com/Automattic/sensei-pro/pull/2394).
- Activate the Course theme and enable Learning Mode.
- Open a lesson in the editor.
- Add a Contact Teacher block if one does not already exist.
- Check that the Contact Teacher button does not extend the width of its container.
- Check that there is some whitespace between the edge of the browser and the post content.
- View the lesson on the frontend.
- Ensure that the Contact Teacher button and the content still looks good.
- Test again on the other Learning Mode templates.
- Test again on themes like Divi and Astra.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
