### PR TITLE
Fix E2E tests failing on WP 6.3

### DIFF
--- a/tests/e2e-playwright/pages/admin/post-type/index.ts
+++ b/tests/e2e-playwright/pages/admin/post-type/index.ts
@@ -61,7 +61,10 @@ export default class PostType {
 	}
 
 	async goToPreview(): Promise< Page > {
-		await this.page.locator( 'button:has-text("Preview")' ).first().click();
+		await this.page
+			.locator( 'button[aria-label="Preview"]' )
+			.first()
+			.click();
 
 		const [ previewPage ] = await Promise.all( [
 			this.page.waitForEvent( 'popup' ),


### PR DESCRIPTION
## Proposed Changes

This PR fixes E2E tests failing on WP 6.3 because of a change to the preview button.

## Testing Instructions
1. Make sure the E2E tests are in CI (which uses WP 6.3)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
