### PR TITLE
Fix student progress reset not working in some cases

### DIFF
--- a/changelog/fix-reset-progress
+++ b/changelog/fix-reset-progress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix student progress reset not working in some cases

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -719,7 +719,7 @@ class Sensei_Frontend {
 	 * @param int    $course_id The course ID.
 	 */
 	public function redirect_to_course_completed_page( $status, $user_id, $course_id ) {
-		if ( 'complete' !== $status || ! $course_id ) {
+		if ( 'complete' !== $status || ! $course_id || Sensei_Utils::is_rest_request() ) {
 			return;
 		}
 


### PR DESCRIPTION
Resolves #7175 

## Proposed Changes 

Fix the progress reset by preventing a redirect from happening during the REST API call.

## Testing Instructions
1. Create a course with a lesson and a quiz.
2. Submit the quiz and complete the course.
3. Go to the admin panel -> Sensei LMS -> Students 
4. Reset the course progress.
5. These should be no error and the progress should be reset.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
