### PR TITLE
Fix error when the module author user is deleted

### DIFF
--- a/changelog/fix-error-when-module-author-does-not-exist
+++ b/changelog/fix-error-when-module-author-does-not-exist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix error when the module author user is deleted

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2289,26 +2289,26 @@ class Sensei_Core_Modules {
 		}
 
 		if ( empty( $slug ) ) {
-
 			return $term_owner;
-
 		}
-		$term = get_term_by( 'slug', $slug, 'module' );
 
+		// Look for the author in the term meta.
+		$term = get_term_by( 'slug', $slug, 'module' );
 		if ( $term ) {
-			$author_meta = get_term_meta( $term->term_id, 'module_author', true );
-			if ( $author_meta ) {
-				return get_user_by( 'id', $author_meta );
+			$author_id = (int) get_term_meta( $term->term_id, 'module_author', true );
+			$author    = get_user_by( 'id', $author_id );
+
+			if ( $author ) {
+				return $author;
 			}
 		}
+
 		// look for the author in the slug.
 		$slug_parts = explode( '-', $slug );
-
 		if (
 			count( $slug_parts ) > 1
 			&& is_numeric( $slug_parts[0] )
 		) {
-
 			// get the user data
 			$possible_user_id = $slug_parts[0];
 			$author           = get_userdata( $possible_user_id );
@@ -2316,9 +2316,7 @@ class Sensei_Core_Modules {
 			// if the user doesnt exist for the first part of the slug
 			// then this slug was also created by admin
 			if ( is_a( $author, 'WP_User' ) ) {
-
 				$term_owner = $author;
-
 			}
 		}
 

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -178,6 +178,31 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$this->assertTrue( $test_user_id === $term_author_teacher->ID, 'The function should return the teacher user if exists using term meta.' );
 	}
 
+	public function testGetTermAuthor_WhenAuthorDoesNotExists_ReturnsFirstAdminUserAsFallback() {
+		/* Arrange */
+		wp_insert_term( 'Get Started', 'module' );
+
+		$term = wp_insert_term(
+			'A test term',
+			'module',
+			array(
+				'description' => 'A yummy apple.',
+				'slug'        => 'a-test-term',
+			)
+		);
+
+		$admin                = get_user_by( 'email', get_bloginfo( 'admin_email' ) );
+		$not_existing_user_id = 2000;
+
+		update_term_meta( $term['term_id'], 'module_author', $not_existing_user_id );
+
+		/* Act */
+		$term_author_admin = Sensei_Core_Modules::get_term_author( 'a-test-term' );
+
+		/* Assert */
+		$this->assertSame( $admin->ID, $term_author_admin->ID );
+	}
+
 	/**
 	 * Ensure the course modules column "more" link is shown
 	 * only if the course has more than 3 modules.


### PR DESCRIPTION
## Proposed Changes

This PR fixes the following error:

```
Notice: Trying to get property 'display_name' of non-object in /home/moduseducation/public_html/wp-content/plugins/sensei-lms/includes/class-sensei-modules.php on line 2662
```

The error happens in cases where the module author user has been deleted.

After applying this fix, if the module author user is deleted, the fallback author is the first admin user.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a teacher user.
2. Login with that user and create a course with a module.
3. Login with the admin user and delete the teacher user.
4. Open the teacher's course and make sure there are no errors.

## Screenshot

![A5guI5.png](https://github.com/Automattic/sensei/assets/1612178/470ffce4-991d-47eb-81a0-c6da67416394)

## Context

6624896-zd-a8c

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues