### PR TITLE
Footer style improvements for quiz on learning mode

### DIFF
--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -17,7 +17,6 @@
 				.sensei-quiz-action {
 					button {
 						font-family: var( --wp--preset--font-family--body );
-						font-size: var(--wp--custom--typography--font-sizes--normal);
 					}
 				}
 			}

--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -1,7 +1,20 @@
 .sensei-course-theme__quiz {
+
 	&__main-content {
 		.wp-block-post-title {
 			margin-bottom: 3.75rem;
+		}
+	}
+	&__footer {
+		.sensei-quiz-actions {
+			.sensei-quiz-actions-secondary {
+				.sensei-quiz-action {
+					button {
+						font-family: var( --wp--preset--font-family--body );
+						font-size: var(--wp--preset--font-size--medium);
+					}
+				}
+			}
 		}
 	}
 }

--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -7,11 +7,17 @@
 	}
 	&__footer {
 		.sensei-quiz-actions {
+			.sensei-quiz-action {
+				button {
+					padding: 0 32px;
+					line-height: 56px;
+				}
+			}
 			.sensei-quiz-actions-secondary {
 				.sensei-quiz-action {
 					button {
 						font-family: var( --wp--preset--font-family--body );
-						font-size: var(--wp--preset--font-size--medium);
+						font-size: var(--wp--custom--typography--font-sizes--normal);
 					}
 				}
 			}

--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -9,8 +9,7 @@
 		.sensei-quiz-actions {
 			.sensei-quiz-action {
 				button {
-					padding: 0 32px;
-					line-height: 56px;
+					padding: 1rem 32px;
 				}
 			}
 			.sensei-quiz-actions-secondary {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -495,20 +495,17 @@ div.sensei-quiz-actions {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	gap: 1.5em;
+	row-gap: 32px;
 
 	@media only screen and (min-width: $tablet-breakpoint) {
 		flex-direction: row;
 		margin-left: auto;
+		justify-content: space-between;
 	}
 
 	.sensei-quiz-action {
 		margin: 0;
 		padding: 0;
-
-		.button {
-			padding: 8px 11px;
-		}
 	}
 
 	.sensei-quiz-actions-primary {
@@ -518,21 +515,17 @@ div.sensei-quiz-actions {
 
 	.sensei-quiz-actions-secondary {
 		display: flex;
-		order: 1;
+		column-gap: 56px;
+		flex-direction: column;
+		row-gap: 32px;
+		align-items: center;
 
 		@media only screen and (min-width: $tablet-breakpoint) {
 			order: 0;
+			flex-direction: row;
 		}
 
 		.sensei-quiz-action {
-			display: flex;
-
-			&:not(:first-child) {
-				margin-left: 0.5em;
-				padding-left: 0.5em;
-				border-left: 2px solid;
-			}
-
 			.button, button {
 				@include button-link;
 			}

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -6,17 +6,17 @@ $breakpoint: 782px;
 	gap: 12px;
 }
 
+
 .sensei-course-theme__button,
-.sensei-course-theme__link {
+.sensei-course-theme__link,
+.sensei-course-theme .wp-block-button.is-style-outline > .wp-block-button__link {
 	align-items: center;
 	height: 100%;
 	justify-content: center;
 	white-space: nowrap;
 	width: 100%;
-
-	@media screen and (max-width: $breakpoint) {
-		padding: .625rem;
-	}
+	padding: 1rem 32px;
+	line-height: 100%;
 
 	&.has-icon {
 		display: flex;

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -18,10 +18,6 @@ $breakpoint: 782px;
 	padding: 1rem 32px;
 	line-height: 100%;
 
-	@media screen and (max-width: $breakpoint) {
-		letter-spacing: -0.14px;
-	}
-
 	&.has-icon {
 		display: flex;
 		gap: 8px;

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -85,8 +85,18 @@ $tablet-breakpoint: 768px;
 
 		.sensei-quiz-actions {
 			width: 100%;
-			flex-direction: column;
-			gap: 2rem;
+
+			.sensei-quiz-actions-secondary {
+
+				.sensei-quiz-action {
+					.button, button {
+						text-decoration: none;
+						&:hover {
+							text-decoration: underline;
+						}
+					}
+				}
+			}
 		}
 
 		.sensei-quiz-pagination {
@@ -120,15 +130,17 @@ $tablet-breakpoint: 768px;
 				right: 0;
 				z-index: 100;
 				background-color: var(--sensei-background-color);
-				box-shadow: 2px 10px 30px 5px rgba(0, 0, 0, 0.1);
 			}
 
 			.sensei-quiz-actions {
-				width: auto;
-				flex-direction: row-reverse;
+				flex-direction: row;
 
 				.sensei-quiz-action {
 					flex: unset;
+				}
+
+				.sensei-quiz-actions-secondary {
+					flex-direction: row;
 				}
 			}
 

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -1,8 +1,3 @@
-/**
- * Variables
- */
-$tablet-breakpoint: 768px;
-
 @import '~@wordpress/base-styles/breakpoints';
 @import '../../shared/blocks/progress-bar/progress-bar';
 
@@ -41,7 +36,7 @@ $tablet-breakpoint: 768px;
 		}
 	}
 
-	&__header, &__footer {
+	&__footer {
 		padding: 24px;
 
 		margin: 0 auto;
@@ -110,7 +105,7 @@ $tablet-breakpoint: 768px;
 	}
 }
 
-@media only screen and (min-width: $tablet-breakpoint) {
+@media only screen and (min-width: $break-medium) {
 	.sensei-course-theme__quiz {
 		&__footer {
 			&__wrapper {

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -37,26 +37,14 @@
 	}
 
 	&__footer {
-		padding: 24px;
-
-		margin: 0 auto;
-		max-width: 1200px;
-
-		display: flex;
 		align-items: center;
-		justify-content: space-between;
-		gap: 24px;
-
-	}
-
-	&__footer {
 		display: flex;
 		flex-direction: row;
+		gap: 24px;
 		justify-content: flex-end;
-		align-items: center;
-		max-width: var(--content-size);
 		margin: 0 auto;
-		padding: 24px 0;
+		max-width: var(--content-size);
+		padding: 24px;
 
 		&__wrapper {
 			margin: 0 !important;

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -1,10 +1,17 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '../../shared/blocks/progress-bar/progress-bar';
 
+$vertical-spacing: 60px;
+$vertical-spacing-desktop: 80px;
+
 .sensei-course-theme__quiz {
 	&__main-content {
-		margin-bottom: 100px !important;
+		margin-bottom: $vertical-spacing;
 		padding-top: clamp(2.5rem, 1.346rem + 3.846vw, 3.75rem);
+
+		@media (min-width: $break-medium) {
+			margin-bottom: $vertical-spacing-desktop;
+		}
 
 		.wp-block-post-title {
 			margin-top: clamp(1.688rem, 0.534rem + 3.846vw, 2.938rem);
@@ -44,11 +51,16 @@
 		justify-content: flex-end;
 		margin: 0 auto;
 		max-width: var(--content-size);
-		padding: 24px;
 
 		&__wrapper {
-			margin: 0 !important;
 			display: block;
+			margin: 0 !important;
+			/* Using padding instead of margin as some themes have a non-white body background color. */
+			padding-bottom: $vertical-spacing;
+
+			@media (min-width: $break-medium) {
+				padding-bottom: $vertical-spacing-desktop;
+			}
 		}
 
 		.wp-block-group__inner-container {

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -114,11 +114,6 @@ $tablet-breakpoint: 768px;
 	.sensei-course-theme__quiz {
 		&__footer {
 			&__wrapper {
-				position: fixed;
-				bottom: 0;
-				left: 0;
-				right: 0;
-				z-index: 100;
 				background-color: var(--sensei-background-color);
 			}
 

--- a/changelog/add-footer-style-update-lm-quiz
+++ b/changelog/add-footer-style-update-lm-quiz
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: changed
 
 Changed the footer styles of Quiz template

--- a/changelog/add-footer-style-update-lm-quiz
+++ b/changelog/add-footer-style-update-lm-quiz
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Changed the footer styles of Quiz template

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1864,10 +1864,10 @@ class Sensei_Quiz {
 							type="submit"
 							name="quiz_complete"
 							form="sensei-quiz-form"
-							class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission"
+							class="wp-block-button__link button quiz-submit complete sensei-course-theme__button sensei-stop-double-submission"
 							style="<?php echo esc_attr( $button_inline_styles ); ?>"
 						>
-							<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
+							<?php esc_attr_e( 'Complete Quiz', 'sensei-lms' ); ?>
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1835,6 +1835,12 @@ class Sensei_Quiz {
 		$is_reset_allowed  = self::is_reset_allowed( $lesson_id );
 		$has_actions       = $is_reset_allowed || ! $is_quiz_completed;
 
+		$wrapper_attributes = get_block_wrapper_attributes(
+			[
+				'class' => 'sensei-quiz-actions',
+			]
+		);
+
 		if ( ! $has_actions ) {
 			return;
 		}
@@ -1844,7 +1850,13 @@ class Sensei_Quiz {
 		wp_enqueue_script( 'sensei-stop-double-submission' );
 		?>
 
-		<div class="sensei-quiz-actions">
+		<?php
+			echo sprintf(
+				'<div %s>',
+				$wrapper_attributes // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- No need to escape output of get_block_wrapper_attributes().
+			);
+		?>
+
 			<?php if ( ! $is_quiz_completed ) : ?>
 				<div class="sensei-quiz-actions-primary wp-block-buttons">
 					<div class="sensei-quiz-action wp-block-button">

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1879,7 +1879,7 @@ class Sensei_Quiz {
 				<?php if ( $is_reset_allowed ) : ?>
 					<div class="sensei-quiz-action">
 						<button type="submit" name="quiz_reset" form="sensei-quiz-form" class="quiz-submit reset sensei-stop-double-submission">
-							<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
+							<?php esc_attr_e( 'Reset Quiz', 'sensei-lms' ); ?>
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
@@ -1889,13 +1889,14 @@ class Sensei_Quiz {
 				<?php if ( ! $is_quiz_completed ) : ?>
 					<div class="sensei-quiz-action">
 						<button type="submit" name="quiz_save" form="sensei-quiz-form" class="quiz-submit save sensei-stop-double-submission">
-							<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
+							<?php esc_attr_e( 'Save Progress', 'sensei-lms' ); ?>
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_save_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
 					</div>
 				<?php endif ?>
 			</div>
+
 		</div>
 		<?php
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7073

## Proposed Changes
* Fixed quiz actions block not adding block attributes during render
* Fixed Button spacings
* Updated styles for desktop and mobile as per the new design

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch of Course theme https://github.com/Automattic/themes/pull/7317
2. Activate course theme
3. Create a course
4. Create a lesson in it with a quiz
5. Enable learning mode
6. Take the course as a student, go to the quiz page
7. Make sure the footer looks as expected
8. Check in both mobile and desktop mode
9. Now disable learning mode
10. Make sure it didn't break anything
11. Now repeat step 5-8 for all variations of course theme, top sensei themes, another block theme

Desktop:
<img width="1050" alt="image" src="https://github.com/Automattic/sensei/assets/6820724/907be25d-d8a5-4b43-80e4-7dfb243d119b">

Mobile:
<img width="491" alt="image" src="https://github.com/Automattic/sensei/assets/6820724/e848aa5e-924c-4222-b309-6dfc66787aad">

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
