### PR TITLE
Split the quiz grade model

### DIFF
--- a/includes/internal/quiz-submission/grade/models/class-comments-based-grade.php
+++ b/includes/internal/quiz-submission/grade/models/class-comments-based-grade.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Quiz_Submission\Grade\Models;
 
+use DateTimeInterface;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -19,5 +21,46 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since $$next_version$$
  */
 class Comments_Based_Grade extends Grade_Abstract {
+	/**
+	 * Constructor.
+	 *
+	 * @internal
+	 *
+	 * @param int               $question_id The question ID.
+	 * @param int               $points      The grade points.
+	 * @param string|null       $feedback    The grade feedback.
+	 * @param DateTimeInterface $created_at  The created data.
+	 * @param DateTimeInterface $updated_at  The update date.
+	 */
+	public function __construct(
+		int $question_id,
+		int $points,
+		?string $feedback,
+		DateTimeInterface $created_at,
+		DateTimeInterface $updated_at
+	) {
+		parent::__construct( 0, 0, $question_id, $points, $feedback, $created_at, $updated_at );
+	}
 
+	/**
+	 * Get the grade ID.
+	 *
+	 * @internal
+	 *
+	 * @throws \BadMethodCallException Comments_Based_Grade does not have an ID.
+	 */
+	public function get_id(): int {
+		throw new \BadMethodCallException( 'Comments_Based_Grade does not have an ID.' );
+	}
+
+	/**
+	 * Get the answer ID.
+	 *
+	 * @internal
+	 *
+	 * @throws \BadMethodCallException Comments_Based_Grade does not have an answer ID.
+	 */
+	public function get_answer_id(): int {
+		throw new \BadMethodCallException( 'Comments_Based_Grade does not have an answer ID.' );
+	}
 }

--- a/includes/internal/quiz-submission/grade/models/class-comments-based-grade.php
+++ b/includes/internal/quiz-submission/grade/models/class-comments-based-grade.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * File containing the Comments_Based_Grade class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Grade\Models;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Grade.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+class Comments_Based_Grade extends Grade_Abstract {
+
+}

--- a/includes/internal/quiz-submission/grade/models/class-grade-abstract.php
+++ b/includes/internal/quiz-submission/grade/models/class-grade-abstract.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Grade class.
+ * File containing the Grade_Abstract class.
  *
  * @package sensei
  */
@@ -14,13 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class Grade.
+ * Class Grade_Abstract.
  *
  * @internal
  *
- * @since 4.7.2
+ * @since $$next_version$$
  */
-class Grade {
+class Grade_Abstract implements Grade_Interface {
 	/**
 	 * The grade ID.
 	 *

--- a/includes/internal/quiz-submission/grade/models/class-grade-interface.php
+++ b/includes/internal/quiz-submission/grade/models/class-grade-interface.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * File containing the Grade_Interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Grade\Models;
+
+use DateTimeInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Interface for the grade models.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+interface Grade_Interface {
+	/**
+	 * Get the grade ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_id(): int;
+
+	/**
+	 * Get the answer ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_answer_id(): int;
+
+	/**
+	 * Get the question ID.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_question_id(): int;
+
+	/**
+	 * Get the grade points.
+	 *
+	 * @internal
+	 *
+	 * @return int
+	 */
+	public function get_points(): int;
+
+	/**
+	 * Get the grade feedback.
+	 *
+	 * @internal
+	 *
+	 * @return string|null
+	 */
+	public function get_feedback(): ?string;
+
+	/**
+	 * Set the grade feedback.
+	 *
+	 * @internal
+	 *
+	 * @param string $feedback The feedback string.
+	 */
+	public function set_feedback( string $feedback ): void;
+
+	/**
+	 * Get the created date.
+	 *
+	 * @internal
+	 *
+	 * @return DateTimeInterface
+	 */
+	public function get_created_at(): DateTimeInterface;
+
+	/**
+	 * Get the updated date.
+	 *
+	 * @internal
+	 *
+	 * @return DateTimeInterface
+	 */
+	public function get_updated_at(): DateTimeInterface;
+}

--- a/includes/internal/quiz-submission/grade/models/class-tables-based-grade.php
+++ b/includes/internal/quiz-submission/grade/models/class-tables-based-grade.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * File containing the Tables_Based_Grade class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Quiz_Submission\Grade\Models;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Grade.
+ *
+ * @internal
+ *
+ * @since $$next_version$$
+ */
+class Tables_Based_Grade extends Grade_Abstract {
+
+}

--- a/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-aggregate-grade-repository.php
@@ -9,10 +9,10 @@ namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
 use DateTimeImmutable;
 use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
-use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Grade_Interface;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Tables_Based_Grade;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
@@ -111,9 +111,9 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
-	 * @return Grade The grade.
+	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade_Interface {
 		$grade = $this->comments_based_repository->create( $submission, $answer_id, $question_id, $points, $feedback );
 
 		if ( $this->use_tables ) {
@@ -170,7 +170,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Grade[] An array of grades.
+	 * @return Grade_Interface[] An array of grades.
 	 */
 	public function get_all( int $submission_id ): array {
 		return $this->comments_based_repository->get_all( $submission_id );
@@ -182,7 +182,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 * @internal
 	 *
 	 * @param Submission_Interface $submission The submission.
-	 * @param Grade[]              $grades     An array of grades.
+	 * @param Grade_Interface[]    $grades     An array of grades.
 	 */
 	public function save_many( Submission_Interface $submission, array $grades ): void {
 		$this->comments_based_repository->save_many( $submission, $grades );
@@ -205,7 +205,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 				$created_at = new DateTimeImmutable( '@' . $grade->get_created_at()->getTimestamp() );
 				$updated_at = new DateTimeImmutable( '@' . $grade->get_updated_at()->getTimestamp() );
 
-				$grades_to_save[] = new Grade(
+				$grades_to_save[] = new Tables_Based_Grade(
 					$tables_based_grade->get_id(),
 					$tables_based_grade->get_answer_id(),
 					$tables_based_grade->get_question_id(),
@@ -225,8 +225,8 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @param Submission_Interface $comments_based_submission The comments based submission.
 	 * @param Submission_Interface $tables_based_submission   The tables based submission.
-	 * @param Grade[]              $comments_based_grades     The comments based grades.
-	 * @return Grade[] The tables based grades.
+	 * @param Grade_Interface[]    $comments_based_grades     The comments based grades.
+	 * @return Grade_Interface[] The tables based grades.
 	 */
 	private function get_or_create_tables_based_grades_for_save(
 		Submission_Interface $comments_based_submission,
@@ -242,7 +242,7 @@ class Aggregate_Grade_Repository implements Grade_Repository_Interface {
 		foreach ( $comments_based_grades as $comments_based_grade ) {
 			$filtered = array_filter(
 				$tables_based_grades,
-				function( Grade $grade ) use ( $comments_based_grade ) {
+				function( Grade_Interface $grade ) use ( $comments_based_grade ) {
 					return $grade->get_question_id() === $comments_based_grade->get_question_id();
 				}
 			);

--- a/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
@@ -7,7 +7,8 @@
 
 namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Comments_Based_Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Grade_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,9 +34,9 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 * @param int                  $points        The points.
 	 * @param string|null          $feedback      The feedback.
 	 *
-	 * @return Grade The grade.
+	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade_Interface {
 		$submission_id              = $submission->get_id();
 		$grades_map                 = get_comment_meta( $submission_id, 'quiz_grades', true );
 		$grades_map                 = is_array( $grades_map ) ? $grades_map : [];
@@ -53,7 +54,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 
 		$created_at = current_datetime();
 
-		return new Grade( 0, 0, $question_id, $points, $feedback, $created_at, $created_at );
+		return new Comments_Based_Grade( 0, 0, $question_id, $points, $feedback, $created_at, $created_at );
 	}
 
 	/**
@@ -63,7 +64,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Grade[] An array of grades.
+	 * @return Grade_Interface[] An array of grades.
 	 */
 	public function get_all( int $submission_id ): array {
 		$grades_map = get_comment_meta( $submission_id, 'quiz_grades', true );
@@ -77,7 +78,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 
 		foreach ( $grades_map as $question_id => $points ) {
 			$feedback = $feedback_map[ $question_id ] ?? null;
-			$grades[] = new Grade( 0, 0, $question_id, $points, $feedback, $created_at, $created_at );
+			$grades[] = new Comments_Based_Grade( 0, 0, $question_id, $points, $feedback, $created_at, $created_at );
 		}
 
 		return $grades;
@@ -89,7 +90,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 * @internal
 	 *
 	 * @param Submission_Interface $submission The submission.
-	 * @param Grade[]              $grades     An array of grades.
+	 * @param Grade_Interface[]    $grades     An array of grades.
 	 */
 	public function save_many( Submission_Interface $submission, array $grades ): void {
 		$grades_map   = [];

--- a/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
@@ -55,7 +55,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 
 		$created_at = current_datetime();
 
-		return new Comments_Based_Grade( 0, 0, $question_id, $points, $feedback, $created_at, $created_at );
+		return new Comments_Based_Grade( $question_id, $points, $feedback, $created_at, $created_at );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 
 		foreach ( $grades_map as $question_id => $points ) {
 			$feedback = $feedback_map[ $question_id ] ?? null;
-			$grades[] = new Comments_Based_Grade( 0, 0, $question_id, $points, $feedback, $created_at, $created_at );
+			$grades[] = new Comments_Based_Grade( $question_id, $points, $feedback, $created_at, $created_at );
 		}
 
 		return $grades;

--- a/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
@@ -7,7 +7,7 @@
 
 namespace Sensei\Internal\Quiz_Submission\Grade\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Grade_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,9 +33,9 @@ interface Grade_Repository_Interface {
 	 * @param int                  $points        The points.
 	 * @param string|null          $feedback      The feedback.
 	 *
-	 * @return Grade The grade.
+	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade;
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, string $feedback = null ): Grade_Interface;
 
 	/**
 	 * Get all grades for a quiz submission.
@@ -44,7 +44,7 @@ interface Grade_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Grade[] An array of grades.
+	 * @return Grade_Interface[] An array of grades.
 	 */
 	public function get_all( int $submission_id ): array;
 
@@ -54,7 +54,7 @@ interface Grade_Repository_Interface {
 	 * @internal
 	 *
 	 * @param Submission_Interface $submission The submission.
-	 * @param Grade[]              $grades     An array of grades.
+	 * @param Grade_Interface[]    $grades     An array of grades.
 	 */
 	public function save_many( Submission_Interface $submission, array $grades ): void;
 

--- a/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
@@ -11,7 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Tables_Based_Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Grade_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Submission_Interface;
 use wpdb;
 
@@ -52,9 +53,9 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
-	 * @return Grade The grade.
+	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade {
+	public function create( Submission_Interface $submission, int $answer_id, int $question_id, int $points, ?string $feedback = null ): Grade_Interface {
 		$current_date = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 		$date_format  = 'Y-m-d H:i:s';
 
@@ -78,7 +79,7 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 			]
 		);
 
-		return new Grade(
+		return new Tables_Based_Grade(
 			$this->wpdb->insert_id,
 			$answer_id,
 			$question_id,
@@ -96,7 +97,7 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @param int $submission_id The submission ID.
 	 *
-	 * @return Grade[] An array of grades.
+	 * @return Grade_Interface[] An array of grades.
 	 */
 	public function get_all( int $submission_id ): array {
 		$answer_ids = $this->get_answer_ids_by_submission_id( $submission_id );
@@ -111,7 +112,7 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 
 		$grades = [];
 		foreach ( $grade_rows as $grade_row ) {
-			$grades[] = new Grade(
+			$grades[] = new Tables_Based_Grade(
 				$grade_row->id,
 				$grade_row->answer_id,
 				$grade_row->question_id,
@@ -131,7 +132,7 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 * @internal
 	 *
 	 * @param Submission_Interface $submission The submission.
-	 * @param Grade[]              $grades     An array of grades.
+	 * @param Grade_Interface[]    $grades     An array of grades.
 	 */
 	public function save_many( Submission_Interface $submission, array $grades ): void {
 		foreach ( $grades as $grade ) {
@@ -161,9 +162,9 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	/**
 	 * Save single grade.
 	 *
-	 * @param Grade $grade The grade.
+	 * @param Grade_Interface $grade The grade.
 	 */
-	private function save( Grade $grade ): void {
+	private function save( Grade_Interface $grade ): void {
 		$updated_at = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 
 		$this->wpdb->update(

--- a/tests/unit-tests/internal/quiz-submission/grade/models/test-class-comments-based-grade.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/models/test-class-comments-based-grade.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * File containing the Tables_Based_Grade_Test class.
+ */
+
+namespace SenseiTest\Internal\Quiz_Submission\Grade\Models;
+
+use Sensei\Internal\Quiz_Submission\Grade\Models\Comments_Based_Grade;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Grade_Test.
+ *
+ * @covers \Sensei\Internal\Quiz_Submission\Grade\Models\Comments_Based_Grade
+ */
+class Comments_Based_Grade_Test extends \WP_UnitTestCase {
+
+	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+
+		/* Act. */
+		$actual = $grade->get_id();
+
+		/* Assert. */
+		self::assertSame( 1, $actual );
+	}
+
+	public function testGetAnswerId_ConstructedWithAnswerId_ReturnsSameAnswerId(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+
+		/* Act. */
+		$actual = $grade->get_answer_id();
+
+		/* Assert. */
+		self::assertSame( 2, $actual );
+	}
+
+	public function testGetQuestionId_ConstructedWithQuestionId_ReturnsSameQuestionId(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+
+		/* Act. */
+		$actual = $grade->get_question_id();
+
+		/* Assert. */
+		self::assertSame( 3, $actual );
+	}
+
+	public function testGetPoints_ConstructedWithPoints_ReturnsSamePoints(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+
+		/* Act. */
+		$actual = $grade->get_points();
+
+		/* Assert. */
+		self::assertSame( 10, $actual );
+	}
+
+	public function testGetFeedback_ConstructedWithFeedback_ReturnsSameFeedback(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+
+		/* Act. */
+		$actual = $grade->get_feedback();
+
+		/* Assert. */
+		self::assertSame( 'Good job!', $actual );
+	}
+
+	public function testGetFeedback_WhenFeedbackSet_ReturnsSameFeedback(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+		$grade->set_feedback( 'Correct!' );
+
+		/* Act. */
+		$actual = $grade->get_feedback();
+
+		/* Assert. */
+		self::assertSame( 'Correct!', $actual );
+	}
+
+	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+
+		/* Act. */
+		$actual = $grade->get_created_at()->format( 'Y-m-d H:i:s' );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:01', $actual );
+	}
+
+	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
+		/* Arrange. */
+		$grade = $this->create_grade();
+
+		/* Act. */
+		$actual = $grade->get_updated_at()->format( 'Y-m-d H:i:s' );
+
+		/* Assert. */
+		self::assertSame( '2020-01-01 00:00:02', $actual );
+	}
+
+	private function create_grade(): Comments_Based_Grade {
+		return new Comments_Based_Grade(
+			1,
+			2,
+			3,
+			10,
+			'Good job!',
+			new \DateTime( '2020-01-01 00:00:01' ),
+			new \DateTime( '2020-01-01 00:00:02' )
+		);
+	}
+}

--- a/tests/unit-tests/internal/quiz-submission/grade/models/test-class-comments-based-grade.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/models/test-class-comments-based-grade.php
@@ -18,26 +18,26 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Comments_Based_Grade_Test extends \WP_UnitTestCase {
 
-	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
+	public function testGetId_WhenCalled_ThrowsException(): void {
 		/* Arrange. */
 		$grade = $this->create_grade();
 
-		/* Act. */
-		$actual = $grade->get_id();
-
 		/* Assert. */
-		self::assertSame( 1, $actual );
+		$this->expectException( \BadMethodCallException::class );
+
+		/* Act. */
+		$grade->get_id();
 	}
 
-	public function testGetAnswerId_ConstructedWithAnswerId_ReturnsSameAnswerId(): void {
+	public function testGetAnswerId_WhenCalled_ThrowsException(): void {
 		/* Arrange. */
 		$grade = $this->create_grade();
 
-		/* Act. */
-		$actual = $grade->get_answer_id();
-
 		/* Assert. */
-		self::assertSame( 2, $actual );
+		$this->expectException( \BadMethodCallException::class );
+
+		/* Act. */
+		$grade->get_answer_id();
 	}
 
 	public function testGetQuestionId_ConstructedWithQuestionId_ReturnsSameQuestionId(): void {
@@ -109,8 +109,6 @@ class Comments_Based_Grade_Test extends \WP_UnitTestCase {
 
 	private function create_grade(): Comments_Based_Grade {
 		return new Comments_Based_Grade(
-			1,
-			2,
 			3,
 			10,
 			'Good job!',

--- a/tests/unit-tests/internal/quiz-submission/grade/models/test-class-tables-based-grade.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/models/test-class-tables-based-grade.php
@@ -1,26 +1,26 @@
 <?php
 /**
- * File containing the Grade_Test class.
+ * File containing the Tables_Based_Grade_Test class.
  */
 
 namespace SenseiTest\Internal\Quiz_Submission\Grade\Models;
 
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Tables_Based_Grade;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Class Grade_Test.
+ * Class Tables_Based_Grade_Test.
  *
- * @covers \Sensei\Internal\Quiz_Submission\Grade\Models\Grade
+ * @covers \Sensei\Internal\Quiz_Submission\Grade\Models\Tables_Based_Grade
  */
-class Grade_Test extends \WP_UnitTestCase {
+class Tables_Based_Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 
 		/* Act. */
 		$actual = $grade->get_id();
@@ -31,7 +31,7 @@ class Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetAnswerId_ConstructedWithAnswerId_ReturnsSameAnswerId(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 
 		/* Act. */
 		$actual = $grade->get_answer_id();
@@ -42,7 +42,7 @@ class Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetQuestionId_ConstructedWithQuestionId_ReturnsSameQuestionId(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 
 		/* Act. */
 		$actual = $grade->get_question_id();
@@ -53,7 +53,7 @@ class Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetPoints_ConstructedWithPoints_ReturnsSamePoints(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 
 		/* Act. */
 		$actual = $grade->get_points();
@@ -64,7 +64,7 @@ class Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetFeedback_ConstructedWithFeedback_ReturnsSameFeedback(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 
 		/* Act. */
 		$actual = $grade->get_feedback();
@@ -75,7 +75,7 @@ class Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetFeedback_WhenFeedbackSet_ReturnsSameFeedback(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 		$grade->set_feedback( 'Correct!' );
 
 		/* Act. */
@@ -87,7 +87,7 @@ class Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 
 		/* Act. */
 		$actual = $grade->get_created_at()->format( 'Y-m-d H:i:s' );
@@ -98,7 +98,7 @@ class Grade_Test extends \WP_UnitTestCase {
 
 	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
 		/* Arrange. */
-		$grade = $this->createGrade();
+		$grade = $this->create_grade();
 
 		/* Act. */
 		$actual = $grade->get_updated_at()->format( 'Y-m-d H:i:s' );
@@ -107,8 +107,8 @@ class Grade_Test extends \WP_UnitTestCase {
 		self::assertSame( '2020-01-01 00:00:02', $actual );
 	}
 
-	private function createGrade(): Grade {
-		return new Grade(
+	private function create_grade(): Tables_Based_Grade {
+		return new Tables_Based_Grade(
 			1,
 			2,
 			3,

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
@@ -9,6 +9,7 @@ use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Models\Comments_Based_Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Tables_Based_Grade;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Aggregate_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comments_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository;
@@ -278,14 +279,14 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 		$comments_based_repository = $this->createMock( Comments_Based_Grade_Repository::class );
 
-		$existing_grade          = new Comments_Based_Grade( 1, 2, 3, 4, 'feedback', new DateTimeImmutable(), new DateTimeImmutable() );
+		$existing_grade          = new Tables_Based_Grade( 1, 2, 3, 4, 'feedback', new DateTimeImmutable(), new DateTimeImmutable() );
 		$tables_based_repository = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_repository
 			->method( 'get_all' )
 			->with( 8 )
 			->willReturn( [ $existing_grade ] );
 
-		$grades = [ new Comments_Based_Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
+		$grades = [ new Comments_Based_Grade( 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
 
 		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$tables_based_submission->method( 'get_id' )->willReturn( 8 );
@@ -335,15 +336,13 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$submission->method( 'get_final_grade' )->willReturn( 7.0 );
 
 		$comments_based_repository = $this->createMock( Comments_Based_Grade_Repository::class );
-
-		$existing_grade          = new Comments_Based_Grade( 1, 2, 3, 4, 'feedback', new DateTimeImmutable(), new DateTimeImmutable() );
-		$tables_based_repository = $this->createMock( Tables_Based_Grade_Repository::class );
+		$tables_based_repository   = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_repository
 			->method( 'get_all' )
 			->with( 8 )
 			->willReturn( [] );
 
-		$grades = [ new Comments_Based_Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
+		$grades = [ new Comments_Based_Grade( 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
 
 		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$tables_based_submission->method( 'get_id' )->willReturn( 8 );

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-aggregate-grade-repository.php
@@ -8,7 +8,7 @@ use Sensei\Internal\Quiz_Submission\Answer\Models\Comments_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Models\Tables_Based_Answer;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Comments_Based_Grade;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Aggregate_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comments_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository;
@@ -219,7 +219,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
 		$tables_based_answer_repository     = $this->createMock( Tables_Based_Answer_Repository::class );
 		$comments_based_answer_repository   = $this->createMock( Comments_Based_Answer_Repository::class );
-		$grades                             = [ $this->createMock( Grade::class ) ];
+		$grades                             = [ $this->createMock( Comments_Based_Grade::class ) ];
 
 		$repository = new Aggregate_Grade_Repository(
 			$comments_based_repository,
@@ -249,7 +249,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 		$tables_based_submission_repository = $this->createMock( Tables_Based_Submission_Repository::class );
 		$tables_based_answer_repository     = $this->createMock( Tables_Based_Answer_Repository::class );
 		$comments_based_answer_repository   = $this->createMock( Comments_Based_Answer_Repository::class );
-		$grades                             = [ $this->createMock( Grade::class ) ];
+		$grades                             = [ $this->createMock( Comments_Based_Grade::class ) ];
 
 		$repository = new Aggregate_Grade_Repository(
 			$comments_based_repository,
@@ -276,14 +276,14 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 		$comments_based_repository = $this->createMock( Comments_Based_Grade_Repository::class );
 
-		$existing_grade          = new Grade( 1, 2, 3, 4, 'feedback', new DateTimeImmutable(), new DateTimeImmutable() );
+		$existing_grade          = new Comments_Based_Grade( 1, 2, 3, 4, 'feedback', new DateTimeImmutable(), new DateTimeImmutable() );
 		$tables_based_repository = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_repository
 			->method( 'get_all' )
 			->with( 8 )
 			->willReturn( [ $existing_grade ] );
 
-		$grades = [ new Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
+		$grades = [ new Comments_Based_Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
 
 		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$tables_based_submission->method( 'get_id' )->willReturn( 8 );
@@ -314,7 +314,7 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 				$this->identicalTo( $tables_based_submission ),
 				$this->callback(
 					function ( array $grades ) {
-						$this->assertSame( 1, count( $grades ) );
+						$this->assertCount( 1, $grades );
 						$this->assertSame( 'feedback2', $grades[0]->get_feedback() );
 
 						return true;
@@ -334,14 +334,14 @@ class Aggregate_Grade_Repository_Test extends \WP_UnitTestCase {
 
 		$comments_based_repository = $this->createMock( Comments_Based_Grade_Repository::class );
 
-		$existing_grade          = new Grade( 1, 2, 3, 4, 'feedback', new DateTimeImmutable(), new DateTimeImmutable() );
+		$existing_grade          = new Comments_Based_Grade( 1, 2, 3, 4, 'feedback', new DateTimeImmutable(), new DateTimeImmutable() );
 		$tables_based_repository = $this->createMock( Tables_Based_Grade_Repository::class );
 		$tables_based_repository
 			->method( 'get_all' )
 			->with( 8 )
 			->willReturn( [] );
 
-		$grades = [ new Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
+		$grades = [ new Comments_Based_Grade( 1, 2, 3, 4, 'feedback2', new DateTimeImmutable(), new DateTimeImmutable() ) ];
 
 		$tables_based_submission = $this->createMock( Tables_Based_Submission::class );
 		$tables_based_submission->method( 'get_id' )->willReturn( 8 );

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
@@ -40,7 +40,6 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$expected = [
-			'answer_id'   => 0,
 			'question_id' => 1,
 			'points'      => 22,
 			'feedback'    => 'Great!',
@@ -186,7 +185,6 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	private function export_grade( Comments_Based_Grade $grade ): array {
 		return [
-			'answer_id'   => $grade->get_answer_id(),
 			'question_id' => $grade->get_question_id(),
 			'points'      => $grade->get_points(),
 			'feedback'    => $grade->get_feedback(),

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-comments-based-grade-repository.php
@@ -2,7 +2,7 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Comments_Based_Grade;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comments_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Comments_Based_Submission;
 use Sensei_Utils;
@@ -177,7 +177,7 @@ class Comments_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		);
 	}
 
-	private function export_grade( Grade $grade ): array {
+	private function export_grade( Comments_Based_Grade $grade ): array {
 		return [
 			'answer_id'   => $grade->get_answer_id(),
 			'question_id' => $grade->get_question_id(),

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
@@ -3,7 +3,7 @@
 namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Tables_Based_Grade_Repository;
-use Sensei\Internal\Quiz_Submission\Grade\Models\Grade;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Tables_Based_Grade;
 use Sensei\Internal\Quiz_Submission\Submission\Models\Tables_Based_Submission;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
 
@@ -100,8 +100,8 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		$submission = $this->createMock( Tables_Based_Submission::class );
 		$submission->method( 'get_id' )->willReturn( 6 );
 		$grades     = [
-			new Grade( 1, 2, 3, 4, 'feedback', new \DateTimeImmutable(), new \DateTimeImmutable() ),
-			new Grade( 5, 6, 7, 8, 'feedback2', new \DateTimeImmutable(), new \DateTimeImmutable() ),
+			new Tables_Based_Grade( 1, 2, 3, 4, 'feedback', new \DateTimeImmutable(), new \DateTimeImmutable() ),
+			new Tables_Based_Grade( 5, 6, 7, 8, 'feedback2', new \DateTimeImmutable(), new \DateTimeImmutable() ),
 		];
 		$repository = new Tables_Based_Grade_Repository( $wpdb );
 
@@ -141,7 +141,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 		$repository = new Tables_Based_Grade_Repository( $wpdb );
 		$grades     = [
-			new Grade( $created['grade_id'], $created['answer_id'], $question_id, 4, 'feedback2', new \DateTimeImmutable(), new \DateTimeImmutable() ),
+			new Tables_Based_Grade( $created['grade_id'], $created['answer_id'], $question_id, 4, 'feedback2', new \DateTimeImmutable(), new \DateTimeImmutable() ),
 		];
 		$submission = $this->createMock( Tables_Based_Submission::class );
 		$submission->method( 'get_id' )->willReturn( $created['submission_id'] );
@@ -416,7 +416,7 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 		);
 	}
 
-	private function export_grade( Grade $grade ) {
+	private function export_grade( Tables_Based_Grade $grade ) {
 		return [
 			'answer_id'   => $grade->get_answer_id(),
 			'question_id' => $grade->get_question_id(),


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7159

## Proposed Changes
* Split the quiz grade model into comments-based and tables-based models.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test that the quiz grades are stored correctly when tables-based progress is disabled.
2. Test that the quiz grades are stored correctly when tables-based progress is enabled.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues