### PR TITLE
Fix AI Course outline not working in woocommerce paid courses

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -20,6 +20,7 @@ import { useBlocksCreator } from '../use-block-creator';
 import OutlineAppender from './outline-appender';
 import OutlinePlaceholder from './outline-placeholder';
 import useSenseiProSettings from './use-sensei-pro-settings';
+import { applyFilters } from '@wordpress/hooks';
 
 const SENSEI_PRO_LINK = 'https://senseilms.com/sensei-pro/';
 
@@ -49,6 +50,19 @@ const OutlineEdit = ( props ) => {
 
 	const { isActivated: isSenseiProActivated } = useSenseiProSettings();
 
+	/**
+	 * Filters if the course outline generator upsell should be removed or not.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param {boolean} removeCourseOutlineGeneratorUpsell Whether to remove the course outline generator upsell.
+	 * @return {boolean} Whether to remove the course outline generator upsell.
+	 */
+	const removeCourseOutlineGeneratorUpsell = applyFilters(
+		'senseiCourseOutlineGeneratorUpsellRemove',
+		isSenseiProActivated
+	);
+
 	useEffect( () => {
 		if ( ! attributes.isPreview ) {
 			loadStructure();
@@ -72,12 +86,12 @@ const OutlineEdit = ( props ) => {
 	);
 
 	const openTailoredModal = useCallback( () => {
-		if ( isSenseiProActivated ) {
+		if ( removeCourseOutlineGeneratorUpsell ) {
 			window.location.hash = 'generate-course-outline-using-ai';
 		} else {
 			window.location.href = SENSEI_PRO_LINK;
 		}
-	}, [ isSenseiProActivated ] );
+	}, [ removeCourseOutlineGeneratorUpsell ] );
 
 	return isEmpty ? (
 		<OutlinePlaceholder

--- a/changelog/fix-ai-course-outline-not-working-for-wcpc
+++ b/changelog/fix-ai-course-outline-not-working-for-wcpc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed AI course outline generator not working in WCPC


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2413

## Proposed Changes
* To take users to the upsell page only when sensei-pro is unavailable, and open the modal otherwise, we [use](https://github.com/Automattic/sensei/blob/769a167b70274efa4098717c5e88042cfba387e8/assets/blocks/course-outline/outline-block/outline-edit.js#L50) a hook that called a backend API through redux store to fetch a list of installed [extensions](https://github.com/Automattic/sensei/blob/769a167b70274efa4098717c5e88042cfba387e8/assets/extensions/store.js#L293-L296) (plugins). If we check the backend API [here](https://github.com/Automattic/sensei/blob/769a167b70274efa4098717c5e88042cfba387e8/includes/admin/class-sensei-extensions.php#L68-L111) and then [here](https://github.com/Automattic/sensei/blob/769a167b70274efa4098717c5e88042cfba387e8/includes/admin/class-sensei-extensions.php#L169-L191), we can see that our backend API call itself then calls an API in senseilms.com to fetch a [list of available plugins/extensions](https://senseilms.com/wp-json/senseilms-products/1.0/search?type=plugin) from there, and then it gets a list of all locally installed plugins and filters the fetched extensions and modifies the data to indicate which plugins are installed and activated or not.

As we know, sensei-pro is available in senseilms.com but wcpc is not, it does not match the logic and sensei-pro shows up in frontend as uninstalled.

One way to solve this could be adding another logic in the backend to mark sensei-pro as installed if wcpc is there, or even send wcpc in the product list from senseilms.com (:p). But there are multiple catches with that, for example, we'll have to handle it differently for multisite and single sites. Which didn't look very good to me.

Also, the main issue I think here is, just to determine if sensei-pro codes are there or not, going through this whole cycle of API calls doesn't looks very good to me. Fetching the products and then checking if they are installed and activated or not is better suited for cases like Sensei LMS -> Home where we showcase a bunch of extensions at the bottom.

For this particular case, I didn't change much and followed how it's handled [here](https://github.com/Automattic/sensei/blob/769a167b70274efa4098717c5e88042cfba387e8/assets/admin/editor-wizard/helpers.js#L165-L185) with a hook. It doesn't depend on somewhat fragile things like what the name of the plugin is, sensei-pro or wcpc, or even something else, or even if we want to hide the upsell when another plugin like interactive blocks is present (as we do with TutorAI). Just set a hook in [sensei-pro](https://github.com/Automattic/sensei-pro/blob/5d499060750fb215ef4fdbfc9969f7c2f40102f4/assets/upsell-hooks.js#L10-L18) or any other codebase and it'll work as expected. I think it's a better way to handle similar situations of upsells and can be used as the de-facto if we agree, will also help to prevent issues like this.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch of pro https://github.com/Automattic/sensei-pro/tree/fix/ai-course-outline-not-working-in-wcpc
2. Create a WCPC build
3. Install it locally
4. Activate it with woocommerce
5. Make sure course outline AI works as expected
6. Make sure sensei-pro also works as expected

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

Could not use the @hook annotation in jsdoc because it's throwing an eslint error
* `senseiCourseOutlineGeneratorUpsellRemove` - Filters if the course outline generator upsell should be removed or not.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
