### PR TITLE
Gracefully handle null values

### DIFF
--- a/changelog/fix-questions-null
+++ b/changelog/fix-questions-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid getting fatal error when questions set to null

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -683,13 +683,16 @@ function sensei_quiz_has_questions() {
 
 	global $sensei_question_loop;
 
-	$questions_count = count( $sensei_question_loop['questions'] );
+	$questions = $sensei_question_loop['questions'] ?? array();
+	$current   = $sensei_question_loop['current'] ?? 0;
+
+	$questions_count = count( $questions );
 
 	if ( 0 === $questions_count ) {
 		return false;
 	}
 
-	return $sensei_question_loop['current'] + 1 < $questions_count;
+	return $current + 1 < $questions_count;
 }
 
 /**


### PR DESCRIPTION
A user has an issue that `question` are `null`. In PHP 8.0+ that produces a fatal error.
I couldn't reproduce the issue and find possible cases when null is set.
This PR adds insurance strap to avoid the error. (Unfortunately, it doesn't guarantee there won't be problems elsewhere.)

## Proposed Changes
* Use default value if the values are not presented in `$sensei_question_loop`.

## Testing Instructions

1. Create a lesson with a quiz.
2. Open the quiz on the frontend.
3. No errors expected.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
