### PR TITLE
Display default lesson first in lesson wizard

### DIFF
--- a/changelog/update-lesson-layouts-order
+++ b/changelog/update-lesson-layouts-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Display "Default Lesson" first in lesson wizard

--- a/includes/block-patterns/class-sensei-block-patterns.php
+++ b/includes/block-patterns/class-sensei-block-patterns.php
@@ -92,11 +92,11 @@ class Sensei_Block_Patterns {
 			];
 		} elseif ( 'lesson' === $post_type ) {
 			$block_patterns = [
+				'default',
 				'video-lesson',
 				'default-with-quiz',
 				'zoom-meeting',
 				'files-to-download',
-				'default',
 			];
 
 			if (


### PR DESCRIPTION
## Proposed Changes
Change the order of the options in the lesson wizard so that _Default Lesson_ is first. Context - p6rkRX-6Ff-p2

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new lesson.
2. Proceed to the second step of the modal.
3. Check that _Default Lesson_ is listed first.

![Screenshot 2023-08-18 at 11 48 06 AM](https://github.com/Automattic/sensei/assets/1190420/bf985699-6b74-4038-b83a-8f4dbb6427d1)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues