### PR TITLE
Fix "View Results" button not working

### DIFF
--- a/changelog/fix-view-results-button-not-working
+++ b/changelog/fix-view-results-button-not-working
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix "view results" button not working

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -72,7 +72,16 @@ class Sensei_Block_View_Results {
 			return '';
 		}
 
-		return '<form method="get" action="' . esc_url( Sensei_Course::get_view_results_link( $course_id ) ) . '" class="sensei-block-wrapper sensei-cta">' .
+		$results_link = Sensei_Course::get_view_results_link( $course_id );
+		parse_str( wp_parse_url( $results_link, PHP_URL_QUERY ), $results_link_query_params );
+
+		$form_inputs = '';
+		foreach ( $results_link_query_params as $name => $value ) {
+			$form_inputs .= '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '">';
+		}
+
+		return '<form method="get" action="' . esc_url( $results_link ) . '" class="sensei-block-wrapper sensei-cta">' .
+			$form_inputs .
 			preg_replace(
 				'/<a(.*)>/',
 				'<button type="submit" $1>',

--- a/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
@@ -87,7 +87,10 @@ class Sensei_Block_View_Results_Test extends WP_UnitTestCase {
 
 		$result = $this->block->render( [], self::CONTENT );
 
-		$this->assertMatchesRegularExpression( "|<form method=\"get\" action=\"http://example.org/\?page_id={$page_id}&#038;course_id={$this->course->ID}\".*>|", $result );
+		$this->assertMatchesRegularExpression(
+			"|<form method=\"get\" action=\"http://example.org/\?page_id={$page_id}&#038;course_id={$this->course->ID}\".*><input type=\"hidden\" name=\"page_id\" value=\"{$page_id}\"><input type=\"hidden\" name=\"course_id\" value=\"{$this->course->ID}\">|",
+			$result
+		);
 	}
 
 	/**


### PR DESCRIPTION
Resolves #6744

## Proposed Changes

This PR fixes the "View Results" button redirecting to the `/course-completed/` without the needed `course_id` param (`/course-completed/?course_id=123`) resulting in the page not displaying the needed results.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure you have the "Course Completed" page set in the Sensei LMS settings.
2. Complete a course.
3. Go to the "My Courses" page in the front-end and click the "Visit Results" button.
4. It should redirect to `/course-completed/?course_id=[your-course-id]` instead of `/course-completed/?`.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
