### PR TITLE
Fix E2E tests failing randomly due to login issues

### DIFF
--- a/tests/e2e-playwright/helpers/context.ts
+++ b/tests/e2e-playwright/helpers/context.ts
@@ -60,10 +60,18 @@ export const createAdminContext = async (
 };
 
 export const login = async ( page: Page, user: User ): Promise< Page > => {
-	await page.goto( 'http://localhost:8889/wp-login.php' );
-	await page.locator( 'input[name="log"]' ).fill( user.username );
-	await page.locator( 'input[name="pwd"]' ).fill( user.password );
-	await page.locator( 'text=Log In' ).click();
+	const response = await page.request.post(
+		'http://localhost:8889/wp-login.php',
+		{
+			failOnStatusCode: true,
+			form: {
+				log: user.username,
+				pwd: user.password,
+			},
+		}
+	);
+
+	await response.dispose();
 
 	return page;
 };


### PR DESCRIPTION
## Proposed Changes

This is a fix attempt for the E2E tests failing because of login issues.

I've run a few E2E CI jobs and they are [passing](https://github.com/Automattic/sensei/actions/runs/5766303200) so 🤞 this fix actually works.

## Testing Instructions

The E2E tests should be passing.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
