### PR TITLE
Log active theme name on plugin deactivation

### DIFF
--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { render } from '@wordpress/element';
 
 /**
@@ -53,6 +54,7 @@ import { ExitSurveyForm } from './form';
 		constructor( { href } ) {
 			this.href = href;
 		}
+
 		/**
 		 * Create and open a modal with an exit survey form.
 		 *
@@ -83,10 +85,22 @@ import { ExitSurveyForm } from './form';
 		 */
 		submitExitSurvey = async ( data ) => {
 			const body = new window.FormData();
+
 			body.append( 'action', 'exit_survey' );
 			body.append( '_wpnonce', window.sensei_exit_survey?.nonce );
 			body.append( 'reason', data.reason );
 			body.append( 'details', data.details );
+
+			// Get the name of the active theme.
+			try {
+				const result = await apiFetch( {
+					path: '/wp/v2/themes?status=active',
+				} );
+
+				if ( result.length > 0 ) {
+					body.append( 'theme', result[ 0 ].name?.raw || '' );
+				}
+			} catch ( e ) {}
 
 			await window.fetch( window.ajaxurl, {
 				method: 'POST',

--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -20,6 +20,7 @@ import { ExitSurveyForm } from './form';
 
 		const deactivateLinks = [
 			getDeactivateLinkElement( 'sensei-lms' ),
+			getDeactivateLinkElement( 'sensei-pro-wc-paid-courses' ),
 			getDeactivateLinkElement( 'sensei-with-woocommerce-paid-courses' ),
 			getDeactivateLinkElement(
 				'woocommerce-com-woocommerce-paid-courses'

--- a/changelog/update-exit-survey-tweaks
+++ b/changelog/update-exit-survey-tweaks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Log active theme name on plugin deactivation

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -58,6 +58,7 @@ class Sensei_Exit_Survey {
 		$feedback = [
 			'reason'  => isset( $_POST['reason'] ) ? sanitize_text_field( wp_unslash( $_POST['reason'] ) ) : null,
 			'details' => isset( $_POST['details'] ) ? sanitize_text_field( wp_unslash( $_POST['details'] ) ) : null,
+			'theme'   => isset( $_POST['theme'] ) ? sanitize_text_field( wp_unslash( $_POST['theme'] ) ) : null,
 		];
 
 		update_option( 'sensei_exit_survey_data', $feedback );


### PR DESCRIPTION
Logging the active theme will better enable us to debug issues reported in the exit survey - p6rkRX-6IQ-p2

## Proposed Changes

1. Logs the active theme name when the user submits the exit survey.
2. Ensure that the exit survey is triggered for Sensei Pro (WC Paid Courses), which is the WooCommerce.com version.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Deactivate Sensei LMS.
2. Submit the exit survey.
3. Verify that the event is logged [here](https://mc.a8c.com/tracks/live/?eventname=sensei_plugin_deactivate&user=&useragent=) after about 15 minutes and that the correct `theme` value was logged.
4. **(Hacky way to test Sensei Pro (WC Paid Courses))** In your code editor, open the version of Sensei Pro that's installed on your dev site.
5. In `sensei-pro.php`, change _Plugin Name_ from _Sensei Pro_ to _Sensei Pro (WC Paid Courses)_.
6. Activate the fake _Sensei Pro (WC Paid Courses)_ plugin if necessary.
7. Deactivate it and ensure the exit survey is displayed.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues