### PR TITLE
Add header on quiz template on Learning Mode

### DIFF
--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -32,8 +32,6 @@ $tablet-breakpoint: 768px;
 	}
 
 	&__header {
-		position: sticky;
-		top: var(--top-offset);
 		background-color: var(--sensei-background-color);
 		z-index: 100;
 

--- a/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
+++ b/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
@@ -38,7 +38,7 @@ $breakpoint: 783px;
 
 // Desktop
 @media screen and (min-width: ($breakpoint)) {
-	.sensei-course-theme__sidebar-toggle {
+	.single-lesson .sensei-course-theme__sidebar-toggle {
 		display: none;
 	}
 }
@@ -46,7 +46,6 @@ $breakpoint: 783px;
 // Mobile
 @media screen and (max-width: ($breakpoint - 1)) {
 	.sensei-course-theme {
-
 		&--sidebar-open {
 			overflow: hidden;
 

--- a/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
+++ b/assets/css/sensei-course-theme/sidebar-mobile-menu.scss
@@ -5,7 +5,11 @@
 
 $breakpoint: 783px;
 
-.sensei-course-theme__sidebar-toggle {
+.single-quiz .sensei-course-theme__sidebar-toggle {
+	display: none;
+}
+
+.single-lesson .sensei-course-theme__sidebar-toggle {
 	display: block;
 	width: 24px;
 	height: 24px;
@@ -31,6 +35,7 @@ $breakpoint: 783px;
 		background: none;
 	}
 }
+
 // Desktop
 @media screen and (min-width: ($breakpoint)) {
 	.sensei-course-theme__sidebar-toggle {
@@ -84,6 +89,5 @@ $breakpoint: 783px;
 		&:not(&--sidebar-open) &__sidebar {
 			opacity: 0;
 		}
-
 	}
 }

--- a/changelog/add-header-on-lm-quiz-template
+++ b/changelog/add-header-on-lm-quiz-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added header on the learning mode template of quizzes

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -70,6 +70,7 @@ class Sensei_Course_Theme_Templates {
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_single_block_template' ], 10, 3 );
 		add_filter( 'theme_lesson_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
 		add_filter( 'theme_quiz_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
+		add_action( 'sensei_course_theme_before_templates_load', [ $this, 'load_course_theme_patterns' ] );
 
 	}
 
@@ -81,6 +82,13 @@ class Sensei_Course_Theme_Templates {
 	 */
 	public function maybe_use_course_theme_templates() {
 		if ( Sensei_Course_Theme_Option::should_use_learning_mode() ) {
+			/**
+			 * Fires before the course theme templates are loaded.
+			 *
+			 * @since $$next-version$$
+			 */
+			do_action( 'sensei_course_theme_before_templates_load' );
+
 			add_filter( 'sensei_use_sensei_template', '__return_false' );
 			add_filter( 'single_template_hierarchy', [ $this, 'set_single_template_hierarchy' ] );
 			add_theme_support( 'block-templates' );
@@ -300,7 +308,6 @@ class Sensei_Course_Theme_Templates {
 	 * @return array
 	 */
 	public function get_block_templates() {
-
 		$this->load_file_templates();
 
 		$db_templates = $this->get_custom_templates();
@@ -499,5 +506,30 @@ class Sensei_Course_Theme_Templates {
 		return false;
 	}
 
+	/**
+	 * Loads and registers the learning mode specific patterns prior to loading the templates so that their
+	 * reference can be used in the LM templates.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 */
+	public function load_course_theme_patterns() {
+		$pattern_files = glob( Sensei_Course_Theme::instance()->get_course_theme_root() . '/patterns/*.html' );
+
+		foreach ( $pattern_files as $pattern_file ) {
+			$pattern_title = basename( $pattern_file, '.html' );
+
+			register_block_pattern(
+				'sensei-course-theme/' . $pattern_title,
+				[
+					'title'    => $pattern_title,
+					'inserter' => false,
+					'content'  => file_get_contents( $pattern_file ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Using local file.
+				]
+			);
+		}
+
+	}
 
 }

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -525,8 +525,9 @@ class Sensei_Course_Theme_Templates {
 				]
 			);
 		}
+	}
 
-  /**
+	/**
 	 * Filters the block templates to hide the lesson template in the post editor if the course does not have learning mode enabled.
 	 *
 	 * @param array  $current_templates The block templates.

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -510,7 +510,7 @@ class Sensei_Course_Theme_Templates {
 	 *
 	 * @since $$next-version$$
 	 */
-	public function load_course_theme_patterns() {
+	public function load_course_theme_patterns() : void {
 		$pattern_files = glob( Sensei_Course_Theme::instance()->get_course_theme_root() . '/patterns/*.html' );
 
 		foreach ( $pattern_files as $pattern_file ) {

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -70,7 +70,7 @@ class Sensei_Course_Theme_Templates {
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_single_block_template' ], 10, 3 );
 		add_filter( 'theme_lesson_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
 		add_filter( 'theme_quiz_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
-		add_action( 'sensei_course_theme_before_templates_load', [ $this, 'load_course_theme_patterns' ] );
+		add_action( 'init', [ $this, 'load_course_theme_patterns' ] );
 
 	}
 
@@ -82,13 +82,6 @@ class Sensei_Course_Theme_Templates {
 	 */
 	public function maybe_use_course_theme_templates() {
 		if ( Sensei_Course_Theme_Option::should_use_learning_mode() ) {
-			/**
-			 * Fires before the course theme templates are loaded.
-			 *
-			 * @since $$next-version$$
-			 */
-			do_action( 'sensei_course_theme_before_templates_load' );
-
 			add_filter( 'sensei_use_sensei_template', '__return_false' );
 			add_filter( 'single_template_hierarchy', [ $this, 'set_single_template_hierarchy' ] );
 			add_theme_support( 'block-templates' );

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
@@ -16,22 +16,41 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Course_Theme_Templates_Test extends WP_UnitTestCase {
 
-	public function testCourseThemePatterns_WhenActionNotCalled_DoesNotCreateThePatterns() {
-		/* Arrange. */
+	public function testSenseiCourseThemeTemplates_WhenClassInitialized_PatternCreationFunctionIsAttachedWithInit() {
+		/* Arrange */
 		$registry = \WP_Block_Patterns_Registry::get_instance();
 
-		/* Assert. */
-		self::assertFalse( $registry->is_registered( 'sensei-course-theme/header' ) );
+		/* Act */
+		$course_theme_templates = Sensei_Course_Theme_Templates::instance();
+
+		/* Assert */
+		self::assertSame( 10, has_filter( 'init', [ $course_theme_templates, 'load_course_theme_patterns' ] ) );
 	}
 
-	public function testCourseThemePatterns_WhenActionCalled_CreatesThePatterns() {
-		/* Arrange. */
+	public function testSenseiCourseThemeTemplates_WhenPatternAccessed_IsCreatedAlreadyByInit() {
+		/* Arrange */
 		$registry = \WP_Block_Patterns_Registry::get_instance();
 
-		/* Act. */
-		do_action( 'sensei_course_theme_before_templates_load' );
-
-		/* Assert. */
+		/* Assert */
 		self::assertTrue( $registry->is_registered( 'sensei-course-theme/header' ) );
+	}
+
+	public function testLoadCoursePattern_WhenCalled_CreatesTheHeaderPattern() {
+		/* Arrange */
+		$registry               = \WP_Block_Patterns_Registry::get_instance();
+		$course_theme_templates = Sensei_Course_Theme_Templates::instance();
+
+		$registry->unregister( 'sensei-course-theme/header' );
+
+		$is_registered_before = $registry->is_registered( 'sensei-course-theme/header' );
+
+		/* Act */
+		$course_theme_templates->load_course_theme_patterns();
+
+		$is_registered_after = $registry->is_registered( 'sensei-course-theme/header' );
+
+		/* Assert */
+		self::assertFalse( $is_registered_before );
+		self::assertTrue( $is_registered_after );
 	}
 }

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file contains the Sensei_Course_Theme_Templates_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Course_Theme_Templates class.
+ *
+ * @group course-theme
+ */
+class Sensei_Course_Theme_Templates_Test extends WP_UnitTestCase {
+
+	public function testCourseThemePatterns_WhenActionNotCalled_DoesNotCreateThePatterns() {
+		/* Arrange. */
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+
+		/* Assert. */
+		self::assertFalse( $registry->is_registered( 'sensei-course-theme/header' ) );
+	}
+
+	public function testCourseThemePatterns_WhenActionCalled_CreatesThePatterns() {
+		/* Arrange. */
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+
+		/* Act. */
+		do_action( 'sensei_course_theme_before_templates_load' );
+
+		/* Assert. */
+		self::assertTrue( $registry->is_registered( 'sensei-course-theme/header' ) );
+	}
+}

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
@@ -52,7 +52,7 @@ class Sensei_Course_Theme_Templates_Test extends WP_UnitTestCase {
 		/* Assert */
 		self::assertFalse( $is_registered_before );
 		self::assertTrue( $is_registered_after );
-  }
+	}
 
 	public function testTemplateFilter_WhenCourseThemeEnabled_ReturnsFilteredTemplateList() {
 		/* Arrange */

--- a/themes/sensei-course-theme/patterns/header.html
+++ b/themes/sensei-course-theme/patterns/header.html
@@ -1,0 +1,32 @@
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-8-0"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-8-0 sensei-course-theme__header">
+	<!-- wp:group {"style":{"spacing":{"padding":{"right":"24px","left":"24px","top":"0px","bottom":"0px"}}},"className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group sensei-course-theme-header-content"
+		 style="padding-top:0px;padding-right:24px;padding-bottom:0px;padding-left:24px">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-logo {"shouldSyncIcon":true,"style":{"layout":{"selfStretch":"fit","flexSize":null}}} /-->
+
+			<!-- wp:sensei-lms/course-title /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"style":{"spacing":{"blockGap":"12px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"className":"sensei-course-theme__header__info","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group sensei-course-theme__header__info">
+				<!-- wp:sensei-lms/course-theme-course-progress-counter /-->
+
+				<!-- wp:sensei-lms/exit-course /-->
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:sensei-lms/sidebar-toggle-button /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:sensei-lms/course-theme-course-progress-bar /-->
+</div>
+<!-- /wp:sensei-lms/ui -->

--- a/themes/sensei-course-theme/patterns/header.html
+++ b/themes/sensei-course-theme/patterns/header.html
@@ -1,5 +1,5 @@
-<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-16-0"} -->
-<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-16-0 sensei-course-theme__header">
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-16-2"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-16-2 sensei-course-theme__header">
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"24px","left":"24px","top":"0px","bottom":"0px"}}},"className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group sensei-course-theme-header-content"
 		 style="padding-top:0px;padding-right:24px;padding-bottom:0px;padding-left:24px">

--- a/themes/sensei-course-theme/patterns/header.html
+++ b/themes/sensei-course-theme/patterns/header.html
@@ -1,5 +1,5 @@
-<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-8-0"} -->
-<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-8-0 sensei-course-theme__header">
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-16-0"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-16-0 sensei-course-theme__header">
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"24px","left":"24px","top":"0px","bottom":"0px"}}},"className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group sensei-course-theme-header-content"
 		 style="padding-top:0px;padding-right:24px;padding-bottom:0px;padding-left:24px">

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -1,38 +1,7 @@
-<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-8-0"} -->
-<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-8-0 sensei-course-theme__header">
-	<!-- wp:group {"style":{"spacing":{"padding":{"right":"24px","left":"24px","top":"0px","bottom":"0px"}}},"className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group sensei-course-theme-header-content"
-		style="padding-top:0px;padding-right:24px;padding-bottom:0px;padding-left:24px">
-		<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group">
-			<!-- wp:site-logo {"shouldSyncIcon":true,"style":{"layout":{"selfStretch":"fit","flexSize":null}}} /-->
+<!-- wp:pattern {"slug":"sensei-course-theme/header"} /-->
 
-			<!-- wp:sensei-lms/course-title /-->
-		</div>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"style":{"spacing":{"blockGap":"12px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group">
-			<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"className":"sensei-course-theme__header__info","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group sensei-course-theme__header__info">
-				<!-- wp:sensei-lms/course-theme-course-progress-counter /-->
-
-				<!-- wp:sensei-lms/exit-course /-->
-			</div>
-			<!-- /wp:group -->
-
-			<!-- wp:sensei-lms/sidebar-toggle-button /-->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:group -->
-
-	<!-- wp:sensei-lms/course-theme-course-progress-bar /-->
-</div>
-<!-- /wp:sensei-lms/ui -->
-
-<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns"} -->
-<div class="wp-block-sensei-lms-ui sensei-course-theme__columns">
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-0"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-version--4-16-0">
 	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":""} -->
 	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar">
 		<!-- wp:sensei-lms/course-navigation /--></div>

--- a/themes/sensei-course-theme/templates/default/lesson.html
+++ b/themes/sensei-course-theme/templates/default/lesson.html
@@ -1,7 +1,7 @@
 <!-- wp:pattern {"slug":"sensei-course-theme/header"} /-->
 
-<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-0"} -->
-<div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-version--4-16-0">
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-2"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-version--4-16-2">
 	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":""} -->
 	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar">
 		<!-- wp:sensei-lms/course-navigation /--></div>

--- a/themes/sensei-course-theme/templates/quiz.html
+++ b/themes/sensei-course-theme/templates/quiz.html
@@ -16,8 +16,8 @@
 </div>
 <!-- /wp:columns -->
 
-<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-0", "tagName": "main"} -->
-<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-0">
+<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2", "tagName": "main"} -->
+<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2">
 	<!-- wp:sensei-lms/course-theme-notices /-->
 	<!-- wp:post-content /-->
 </main>

--- a/themes/sensei-course-theme/templates/quiz.html
+++ b/themes/sensei-course-theme/templates/quiz.html
@@ -1,3 +1,5 @@
+<!-- wp:pattern {"slug":"sensei-course-theme/header"} /-->
+
 <!-- wp:columns {"className":"sensei-course-theme__quiz__header sensei-course-theme__frame"} -->
 <div class="wp-block-columns sensei-course-theme__quiz__header sensei-course-theme__frame">
 	<!-- wp:column {"className":"sensei-course-theme__quiz__header__left"} -->
@@ -14,8 +16,8 @@
 </div>
 <!-- /wp:columns -->
 
-<!-- wp:group {"className":"sensei-course-theme__quiz__main-content", "tagName": "main"} -->
-<main class="wp-block-group sensei-course-theme__quiz__main-content">
+<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-0", "tagName": "main"} -->
+<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-0">
 	<!-- wp:sensei-lms/course-theme-notices /-->
 	<!-- wp:post-content /-->
 </main>


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7069

## Proposed Changes
* Added header on quiz template
* As the header on lesson and quiz is exactly the same, the header is moved to a common pattern file and the templates refer to that header pattern when needed just as we do with other themes.
* The quiz title was overlapping the header and becoming sticky when scrolled, just removed the sticky style for now to keep the header as it should for this design. Title area should be made proper under the issue for title and navigation

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with lessons and quizzes
2. Make sure to turn learning mode on
3. Visit the lessons and the quizzes from the frontend
4. Make sure they look the same as before for lesson, and that the header looks the same on both lesson and quiz
5. Check using all variations of Course theme
6. Check using other top themes for sensei

![image](https://github.com/Automattic/sensei/assets/6820724/3e564621-20ae-4ac2-97b9-562f0450a8f8)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
