### PR TITLE
Split the quiz submission model

### DIFF
--- a/includes/internal/quiz-submission/answer/repositories/class-aggregate-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-aggregate-answer-repository.php
@@ -8,7 +8,7 @@
 namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -79,13 +79,13 @@ class Aggregate_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission  The submission.
-	 * @param int        $question_id The question ID.
-	 * @param string     $value       The answer value.
+	 * @param Submission_Interface $submission  The submission.
+	 * @param int                  $question_id The question ID.
+	 * @param string               $value       The answer value.
 	 *
 	 * @return Answer The answer model.
 	 */
-	public function create( Submission $submission, int $question_id, string $value ): Answer {
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer {
 		$answer = $this->comments_based_repository->create( $submission, $question_id, $value );
 
 		if ( $this->use_tables ) {
@@ -114,9 +114,9 @@ class Aggregate_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void {
+	public function delete_all( Submission_Interface $submission ): void {
 		$this->comments_based_repository->delete_all( $submission );
 
 		if ( $this->use_tables ) {
@@ -128,11 +128,11 @@ class Aggregate_Answer_Repository implements Answer_Repository_Interface {
 	/**
 	 * Get the tables based submission for a given submission or create if not exists.
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 *
-	 * @return Submission The tables based submission or null if it does not exist.
+	 * @return Submission_Interface The tables based submission or null if it does not exist.
 	 */
-	private function get_or_create_tables_based_submission( Submission $submission ): Submission {
+	private function get_or_create_tables_based_submission( Submission_Interface $submission ): Submission_Interface {
 		return $this->tables_based_submission_repository->get_or_create(
 			$submission->get_quiz_id(),
 			$submission->get_user_id(),

--- a/includes/internal/quiz-submission/answer/repositories/class-answer-repository-interface.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-answer-repository-interface.php
@@ -8,7 +8,7 @@
 namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,13 +27,13 @@ interface Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission  The submission.
-	 * @param int        $question_id The question ID.
-	 * @param string     $value       The answer value.
+	 * @param Submission_Interface $submission  The submission.
+	 * @param int                  $question_id The question ID.
+	 * @param string               $value       The answer value.
 	 *
 	 * @return Answer The answer model.
 	 */
-	public function create( Submission $submission, int $question_id, string $value ): Answer;
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer;
 
 	/**
 	 * Get all answers for a quiz submission.
@@ -51,7 +51,7 @@ interface Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void;
+	public function delete_all( Submission_Interface $submission ): void;
 }

--- a/includes/internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php
@@ -8,7 +8,7 @@
 namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,13 +27,13 @@ class Comments_Based_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission  The submission.
-	 * @param int        $question_id The question ID.
-	 * @param string     $value       The answer value.
+	 * @param Submission_Interface $submission  The submission.
+	 * @param int                  $question_id The question ID.
+	 * @param string               $value       The answer value.
 	 *
 	 * @return Answer The answer model.
 	 */
-	public function create( Submission $submission, int $question_id, string $value ): Answer {
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer {
 		$submission_id               = $submission->get_id();
 		$answers_map                 = $this->get_answers_map( $submission_id );
 		$answers_map[ $question_id ] = $value;
@@ -72,9 +72,9 @@ class Comments_Based_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void {
+	public function delete_all( Submission_Interface $submission ): void {
 		delete_comment_meta( $submission->get_id(), 'quiz_answers' );
 		delete_comment_meta( $submission->get_id(), 'questions_asked' );
 	}

--- a/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
@@ -10,7 +10,7 @@ namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 use DateTimeImmutable;
 use DateTimeZone;
 use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use wpdb;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -48,13 +48,13 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission  The submission.
-	 * @param int        $question_id The question ID.
-	 * @param string     $value       The answer value.
+	 * @param Submission_Interface $submission  The submission.
+	 * @param int                  $question_id The question ID.
+	 * @param string               $value       The answer value.
 	 *
 	 * @return Answer The answer model.
 	 */
-	public function create( Submission $submission, int $question_id, string $value ): Answer {
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer {
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
 
@@ -123,9 +123,9 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void {
+	public function delete_all( Submission_Interface $submission ): void {
 		$this->wpdb->delete(
 			$this->get_table_name(),
 			[

--- a/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
@@ -12,7 +12,7 @@ use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -104,15 +104,15 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission  $submission  The submission ID.
-	 * @param int         $answer_id   The answer ID.
-	 * @param int         $question_id The question ID.
-	 * @param int         $points      The points.
-	 * @param string|null $feedback    The feedback.
+	 * @param Submission_Interface $submission  The submission ID.
+	 * @param int                  $answer_id   The answer ID.
+	 * @param int                  $question_id The question ID.
+	 * @param int                  $points      The points.
+	 * @param string|null          $feedback    The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
 		$grade = $this->comments_based_repository->create( $submission, $answer_id, $question_id, $points, $feedback );
 
 		if ( $this->use_tables ) {
@@ -132,11 +132,11 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	/**
 	 * Get or create all answers for the table based submission.
 	 *
-	 * @param Submission $comments_based_submission The comments based submission.
-	 * @param Submission $tables_based_submission   The tables based submission.
+	 * @param Submission_Interface $comments_based_submission The comments based submission.
+	 * @param Submission_Interface $tables_based_submission   The tables based submission.
 	 * @return Answer[] The answers.
 	 */
-	public function get_or_create_tables_based_answers( $comments_based_submission, $tables_based_submission ): array {
+	public function get_or_create_tables_based_answers( Submission_Interface $comments_based_submission, Submission_Interface $tables_based_submission ): array {
 		$comments_based_answers = $this->comments_based_answer_repository->get_all( $comments_based_submission->get_id() );
 		$tables_based_answers   = $this->tables_based_answer_repository->get_all( $tables_based_submission->get_id() );
 		$result                 = array();
@@ -180,10 +180,10 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
-	 * @param Grade[]    $grades     An array of grades.
+	 * @param Submission_Interface $submission The submission.
+	 * @param Grade[]              $grades     An array of grades.
 	 */
-	public function save_many( Submission $submission, array $grades ): void {
+	public function save_many( Submission_Interface $submission, array $grades ): void {
 		$this->comments_based_repository->save_many( $submission, $grades );
 
 		if ( $this->use_tables ) {
@@ -222,14 +222,14 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	/**
 	 * Get or create all grades for the table based submission.
 	 *
-	 * @param Submission $comments_based_submission The comments based submission.
-	 * @param Submission $tables_based_submission   The tables based submission.
-	 * @param Grade[]    $comments_based_grades     The comments based grades.
+	 * @param Submission_Interface $comments_based_submission The comments based submission.
+	 * @param Submission_Interface $tables_based_submission   The tables based submission.
+	 * @param Grade[]              $comments_based_grades     The comments based grades.
 	 * @return Grade[] The tables based grades.
 	 */
 	private function get_or_create_tables_based_grades_for_save(
-		Submission $comments_based_submission,
-		Submission $tables_based_submission,
+		Submission_Interface $comments_based_submission,
+		Submission_Interface $tables_based_submission,
 		array $comments_based_grades
 	): array {
 		$tables_based_answers = $this->get_or_create_tables_based_answers(
@@ -272,9 +272,9 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void {
+	public function delete_all( Submission_Interface $submission ): void {
 		$this->comments_based_repository->delete_all( $submission );
 
 		if ( $this->use_tables ) {
@@ -286,11 +286,11 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	/**
 	 * Get the tables based submission for a given submission or create if not exists.
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 *
-	 * @return Submission The tables based submission.
+	 * @return Submission_Interface The tables based submission.
 	 */
-	private function get_or_create_tables_based_submission( Submission $submission ): Submission {
+	private function get_or_create_tables_based_submission( Submission_Interface $submission ): Submission_Interface {
 		return $this->tables_based_submission_repository->get_or_create(
 			$submission->get_quiz_id(),
 			$submission->get_user_id(),

--- a/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
@@ -8,7 +8,7 @@
 namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,15 +27,15 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission  $submission The submission ID.
-	 * @param int         $answer_id     The answer ID.
-	 * @param int         $question_id   The question ID.
-	 * @param int         $points        The points.
-	 * @param string|null $feedback      The feedback.
+	 * @param Submission_Interface $submission The submission ID.
+	 * @param int                  $answer_id     The answer ID.
+	 * @param int                  $question_id   The question ID.
+	 * @param int                  $points        The points.
+	 * @param string|null          $feedback      The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade {
 		$submission_id              = $submission->get_id();
 		$grades_map                 = get_comment_meta( $submission_id, 'quiz_grades', true );
 		$grades_map                 = is_array( $grades_map ) ? $grades_map : [];
@@ -88,10 +88,10 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
-	 * @param Grade[]    $grades     An array of grades.
+	 * @param Submission_Interface $submission The submission.
+	 * @param Grade[]              $grades     An array of grades.
 	 */
-	public function save_many( Submission $submission, array $grades ): void {
+	public function save_many( Submission_Interface $submission, array $grades ): void {
 		$grades_map   = [];
 		$feedback_map = [];
 
@@ -109,9 +109,9 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void {
+	public function delete_all( Submission_Interface $submission ): void {
 		delete_comment_meta( $submission->get_id(), 'quiz_grades' );
 		delete_comment_meta( $submission->get_id(), 'quiz_answers_feedback' );
 	}

--- a/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
@@ -8,7 +8,7 @@
 namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,15 +27,15 @@ interface Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission  $submission    The submission.
-	 * @param int         $answer_id     The answer ID.
-	 * @param int         $question_id   The question ID.
-	 * @param int         $points        The points.
-	 * @param string|null $feedback      The feedback.
+	 * @param Submission_Interface $submission    The submission.
+	 * @param int                  $answer_id     The answer ID.
+	 * @param int                  $question_id   The question ID.
+	 * @param int                  $points        The points.
+	 * @param string|null          $feedback      The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade;
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade;
 
 	/**
 	 * Get all grades for a quiz submission.
@@ -53,17 +53,17 @@ interface Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
-	 * @param Grade[]    $grades     An array of grades.
+	 * @param Submission_Interface $submission The submission.
+	 * @param Grade[]              $grades     An array of grades.
 	 */
-	public function save_many( Submission $submission, array $grades ): void;
+	public function save_many( Submission_Interface $submission, array $grades ): void;
 
 	/**
 	 * Delete all grades for a submission.
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void;
+	public function delete_all( Submission_Interface $submission ): void;
 }

--- a/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use wpdb;
 
 /**
@@ -46,15 +46,15 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission  $submission  The submission.
-	 * @param int         $answer_id   The answer ID.
-	 * @param int         $question_id The question ID.
-	 * @param int         $points      The points.
-	 * @param string|null $feedback    The feedback.
+	 * @param Submission_Interface $submission  The submission.
+	 * @param int                  $answer_id   The answer ID.
+	 * @param int                  $question_id The question ID.
+	 * @param int                  $points      The points.
+	 * @param string|null          $feedback    The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
 		$current_date = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 		$date_format  = 'Y-m-d H:i:s';
 
@@ -130,10 +130,10 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
-	 * @param Grade[]    $grades     An array of grades.
+	 * @param Submission_Interface $submission The submission.
+	 * @param Grade[]              $grades     An array of grades.
 	 */
-	public function save_many( Submission $submission, array $grades ): void {
+	public function save_many( Submission_Interface $submission, array $grades ): void {
 		foreach ( $grades as $grade ) {
 			$this->save( $grade );
 		}
@@ -144,9 +144,9 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The submission.
+	 * @param Submission_Interface $submission The submission.
 	 */
-	public function delete_all( Submission $submission ): void {
+	public function delete_all( Submission_Interface $submission ): void {
 		$answer_ids = $this->get_answer_ids_by_submission_id( $submission->get_id() );
 		if ( empty( $answer_ids ) ) {
 			return;

--- a/includes/internal/quiz-submission/submission/models/class-comments-based-submission.php
+++ b/includes/internal/quiz-submission/submission/models/class-comments-based-submission.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * File containing the Comments_Based_Submission class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Submission\Models;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Submission.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+class Comments_Based_Submission extends Submission_Abstract {
+
+}

--- a/includes/internal/quiz-submission/submission/models/class-submission-abstract.php
+++ b/includes/internal/quiz-submission/submission/models/class-submission-abstract.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Submission class.
+ * File containing the Submission_Abstract class.
  *
  * @package sensei
  */
@@ -14,13 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class Submission.
+ * Abstract class for the submission model.
  *
  * @internal
  *
- * @since 4.7.2
+ * @since $$next_version$$
  */
-class Submission {
+class Submission_Abstract implements Submission_Interface {
 	/**
 	 * The submission ID.
 	 *

--- a/includes/internal/quiz-submission/submission/models/class-submission-interface.php
+++ b/includes/internal/quiz-submission/submission/models/class-submission-interface.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * File containing the Submission_Interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Submission\Models;
+
+use DateTimeInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Interface for the submission.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+interface Submission_Interface {
+	/**
+	 * Get the submission ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_id(): int;
+
+	/**
+	 * Get the quiz ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_quiz_id(): int;
+
+	/**
+	 * Get the user ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_user_id(): int;
+
+	/**
+	 * Get the final grade.
+	 *
+	 * @internal
+	 *
+	 * @return float|null
+	 */
+	public function get_final_grade(): ?float;
+
+	/**
+	 * Set the final grade.
+	 *
+	 * @internal
+	 *
+	 * @param float|null $final_grade The final grade.
+	 */
+	public function set_final_grade( ?float $final_grade ): void;
+
+	/**
+	 * Get the created date.
+	 *
+	 * @internal
+	 *
+	 * @return DateTimeInterface
+	 */
+	public function get_created_at(): DateTimeInterface;
+
+	/**
+	 * Get the updated date.
+	 *
+	 * @internal
+	 *
+	 * @return DateTimeInterface
+	 */
+	public function get_updated_at(): DateTimeInterface;
+
+	/**
+	 * Set the updated at date.
+	 *
+	 * @internal
+	 *
+	 * @param DateTimeInterface $updated_at The updated date.
+	 */
+	public function set_updated_at( DateTimeInterface $updated_at ): void;
+}

--- a/includes/internal/quiz-submission/submission/models/class-tables-based-submission.php
+++ b/includes/internal/quiz-submission/submission/models/class-tables-based-submission.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * File containing the Tables_Based_Submission class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Submission\Models;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Tables_Based_Submission.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+class Tables_Based_Submission extends Submission_Abstract {
+
+}

--- a/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-aggregate-submission-repository.php
@@ -8,7 +8,8 @@
 namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
 
 use DateTimeImmutable;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -67,9 +68,9 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission The quiz submission.
+	 * @return Submission_Interface The quiz submission.
 	 */
-	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
 		$submission = $this->comments_based_repository->create( $quiz_id, $user_id, $final_grade );
 
 		if ( $this->use_tables ) {
@@ -88,9 +89,9 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission The quiz submission.
+	 * @return Submission_Interface The quiz submission.
 	 */
-	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
 		return $this->comments_based_repository->get_or_create( $quiz_id, $user_id, $final_grade );
 	}
 
@@ -102,9 +103,9 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 	 * @param int $quiz_id The quiz ID.
 	 * @param int $user_id The user ID.
 	 *
-	 * @return Submission|null The quiz submission.
+	 * @return Submission_Interface|null The quiz submission.
 	 */
-	public function get( int $quiz_id, int $user_id ): ?Submission {
+	public function get( int $quiz_id, int $user_id ): ?Submission_Interface {
 		return $this->comments_based_repository->get( $quiz_id, $user_id );
 	}
 
@@ -126,9 +127,9 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 */
-	public function save( Submission $submission ): void {
+	public function save( Submission_Interface $submission ): void {
 		$this->comments_based_repository->save( $submission );
 
 		if ( $this->use_tables ) {
@@ -142,7 +143,7 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 			$created_at = new DateTimeImmutable( '@' . $submission->get_created_at()->getTimestamp() );
 			$updated_at = new DateTimeImmutable( '@' . $submission->get_updated_at()->getTimestamp() );
 
-			$submission_to_save = new Submission(
+			$submission_to_save = new Tables_Based_Submission(
 				$tables_based_submission->get_id(),
 				$submission->get_quiz_id(),
 				$submission->get_user_id(),
@@ -160,9 +161,9 @@ class Aggregate_Submission_Repository implements Submission_Repository_Interface
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 */
-	public function delete( Submission $submission ): void {
+	public function delete( Submission_Interface $submission ): void {
 		$this->comments_based_repository->delete( $submission );
 
 		if ( $this->use_tables ) {

--- a/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php
@@ -10,7 +10,8 @@ namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
 use DateTimeImmutable;
 use DateTimeInterface;
 use RuntimeException;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use Sensei_Utils;
 use WP_Comment;
 
@@ -35,10 +36,10 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission       The quiz submission.
-	 * @throws RuntimeException In case the lesson status is missing.
+	 * @return Submission_Interface The quiz submission.
+	 * @throws RuntimeException     In case the lesson status is missing.
 	 */
-	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
 		$status_comment = $this->get_status_comment( $quiz_id, $user_id );
 
 		if ( ! $status_comment ) {
@@ -51,7 +52,7 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 
 		$created_at = $this->get_created_date( $status_comment );
 
-		return new Submission(
+		return new Comments_Based_Submission(
 			$status_comment->comment_ID,
 			$quiz_id,
 			$user_id,
@@ -70,9 +71,9 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission The quiz submission.
+	 * @return Submission_Interface The quiz submission.
 	 */
-	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
 		$submission = $this->get( $quiz_id, $user_id );
 
 		if ( $submission ) {
@@ -90,9 +91,9 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	 * @param int $quiz_id The quiz ID.
 	 * @param int $user_id The user ID.
 	 *
-	 * @return Submission|null The quiz submission.
+	 * @return Submission_Interface|null The quiz submission.
 	 */
-	public function get( int $quiz_id, int $user_id ): ?Submission {
+	public function get( int $quiz_id, int $user_id ): ?Submission_Interface {
 		$status_comment = $this->get_status_comment( $quiz_id, $user_id );
 
 		if (
@@ -105,7 +106,7 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 		$final_grade = get_comment_meta( $status_comment->comment_ID, 'grade', true );
 		$created_at  = $this->get_created_date( $status_comment );
 
-		return new Submission(
+		return new Comments_Based_Submission(
 			$status_comment->comment_ID,
 			$quiz_id,
 			$user_id,
@@ -141,11 +142,11 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 *
 	 * @throws RuntimeException In case the lesson status is missing.
 	 */
-	public function save( Submission $submission ): void {
+	public function save( Submission_Interface $submission ): void {
 		$status_comment = $this->get_status_comment( $submission->get_quiz_id(), $submission->get_user_id() );
 
 		if ( ! $status_comment ) {
@@ -164,9 +165,9 @@ class Comments_Based_Submission_Repository implements Submission_Repository_Inte
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 */
-	public function delete( Submission $submission ): void {
+	public function delete( Submission_Interface $submission ): void {
 		delete_comment_meta( $submission->get_id(), 'grade' );
 	}
 

--- a/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
@@ -7,7 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -30,9 +30,9 @@ interface Submission_Repository_Interface {
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission The quiz submission.
+	 * @return Submission_Interface The quiz submission.
 	 */
-	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission;
+	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface;
 
 	/**
 	 * Get or create a new quiz submission if it doesn't exist.
@@ -43,9 +43,9 @@ interface Submission_Repository_Interface {
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission The quiz submission.
+	 * @return Submission_Interface The quiz submission.
 	 */
-	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission;
+	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface;
 
 	/**
 	 * Gets a quiz submission.
@@ -55,9 +55,9 @@ interface Submission_Repository_Interface {
 	 * @param int $quiz_id The quiz ID.
 	 * @param int $user_id The user ID.
 	 *
-	 * @return Submission|null The quiz submission.
+	 * @return Submission_Interface|null The quiz submission.
 	 */
-	public function get( int $quiz_id, int $user_id ): ?Submission;
+	public function get( int $quiz_id, int $user_id ): ?Submission_Interface;
 
 	/**
 	 * Get the questions related to the quiz submission.
@@ -75,16 +75,16 @@ interface Submission_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 */
-	public function save( Submission $submission ): void;
+	public function save( Submission_Interface $submission ): void;
 
 	/**
 	 * Delete the quiz submission.
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 */
-	public function delete( Submission $submission ): void;
+	public function delete( Submission_Interface $submission ): void;
 }

--- a/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
@@ -9,7 +9,8 @@ namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
 use wpdb;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -51,9 +52,9 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission The quiz submission.
+	 * @return Submission_Interface The quiz submission.
 	 */
-	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
 
@@ -75,7 +76,7 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 			]
 		);
 
-		return new Submission(
+		return new Tables_Based_Submission(
 			$this->wpdb->insert_id,
 			$quiz_id,
 			$user_id,
@@ -94,9 +95,9 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
-	 * @return Submission The quiz submission.
+	 * @return Submission_Interface The quiz submission.
 	 */
-	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission {
+	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
 		$submission = $this->get( $quiz_id, $user_id );
 
 		if ( $submission ) {
@@ -114,9 +115,9 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 	 * @param int $quiz_id The quiz ID.
 	 * @param int $user_id The user ID.
 	 *
-	 * @return Submission|null The quiz submission.
+	 * @return Submission_Interface|null The quiz submission.
 	 */
-	public function get( int $quiz_id, int $user_id ): ?Submission {
+	public function get( int $quiz_id, int $user_id ): ?Submission_Interface {
 		$query = $this->wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			"SELECT * FROM {$this->get_table_name()} WHERE quiz_id = %d AND user_id = %d",
@@ -131,7 +132,7 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 			return null;
 		}
 
-		return new Submission(
+		return new Tables_Based_Submission(
 			(int) $row->id,
 			(int) $row->quiz_id,
 			(int) $row->user_id,
@@ -170,9 +171,9 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 */
-	public function save( Submission $submission ): void {
+	public function save( Submission_Interface $submission ): void {
 		$updated_at = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$submission->set_updated_at( $updated_at );
 
@@ -200,9 +201,9 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 	 *
 	 * @internal
 	 *
-	 * @param Submission $submission The quiz submission.
+	 * @param Submission_Interface $submission The quiz submission.
 	 */
-	public function delete( Submission $submission ): void {
+	public function delete( Submission_Interface $submission ): void {
 		$this->wpdb->delete(
 			$this->get_table_name(),
 			[

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-aggregate-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-aggregate-answer-repository.php
@@ -2,13 +2,11 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Aggregate_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
 /**
@@ -19,12 +17,12 @@ use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submiss
 class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
 	public function testCreate_UseTablesOn_CallsTablesBasedRepository(): void {
 		/* Arrange. */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Comments_Based_Submission::class );
 		$submission->method( 'get_quiz_id' )->willReturn( 1 );
 		$submission->method( 'get_user_id' )->willReturn( 2 );
 		$submission->method( 'get_final_grade' )->willReturn( 3.0 );
 
-		$tables_based_submission = $this->createMock( Submission::class );
+		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$comments_based          = $this->createMock( Comments_Based_Answer_Repository::class );
 		$tables_based            = $this->createMock( Tables_Based_Answer_Repository::class );
 
@@ -52,7 +50,7 @@ class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_UseTablesOn_CallsCommentsBasedRepository(): void {
 		/* Arrange. */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based                     = $this->createMock( Comments_Based_Answer_Repository::class );
 		$tables_based                       = $this->createMock( Tables_Based_Answer_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -74,7 +72,7 @@ class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_UseTablesOff_DoesntCallTablesBasedRepository(): void {
 		/* Arrange. */
-		$submission     = $this->createMock( Submission::class );
+		$submission     = $this->createMock( Comments_Based_Submission::class );
 		$comments_based = $this->createMock( Comments_Based_Answer_Repository::class );
 		$tables_based   = $this->createMock( Tables_Based_Answer_Repository::class );
 
@@ -96,7 +94,7 @@ class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_UseTablesOff_CallsCommentsBasedRepository(): void {
 		/* Arrange. */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based                     = $this->createMock( Comments_Based_Answer_Repository::class );
 		$tables_based                       = $this->createMock( Tables_Based_Answer_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -139,7 +137,7 @@ class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testDeleteAll_UseTablesOff_DoesntCallTablesBasedRepository(): void {
 		/* Arrange. */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based                     = $this->createMock( Comments_Based_Answer_Repository::class );
 		$tables_based                       = $this->createMock( Tables_Based_Answer_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -160,12 +158,12 @@ class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testDeleteAll_UseTablesOn_CallsTablesBasedRepository(): void {
 		/* Arrange. */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Comments_Based_Submission::class );
 		$submission->method( 'get_quiz_id' )->willReturn( 1 );
 		$submission->method( 'get_user_id' )->willReturn( 2 );
 		$submission->method( 'get_final_grade' )->willReturn( 3.0 );
 
-		$tables_based_submission = $this->createMock( Submission::class );
+		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$comments_based          = $this->createMock( Comments_Based_Answer_Repository::class );
 		$tables_based            = $this->createMock( Tables_Based_Answer_Repository::class );
 
@@ -200,7 +198,7 @@ class Aggregate_Answer_Repository_Test extends \WP_UnitTestCase {
 	 */
 	public function testDeleteAll_Always_CallsCommentsBasedRepository( bool $use_tables ): void {
 		/* Arrange. */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based                     = $this->createMock( Comments_Based_Answer_Repository::class );
 		$tables_based                       = $this->createMock( Tables_Based_Answer_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-comments-based-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-comments-based-answer-repository.php
@@ -4,7 +4,7 @@ namespace SenseiTest\Internal\Quiz_Submission\Answer\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
 use Sensei_Utils;
 
 /**
@@ -110,9 +110,9 @@ class Comments_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 		);
 	}
 
-	private function create_submission( $lesson_id, $user_id ): Submission {
+	private function create_submission( $lesson_id, $user_id ): Comments_Based_Submission {
 		$submission_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
-		return new Submission(
+		return new Comments_Based_Submission(
 			$submission_id,
 			$lesson_id,
 			$user_id,

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
@@ -5,7 +5,7 @@ namespace SenseiTest\Internal\Quiz_Submission\Answer\Repositories;
 use DateTimeImmutable;
 use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use wpdb;
 
 /**
@@ -28,7 +28,7 @@ class Tables_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_WhenCalled_InsertsToWpdb(): void {
 		/* Arrange. */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Submission_Interface::class );
 		$submission->method( 'get_id' )->willReturn( 1 );
 		$wpdb       = $this->createMock( wpdb::class );
 		$repository = new Tables_Based_Answer_Repository( $wpdb );
@@ -60,7 +60,7 @@ class Tables_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_WhenCalled_ReturnsAnswer(): void {
 		/* Arrange. */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Submission_Interface::class );
 		$submission->method( 'get_id' )->willReturn( 1 );
 		$wpdb            = $this->createMock( wpdb::class );
 		$wpdb->insert_id = 3;
@@ -191,7 +191,7 @@ class Tables_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 
 	public function testDeleteAll_WhenCalled_DeletesAllFromTheDatabase(): void {
 		/* Arrange. */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Submission_Interface::class );
 		$submission->method( 'get_id' )->willReturn( 1 );
 
 		$wpdb       = $this->createMock( wpdb::class );

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
@@ -11,7 +11,8 @@ use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Aggregate_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comments_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
 /**
@@ -22,7 +23,7 @@ use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submiss
 class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 	public function testCreate_Always_UsesCommentsBasedRepository(): void {
 		/* Arrange */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -48,7 +49,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_UseTablesSetToFalse_DoesntUseCommentsBasedRepository(): void {
 		/* Arrange */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -122,7 +123,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testDeleteAll_Always_UsesCommentsBasedRepository(): void {
 		/* Arrange */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -148,7 +149,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testDeleteAll_UseTablesSetToFalse_DoesntUseTablesBasedRepository(): void {
 		/* Arrange */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -173,12 +174,12 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testDeleteAll_UseTablesSetToTrue_UsesTablesBasedRepository(): void {
 		/* Arrange */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Comments_Based_Submission::class );
 		$submission->method( 'get_quiz_id' )->willReturn( 1 );
 		$submission->method( 'get_user_id' )->willReturn( 2 );
 		$submission->method( 'get_final_grade' )->willReturn( 3.0 );
 
-		$tables_based_submission = $this->createMock( Submission::class );
+		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 
 		$comments_based_repository = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository   = $this->createMock( Tables_Based_Grade_Repository::class );
@@ -211,7 +212,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testSaveMany_Always_UsesCommentsBasedRepository(): void {
 		/* Arrange */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -241,7 +242,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testSaveMany_UseTablesSetToFalse_DoesntUseTablesBasedRepository(): void {
 		/* Arrange */
-		$submission                         = $this->createMock( Submission::class );
+		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -267,7 +268,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testSaveMany_UseTablesSetToTrue_UsesTablesBasedRepository(): void {
 		/* Arrange */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Comments_Based_Submission::class );
 		$submission->method( 'get_quiz_id' )->willReturn( 5 );
 		$submission->method( 'get_user_id' )->willReturn( 6 );
 		$submission->method( 'get_final_grade' )->willReturn( 7.0 );
@@ -283,7 +284,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 		$grades = [ new Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
 
-		$tables_based_submission = $this->createMock( Submission::class );
+		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$tables_based_submission->method( 'get_id' )->willReturn( 8 );
 
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
@@ -324,7 +325,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testSaveMany_UseTablesSetToTrueAndTablesBasedGradesNotFound_CreatesTablesBasedGrades(): void {
 		/* Arrange */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Comments_Based_Submission::class );
 		$submission->method( 'get_id' )->willReturn( 4 );
 		$submission->method( 'get_quiz_id' )->willReturn( 5 );
 		$submission->method( 'get_user_id' )->willReturn( 6 );
@@ -341,7 +342,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 		$grades = [ new Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
 
-		$tables_based_submission = $this->createMock( Submission::class );
+		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$tables_based_submission->method( 'get_id' )->willReturn( 8 );
 
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
@@ -4,8 +4,7 @@ namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comments_Based_Grade_Repository;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
-use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
 use Sensei_Utils;
 
 /**
@@ -187,9 +186,9 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		];
 	}
 
-	private function create_submission( $lesson_id, $user_id ): Submission {
+	private function create_submission( $lesson_id, $user_id ): Comments_Based_Submission {
 		$submission_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
-		return new Submission(
+		return new Comments_Based_Submission(
 			$submission_id,
 			$lesson_id,
 			$user_id,

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
@@ -4,7 +4,7 @@ namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
 /**
@@ -27,9 +27,9 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_ParamsGiven_ReturnsGrade(): void {
 		/* Arrange */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Tables_Based_Submission::class );
 		$wpdb       = $this->createMock( \wpdb::class );
-		$repository = new \Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository( $wpdb );
+		$repository = new Tables_Based_Grade_Repository( $wpdb );
 
 		/* Act */
 		$grade = $repository->create( $submission, 2, 3, 4, 'feedback' );
@@ -47,9 +47,9 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_ParamsGiven_InserstsData(): void {
 		/* Arrange */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Tables_Based_Submission::class );
 		$wpdb       = $this->createMock( \wpdb::class );
-		$repository = new \Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository( $wpdb );
+		$repository = new Tables_Based_Grade_Repository( $wpdb );
 
 		/* Expect & Act */
 		$wpdb->expects( $this->once() )
@@ -75,7 +75,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		/* Arrange */
 		global $wpdb;
 		$repository = new Tables_Based_Grade_Repository( $wpdb );
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Tables_Based_Submission::class );
 
 		/* Act */
 		$grade = $repository->create( $submission, 2, 3, 4, 'feedback' );
@@ -97,13 +97,13 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 	public function testSaveMany_GradesGiven_UpdatesData(): void {
 		/* Arrange */
 		$wpdb       = $this->createMock( \wpdb::class );
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Tables_Based_Submission::class );
 		$submission->method( 'get_id' )->willReturn( 6 );
 		$grades     = [
 			new Grade( 1, 2, 3, 4, 'feedback', new \DateTimeImmutable(), new \DateTimeImmutable() ),
 			new Grade( 5, 6, 7, 8, 'feedback2', new \DateTimeImmutable(), new \DateTimeImmutable() ),
 		];
-		$repository = new \Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository( $wpdb );
+		$repository = new Tables_Based_Grade_Repository( $wpdb );
 
 		/* Expect & Act */
 		$wpdb
@@ -143,7 +143,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$grades     = [
 			new Grade( $created['grade_id'], $created['answer_id'], $question_id, 4, 'feedback2', new \DateTimeImmutable(), new \DateTimeImmutable() ),
 		];
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Tables_Based_Submission::class );
 		$submission->method( 'get_id' )->willReturn( $created['submission_id'] );
 
 		/* Act */
@@ -169,7 +169,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testDeleteAll_SubmissionIdGiven_ExecutesDeleteQuery(): void {
 		/* Arrange */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Tables_Based_Submission::class );
 		$submission
 			->method( 'get_id' )
 			->willReturn( 6 );
@@ -276,7 +276,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 			]
 		);
 
-		$repository = new \Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository( $wpdb );
+		$repository = new Tables_Based_Grade_Repository( $wpdb );
 
 		/* Act */
 		$grades = $repository->get_all( 6 );
@@ -416,7 +416,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		);
 	}
 
-	private function export_grade( \Sensei\Internal\Quiz_Submission\Grade\Models\Grade $grade ) {
+	private function export_grade( Grade $grade ) {
 		return [
 			'answer_id'   => $grade->get_answer_id(),
 			'question_id' => $grade->get_question_id(),

--- a/tests/unit-tests/internal/quiz-submission/submission/models/test-class-comments-based-submission.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/models/test-class-comments-based-submission.php
@@ -1,26 +1,22 @@
 <?php
-/**
- * File containing the Grade_Test class.
- */
 
 namespace SenseiTest\Internal\Quiz_Submission\Submission\Models;
 
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Class Submission_Test.
+ * Class Comments_Based_Submission_Test.
  *
- * @covers \Sensei\Internal\Quiz_Submission\Submission\Models\Submission
+ * @covers \Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission
  */
-class Submission_Test extends \WP_UnitTestCase {
-
+class Comments_Based_Submission_Test extends \WP_UnitTestCase {
 	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 
 		/* Act. */
 		$actual = $submission->get_id();
@@ -31,7 +27,7 @@ class Submission_Test extends \WP_UnitTestCase {
 
 	public function testGetQuizId_ConstructedWithQuizId_ReturnsSameQuizId(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 
 		/* Act. */
 		$actual = $submission->get_quiz_id();
@@ -42,7 +38,7 @@ class Submission_Test extends \WP_UnitTestCase {
 
 	public function testGetUserId_ConstructedWithUserId_ReturnsSameUserId(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 
 		/* Act. */
 		$actual = $submission->get_user_id();
@@ -53,7 +49,7 @@ class Submission_Test extends \WP_UnitTestCase {
 
 	public function testGetFinalGrade_ConstructedWithFinalGrade_ReturnsSameFinalGrade(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 
 		/* Act. */
 		$actual = $submission->get_final_grade();
@@ -64,7 +60,7 @@ class Submission_Test extends \WP_UnitTestCase {
 
 	public function testGetFinalGrade_WhenFinalGradeSet_ReturnsSameFinalGrade(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 		$submission->set_final_grade( 34.21 );
 
 		/* Act. */
@@ -76,7 +72,7 @@ class Submission_Test extends \WP_UnitTestCase {
 
 	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 
 		/* Act. */
 		$actual = $submission->get_created_at()->format( 'Y-m-d H:i:s' );
@@ -87,7 +83,7 @@ class Submission_Test extends \WP_UnitTestCase {
 
 	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 
 		/* Act. */
 		$actual = $submission->get_updated_at()->format( 'Y-m-d H:i:s' );
@@ -98,7 +94,7 @@ class Submission_Test extends \WP_UnitTestCase {
 
 	public function testSetUpdatedAt_WhenCalled_SetsUpdatedAt(): void {
 		/* Arrange. */
-		$submission = $this->createSubmission();
+		$submission = $this->create_submission();
 
 		/* Act. */
 		$submission->set_updated_at( new \DateTime( '2020-01-01 00:00:01' ) );
@@ -107,8 +103,8 @@ class Submission_Test extends \WP_UnitTestCase {
 		self::assertSame( '2020-01-01 00:00:01', $submission->get_updated_at()->format( 'Y-m-d H:i:s' ) );
 	}
 
-	private function createSubmission(): Submission {
-		return new Submission(
+	private function create_submission(): Comments_Based_Submission {
+		return new Comments_Based_Submission(
 			1,
 			2,
 			3,

--- a/tests/unit-tests/internal/quiz-submission/submission/models/test-class-tables-based-submission.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/models/test-class-tables-based-submission.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace SenseiTest\Internal\Quiz_Submission\Submission\Models;
+
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Tables_Based_Submission_Test.
+ *
+ * @covers \Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission
+ */
+class Tables_Based_Submission_Test extends \WP_UnitTestCase {
+	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+
+		/* Act. */
+		$actual = $submission->get_id();
+
+		/* Assert. */
+		self::assertSame( 1, $actual );
+	}
+
+	public function testGetQuizId_ConstructedWithQuizId_ReturnsSameQuizId(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+
+		/* Act. */
+		$actual = $submission->get_quiz_id();
+
+		/* Assert. */
+		self::assertSame( 2, $actual );
+	}
+
+	public function testGetUserId_ConstructedWithUserId_ReturnsSameUserId(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+
+		/* Act. */
+		$actual = $submission->get_user_id();
+
+		/* Assert. */
+		self::assertSame( 3, $actual );
+	}
+
+	public function testGetFinalGrade_ConstructedWithFinalGrade_ReturnsSameFinalGrade(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+
+		/* Act. */
+		$actual = $submission->get_final_grade();
+
+		/* Assert. */
+		self::assertSame( 12.34, $actual );
+	}
+
+	public function testGetFinalGrade_WhenFinalGradeSet_ReturnsSameFinalGrade(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+		$submission->set_final_grade( 34.21 );
+
+		/* Act. */
+		$actual = $submission->get_final_grade();
+
+		/* Assert. */
+		self::assertSame( 34.21, $actual );
+	}
+
+	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+
+		/* Act. */
+		$actual = $submission->get_created_at()->format( 'Y-m-d H:i:s' );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:01', $actual );
+	}
+
+	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+
+		/* Act. */
+		$actual = $submission->get_updated_at()->format( 'Y-m-d H:i:s' );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:02', $actual );
+	}
+
+	public function testSetUpdatedAt_WhenCalled_SetsUpdatedAt(): void {
+		/* Arrange. */
+		$submission = $this->create_submission();
+
+		/* Act. */
+		$submission->set_updated_at( new \DateTime( '2020-01-01 00:00:01' ) );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:01', $submission->get_updated_at()->format( 'Y-m-d H:i:s' ) );
+	}
+
+	private function create_submission(): Tables_Based_Submission {
+		return new Tables_Based_Submission(
+			1,
+			2,
+			3,
+			12.34,
+			new \DateTime( '2020-01-01 00:00:01' ),
+			new \DateTime( '2020-01-01 00:00:02' )
+		);
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-aggregate-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-aggregate-submission-repository.php
@@ -4,7 +4,8 @@ namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Aggregate_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
@@ -85,7 +86,7 @@ class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_or_create' )
 			->with( 1, 2, 12.34 )
-			->willReturn( $this->createMock( Submission::class ) );
+			->willReturn( $this->createMock( Comments_Based_Submission::class ) );
 		$repository->get_or_create( 1, 2, 12.34 );
 	}
 
@@ -180,7 +181,7 @@ class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
 			->method( 'save' )
 			->with(
 				$this->callback(
-					function ( Submission $submission_to_save ) use ( $submission, $found_submission ) {
+					function ( Tables_Based_Submission $submission_to_save ) use ( $submission, $found_submission ) {
 						self::assertNotSame( $submission, $submission_to_save, 'We should create a new submission based on a found one: not using passed for saving.' );
 						self::assertNotSame( $found_submission, $submission_to_save, 'We should create a new submission based on a found one: not the found one itself.' );
 						return true;
@@ -213,7 +214,7 @@ class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$comments_based = $this->createMock( Comments_Based_Submission_Repository::class );
 		$tables_based   = $this->createMock( Tables_Based_Submission_Repository::class );
-		$submission     = new Submission(
+		$submission     = new Comments_Based_Submission(
 			1,
 			2,
 			3,
@@ -235,7 +236,7 @@ class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
 			->method( 'save' )
 			->with(
 				$this->callback(
-					function ( Submission $submission_to_save ) {
+					function ( Tables_Based_Submission $submission_to_save ) {
 						$this->assertSame( '+00:00', $submission_to_save->get_created_at()->getTimezone()->getName() );
 						$this->assertSame( '+00:00', $submission_to_save->get_updated_at()->getTimezone()->getName() );
 
@@ -310,10 +311,10 @@ class Aggregate_Submission_Repository_Test extends \WP_UnitTestCase {
 	/**
 	 * Creates a submission object.
 	 *
-	 * @return Submission
+	 * @return Comments_Based_Submission
 	 */
-	public function create_submission(): Submission {
-		return new Submission(
+	public function create_submission(): Comments_Based_Submission {
+		return new Comments_Based_Submission(
 			1,
 			2,
 			3,

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
@@ -3,7 +3,7 @@
 namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
 
 use RuntimeException;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
 use Sensei_Utils;
 
@@ -70,7 +70,7 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$repository_mock
 			->expects( $this->once() )
 			->method( 'get' )
-			->willReturn( $this->createMock( Submission::class ) );
+			->willReturn( $this->createMock( Comments_Based_Submission::class ) );
 
 		$repository_mock
 			->expects( $this->never() )
@@ -186,7 +186,7 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 
 	public function testSave_WhenLessonStatusNotFound_ThrowsException(): void {
 		/* Arrange. */
-		$submission = $this->createMock( Submission::class );
+		$submission = $this->createMock( Comments_Based_Submission::class );
 		$repository = new Comments_Based_Submission_Repository();
 
 		/* Assert. */
@@ -264,7 +264,7 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$this->assertNull( $repository->get( $quiz_id, $user_id )->get_final_grade() );
 	}
 
-	private function export_submission( Submission $submission ): array {
+	private function export_submission( Comments_Based_Submission $submission ): array {
 		return [
 			'quiz_id'     => $submission->get_quiz_id(),
 			'user_id'     => $submission->get_user_id(),

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
@@ -4,7 +4,7 @@ namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 use wpdb;
 
@@ -108,7 +108,7 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$repository_mock
 			->expects( $this->once() )
 			->method( 'get' )
-			->willReturn( $this->createMock( Submission::class ) );
+			->willReturn( $this->createMock( Tables_Based_Submission::class ) );
 
 		$repository_mock
 			->expects( $this->never() )
@@ -116,7 +116,7 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 
 		$submission = $repository_mock->get_or_create( 1, 2 );
 
-		$this->assertInstanceOf( Submission::class, $submission );
+		$this->assertInstanceOf( Tables_Based_Submission::class, $submission );
 	}
 
 	public function testGetOrCreate_WhenSubmissionDoesNotExist_ReturnsNewSubmission(): void {
@@ -135,11 +135,11 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$repository_mock
 			->expects( $this->once() )
 			->method( 'create' )
-			->willReturn( $this->createMock( Submission::class ) );
+			->willReturn( $this->createMock( Tables_Based_Submission::class ) );
 
 		$submission = $repository_mock->get_or_create( 1, 2 );
 
-		$this->assertInstanceOf( Submission::class, $submission );
+		$this->assertInstanceOf( Tables_Based_Submission::class, $submission );
 	}
 
 	public function testGet_WhenNotFound_ReturnsNull(): void {
@@ -277,7 +277,7 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpdb       = $this->createMock( wpdb::class );
 		$timezone   = new DateTimeZone( 'UTC' );
-		$submission = new Submission(
+		$submission = new Tables_Based_Submission(
 			1,
 			2,
 			3,
@@ -317,7 +317,7 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 	public function testDelete_WhenCalled_DeletesFromTheDatabase(): void {
 		/* Arrange. */
 		$wpdb       = $this->createMock( wpdb::class );
-		$submission = new Submission(
+		$submission = new Tables_Based_Submission(
 			1,
 			2,
 			3,
@@ -346,7 +346,7 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		$repository->delete( $submission );
 	}
 
-	private function export_submission( Submission $submission ): array {
+	private function export_submission( Tables_Based_Submission $submission ): array {
 		return [
 			'id'          => $submission->get_id(),
 			'quiz_id'     => $submission->get_quiz_id(),
@@ -355,7 +355,7 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		];
 	}
 
-	private function export_submission_with_dates( Submission $submission ): array {
+	private function export_submission_with_dates( Tables_Based_Submission $submission ): array {
 		return array_merge(
 			$this->export_submission( $submission ),
 			[

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -2,9 +2,8 @@
 
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interface;
-use Sensei\Internal\Quiz_Submission\Submission\Models\Submission;
+use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface;
-use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
 
 require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-file-system-helper.php';
 
@@ -387,7 +386,7 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 	public function testSenseiDeleteQuizAnswers_WhenHasQuizSubmission_DeletesTheQuizData() {
 		/* Arrange. */
 		$submission_id = 123;
-		$submission    = $this->createMock( Submission::class );
+		$submission    = $this->createMock( Submission_Interface::class );
 		$submission->method( 'get_id' )->willReturn( $submission_id );
 
 		Sensei()->quiz_answer_repository     = $this->createMock( Answer_Repository_Interface::class );


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/7159
Related to https://github.com/Automattic/sensei/pull/7172  



## Proposed Changes
* Split the submission model into comments-based and tables-based models.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test that the quiz submission is working when tables-based progress is disabled.
2. Test that the quiz submission is working when tables-based progress is enabled.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues