### PR TITLE
Split the quiz answer model

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1080,7 +1080,7 @@ class Sensei_Quiz {
 
 		foreach ( $quiz_grades as $question_id => $points ) {
 			$answer = $answers_map[ $question_id ];
-			Sensei()->quiz_grade_repository->create( $submission, $answer->get_id(), $question_id, $points );
+			Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, $points );
 		}
 
 		$transient_key = 'quiz_grades_' . $user_id . '_' . $lesson_id;

--- a/includes/internal/quiz-submission/answer/models/class-answer-abstract.php
+++ b/includes/internal/quiz-submission/answer/models/class-answer-abstract.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Answer class.
+ * File containing the Answer_Abstract class.
  *
  * @package sensei
  */
@@ -14,13 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class Answer.
+ * Class Answer_Abstract.
  *
  * @internal
  *
- * @since 4.7.2
+ * @since $$next_version$$
  */
-class Answer {
+class Answer_Abstract implements Answer_Interface {
 	/**
 	 * The answer ID.
 	 *

--- a/includes/internal/quiz-submission/answer/models/class-answer-interface.php
+++ b/includes/internal/quiz-submission/answer/models/class-answer-interface.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * File containing the Answer_Interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Answer\Models;
+
+use DateTimeInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Interface for the answer models.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+interface Answer_Interface {
+	/**
+	 * Get the answer ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_id(): int;
+
+	/**
+	 * Get the submission ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_submission_id(): int;
+
+	/**
+	 * Get the question ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_question_id(): int;
+
+	/**
+	 * Get the answer value.
+	 *
+	 * @internal
+	 *
+	 * @return string
+	 */
+	public function get_value(): string;
+
+	/**
+	 * Get the created date.
+	 *
+	 * @internal
+	 *
+	 * @return DateTimeInterface
+	 */
+	public function get_created_at(): DateTimeInterface;
+
+	/**
+	 * Get the updated date.
+	 *
+	 * @internal
+	 *
+	 * @return DateTimeInterface
+	 */
+	public function get_updated_at(): DateTimeInterface;
+}

--- a/includes/internal/quiz-submission/answer/models/class-comments-based-answer.php
+++ b/includes/internal/quiz-submission/answer/models/class-comments-based-answer.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Quiz_Submission\Answer\Models;
 
+use DateTimeInterface;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -19,5 +21,35 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since $$next_version$$
  */
 class Comments_Based_Answer extends Answer_Abstract {
+	/**
+	 * Constructor.
+	 *
+	 * @internal
+	 *
+	 * @param int               $submission_id The submission ID.
+	 * @param int               $question_id   The question ID.
+	 * @param string            $value         The answer value.
+	 * @param DateTimeInterface $created_at    The created date.
+	 * @param DateTimeInterface $updated_at    The updated date.
+	 */
+	public function __construct(
+		int $submission_id,
+		int $question_id,
+		string $value,
+		DateTimeInterface $created_at,
+		DateTimeInterface $updated_at
+	) {
+		parent::__construct( 0, $submission_id, $question_id, $value, $created_at, $updated_at );
+	}
 
+	/**
+	 * Get the answer ID.
+	 *
+	 * @internal
+	 *
+	 * @throws \BadMethodCallException Comments_Based_Answer does not have an ID.
+	 */
+	public function get_id(): int {
+		throw new \BadMethodCallException( 'Comments_Based_Answer does not have an ID.' );
+	}
 }

--- a/includes/internal/quiz-submission/answer/models/class-comments-based-answer.php
+++ b/includes/internal/quiz-submission/answer/models/class-comments-based-answer.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * File containing the Comments_Based_Answer class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Answer\Models;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Answer.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+class Comments_Based_Answer extends Answer_Abstract {
+
+}

--- a/includes/internal/quiz-submission/answer/models/class-tables-based-answer.php
+++ b/includes/internal/quiz-submission/answer/models/class-tables-based-answer.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * File containing the Tables_Based_Answer class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Answer\Models;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Tables_Based_Answer.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+class Tables_Based_Answer extends Answer_Abstract {
+
+}

--- a/includes/internal/quiz-submission/answer/repositories/class-aggregate-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-aggregate-answer-repository.php
@@ -7,7 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
@@ -83,9 +83,9 @@ class Aggregate_Answer_Repository implements Answer_Repository_Interface {
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
-	 * @return Answer The answer model.
+	 * @return Answer_Interface The answer model.
 	 */
-	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer {
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface {
 		$answer = $this->comments_based_repository->create( $submission, $question_id, $value );
 
 		if ( $this->use_tables ) {
@@ -103,7 +103,7 @@ class Aggregate_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Answer[] An array of answers.
+	 * @return Answer_Interface[] An array of answers.
 	 */
 	public function get_all( int $submission_id ): array {
 		return $this->comments_based_repository->get_all( $submission_id );

--- a/includes/internal/quiz-submission/answer/repositories/class-answer-repository-interface.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-answer-repository-interface.php
@@ -7,7 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,9 +31,9 @@ interface Answer_Repository_Interface {
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
-	 * @return Answer The answer model.
+	 * @return Answer_Interface The answer model.
 	 */
-	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer;
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface;
 
 	/**
 	 * Get all answers for a quiz submission.
@@ -42,7 +42,7 @@ interface Answer_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Answer[] An array of answers.
+	 * @return Answer_Interface[] An array of answers.
 	 */
 	public function get_all( int $submission_id ): array;
 

--- a/includes/internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php
@@ -7,7 +7,8 @@
 
 namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Comments_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,9 +32,9 @@ class Comments_Based_Answer_Repository implements Answer_Repository_Interface {
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
-	 * @return Answer The answer model.
+	 * @return Answer_Interface The answer model.
 	 */
-	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer {
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface {
 		$submission_id               = $submission->get_id();
 		$answers_map                 = $this->get_answers_map( $submission_id );
 		$answers_map[ $question_id ] = $value;
@@ -44,7 +45,7 @@ class Comments_Based_Answer_Repository implements Answer_Repository_Interface {
 
 		$created_at = current_datetime();
 
-		return new Answer( 0, $submission_id, $question_id, $value, $created_at, $created_at );
+		return new Comments_Based_Answer( 0, $submission_id, $question_id, $value, $created_at, $created_at );
 	}
 
 	/**
@@ -54,14 +55,14 @@ class Comments_Based_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Answer[] An array of answers.
+	 * @return Answer_Interface[] An array of answers.
 	 */
 	public function get_all( int $submission_id ): array {
 		$answers    = [];
 		$created_at = current_datetime();
 
 		foreach ( $this->get_answers_map( $submission_id ) as $question_id => $value ) {
-			$answers[] = new Answer( 0, $submission_id, $question_id, $value, $created_at, $created_at );
+			$answers[] = new Comments_Based_Answer( 0, $submission_id, $question_id, $value, $created_at, $created_at );
 		}
 
 		return $answers;

--- a/includes/internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-comments-based-answer-repository.php
@@ -45,7 +45,7 @@ class Comments_Based_Answer_Repository implements Answer_Repository_Interface {
 
 		$created_at = current_datetime();
 
-		return new Comments_Based_Answer( 0, $submission_id, $question_id, $value, $created_at, $created_at );
+		return new Comments_Based_Answer( $submission_id, $question_id, $value, $created_at, $created_at );
 	}
 
 	/**
@@ -62,7 +62,7 @@ class Comments_Based_Answer_Repository implements Answer_Repository_Interface {
 		$created_at = current_datetime();
 
 		foreach ( $this->get_answers_map( $submission_id ) as $question_id => $value ) {
-			$answers[] = new Comments_Based_Answer( 0, $submission_id, $question_id, $value, $created_at, $created_at );
+			$answers[] = new Comments_Based_Answer( $submission_id, $question_id, $value, $created_at, $created_at );
 		}
 
 		return $answers;

--- a/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
@@ -9,7 +9,8 @@ namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use wpdb;
 
@@ -52,9 +53,9 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
-	 * @return Answer The answer model.
+	 * @return Answer_Interface The answer model.
 	 */
-	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer {
+	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface {
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
 
@@ -76,7 +77,7 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 			]
 		);
 
-		return new Answer(
+		return new Tables_Based_Answer(
 			$this->wpdb->insert_id,
 			$submission->get_id(),
 			$question_id,
@@ -93,7 +94,7 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Answer[] An array of answers.
+	 * @return Answer_Interface[] An array of answers.
 	 */
 	public function get_all( int $submission_id ): array {
 		$query = $this->wpdb->prepare(
@@ -105,7 +106,7 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 		$answers = [];
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared earlier.
 		foreach ( $this->wpdb->get_results( $query ) as $result ) {
-			$answers[] = new Answer(
+			$answers[] = new Tables_Based_Answer(
 				$result->id,
 				$result->submission_id,
 				$result->question_id,

--- a/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
@@ -106,24 +106,23 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 * @internal
 	 *
 	 * @param Submission_Interface $submission  The submission ID.
-	 * @param int                  $answer_id   The answer ID.
+	 * @param Answer_Interface     $answer      The answer.
 	 * @param int                  $question_id The question ID.
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
-		$grade = $this->comments_based_repository->create( $submission, $answer_id, $question_id, $points, $feedback );
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade {
+		$grade = $this->comments_based_repository->create( $submission, $answer, $question_id, $points, $feedback );
 
 		if ( $this->use_tables ) {
 			$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
+			$tables_based_answers    = $this->get_or_create_tables_based_answers( $submission, $tables_based_submission );
+			$tables_based_answer     = $tables_based_answers[ $question_id ] ?? null;
 
-			$answers = $this->get_or_create_tables_based_answers( $submission, $tables_based_submission );
-			$answer  = $answers[ $question_id ] ?? null;
-
-			if ( $answer ) {
-				$this->tables_based_repository->create( $tables_based_submission, $answer->get_id(), $question_id, $points, $feedback );
+			if ( $tables_based_answer ) {
+				$this->tables_based_repository->create( $tables_based_submission, $tables_based_answer, $question_id, $points, $feedback );
 			}
 		}
 
@@ -257,7 +256,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 
 				$result[ $comments_based_grade->get_question_id() ] = $this->tables_based_repository->create(
 					$tables_based_submission,
-					$answer->get_id(),
+					$answer,
 					$comments_based_grade->get_question_id(),
 					$comments_based_grade->get_points(),
 					$comments_based_grade->get_feedback()

--- a/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
@@ -8,7 +8,8 @@
 namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
 use DateTimeImmutable;
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
@@ -134,7 +135,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @param Submission_Interface $comments_based_submission The comments based submission.
 	 * @param Submission_Interface $tables_based_submission   The tables based submission.
-	 * @return Answer[] The answers.
+	 * @return Answer_Interface[] The answers.
 	 */
 	public function get_or_create_tables_based_answers( Submission_Interface $comments_based_submission, Submission_Interface $tables_based_submission ): array {
 		$comments_based_answers = $this->comments_based_answer_repository->get_all( $comments_based_submission->get_id() );
@@ -143,7 +144,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 		foreach ( $comments_based_answers as $comments_based_answer ) {
 			$filtered = array_filter(
 				$tables_based_answers,
-				function( Answer $answer ) use ( $comments_based_answer ) {
+				function( Answer_Interface $answer ) use ( $comments_based_answer ) {
 					return $answer->get_question_id() === $comments_based_answer->get_question_id();
 				}
 			);

--- a/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
@@ -7,6 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
@@ -27,15 +28,15 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission_Interface $submission The submission ID.
-	 * @param int                  $answer_id     The answer ID.
-	 * @param int                  $question_id   The question ID.
-	 * @param int                  $points        The points.
-	 * @param string|null          $feedback      The feedback.
+	 * @param Submission_Interface $submission  The submission ID.
+	 * @param Answer_Interface     $answer      The answer.
+	 * @param int                  $question_id The question ID.
+	 * @param int                  $points      The points.
+	 * @param string|null          $feedback    The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, string $feedback = null ): Grade {
 		$submission_id              = $submission->get_id();
 		$grades_map                 = get_comment_meta( $submission_id, 'quiz_grades', true );
 		$grades_map                 = is_array( $grades_map ) ? $grades_map : [];

--- a/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
@@ -7,6 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
@@ -27,15 +28,15 @@ interface Grade_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param Submission_Interface $submission    The submission.
-	 * @param int                  $answer_id     The answer ID.
-	 * @param int                  $question_id   The question ID.
-	 * @param int                  $points        The points.
-	 * @param string|null          $feedback      The feedback.
+	 * @param Submission_Interface $submission  The submission.
+	 * @param Answer_Interface     $answer      The answer.
+	 * @param int                  $question_id The question ID.
+	 * @param int                  $points      The points.
+	 * @param string|null          $feedback    The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade;
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, string $feedback = null ): Grade;
 
 	/**
 	 * Get all grades for a quiz submission.

--- a/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use wpdb;
@@ -47,21 +48,21 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 * @internal
 	 *
 	 * @param Submission_Interface $submission  The submission.
-	 * @param int                  $answer_id   The answer ID.
+	 * @param Answer_Interface     $answer      The answer.
 	 * @param int                  $question_id The question ID.
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
 	 * @return Grade The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade {
 		$current_date = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 		$date_format  = 'Y-m-d H:i:s';
 
 		$this->wpdb->insert(
 			$this->get_table_name(),
 			[
-				'answer_id'   => $answer_id,
+				'answer_id'   => $answer->get_id(),
 				'question_id' => $question_id,
 				'points'      => $points,
 				'feedback'    => $feedback,
@@ -80,7 +81,7 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 
 		return new Grade(
 			$this->wpdb->insert_id,
-			$answer_id,
+			$answer->get_id(),
 			$question_id,
 			$points,
 			$feedback,

--- a/tests/unit-tests/internal/quiz-submission/answer/models/test-class-comments-based-answer.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/models/test-class-comments-based-answer.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * File containing the Comments_Based_Answer_Test class.
+ */
+
+namespace SenseiTest\Internal\Quiz_Submission\Answer\Models;
+
+use Sensei\Internal\Quiz_Submission\Answer\Models\Comments_Based_Answer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Answer_Test.
+ *
+ * @covers \Sensei\Internal\Quiz_Submission\Answer\Models\Comments_Based_Answer
+ */
+class Comments_Based_Answer_Test extends \WP_UnitTestCase {
+
+	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
+		/* Arrange. */
+		$answer = $this->create_answer();
+
+		/* Act. */
+		$actual = $answer->get_id();
+
+		/* Assert. */
+		self::assertSame( 1, $actual );
+	}
+
+	public function testGetSubmissionId_ConstructedWithSubmissionId_ReturnsSameSubmissionId(): void {
+		/* Arrange. */
+		$answer = $this->create_answer();
+
+		/* Act. */
+		$actual = $answer->get_submission_id();
+
+		/* Assert. */
+		self::assertSame( 2, $actual );
+	}
+
+	public function testGetQuestionId_ConstructedWithQuestionId_ReturnsSameQuestionId(): void {
+		/* Arrange. */
+		$answer = $this->create_answer();
+
+		/* Act. */
+		$actual = $answer->get_question_id();
+
+		/* Assert. */
+		self::assertSame( 3, $actual );
+	}
+
+	public function testGetValue_ConstructedWithValue_ReturnsSameValue(): void {
+		/* Arrange. */
+		$answer = $this->create_answer();
+
+		/* Act. */
+		$actual = $answer->get_value();
+
+		/* Assert. */
+		self::assertSame( 'yes', $actual );
+	}
+
+	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
+		/* Arrange. */
+		$answer = $this->create_answer();
+
+		/* Act. */
+		$actual = $answer->get_created_at()->format( 'Y-m-d H:i:s' );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:01', $actual );
+	}
+
+	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
+		/* Arrange. */
+		$answer = $this->create_answer();
+
+		/* Act. */
+		$actual = $answer->get_updated_at()->format( 'Y-m-d H:i:s' );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:02', $actual );
+	}
+
+	private function create_answer(): Comments_Based_Answer {
+		return new Comments_Based_Answer(
+			1,
+			2,
+			3,
+			'yes',
+			new \DateTime( '2020-01-01 00:00:01' ),
+			new \DateTime( '2020-01-01 00:00:02' )
+		);
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/answer/models/test-class-comments-based-answer.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/models/test-class-comments-based-answer.php
@@ -18,15 +18,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Comments_Based_Answer_Test extends \WP_UnitTestCase {
 
-	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
+	public function testGetId_WhenCalled_ThrowsException(): void {
 		/* Arrange. */
 		$answer = $this->create_answer();
 
-		/* Act. */
-		$actual = $answer->get_id();
-
 		/* Assert. */
-		self::assertSame( 1, $actual );
+		self::expectException( \BadMethodCallException::class );
+
+		/* Act. */
+		$answer->get_id();
 	}
 
 	public function testGetSubmissionId_ConstructedWithSubmissionId_ReturnsSameSubmissionId(): void {
@@ -86,7 +86,6 @@ class Comments_Based_Answer_Test extends \WP_UnitTestCase {
 
 	private function create_answer(): Comments_Based_Answer {
 		return new Comments_Based_Answer(
-			1,
 			2,
 			3,
 			'yes',

--- a/tests/unit-tests/internal/quiz-submission/answer/models/test-class-tables-based-answer.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/models/test-class-tables-based-answer.php
@@ -1,26 +1,26 @@
 <?php
 /**
- * File containing the Answer_Test class.
+ * File containing the Tables_Based_Answer_Test class.
  */
 
 namespace SenseiTest\Internal\Quiz_Submission\Answer\Models;
 
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Class Answer_Test.
+ * Class Tables_Based_Answer_Test.
  *
- * @covers \Sensei\Internal\Quiz_Submission\Answer\Models\Answer
+ * @covers \Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer
  */
-class Answer_Test extends \WP_UnitTestCase {
+class Tables_Based_Answer_Test extends \WP_UnitTestCase {
 
 	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
 		/* Arrange. */
-		$answer = $this->createAnswer();
+		$answer = $this->create_answer();
 
 		/* Act. */
 		$actual = $answer->get_id();
@@ -31,7 +31,7 @@ class Answer_Test extends \WP_UnitTestCase {
 
 	public function testGetSubmissionId_ConstructedWithSubmissionId_ReturnsSameSubmissionId(): void {
 		/* Arrange. */
-		$answer = $this->createAnswer();
+		$answer = $this->create_answer();
 
 		/* Act. */
 		$actual = $answer->get_submission_id();
@@ -42,7 +42,7 @@ class Answer_Test extends \WP_UnitTestCase {
 
 	public function testGetQuestionId_ConstructedWithQuestionId_ReturnsSameQuestionId(): void {
 		/* Arrange. */
-		$answer = $this->createAnswer();
+		$answer = $this->create_answer();
 
 		/* Act. */
 		$actual = $answer->get_question_id();
@@ -53,7 +53,7 @@ class Answer_Test extends \WP_UnitTestCase {
 
 	public function testGetValue_ConstructedWithValue_ReturnsSameValue(): void {
 		/* Arrange. */
-		$answer = $this->createAnswer();
+		$answer = $this->create_answer();
 
 		/* Act. */
 		$actual = $answer->get_value();
@@ -64,7 +64,7 @@ class Answer_Test extends \WP_UnitTestCase {
 
 	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
 		/* Arrange. */
-		$answer = $this->createAnswer();
+		$answer = $this->create_answer();
 
 		/* Act. */
 		$actual = $answer->get_created_at()->format( 'Y-m-d H:i:s' );
@@ -75,7 +75,7 @@ class Answer_Test extends \WP_UnitTestCase {
 
 	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
 		/* Arrange. */
-		$answer = $this->createAnswer();
+		$answer = $this->create_answer();
 
 		/* Act. */
 		$actual = $answer->get_updated_at()->format( 'Y-m-d H:i:s' );
@@ -84,8 +84,8 @@ class Answer_Test extends \WP_UnitTestCase {
 		self::assertSame( '2020-01-01 00:00:02', $actual );
 	}
 
-	private function createAnswer(): Answer {
-		return new Answer(
+	private function create_answer(): Tables_Based_Answer {
+		return new Tables_Based_Answer(
 			1,
 			2,
 			3,

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-comments-based-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-comments-based-answer-repository.php
@@ -2,7 +2,7 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Answer\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Comments_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
 use Sensei_Utils;
@@ -141,7 +141,7 @@ class Comments_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 		);
 	}
 
-	private function export_answer( Answer $answer ): array {
+	private function export_answer( Comments_Based_Answer $answer ): array {
 		return [
 			'question_id' => $answer->get_question_id(),
 			'value'       => $answer->get_value(),

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
@@ -3,7 +3,7 @@
 namespace SenseiTest\Internal\Quiz_Submission\Answer\Repositories;
 
 use DateTimeImmutable;
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use wpdb;
@@ -214,7 +214,7 @@ class Tables_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 		$repository->delete_all( $submission );
 	}
 
-	private function export_answer( Answer $answer ): array {
+	private function export_answer( Tables_Based_Answer $answer ): array {
 		return [
 			'id'            => $answer->get_id(),
 			'submission_id' => $answer->get_submission_id(),
@@ -223,7 +223,7 @@ class Tables_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 		];
 	}
 
-	private function export_answer_with_dates( Answer $answer ): array {
+	private function export_answer_with_dates( Tables_Based_Answer $answer ): array {
 		return array_merge(
 			$this->export_answer( $answer ),
 			[

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
@@ -4,7 +4,8 @@ namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
 use DateTime;
 use DateTimeImmutable;
-use Sensei\Internal\Quiz_Submission\Answer\Models\Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Comments_Based_Answer;
+use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
@@ -351,14 +352,14 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 			->with( 5, 6, 7.0 )
 			->willReturn( $tables_based_submission );
 
-		$tables_based_answer            = new Answer( 2, 8, 3, '4', new DateTime( '@5' ), new DateTime( '@6' ) );
+		$tables_based_answer            = new Tables_Based_Answer( 2, 8, 3, '4', new DateTime( '@5' ), new DateTime( '@6' ) );
 		$tables_based_answer_repository = $this->createMock( Tables_Based_Answer_Repository::class );
 		$tables_based_answer_repository
 			->method( 'get_all' )
 			->with( 8 )
 			->willReturn( [ $tables_based_answer ] );
 
-		$comments_based_answer            = new Answer( 2, 8, 3, '4', new DateTime( '@5' ), new DateTime( '@6' ) );
+		$comments_based_answer            = new Comments_Based_Answer( 2, 8, 3, '4', new DateTime( '@5' ), new DateTime( '@6' ) );
 		$comments_based_answer_repository = $this->createMock( Comments_Based_Answer_Repository::class );
 		$comments_based_answer_repository
 			->method( 'get_all' )

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
@@ -24,6 +24,7 @@ use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submiss
 class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 	public function testCreate_Always_UsesCommentsBasedRepository(): void {
 		/* Arrange */
+		$answer                             = $this->createMock( Comments_Based_Answer::class );
 		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
@@ -44,12 +45,13 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$comments_based_repository
 			->expects( $this->once() )
 			->method( 'create' )
-			->with( $this->identicalTo( $submission ), 2, 3, 4, 'feedback' );
-		$repository->create( $submission, 2, 3, 4, 'feedback' );
+			->with( $this->identicalTo( $submission ), $this->identicalTo( $answer ), 3, 4, 'feedback' );
+		$repository->create( $submission, $answer, 3, 4, 'feedback' );
 	}
 
 	public function testCreate_UseTablesSetToFalse_DoesntUseCommentsBasedRepository(): void {
 		/* Arrange */
+		$answer                             = $this->createMock( Tables_Based_Answer::class );
 		$submission                         = $this->createMock( Comments_Based_Submission::class );
 		$comments_based_repository          = $this->createMock( Comments_Based_Grade_Repository::class );
 		$tables_based_repository            = $this->createMock( Tables_Based_Grade_Repository::class );
@@ -70,7 +72,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$tables_based_repository
 			->expects( $this->never() )
 			->method( 'create' );
-		$repository->create( $submission, 2, 3, 4, 'feedback' );
+		$repository->create( $submission, $answer, 3, 4, 'feedback' );
 	}
 
 	public function testGetAll_Always_UsesCommentsBasedRepository(): void {
@@ -359,7 +361,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 			->with( 8 )
 			->willReturn( [ $tables_based_answer ] );
 
-		$comments_based_answer            = new Comments_Based_Answer( 2, 8, 3, '4', new DateTime( '@5' ), new DateTime( '@6' ) );
+		$comments_based_answer            = new Comments_Based_Answer( 8, 3, '4', new DateTime( '@5' ), new DateTime( '@6' ) );
 		$comments_based_answer_repository = $this->createMock( Comments_Based_Answer_Repository::class );
 		$comments_based_answer_repository
 			->method( 'get_all' )
@@ -381,7 +383,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 			->method( 'create' )
 			->with(
 				$this->identicalTo( $tables_based_submission ),
-				2,
+				$this->identicalTo( $tables_based_answer ),
 				3,
 				4,
 				'feedback2'

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
@@ -2,6 +2,7 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comments_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
@@ -32,9 +33,10 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$user_id          = $this->factory->user->create();
 		$grade_repository = new Comments_Based_Grade_Repository();
 		$submission       = $this->create_submission( $lesson_id, $user_id );
+		$answer           = $this->createMock( Answer_Interface::class );
 
 		/* Act. */
-		$grade = $grade_repository->create( $submission, 0, 1, 22, 'Great!' );
+		$grade = $grade_repository->create( $submission, $answer, 1, 22, 'Great!' );
 
 		/* Assert. */
 		$expected = [
@@ -53,10 +55,11 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$user_id          = $this->factory->user->create();
 		$grade_repository = new Comments_Based_Grade_Repository();
 		$submission       = $this->create_submission( $lesson_id, $user_id );
+		$answer           = $this->createMock( Answer_Interface::class );
 
 		/* Act. */
-		$grade_repository->create( $submission, 0, 1, 22, 'Great!' );
-		$grade_repository->create( $submission, 0, 2, 33, 'Awesome!' );
+		$grade_repository->create( $submission, $answer, 1, 22, 'Great!' );
+		$grade_repository->create( $submission, $answer, 2, 33, 'Awesome!' );
 
 		/* Assert. */
 		$this->assertSame(
@@ -74,10 +77,11 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$user_id          = $this->factory->user->create();
 		$grade_repository = new Comments_Based_Grade_Repository();
 		$submission       = $this->create_submission( $lesson_id, $user_id );
+		$answer           = $this->createMock( Answer_Interface::class );
 
 		/* Act. */
-		$grade_repository->create( $submission, 0, 1, 22, 'Great!' );
-		$grade_repository->create( $submission, 0, 2, 33, 'Awesome!' );
+		$grade_repository->create( $submission, $answer, 1, 22, 'Great!' );
+		$grade_repository->create( $submission, $answer, 2, 33, 'Awesome!' );
 
 		/* Assert. */
 		$this->assertSame(
@@ -108,10 +112,11 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$lesson_id        = $this->factory->lesson->create();
 		$user_id          = $this->factory->user->create();
 		$submission       = $this->create_submission( $lesson_id, $user_id );
+		$answer           = $this->createMock( Answer_Interface::class );
 		$grade_repository = new Comments_Based_Grade_Repository();
 
-		$grade_1 = $grade_repository->create( $submission, 0, 1, 22, 'Great!' );
-		$grade_2 = $grade_repository->create( $submission, 0, 2, 33, 'Awesome!' );
+		$grade_1 = $grade_repository->create( $submission, $answer, 1, 22, 'Great!' );
+		$grade_2 = $grade_repository->create( $submission, $answer, 2, 33, 'Awesome!' );
 
 		/* Act. */
 		$grades = $grade_repository->get_all( $submission->get_id() );
@@ -134,10 +139,11 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$lesson_id        = $this->factory->lesson->create();
 		$user_id          = $this->factory->user->create();
 		$submission       = $this->create_submission( $lesson_id, $user_id );
+		$answer           = $this->createMock( Answer_Interface::class );
 		$grade_repository = new Comments_Based_Grade_Repository();
 
-		$grade_1 = $grade_repository->create( $submission, 0, 1, 22, 'Great!' );
-		$grade_2 = $grade_repository->create( $submission, 0, 2, 33, 'Awesome!' );
+		$grade_1 = $grade_repository->create( $submission, $answer, 1, 22, 'Great!' );
+		$grade_2 = $grade_repository->create( $submission, $answer, 2, 33, 'Awesome!' );
 
 		$grade_1->set_feedback( 'Amazing!' );
 		$grade_2->set_feedback( 'Wow!' );
@@ -164,8 +170,9 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$user_id          = $this->factory->user->create();
 		$grade_repository = new Comments_Based_Grade_Repository();
 		$submission       = $this->create_submission( $lesson_id, $user_id );
+		$answer           = $this->createMock( Answer_Interface::class );
 
-		$grade_repository->create( $submission, 0, 1, 22, 'Great!' );
+		$grade_repository->create( $submission, $answer, 1, 22, 'Great!' );
 
 		/* Act. */
 		$grade_repository->delete_all( $submission );

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
@@ -2,6 +2,7 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
+use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
@@ -28,11 +29,12 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 	public function testCreate_ParamsGiven_ReturnsGrade(): void {
 		/* Arrange */
 		$submission = $this->createMock( Tables_Based_Submission::class );
+		$answer     = new Tables_Based_Answer( 2, 3, 4, 'value', new \DateTimeImmutable(), new \DateTimeImmutable() );
 		$wpdb       = $this->createMock( \wpdb::class );
 		$repository = new Tables_Based_Grade_Repository( $wpdb );
 
 		/* Act */
-		$grade = $repository->create( $submission, 2, 3, 4, 'feedback' );
+		$grade = $repository->create( $submission, $answer, 3, 4, 'feedback' );
 
 		/* Assert */
 		$expected = [
@@ -45,9 +47,10 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 	}
 
 
-	public function testCreate_ParamsGiven_InserstsData(): void {
+	public function testCreate_ParamsGiven_InsertsData(): void {
 		/* Arrange */
 		$submission = $this->createMock( Tables_Based_Submission::class );
+		$answer     = new Tables_Based_Answer( 2, 3, 4, 'value', new \DateTimeImmutable(), new \DateTimeImmutable() );
 		$wpdb       = $this->createMock( \wpdb::class );
 		$repository = new Tables_Based_Grade_Repository( $wpdb );
 
@@ -68,7 +71,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 					}
 				)
 			);
-		$repository->create( $submission, 2, 3, 4, 'feedback' );
+		$repository->create( $submission, $answer, 3, 4, 'feedback' );
 	}
 
 	public function testIntegrationCreate_ParamsGiven_ReturnsGrade(): void {
@@ -76,9 +79,10 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$repository = new Tables_Based_Grade_Repository( $wpdb );
 		$submission = $this->createMock( Tables_Based_Submission::class );
+		$answer     = new Tables_Based_Answer( 2, 3, 4, 'value', new \DateTimeImmutable(), new \DateTimeImmutable() );
 
 		/* Act */
-		$grade = $repository->create( $submission, 2, 3, 4, 'feedback' );
+		$grade = $repository->create( $submission, $answer, 3, 4, 'feedback' );
 
 		/* Assert */
 		$expected = [
@@ -131,7 +135,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$repository->save_many( $submission, $grades );
 	}
 
-	public function testIntegrationSaveMany_GradesGiven_UptadesData(): void {
+	public function testIntegrationSaveMany_GradesGiven_UpdatesData(): void {
 		/* Arrange */
 		global $wpdb;
 


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/7159

## Proposed Changes
* Split the quiz answer model into comments-based and tables-based models.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test that the quiz answers are stored correctly when tables-based progress is disabled.
2. Test that the quiz answers are stored correctly when tables-based progress is enabled.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues