### PR TITLE
Fix lessons not being saved when creating a course on the latest Gutenberg version

### DIFF
--- a/assets/shared/structure/structure-store.js
+++ b/assets/shared/structure/structure-store.js
@@ -245,27 +245,27 @@ export function registerStructureStore( {
 				return;
 			}
 
-			const isSavingPost =
-				editor.isSavingPost() && ! editor.isAutosavingPost();
 			const isSavingStructure = select(
 				storeName
 			).getIsSavingStructure();
 
+			const isSavingPost =
+				editor.isSavingPost() && ! editor.isAutosavingPost();
 			if ( isSavingPost ) {
 				editorStartedSaving = true;
-				metaSavingStarted = false;
 			}
 
-			if ( editorStartedSaving && ! metaSavingStarted ) {
-				metaSavingStarted = editPostSelector.isSavingMetaBoxes();
+			const isSavingMetaBoxes = editPostSelector.isSavingMetaBoxes();
+			if ( isSavingMetaBoxes ) {
+				metaSavingStarted = true;
 			}
 
 			if (
 				! structureStartedSaving &&
 				! isSavingPost &&
+				! isSavingMetaBoxes &&
 				editorStartedSaving &&
-				metaSavingStarted &&
-				! editPostSelector.isSavingMetaBoxes()
+				metaSavingStarted
 			) {
 				// Start saving structure when post has finished saving.
 				structureStartedSaving = true;

--- a/changelog/fix-lessons-not-saved-when-creating-course
+++ b/changelog/fix-lessons-not-saved-when-creating-course
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix lessons not being saved when creating a course on the latest Gutenberg version


### PR DESCRIPTION
Resolves #7083

## Proposed Changes

This bug was caused because of the logic detecting if a post is saved does not work on the latest Gutenberg version.

In our logic, we're tracking 3 different save requests - saving the post, saving the post meta, and saving the course structure. The problem was that in the latest Gutenberg version, the post meta saving request starts while the post saving request is still running. That caused a bug because the logic wasn't expecting the requests to happen in parallel. This PR changes the logic to track the requests independently.

I wasn't able to find a good way to add integration tests for this, but it should be covered by E2E tests already.

## Testing Instructions
1. Install the latest version of the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/)
2. Go to Sensei LMS -> Courses -> New Course
3. In the Course Outline block, select "Start with a blank canvas"
4. Save the course as draft
5. Make sure the lessons are saved
6. Disable the Gutenberg plugin and make sure the same process works

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
