### PR TITLE
Fix creation of dynamic property

### DIFF
--- a/changelog/fix-php8.0-dynamic-property
+++ b/changelog/fix-php8.0-dynamic-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.2 compatibilty issue: creation of dynamic property.

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -2860,25 +2860,6 @@
     <UndefinedConstant occurrences="1">
       <code>OBJECT_K</code>
     </UndefinedConstant>
-    <UndefinedThisPropertyAssignment occurrences="11">
-      <code>$this-&gt;course_id</code>
-      <code>$this-&gt;filter_by_course_id</code>
-      <code>$this-&gt;filter_type</code>
-      <code>$this-&gt;lesson_id</code>
-      <code>$this-&gt;offset</code>
-      <code>$this-&gt;order_by</code>
-      <code>$this-&gt;order_type</code>
-      <code>$this-&gt;per_page</code>
-      <code>$this-&gt;search</code>
-      <code>$this-&gt;total_items</code>
-      <code>$this-&gt;total_items</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="4">
-      <code>$this-&gt;filter_type</code>
-      <code>$this-&gt;offset</code>
-      <code>$this-&gt;order_type</code>
-      <code>$this-&gt;per_page</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="includes/class-sensei-dependency-checker.php">
     <MissingReturnType occurrences="4">
@@ -3780,12 +3761,6 @@
       <code>$cat-&gt;name</code>
       <code>$question_cat-&gt;name</code>
     </UndefinedPropertyFetch>
-    <UndefinedThisPropertyAssignment occurrences="4">
-      <code>$this-&gt;question_order</code>
-      <code>$this-&gt;question_order</code>
-      <code>$this-&gt;question_order</code>
-      <code>$this-&gt;question_order</code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="includes/class-sensei-list-table.php">
     <ArgumentTypeCoercion occurrences="2">
@@ -4318,24 +4293,6 @@
       <code>get_queried_object()-&gt;ID</code>
       <code>get_queried_object()-&gt;post_type</code>
     </UndefinedPropertyFetch>
-    <UndefinedThisPropertyAssignment occurrences="8">
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="6">
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-      <code>$this-&gt;labels</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="includes/class-sensei-preview-user.php">
     <ArgumentTypeCoercion occurrences="2">
@@ -4410,10 +4367,6 @@
       <code>$quiz_id</code>
       <code>$quiz_id</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="2">
-      <code>$meta_fields</code>
-      <code>$token</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="20">
       <code>add_custom_navigation</code>
       <code>answer_feedback_notes</code>
@@ -4529,13 +4482,6 @@
       <code>Sensei()</code>
       <code>Sensei()</code>
     </UndefinedFunction>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;question_types</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="2">
-      <code>$this-&gt;question_types</code>
-      <code>$this-&gt;question_types</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="includes/class-sensei-quiz.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -4741,9 +4687,6 @@
       <code>Sensei()</code>
       <code>Sensei()</code>
     </UndefinedFunction>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;data</code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="includes/class-sensei-settings-api.php">
     <DocblockTypeContradiction occurrences="1">
@@ -4815,14 +4758,6 @@
       <code>Sensei()</code>
       <code>Sensei()</code>
     </UndefinedFunction>
-    <UndefinedThisPropertyAssignment occurrences="3">
-      <code>$this-&gt;hook</code>
-      <code>$this-&gt;remaining_fields</code>
-      <code>$this-&gt;remaining_fields</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;remaining_fields</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="includes/class-sensei-settings.php">
     <DocblockTypeContradiction occurrences="2">
@@ -4873,9 +4808,6 @@
       <code>\Sensei()</code>
       <code>\Sensei()</code>
     </UndefinedFunction>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;hook</code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="includes/class-sensei-teacher.php">
     <ArgumentTypeCoercion occurrences="8">
@@ -5741,9 +5673,6 @@
       <code>Sensei()</code>
       <code>Sensei()</code>
     </UndefinedFunction>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;Sensei_WPML</code>
-    </UndefinedThisPropertyAssignment>
     <UnresolvableInclude occurrences="6">
       <code>require_once $this-&gt;plugin_path . 'widgets/class-sensei-' . $key . '-widget.php'</code>
       <code>require_once $this-&gt;resolve_path( 'includes/3rd-party/3rd-party.php' )</code>
@@ -6900,9 +6829,6 @@
     <UndefinedFunction occurrences="1">
       <code>Sensei()</code>
     </UndefinedFunction>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;processed_multiple_choice_answers</code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="includes/email-signup/class-sensei-email-signup-form.php">
     <DocblockTypeContradiction occurrences="2">
