### PR TITLE
Fix learning mode lesson button, image and featured video style in Course theme

### DIFF
--- a/assets/css/3rd-party/themes/course/learning-mode.scss
+++ b/assets/css/3rd-party/themes/course/learning-mode.scss
@@ -33,6 +33,15 @@ body {
 	.wp-block-sensei-lms-course-theme-course-progress-bar {
 		background-color: var(--border-color);
 	}
+
+	.wp-block-image, .wp-block-video {
+		border-radius: 4px;
+		border: 1px solid var(--wp--preset--color--foreground);
+	}
+
+	.wp-block-video {
+		line-height: 0;
+	}
 }
 
 .sensei-course-theme__sidebar {

--- a/assets/css/3rd-party/themes/course/learning-mode.scss
+++ b/assets/css/3rd-party/themes/course/learning-mode.scss
@@ -34,7 +34,7 @@ body {
 		background-color: var(--border-color);
 	}
 
-	.wp-block-image, .wp-block-video {
+	.wp-block-image img, .wp-block-video video {
 		border-radius: 4px;
 		border: 1px solid var(--wp--preset--color--foreground);
 	}

--- a/assets/css/sensei-course-theme/blocks/lesson-actions.scss
+++ b/assets/css/sensei-course-theme/blocks/lesson-actions.scss
@@ -3,7 +3,7 @@ $breakpoint: 782px;
 .sensei-course-theme .sensei-course-theme-lesson-actions,
 .editor-styles-wrapper .sensei-course-theme-lesson-actions {
 	display: flex;
-	gap: 16px;
+	gap: 20px;
 	list-style: none;
 
 	&__complete-lesson-form {

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -17,7 +17,9 @@ $breakpoint: 782px;
 	justify-content: center;
 
 	@media screen and (max-width: $breakpoint) {
-		padding: .625rem;
+		padding: 20px;
+		line-height: 100%;
+		letter-spacing: -0.14px;
 	}
 
 

--- a/changelog/fix-lm-button-padding-and-gap-style
+++ b/changelog/fix-lm-button-padding-and-gap-style
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Button style fix for lessons in learning mode in Course theme
+Button and Image style fix for lessons in learning mode in Course theme

--- a/changelog/fix-lm-button-padding-and-gap-style
+++ b/changelog/fix-lm-button-padding-and-gap-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Button style fix for lessons in learning mode in Course theme


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7134

## Proposed Changes
* The buttons under the lessons in Learning Mode looked narrower than the design. So we've changed the padding and fixed some other discrepancies like gap, text spacings etc to make it match the design.
* I didn't find any design issue with the featured image for lesson. If we add normal images which are not featured image, they don't have the border and border radius. So we've added border with radius around them.
* Also, if we add featured video, it didn't have border with radius around it. So we've added that as well.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate Course theme
2. Select the gold variant of the theme
3. Create a course, make sure LM is enabled for that course
4. Create a lesson in that course with a quiz
5. Add a featured image on top of that lesson
6. Add a normal image somewhere inside that lesson
7. Now take that course as a Student and view that lesson
8. Check the buttons below
9. Make sure all of those match the design
10. Match the design for other variations of Course theme
11. Replace the featured image with a featured video and follow the steps above again.

### Before

![image](https://github.com/Automattic/sensei/assets/6820724/984d403c-c090-46b9-a0cf-9f82892200b5)

### After

![image](https://github.com/Automattic/sensei/assets/6820724/2662fb81-1ac4-4430-adc8-dded88a714e8)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
