### PR TITLE
Quote path to allow spaces in it

### DIFF
--- a/scripts/release-pr.sh
+++ b/scripts/release-pr.sh
@@ -23,7 +23,7 @@ echo $SCRIPT_DIR
 # TODO: https://www.fastruby.io/blog/docker/docker-ssh-keys.html
 cp -r ~/.ssh "$SCRIPT_DIR/ssh-data"
 
-docker build -t release-build $SCRIPT_DIR &&  \
+docker build -t release-build "$SCRIPT_DIR" &&  \
 	docker run --name release-steps --rm -it \
 	-v ~/.gitconfig:/etc/gitconfig \
 	release-build \


### PR DESCRIPTION
Fix the release PR preparation script.
Quote the current script path to allow spaces in it.

## Proposed Changes
* Quote path to allow spaces in it.

## Testing Instructions

1. Rename your sensei folder to have a space in the directory name.
2. Run the script, like `scripts/release-pr.sh 9.9.9 fix/release-pr-script-docker-build`
3. Follow instructions, no errors expected.

Here is the result of my test run: https://github.com/Automattic/sensei/pull/7117