### PR TITLE
Fix attempt to create quiz progress in the tables when the feature is disabled

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2335,6 +2335,11 @@ class Sensei_Quiz {
 	 * @param int|string $user_id The user ID.
 	 */
 	public function maybe_create_quiz_progress( $quiz_id = '', $user_id = '' ): void {
+		$tables_based_progress_feature = Sensei()->feature_flags->is_enabled( 'tables_based_progress' );
+		if ( ! $tables_based_progress_feature ) {
+			return;
+		}
+
 		if ( empty( $quiz_id ) || ! is_int( $quiz_id ) ) {
 			$quiz_id = get_the_ID();
 		}
@@ -2352,8 +2357,7 @@ class Sensei_Quiz {
 			return;
 		}
 
-		$tables_based_progress_feature = Sensei()->feature_flags->is_enabled( 'tables_based_progress' );
-		$quiz_progress_repository      = ( new Quiz_Progress_Repository_Factory( $tables_based_progress_feature ) )
+		$quiz_progress_repository = ( new Quiz_Progress_Repository_Factory( $tables_based_progress_feature ) )
 			->create_tables_based_repository();
 
 		$quiz_progress = $quiz_progress_repository->get( $quiz_id, $user_id );


### PR DESCRIPTION
Reported in p1694436788183699-slack-C02NWDZBL0H.

This fixes an error generated when accessing a quiz when the tables-based progress feature is disabled.

![image](https://github.com/Automattic/sensei/assets/1612178/0a25b9d1-3d55-4583-b5a0-7588a91114ad)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure the `tables_based_progress` feature is disabled.
1. Create a lesson with a quiz.
1. Access the quiz.
1. There should be no errors.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues