### PR TITLE
Split manual enrollment title in order to allow different gender on the translation

### DIFF
--- a/changelog/fix-translation-with-gender-issues
+++ b/changelog/fix-translation-with-gender-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Split manual enrollment title in order to allow different gender on the translation

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -1155,12 +1155,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		$form_lesson_id = 0;
 		if ( $this->course_id && ! $this->lesson_id ) {
 			$post_title     = get_the_title( $this->course_id );
-			$post_type      = __( 'Course', 'sensei-lms' );
+			$box_title      = __( 'Add Student to Course', 'sensei-lms' );
 			$form_post_type = 'course';
 			$form_course_id = $this->course_id;
 		} elseif ( $this->course_id && $this->lesson_id ) {
 			$post_title     = get_the_title( $this->lesson_id );
-			$post_type      = __( 'Lesson', 'sensei-lms' );
+			$box_title      = __( 'Add Student to Lesson', 'sensei-lms' );
 			$form_post_type = 'lesson';
 			$form_course_id = $this->course_id;
 			$form_lesson_id = $this->lesson_id;
@@ -1172,10 +1172,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		?>
 		<div class="postbox">
 			<h2 id="add-student-to-course-header">
-				<?php
-				// translators: Placeholder is the post type.
-				printf( esc_html__( 'Add Student to %1$s', 'sensei-lms' ), esc_html( $post_type ) );
-				?>
+				<?php echo esc_html( $box_title ); ?>
 			</h2>
 			<div class="inside">
 				<form name="add_learner" action="" method="post">

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -1148,7 +1148,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			return;
 		}
 
-		$post_type      = '';
+		$box_title      = '';
 		$post_title     = '';
 		$form_post_type = '';
 		$form_course_id = 0;


### PR DESCRIPTION
Resolves #6184

## Proposed Changes

* As reported in the original issue, some languages need to translate "Add Student to" to a different thing if it's a lesson or a course because of gender. So this PR splits the string into 2 different strings.

### Considered alternative

Notice that this approach will invalidate existing translations, making new translations necessary.

I thought to have a temporary conditional like `if ( __( 'Add Student to Course', 'sensei-lms' ) === 'Add Student to Course' )` in order to use the old string until the new one is translated. But I decided to go with the simplest approach considering that it's just a box inside the WP Admin, so the impact shouldn't be big.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In order to make sure the text continues being displayed properly on the screens, use the following steps:

1. If you don't have yet, publish a course with lessons.
2. Navigate to WP admin > Sensei LMS > Students.
3. Use the filter "Filter By Course", and go to a course management.
4. Click on "Add Students".
5. Check that it has a box with the title "Add Student to Course".
6. Click on "Lessons" on the top navigation.
7. Click on "Manage students" for a lesson.
8. Make sure the box now has the title "Add Student to Lesson".

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
