### PR TITLE
Fix changelog category names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,13 +106,13 @@
 		"changelogger": {
 			"changelog": "changelog.txt",
 			"types": {
-				"security": "Vulnerability fix (e.g. Fix XSS vulnerability)",
-				"added": "New feature (e.g. Add quiz generation using AI)",
-				"changed": "Changes to existing functionality (e.g. Redirect to next lesson without showing a message, Bump minimum required PHP version to 7.3)",
-				"deprecated": "Soon-to-be removed feature (e.g. Deprecate the legacy email system in favor of the new one)",
-				"removed": "Removed feature (e.g. Remove the legacy email system)",
-				"fixed": "Bug fix (e.g. Fix admin notice styles)",
-				"dev": "Changes that third-party devs should be aware of (e.g. Deprecate the `Sensei_Emails` class, Remove wrapper elements from templates, Introduce new hook: `sensei_email_send`)"
+				"security": "Security",
+				"added": "Added",
+				"changed": "Changed",
+				"deprecated": "Deprecated",
+				"removed": "Removed",
+				"fixed": "Fixed",
+				"dev": "Dev"
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #7113

This PR reverts the changelog category names changed in https://github.com/Automattic/sensei/pull/6804.

I wasn't able to find a way to add a category description, so a future P2 post will explain how to use them.

## Proposed Changes

* Revert to the old changelog category names.

## Testing Instructions

1. Run `npm run changelog`.
2. Make sure the category names are correct.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