@@ -8984,24 +8910,6 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$term-&gt;term_id</code>
     </PossiblyInvalidPropertyFetch>
-    <UndefinedThisPropertyAssignment occurrences="7">
-      <code>$this-&gt;exclude</code>
-      <code>$this-&gt;hide_empty</code>
-      <code>$this-&gt;include</code>
-      <code>$this-&gt;number</code>
-      <code>$this-&gt;order</code>
-      <code>$this-&gt;orderby</code>
-      <code>$this-&gt;parent</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="7">
-      <code>$this-&gt;exclude</code>
-      <code>$this-&gt;hide_empty</code>
-      <code>$this-&gt;include</code>
-      <code>$this-&gt;number</code>
-      <code>$this-&gt;order</code>
-      <code>$this-&gt;orderby</code>
-      <code>$this-&gt;parent</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="includes/shortcodes/class-sensei-shortcode-course-page.php">
     <InvalidArgument occurrences="1">
@@ -9058,9 +8966,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$lesson_page_query</code>
     </PropertyNotSetInConstructor>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;id</code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="includes/shortcodes/class-sensei-shortcode-loader.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -6,6 +6,75 @@
  * Helper to fetch learners.
  */
 class Sensei_Db_Query_Learners {
+	/**
+	 * Number of items to return per page.
+	 *
+	 * @var int
+	 */
+	public $per_page;
+
+	/**
+	 * Offset to start from.
+	 *
+	 * @var int
+	 */
+	public $offset;
+
+	/**
+	 * Course ID.
+	 *
+	 * @var int
+	 */
+	public $course_id;
+
+	/**
+	 * Lesson ID.
+	 *
+	 * @var int
+	 */
+	public $lesson_id;
+
+	/**
+	 * Order by field.
+	 *
+	 * @var string
+	 */
+	public $order_by;
+
+	/**
+	 * Order direction.
+	 *
+	 * @var string
+	 */
+	public $order_type;
+
+	/**
+	 * Search term.
+	 *
+	 * @var string
+	 */
+	public $search;
+
+	/**
+	 * Filter by course ID.
+	 *
+	 * @var int
+	 */
+	public $filter_by_course_id;
+
+	/**
+	 * Filter type.
+	 *
+	 * @var string
+	 */
+	public $filter_type;
+
+	/**
+	 * Total number of items.
+	 *
+	 * @var int
+	 */
+	public $total_items;
 
 	/**
 	 * Sensei_Db_Query_Learners constructor.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -19,6 +19,13 @@ class Sensei_Lesson {
 	public $allowed_html;
 
 	/**
+	 * Question order.
+	 *
+	 * @var string
+	 */
+	public $question_order;
+
+	/**
 	 * Lesson ID being saved.
 	 *
 	 * @since 3.8.0
@@ -1318,6 +1325,7 @@ class Sensei_Lesson {
 
 					$html .= '</table>';
 
+		/** @psalm-suppress RedundantPropertyInitializationCheck */
 		if ( ! isset( $this->question_order ) ) {
 			$this->question_order = '';
 		}
@@ -1424,8 +1432,10 @@ class Sensei_Lesson {
 				$html             .= $this->quiz_panel_question( $question_type, $question_counter, $question_id, 'quiz', $multiple_data );
 				$question_counter += $question_increment;
 
+				/** @psalm-suppress RedundantConditionGivenDocblockType */
 				if ( isset( $this->question_order ) && strlen( $this->question_order ) > 0 ) {
-					$this->question_order .= ','; }
+					$this->question_order .= ',';
+				}
 				$this->question_order .= $question_id;
 			}
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1325,7 +1325,11 @@ class Sensei_Lesson {
 
 					$html .= '</table>';
 
-		/** @psalm-suppress RedundantPropertyInitializationCheck */
+		/**
+		 * In case the question order is not set, we need to initialize it to an empty string.
+		 *
+		 * @psalm-suppress RedundantPropertyInitializationCheck
+		 */
 		if ( ! isset( $this->question_order ) ) {
 			$this->question_order = '';
 		}
@@ -1432,7 +1436,11 @@ class Sensei_Lesson {
 				$html             .= $this->quiz_panel_question( $question_type, $question_counter, $question_id, 'quiz', $multiple_data );
 				$question_counter += $question_increment;
 
-				/** @psalm-suppress RedundantConditionGivenDocblockType */
+				/**
+				 * In case the question order is not set, we need to initialize it to an empty string.
+				 *
+				 * @psalm-suppress RedundantConditionGivenDocblockType
+				*/
 				if ( isset( $this->question_order ) && strlen( $this->question_order ) > 0 ) {
 					$this->question_order .= ',';
 				}

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -57,6 +57,13 @@ class Sensei_PostTypes {
 	public $messages;
 
 	/**
+	 * Labels for post types.
+	 *
+	 * @var array
+	 */
+	public $labels;
+
+	/**
 	 * Array of post ID's for which to fire an "initial publish" action.
 	 *
 	 * @var array

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -14,8 +14,26 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class Sensei_Question {
+	/**
+	 * Question token.
+	 *
+	 * @var string
+	 */
 	public $token;
+
+	/**
+	 * Question meta fields.
+	 *
+	 * @var array
+	 */
 	public $meta_fields;
+
+	/**
+	 * Question types.
+	 *
+	 * @var array
+	 */
+	public $question_types;
 
 	/**
 	 * Constructor.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -38,6 +38,13 @@ class Sensei_Quiz {
 	public $file;
 
 	/**
+	 * Frontend data object. Filled in `Sensei_Quiz::load_global_quiz_data()`.
+	 *
+	 * @var stdClass|null
+	 */
+	public $data;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since  1.0.0

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -30,6 +30,20 @@ class Sensei_Settings_API {
 	public $settings_version;
 
 	/**
+	 * Array of fields that have not been added to a section.
+	 *
+	 * @var array|null
+	 */
+	public $remaining_fields;
+
+	/**
+	 * Page's hook suffix.
+	 *
+	 * @var string|false
+	 */
+	public $hook = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @access public

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -259,6 +259,15 @@ class Sensei_Main {
 	public $admin_notices;
 
 	/**
+	 * WPML compatibility class.
+	 *
+	 * @var Sensei_WPML
+	 *
+	 * @psalm-suppress PropertyNotSetInConstructor
+	 */
+	public $sensei_wpml;
+
+	/**
 	 * Course progress repository.
 	 *
 	 * @var Course_Progress_Repository_Interface
@@ -562,7 +571,7 @@ class Sensei_Main {
 		$this->learner_profiles = new Sensei_Learner_Profiles();
 
 		// Load WPML compatibility class
-		$this->Sensei_WPML = new Sensei_WPML();
+		$this->sensei_wpml = new Sensei_WPML();
 
 		$this->rest_api_internal = new Sensei_REST_API_Internal();
 

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -32,6 +32,13 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 	private $question_type;
 
 	/**
+	 * Cached processed multiple choice answers.
+	 *
+	 * @var array|null
+	 */
+	private $processed_multiple_choice_answers;
+
+	/**
 	 * Create a new question or update an existing question.
 	 *
 	 * @return true|WP_Error

--- a/includes/shortcodes/class-sensei-shortcode-course-categories.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-categories.php
@@ -29,6 +29,56 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 
 	/**
+	 * Order categories by field.
+	 *
+	 * @var string
+	 */
+	public $orderby;
+
+	/**
+	 * Order direction.
+	 *
+	 * @var string
+	 */
+	public $order;
+
+	/**
+	 * Number of categories to display.
+	 *
+	 * @var int
+	 */
+	public $number;
+
+	/**
+	 * Parent category id.
+	 *
+	 * @var int
+	 */
+	public $parent;
+
+	/**
+	 * Include categories.
+	 *
+	 * @var array
+	 */
+	public $include;
+
+	/**
+	 * Exclude categories.
+	 *
+	 * @var array
+	 */
+	public $exclude;
+
+	/**
+	 * Hide empty categories.
+	 *
+	 * @var bool
+	 */
+	public $hide_empty;
+
+
+	/**
 	 * @var array list of taxonomy terms.
 	 */
 	protected $sensei_course_taxonomy_terms;

--- a/includes/shortcodes/class-sensei-shortcode-lesson-page.php
+++ b/includes/shortcodes/class-sensei-shortcode-lesson-page.php
@@ -19,6 +19,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Shortcode_Lesson_Page implements Sensei_Shortcode_Interface {
 
 	/**
+	 * The lesson id
+	 *
+	 * @var int
+	 */
+	public $id;
+
+	/**
 	 * @var array $lesson_page_query {
 	 *     @type WP_Post
 	 * }


### PR DESCRIPTION
Resolves #6814 

## Proposed Changes
* Fix deprecation notice for creation of dynamic property.

## Testing Instructions
1. Activate the Sensei extension on a site with PHP 8.2 and debug logging enabled.
2. View the log file, no deprecation notices expected.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
