### PR TITLE
Incorrect lesson layout sometimes added in editor

### DIFF
--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -6,16 +6,16 @@
 	height: 100%;
 
 	&__footer {
-		position: sticky;
-		bottom: 0;
-		width: 100%;
+		align-items: center;
 		background: #ffffff;
+		border-top: 1px solid rgba(30, 30, 30, 0.12);
+		bottom: 0;
 		display: flex;
 		flex-wrap: wrap;
-		align-items: center;
 		gap: 12px;
-		border-top: 1px solid rgba(30, 30, 30, 0.12);
 		padding: 18px;
+		position: sticky;
+		width: 100%;
 		z-index: 10;
 
 		@media ( min-width: 600px ) {

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -16,6 +16,7 @@
 		gap: 12px;
 		border-top: 1px solid rgba(30, 30, 30, 0.12);
 		padding: 18px;
+		z-index: 10;
 
 		@media ( min-width: 600px ) {
 			padding: 18px 30px;

--- a/changelog/fix-lesson-template-selection
+++ b/changelog/fix-lesson-template-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Incorrect lesson layout sometimes added in editor


### PR DESCRIPTION
## Proposed Changes
This PR fixes an issue where clicking the _Start with default layout_ link in the _Lesson Layout_ modal would add the wrong template if the link and the template beneath it overlapped (see screenshot). The solution was to add a `z-index` to the modal's footer so that the link is on top and will get the click.

![Screenshot 2023-09-11 at 11 29 04 AM](https://github.com/Automattic/sensei/assets/1190420/ab2697f4-9f1f-4f35-843d-a51e1c1c62cc)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new lesson.
2. In the _Lesson Layout_ modal, zoom in until the template overlaps with the _Start with default layout_ link.
3. Click the _Start with default layout_ link.
4. Ensure the default layout template is added in the editor.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
