### PR TITLE
Changed styles for question feedback

### DIFF
--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -121,7 +121,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 	--color: #DCDCDE;
 	border: 2px solid var(--border-color);
 	border-radius: 1px;
-	font-family: var(--wp--preset--font-family--system);
+	font-family: var(--wp--preset--font-family--system, var(--wp--preset--font-family--body-font));
 	margin: 12px auto;
 	color: #1e1e1e;
 	font-size: 1.125rem;

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -122,6 +122,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 	$horizontal-padding: 24px;
 	border: 1px solid var(--color);
 	border-radius: 1px;
+	font-family: var(--wp--preset--font-family--system);
 	margin: 12px auto;
 
 	&--correct {

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -125,6 +125,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 	font-family: var(--wp--preset--font-family--system);
 	margin: 12px auto;
 	color: #1e1e1e;
+	font-size: 1.125rem;
 
 	&--correct {
 		--color: #d6edda;

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -124,6 +124,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 	border-radius: 1px;
 	font-family: var(--wp--preset--font-family--system);
 	margin: 12px auto;
+	color: #1e1e1e;
 
 	&--correct {
 		--color: #d6edda;

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -120,7 +120,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 .sensei-lms-question__answer-feedback {
 	--color: #DCDCDE;
 	$horizontal-padding: 24px;
-	border: 1px solid var(--color);
+	border: 2px solid var(--color);
 	border-radius: 1px;
 	font-family: var(--wp--preset--font-family--system);
 	margin: 12px auto;

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -143,7 +143,6 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 		display: flex;
 		padding: 14px;
 		background: var(--color);
-		font-size: 80%;
 		align-items: center;
 	}
 	&__title {

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -119,7 +119,6 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 
 .sensei-lms-question__answer-feedback {
 	--color: #DCDCDE;
-	$horizontal-padding: 24px;
 	border: 2px solid var(--border-color);
 	border-radius: 1px;
 	font-family: var(--wp--preset--font-family--system);

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -126,13 +126,13 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 	margin: 12px auto;
 
 	&--correct {
-		--color: #B8E6BF;
-		--icon: '\f058';
+		--color: #4ab866;
+		--icon: "\f15e";
 	}
 
 	&--incorrect {
-		--color: #F7DCC6;
-		--icon: '\f057';
+		--color: #e26f56;
+		--icon: "\f335";
 	}
 
 	&.empty {

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -150,7 +150,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 	}
 
 	&__content {
-		padding: 12px $horizontal-padding;
+		padding: 18px;
 	}
 
 	&__correct-answer {

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -177,10 +177,18 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 		}
 	}
 
-	&__icon:after {
-		content: var(--icon);
-		font-family: FontAwesomeSensei, FontAwesome, sans-serif;
-		margin-right: 6px;
+	&__icon {
+		display: flex;
+
+		&:after {
+			box-sizing: border-box;
+			color: #1e1e1e;
+			content: var(--icon);
+			font-family: dashicons, sans-serif;
+			font-size: 1.5rem;
+			line-height: 1;
+			margin-right: 8px;
+		}
 	}
 
 }

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -141,7 +141,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 
 	&__header {
 		display: flex;
-		padding: 6px $horizontal-padding;
+		padding: 14px;
 		background: var(--color);
 		font-size: 80%;
 		align-items: center;

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -149,10 +149,6 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 		flex: 1;
 	}
 
-	&__points {
-		font-weight: bold;
-	}
-
 	&__content {
 		padding: 12px $horizontal-padding;
 	}

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -120,18 +120,20 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 .sensei-lms-question__answer-feedback {
 	--color: #DCDCDE;
 	$horizontal-padding: 24px;
-	border: 2px solid var(--color);
+	border: 2px solid var(--border-color);
 	border-radius: 1px;
 	font-family: var(--wp--preset--font-family--system);
 	margin: 12px auto;
 
 	&--correct {
-		--color: #4ab866;
+		--color: #d6edda;
+		--border-color: #5c936b;
 		--icon: "\f15e";
 	}
 
 	&--incorrect {
-		--color: #e26f56;
+		--border-color: #cf8b25;
+		--color: #faebe0;
 		--icon: "\f335";
 	}
 
@@ -178,7 +180,7 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 
 		&:after {
 			box-sizing: border-box;
-			color: #1e1e1e;
+			color: var(--border-color);
 			content: var(--icon);
 			font-family: dashicons, sans-serif;
 			font-size: 1.5rem;

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -157,6 +157,10 @@ $question-input-border-color: var(--wp--preset--color--foreground, #155E65 );
 		padding: 18px;
 	}
 
+	&__answer-notes > *:first-child {
+		margin-top: 0;
+	}
+
 	&__correct-answer {
 		.highlight {
 			background: var(--color);

--- a/assets/css/3rd-party/themes/divi/learning-mode.scss
+++ b/assets/css/3rd-party/themes/divi/learning-mode.scss
@@ -13,6 +13,19 @@ $desktop_min_width: 783px;
 	padding-bottom: 0;
 }
 
+.wp-block-post-content {
+	.sensei-lms-question__answer-feedback__content {
+		padding-bottom: 18px;
+
+		p {
+			margin-bottom: 1.6em;
+		}
+	}
+
+	.sensei-lms-question__answer-feedback__header {
+		padding: 14px;
+	}
+}
 
 .sensei-course-theme__frame .sensei-course-theme-course-progress-bar-inner {
 	background-color: var(--sensei-primary-color);

--- a/assets/css/3rd-party/themes/divi/learning-mode.scss
+++ b/assets/css/3rd-party/themes/divi/learning-mode.scss
@@ -14,16 +14,18 @@ $desktop_min_width: 783px;
 }
 
 .wp-block-post-content {
-	.sensei-lms-question__answer-feedback__content {
-		padding-bottom: 18px;
+	.sensei-lms-question__answer-feedback {
+		&__content {
+			padding-bottom: 18px;
 
-		p {
-			margin-bottom: 1.6em;
+			p {
+				margin-bottom: 1.6em;
+			}
 		}
-	}
 
-	.sensei-lms-question__answer-feedback__header {
-		padding: 14px;
+		&__header {
+			padding: 14px;
+		}
 	}
 }
 

--- a/changelog/add-changed-styles-for-question-feedback
+++ b/changelog/add-changed-styles-for-question-feedback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed styles for graded question answer feedbacks

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1044,7 +1044,7 @@ class Sensei_Question {
 					<?php if ( $correct_answer ) { ?>
 						<div class="sensei-lms-question__answer-feedback__correct-answer">
 							<?php echo wp_kses_post( __( 'Right Answer:', 'sensei-lms' ) ); ?>
-							<strong><?php echo wp_kses_post( $correct_answer ); ?></strong>
+							<?php echo wp_kses_post( $correct_answer ); ?>
 						</div>
 					<?php } ?>
 					<?php if ( $has_answer_notes ) { ?>


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7115

## Proposed Changes
* Updated answer feedback styles for quizzes.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch of pro https://github.com/Automattic/sensei-pro/pull/2421
2. Checkout this branch of course theme https://github.com/Automattic/themes/pull/7373
3. Create a course with a lesson with a quiz that has all types of questions
4. Take the quiz as a student, answer some wrong and some right
5. Grade the quiz as a teacher, provide additional feedbacks for some and don't provide for some. Mark some as wrong and some as right.
6. Check the graded quiz from the frontend.
7. Check for all course theme variations and also a couple of top themes apart from course

![Screenshot 2023-09-15 at 9 58 32 PM](https://github.com/Automattic/sensei/assets/6820724/c29795ef-a34c-4d76-8c5f-0a7d678659a5)


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
