### PR TITLE
Fix tinymce stylesheet not found in build

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -311,7 +311,7 @@ class Sensei_Utils {
 			$global_variables = str_replace( '"', "'", wp_get_global_stylesheet( [ 'variables' ] ) );
 
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, Squiz.Strings.DoubleQuoteUsage.NotRequired -- Using local file and need double quote for newline.
-			$question_editor_styles               = str_replace( "\n", "", file_get_contents( Sensei()->assets->src_path( 'css/question-answer-tinymce-editor.css' ) ) );
+			$question_editor_styles               = str_replace( "\n", "", file_get_contents( Sensei()->assets->dist_path( 'css/question-answer-tinymce-editor.css' ) ) );
 			$settings['tinymce']['content_style'] = $global_variables . ' ' . $question_editor_styles;
 		}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,7 @@ const files = [
 	'css/learning-mode-compat.scss',
 	'css/learning-mode.editor.scss',
 	'css/learning-mode.theme.scss',
+	'css/question-answer-tinymce-editor.css',
 	'css/sensei-theme-blocks.scss',
 	'css/sensei-course-theme/sidebar-mobile-menu.scss',
 	'css/showcase-upsell.scss',


### PR DESCRIPTION
## Proposed Changes
* We were using `file_get_contents` with the [assets URL](https://github.com/Automattic/sensei/blob/ff122969ccad640a1f6a0875ea4e9c509c91fdc4/includes/class-sensei-utils.php#L314) of CSS, but assets/css is removed in build, or any other CSS file there. So though locally there was no issue, in the built version, it does not find the CSS. We've fixed it here by targeting the dist path instead.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a build of sensei
2. Install the build in a site
3. Keep debug log on
4. Create a course with a lesson containing a quiz with multiline answer
5. Make sure you see no error message

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
