### PR TITLE
Use student progress models on the frontend

### DIFF
--- a/assets/course-theme/blocks/quiz-blocks/index.js
+++ b/assets/course-theme/blocks/quiz-blocks/index.js
@@ -13,6 +13,11 @@ import quizActionsMeta from './quiz-actions.block.json';
 import quizBackToLessonMeta from './quiz-back-to-lesson.block.json';
 import quizProgressMeta from './quiz-progress.block.json';
 
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
 const meta = {
 	attributes: {},
 	icon: {
@@ -64,9 +69,16 @@ export default [
 			'Return to the lesson the quiz belongs to.',
 			'sensei-lms'
 		),
-		edit() {
+		edit: function EditQuizBackToLesson() {
+			const blockProps = useBlockProps( {
+				className: classNames(
+					'sensei-lms-href',
+					'sensei-lms-quiz-back-to-lesson'
+				),
+			} );
+
 			return (
-				<span className="sensei-lms-href sensei-lms-quiz-back-to-lesson">
+				<span { ...blockProps }>
 					<ChevronLeft />
 					{ __( 'Back to lesson', 'sensei-lms' ) }
 				</span>

--- a/assets/course-theme/blocks/quiz-blocks/quiz-back-to-lesson.block.json
+++ b/assets/course-theme/blocks/quiz-blocks/quiz-back-to-lesson.block.json
@@ -1,5 +1,6 @@
 {
   "name": "sensei-lms/quiz-back-to-lesson",
+  "apiVersion": 2,
   "category": "theme",
   "supports": {
     "align": true,

--- a/changelog/add-update-design-on-navigation-in-quiz-template-editor
+++ b/changelog/add-update-design-on-navigation-in-quiz-template-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed back to lesson block to apply block styles in quiz navigation area

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -897,11 +897,6 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="includes/blocks/course-theme/class-course-navigation.php">
-    <MissingClosureParamType occurrences="3">
-      <code>$lesson</code>
-      <code>$lesson</code>
-      <code>$lesson</code>
-    </MissingClosureParamType>
     <PossiblyFalseArgument occurrences="3">
       <code>get_permalink( $lesson_id )</code>
       <code>get_permalink( $lesson_id )</code>
@@ -915,9 +910,6 @@
       <code>$is_enrolled</code>
       <code>$user_id</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>isset( $user_lesson_status-&gt;comment_approved )</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/blocks/course-theme/class-exit-course.php">
     <PossiblyFalseArgument occurrences="1">
@@ -1578,13 +1570,12 @@
       <code>get_the_ID()</code>
       <code>get_the_ID()</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="7">
+    <PossiblyInvalidArgument occurrences="5">
       <code>$category_output</code>
       <code>$category_output</code>
       <code>$category_output</code>
       <code>$course</code>
       <code>$output</code>
-      <code>$progress_percentage</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidPropertyFetch occurrences="25">
       <code>$course-&gt;ID</code>
@@ -2113,7 +2104,7 @@
       <code>$question_cats</code>
       <code>$questions_array</code>
     </PossibleRawObjectIteration>
-    <PossiblyFalseArgument occurrences="16">
+    <PossiblyFalseArgument occurrences="15">
       <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
@@ -2644,10 +2635,6 @@
     <InvalidReturnType occurrences="1">
       <code>int</code>
     </InvalidReturnType>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(array) $user-&gt;roles</code>
-      <code>(int) $course_id</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/class-sensei-question.php">
     <DeprecatedMethod occurrences="1">
@@ -3285,18 +3272,14 @@
       <code>require_once ABSPATH . 'wp-admin/includes/image.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/plugin-install.php'</code>
     </MissingFile>
-    <MissingParamType occurrences="20">
+    <MissingParamType occurrences="18">
       <code>$attributes</code>
       <code>$course_id</code>
       <code>$data_key</code>
-      <code>$denominator</code>
-      <code>$denominator</code>
       <code>$file</code>
       <code>$from_course</code>
       <code>$key</code>
       <code>$mode</code>
-      <code>$numerator</code>
-      <code>$numerator</code>
       <code>$options</code>
       <code>$plugin_class_to_look_for</code>
       <code>$plugin_registered_path</code>
@@ -3349,9 +3332,6 @@
       <code>DAY_IN_SECONDS</code>
       <code>WP_PLUGIN_DIR</code>
     </UndefinedConstant>
-    <UndefinedDocblockClass occurrences="1">
-      <code>int|number</code>
-    </UndefinedDocblockClass>
     <UndefinedFunction occurrences="1">
       <code>WC()</code>
     </UndefinedFunction>
@@ -3659,11 +3639,7 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$post-&gt;post_author</code>
     </InvalidPropertyAssignmentValue>
-    <PossiblyInvalidPropertyFetch occurrences="1">
-      <code>$post-&gt;post_type</code>
-    </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="2">
-      <code>$lesson_id</code>
+    <PossiblyNullArgument occurrences="1">
       <code>$query['post_type'] ?? null</code>
     </PossiblyNullArgument>
     <RedundantConditionGivenDocblockType occurrences="5">
@@ -4606,13 +4582,6 @@
       <code>function() {</code>
     </MissingClosureReturnType>
   </file>
-  <file src="includes/enrolment/class-sensei-enrolment-learner-calculation-job.php">
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(int) $this-&gt;batch_size</code>
-      <code>(int) $user_id</code>
-      <code>(int) $user_query-&gt;get_total()</code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="includes/enrolment/class-sensei-enrolment-provider-journal-store.php">
     <DocblockTypeContradiction occurrences="1">
       <code>is_wp_error( $result )</code>
@@ -4644,9 +4613,6 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$provider_states</code>
     </InvalidPropertyAssignmentValue>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(bool) $has_changed</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/hooks/template.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -4963,11 +4929,6 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php">
-    <InvalidPropertyFetch occurrences="3">
-      <code>$comment-&gt;comment_ID</code>
-      <code>$comment-&gt;comment_approved</code>
-      <code>$comment-&gt;comment_date</code>
-    </InvalidPropertyFetch>
     <PossiblyNullArgument occurrences="1">
       <code>$course_progress-&gt;get_status()</code>
     </PossiblyNullArgument>
@@ -4983,16 +4944,8 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php">
-    <InvalidPropertyFetch occurrences="3">
-      <code>$comment-&gt;comment_ID</code>
-      <code>$comment-&gt;comment_approved</code>
-      <code>$comment-&gt;comment_date</code>
-    </InvalidPropertyFetch>
     <PossiblyNullReference occurrences="1">
       <code>format</code>
     </PossiblyNullReference>
@@ -5008,9 +4961,6 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php">
     <PossiblyInvalidIterator occurrences="2">
@@ -5029,9 +4979,6 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/student-progress/services/class-course-deleted-handler.php">
     <UndefinedDocblockClass occurrences="1">
@@ -5983,9 +5930,8 @@
       <code>$question_type</code>
       <code>$template_name</code>
     </MissingParamType>
-    <PossiblyFalseArgument occurrences="2">
+    <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $course_id )</code>
-      <code>get_the_ID()</code>
     </PossiblyFalseArgument>
     <PossiblyInvalidArgument occurrences="2">
       <code>$item</code>

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
-  <file src="includes/3rd-party/themes/astra.php">
-    <MissingReturnType occurrences="1">
-      <code>sensei_load_learning_mode_styles_for_astra_theme</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/3rd-party/themes/course.php">
-    <MissingReturnType occurrences="3">
-      <code>sensei_admin_load_learning_mode_style_for_course_theme</code>
-      <code>sensei_disable_learning_mode_style_for_course_theme</code>
-      <code>sensei_load_learning_mode_style_for_course_theme</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="3">
       <code>$screen-&gt;base</code>
       <code>$screen-&gt;id</code>
@@ -18,13 +8,6 @@
     </PossiblyNullPropertyFetch>
   </file>
   <file src="includes/3rd-party/themes/divi.php">
-    <MissingReturnType occurrences="5">
-      <code>sensei_admin_load_learning_mode_style_for_divi_theme</code>
-      <code>sensei_fix_divi_learning_mode_video_template_excerpt</code>
-      <code>sensei_fix_divi_theme_builder_and_learning_mode_conflict</code>
-      <code>sensei_fix_divi_yoast_conflict</code>
-      <code>sensei_load_learning_mode_style_for_divi_theme</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="2">
       <code>$course_id</code>
       <code>$course_id</code>
@@ -39,11 +22,6 @@
       <code>'sensei_load_learning_mode_style_for_course_theme'</code>
     </UndefinedFunction>
   </file>
-  <file src="includes/3rd-party/woocommerce.php">
-    <MissingReturnType occurrences="1">
-      <code>sensei_woocommerce_show_admin_bar</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/admin/class-sensei-admin-notices.php">
     <DocblockTypeContradiction occurrences="2">
       <code>! self::$instance</code>
@@ -52,13 +30,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="5">
-      <code>add_admin_notice</code>
-      <code>add_admin_notices</code>
-      <code>handle_notice_dismiss</code>
-      <code>init</code>
-      <code>save_dismissed_notices</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>$plugin_version</code>
       <code>$plugin_version</code>
@@ -78,20 +49,11 @@
       <code>$meta_key</code>
       <code>$post_id</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="3">
-      <code>enqueue_admin_scripts</code>
-      <code>init</code>
-      <code>register_post_metas</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$post_id</code>
     </PossiblyFalseArgument>
   </file>
   <file src="includes/admin/class-sensei-exit-survey.php">
-    <MissingReturnType occurrences="2">
-      <code>enqueue_admin_assets</code>
-      <code>save_exit_survey</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$screen-&gt;id</code>
     </PossiblyNullPropertyFetch>
@@ -115,12 +77,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="4">
-      <code>add_admin_menu_item</code>
-      <code>enqueue_admin_assets</code>
-      <code>init</code>
-      <code>render</code>
-    </MissingReturnType>
     <PossiblyFalseOperand occurrences="1">
       <code>wp_json_encode( $additional_query_args )</code>
     </PossiblyFalseOperand>
@@ -133,14 +89,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="6">
-      <code>add_admin_menu_item</code>
-      <code>enqueue_admin_assets</code>
-      <code>handle_tasks_dismiss</code>
-      <code>init</code>
-      <code>localize_script</code>
-      <code>render</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$screen-&gt;id</code>
     </PossiblyNullPropertyFetch>
@@ -165,27 +113,6 @@
       <code>wp_unslash( $_GET['course_id'] ?? 0 )</code>
       <code>wp_unslash( $_GET['lesson_id'] ?? 0 )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="19">
-      <code>add_custom_navigation</code>
-      <code>add_learner_notices</code>
-      <code>display_students_navigation</code>
-      <code>edit_date_started</code>
-      <code>enqueue_scripts</code>
-      <code>enqueue_styles</code>
-      <code>get_redirect_url</code>
-      <code>handle_learner_actions</code>
-      <code>handle_user_async_action</code>
-      <code>json_search_users</code>
-      <code>learners_admin_menu</code>
-      <code>learners_default_nav</code>
-      <code>learners_headers</code>
-      <code>learners_page</code>
-      <code>load_data_table_files</code>
-      <code>load_screen_options_when_on_bulk_actions</code>
-      <code>remove_user_from_post</code>
-      <code>reset_user_post</code>
-      <code>wrapper_container</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="3">
       <code>$course-&gt;post_author</code>
       <code>$post-&gt;post_author</code>
@@ -205,18 +132,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/admin/class-sensei-learners-admin-bulk-actions-controller.php">
-    <MissingReturnType occurrences="10">
-      <code>add_notices</code>
-      <code>check_nonce</code>
-      <code>do_user_action</code>
-      <code>enqueue_scripts</code>
-      <code>handle_http_post</code>
-      <code>is_current_page</code>
-      <code>learner_admin_page</code>
-      <code>learners_admin_menu</code>
-      <code>redirect_to_learner_admin_index</code>
-      <code>register_hooks</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$edit_course_cap</code>
     </PossiblyNullArgument>
@@ -256,14 +171,6 @@
       <code>$user_id</code>
       <code>Sensei_Learner::get_full_name( $learner-&gt;user_id )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="6">
-      <code>courses_select</code>
-      <code>data_table_header</code>
-      <code>extra_tablenav</code>
-      <code>output_headers</code>
-      <code>prepare_items</code>
-      <code>search_button</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="3">
       <code>$course-&gt;ID</code>
       <code>$course-&gt;post_title</code>
@@ -304,9 +211,6 @@
       <code>$title</code>
       <code>$title</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>extra_tablenav</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$cats</code>
     </PossibleRawObjectIteration>
@@ -376,19 +280,6 @@
       <code>require_once ABSPATH . 'wp-admin/includes/plugin-install.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="11">
-      <code>activate_plugin</code>
-      <code>associate_plugin_file</code>
-      <code>background_installer</code>
-      <code>close_http_connection</code>
-      <code>complete_installation</code>
-      <code>install_plugin</code>
-      <code>install_plugins</code>
-      <code>run_deferred_actions</code>
-      <code>save_error</code>
-      <code>set_installing_plugins</code>
-      <code>set_time_limit</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="4">
       <code>$download</code>
       <code>$download</code>
@@ -414,9 +305,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$page_data</code>
     </ArgumentTypeCoercion>
-    <MissingReturnType occurrences="1">
-      <code>create_pages</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$page-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
@@ -441,22 +329,6 @@
     <InvalidPropertyFetch occurrences="1">
       <code>$extension-&gt;price</code>
     </InvalidPropertyFetch>
-    <MissingReturnType occurrences="14">
-      <code>activation_redirect</code>
-      <code>add_setup_wizard_help_tab</code>
-      <code>close_wccom_install</code>
-      <code>enqueue_scripts</code>
-      <code>enqueue_styles</code>
-      <code>finish_setup_wizard</code>
-      <code>install_extensions</code>
-      <code>prepare_wizard_page</code>
-      <code>redirect_to_setup_wizard</code>
-      <code>register_wizard_page</code>
-      <code>remove_notices_from_setup_wizard</code>
-      <code>render_wizard_page</code>
-      <code>setup_wizard_notice</code>
-      <code>skip_setup_wizard</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$extension</code>
     </PossiblyInvalidArgument>
@@ -475,9 +347,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$installed_time</code>
     </PossiblyFalseArgument>
@@ -490,14 +359,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="6">
-      <code>add_menu_pages</code>
-      <code>get_tool_url</code>
-      <code>init</code>
-      <code>output</code>
-      <code>process</code>
-      <code>trigger_invalid_request</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$tools</code>
     </PropertyNotSetInConstructor>
@@ -518,11 +379,6 @@
     <InvalidReturnType occurrences="1">
       <code>false|object</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="3">
-      <code>init</code>
-      <code>invalid_license_update_disclaimer</code>
-      <code>plugins_loaded</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="18">
       <code>$remote-&gt;author</code>
       <code>$remote-&gt;banners</code>
@@ -578,9 +434,6 @@
     </UndefinedConstant>
   </file>
   <file src="includes/admin/home/class-sensei-home-remote-data-api.php">
-    <MissingReturnType occurrences="1">
-      <code>set_fail_retry</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$response</code>
     </PossiblyInvalidArgument>
@@ -611,9 +464,6 @@
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/update.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$plugin_data-&gt;update-&gt;plugin ?? null</code>
     </PossiblyNullArgument>
@@ -637,11 +487,6 @@
     </InvalidReturnType>
   </file>
   <file src="includes/admin/home/tasks/class-sensei-home-tasks-provider.php">
-    <MissingReturnType occurrences="3">
-      <code>attach_tasks_statuses_hooks</code>
-      <code>mark_as_completed</code>
-      <code>update_tasks_statuses</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_title</code>
     </PossiblyInvalidPropertyFetch>
@@ -674,11 +519,6 @@
     <MissingConstructor occurrences="1">
       <code>$results</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="3">
-      <code>output</code>
-      <code>process</code>
-      <code>return_with_message</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$course</code>
       <code>$course</code>
@@ -699,33 +539,6 @@
       <code>debug</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="includes/admin/tools/class-sensei-tool-ensure-roles.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-export.php">
-    <MissingReturnType occurrences="2">
-      <code>output</code>
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-import.php">
-    <MissingReturnType occurrences="2">
-      <code>output</code>
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-interactive-interface.php">
-    <MissingReturnType occurrences="1">
-      <code>output</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-interface.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php">
     <InvalidReturnStatement occurrences="1">
       <code>$terms</code>
@@ -733,28 +546,11 @@
     <InvalidReturnType occurrences="1">
       <code>\WP_Term[]</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
   </file>
   <file src="includes/admin/tools/class-sensei-tool-recalculate-course-enrolment.php">
-    <MissingReturnType occurrences="2">
-      <code>output</code>
-      <code>process</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$course</code>
     </PossiblyInvalidArgument>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-recalculate-enrolment.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-remove-deleted-user-data.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
   </file>
   <file src="includes/admin/tools/views/html-enrolment-debug-form.php">
     <InvalidScalarArgument occurrences="2">
@@ -785,23 +581,7 @@
       <code>empty( $tool )</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="includes/background-jobs/class-sensei-background-job-batch.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/background-jobs/class-sensei-background-job-interface.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/background-jobs/class-sensei-background-job-stateful.php">
-    <MissingReturnType occurrences="4">
-      <code>cleanup</code>
-      <code>persist</code>
-      <code>restore_state</code>
-      <code>set_state</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $this-&gt;get_args() )</code>
     </PossiblyFalseArgument>
@@ -819,31 +599,14 @@
     <MissingConstructor occurrences="1">
       <code>$current_job</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="3">
-      <code>cancel_all_jobs</code>
-      <code>cancel_scheduled_job</code>
-      <code>run</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="includes/background-jobs/class-sensei-scheduler-interface.php">
-    <MissingReturnType occurrences="3">
-      <code>cancel_all_jobs</code>
-      <code>cancel_scheduled_job</code>
-      <code>run</code>
-    </MissingReturnType>
   </file>
   <file src="includes/background-jobs/class-sensei-scheduler-wp-cron.php">
     <InvalidReturnType occurrences="1">
       <code>mixed</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="3">
-      <code>cancel_all_jobs</code>
-      <code>cancel_scheduled_job</code>
-      <code>run</code>
-    </MissingReturnType>
   </file>
   <file src="includes/background-jobs/class-sensei-scheduler.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -862,9 +625,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>self::$instance</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_Scheduler_Interface</code>
     </MoreSpecificReturnType>
@@ -883,24 +643,9 @@
     <MissingClosureParamType occurrences="1">
       <code>$attributes</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="8">
-      <code>enqueue_scripts</code>
-      <code>get_patterns_category_name</code>
-      <code>get_post_content_block_type_name</code>
-      <code>init</code>
-      <code>maybe_register_pattern_block_polyfill</code>
-      <code>register_block_patterns</code>
-      <code>register_block_patterns_category</code>
-      <code>register_course_list_block_patterns</code>
-    </MissingReturnType>
     <UnresolvableInclude occurrences="1">
       <code>require __DIR__ . "/{$post_type}/{$block_pattern}.php"</code>
     </UnresolvableInclude>
-  </file>
-  <file src="includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php">
-    <MissingReturnType occurrences="1">
-      <code>register_course_list_block_patterns</code>
-    </MissingReturnType>
   </file>
   <file src="includes/block-patterns/course/course-default.php">
     <UnresolvableInclude occurrences="1"/>
@@ -923,10 +668,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>absint( $post-&gt;ID )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="2">
-      <code>add_notices</code>
-      <code>register_block</code>
-    </MissingReturnType>
   </file>
   <file src="includes/blocks/class-sensei-block-helpers.php">
     <DocblockTypeContradiction occurrences="1">
@@ -939,9 +680,6 @@
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-block-take-course.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $course_id )</code>
     </PossiblyFalseArgument>
@@ -950,9 +688,6 @@
     </PossiblyNullArgument>
   </file>
   <file src="includes/blocks/class-sensei-block-view-results.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>$course_id</code>
       <code>$course_id</code>
@@ -969,12 +704,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/post.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="4">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-      <code>maybe_initialize_blocks</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_post_type()</code>
     </PossiblyFalseArgument>
@@ -990,10 +719,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$block_content</code>
     </ArgumentTypeCoercion>
-    <MissingReturnType occurrences="2">
-      <code>register_generic_assets</code>
-      <code>register_sensei_block</code>
-    </MissingReturnType>
     <PossiblyInvalidCast occurrences="1">
       <code>$post</code>
     </PossiblyInvalidCast>
@@ -1031,11 +756,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/blocks/class-sensei-course-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignment occurrences="1">
       <code>$post_type_object</code>
     </PossiblyNullPropertyAssignment>
@@ -1047,20 +767,11 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/blocks/class-sensei-course-categories-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$terms</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-outline-block.php">
-    <MissingReturnType occurrences="4">
-      <code>add_block_attributes</code>
-      <code>clear_block_content</code>
-      <code>get_block_structure</code>
-      <code>register_blocks</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -1092,19 +803,11 @@
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-progress-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$course_id</code>
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-results-block.php">
-    <MissingReturnType occurrences="3">
-      <code>clear_block_content</code>
-      <code>register_block</code>
-      <code>render_lesson</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $item['id'] )</code>
     </PossiblyFalseArgument>
@@ -1114,18 +817,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$block_content</code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="includes/blocks/class-sensei-featured-video-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/blocks/class-sensei-global-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
   </file>
   <file src="includes/blocks/class-sensei-learner-courses-block.php">
     <NullArgument occurrences="2">
@@ -1138,10 +829,6 @@
     </PossiblyNullArgument>
   </file>
   <file src="includes/blocks/class-sensei-learner-messages-button-block.php">
-    <MissingReturnType occurrences="2">
-      <code>admin_enqueue_scripts</code>
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_post_type_archive_link( 'sensei_message' )</code>
     </PossiblyFalseArgument>
@@ -1152,12 +839,6 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/blocks/class-sensei-lesson-blocks.php">
-    <MissingReturnType occurrences="4">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-      <code>remove_block_related_content</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignment occurrences="1">
       <code>$post_type_object</code>
     </PossiblyNullPropertyAssignment>
@@ -1176,26 +857,13 @@
       <code>$lesson-&gt;ID</code>
       <code>$lesson-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson-&gt;ID )</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/blocks/class-sensei-page-blocks.php">
     <InvalidArrayAccess occurrences="1">
       <code>$block_parent['blockName']</code>
     </InvalidArrayAccess>
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
   </file>
   <file src="includes/blocks/class-sensei-quiz-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignment occurrences="2">
       <code>$post_type_object</code>
       <code>$post_type_object</code>
@@ -1228,28 +896,17 @@
       <code>$course_categories</code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="includes/blocks/course-list/class-sensei-course-list-filter-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/blocks/course-theme/class-course-navigation.php">
     <MissingClosureParamType occurrences="3">
       <code>$lesson</code>
       <code>$lesson</code>
       <code>$lesson</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>get_permalink( $lesson_id )</code>
       <code>get_permalink( $lesson_id )</code>
       <code>get_permalink( $quiz_id )</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidPropertyFetch occurrences="1">
-      <code>$user_lesson_status-&gt;comment_approved</code>
-    </PossiblyInvalidPropertyFetch>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>\Sensei_Utils::get_current_course()</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -1258,16 +915,6 @@
       <code>$is_enrolled</code>
       <code>$user_id</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>isset( $user_lesson_status-&gt;comment_approved )</code>
-    </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="includes/blocks/course-theme/class-course-theme-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
   </file>
   <file src="includes/blocks/course-theme/class-exit-course.php">
     <PossiblyFalseArgument occurrences="1">
@@ -1284,9 +931,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$lesson_id</code>
     </PossiblyNullArgument>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/blocks/course-theme/class-lesson-video.php">
     <MissingClosureParamType occurrences="1">
@@ -1300,23 +944,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$aria_label</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
-    </UndefinedFunction>
-  </file>
-  <file src="includes/blocks/course-theme/class-quiz-content.php">
-    <MissingReturnType occurrences="1">
-      <code>render_questions_loop</code>
-    </MissingReturnType>
-    <UndefinedFunction occurrences="7">
-      <code>sensei_get_the_question_id()</code>
-      <code>sensei_get_the_question_id()</code>
-      <code>sensei_get_the_question_number()</code>
-      <code>sensei_quiz_has_questions()</code>
-      <code>sensei_setup_the_question()</code>
-      <code>sensei_the_question_class()</code>
-      <code>sensei_the_question_content()</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/class-sensei-admin.php">
     <ArgumentTypeCoercion occurrences="3">
@@ -1367,28 +994,6 @@
       <code>$course_order_page_slug</code>
       <code>$lesson_order_page_slug</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="20">
-      <code>add_course_order</code>
-      <code>add_lesson_order</code>
-      <code>admin_styles_global</code>
-      <code>ajax_log_event</code>
-      <code>get_course_order</code>
-      <code>handle_order_courses</code>
-      <code>handle_order_lessons</code>
-      <code>install_pages</code>
-      <code>notify_if_admin_email_not_real_admin_user</code>
-      <code>output_cpt_block_editor_workaround</code>
-      <code>register_scripts</code>
-      <code>remove_trashed_course_from_course_order</code>
-      <code>render_settings</code>
-      <code>save_course_order</code>
-      <code>save_lesson_order</code>
-      <code>sensei_add_custom_menu_items</code>
-      <code>sensei_set_plugin_url</code>
-      <code>update_lesson_order_on_course</code>
-      <code>update_lesson_order_on_lesson</code>
-      <code>wp_nav_menu_item_sensei_links_meta_box</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="2">
       <code>$new_post</code>
       <code>null</code>
@@ -1469,11 +1074,6 @@
       <code>$report</code>
       <code>$text</code>
     </MissingParamType>
-    <MissingReturnType occurrences="3">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-      <code>output_top_filters</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="2">
       <code>$search</code>
       <code>$search</code>
@@ -1504,11 +1104,6 @@
       <code>WooThemes_Sensei_Analysis_Course_List_Table</code>
       <code>WooThemes_Sensei_Analysis_Course_List_Table</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(array) $learners_search-&gt;get_results()</code>
-      <code>(int) $course_id</code>
-      <code>(int) $user_id</code>
-    </RedundantCastGivenDocblockType>
     <UndefinedDocblockClass occurrences="1">
       <code>data</code>
     </UndefinedDocblockClass>
@@ -1535,10 +1130,6 @@
       <code>$lesson_id</code>
       <code>$page_slug</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="2">
       <code>$search</code>
       <code>$search</code>
@@ -1562,9 +1153,6 @@
       <code>WooThemes_Sensei_Analysis_Lesson_List_Table</code>
       <code>WooThemes_Sensei_Analysis_Lesson_List_Table</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $learners_search-&gt;get_results()</code>
-    </RedundantCastGivenDocblockType>
     <UndefinedDocblockClass occurrences="1">
       <code>data</code>
     </UndefinedDocblockClass>
@@ -1606,14 +1194,6 @@
       <code>$page_slug</code>
       <code>$type</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="6">
-      <code>add_last_activity_to_user_query</code>
-      <code>add_orderby_custom_field_to_non_user_query</code>
-      <code>add_orderby_custom_field_to_query</code>
-      <code>filter_users_by_last_activity</code>
-      <code>output_course_select_input</code>
-      <code>output_top_filters</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>wp_get_object_terms( $lessons, 'module', $default_args )</code>
     </PossiblyInvalidArgument>
@@ -1655,10 +1235,6 @@
       <code>$page_slug</code>
       <code>$user_id</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="2">
       <code>$search</code>
       <code>$search</code>
@@ -1700,14 +1276,6 @@
       <code>$type</code>
       <code>$which</code>
     </MissingParamType>
-    <MissingReturnType occurrences="6">
-      <code>add_custom_navigation</code>
-      <code>check_course_lesson</code>
-      <code>display_nav</code>
-      <code>display_report_page</code>
-      <code>display_reports_navigation</code>
-      <code>enqueue_scripts</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_List_Table</code>
     </MoreSpecificReturnType>
@@ -1724,17 +1292,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/class-sensei-assets.php">
-    <MissingReturnType occurrences="9">
-      <code>call_wp</code>
-      <code>disable_frontend_styles</code>
-      <code>enqueue</code>
-      <code>enqueue_script</code>
-      <code>enqueue_style</code>
-      <code>override_script</code>
-      <code>preload_data</code>
-      <code>register</code>
-      <code>wp_compat</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $preload_data )</code>
     </PossiblyFalseArgument>
@@ -1748,30 +1305,15 @@
       <code>$handle</code>
     </PossiblyNullArgument>
   </file>
-  <file src="includes/class-sensei-autoloader.php">
-    <MissingReturnType occurrences="2">
-      <code>autoload</code>
-      <code>initialize_class_file_map</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/class-sensei-bootstrap.php">
     <DocblockTypeContradiction occurrences="1">
       <code>null === self::$instance</code>
     </DocblockTypeContradiction>
   </file>
   <file src="includes/class-sensei-cli.php">
-    <MissingReturnType occurrences="2">
-      <code>load</code>
-      <code>register</code>
-    </MissingReturnType>
     <UndefinedClass occurrences="1">
       <code>WP_CLI</code>
     </UndefinedClass>
-  </file>
-  <file src="includes/class-sensei-context-notices.php">
-    <MissingReturnType occurrences="1">
-      <code>add_notice</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-core-lesson-modules.php">
     <MissingParamType occurrences="1">
@@ -1780,10 +1322,6 @@
     <MissingPropertyType occurrences="1">
       <code>$lesson_id</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>modules_taxonomy</code>
-      <code>set_module</code>
-    </MissingReturnType>
     <ParadoxicalCondition occurrences="2">
       <code>! $module_id || empty( $module_id ) || ! $module_exists_in_course</code>
       <code>$module_id || ! empty( $module_id )</code>
@@ -1796,9 +1334,6 @@
     <InvalidReturnStatement occurrences="1">
       <code>$title</code>
     </InvalidReturnStatement>
-    <MissingReturnType occurrences="1">
-      <code>fire_sensei_message_hook</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$course-&gt;post_name</code>
       <code>$course-&gt;post_name</code>
@@ -1853,11 +1388,6 @@
       <code>$teacher_user_id</code>
       <code>get_post( $this-&gt;course_id )-&gt;post_author</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="3">
-      <code>clear_lesson_associations</code>
-      <code>create_quiz</code>
-      <code>save_module_order</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="2">
       <code>$lesson-&gt;ID</code>
       <code>$term-&gt;term_id</code>
@@ -1906,9 +1436,6 @@
       <code>get_post( $this-&gt;course_id )-&gt;post_author</code>
       <code>get_post( $this-&gt;course_id )-&gt;post_author</code>
     </PossiblyNullPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $existing_module-&gt;term_id</code>
-    </RedundantCastGivenDocblockType>
     <UndefinedMethod occurrences="3">
       <code>$create_result</code>
       <code>$lesson</code>
@@ -1926,9 +1453,8 @@
     </UnsafeInstantiation>
   </file>
   <file src="includes/class-sensei-course.php">
-    <ArgumentTypeCoercion occurrences="7">
+    <ArgumentTypeCoercion occurrences="6">
       <code>$post_args</code>
-      <code>$user_course_status</code>
       <code>'WP_Post'</code>
       <code>'WP_Post'</code>
       <code>'WP_Post'</code>
@@ -1938,18 +1464,14 @@
     <DeprecatedMethod occurrences="1">
       <code>get_archive_query_args</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_a( $course_id, 'WP_Post' )</code>
-    </DocblockTypeContradiction>
     <FalsableReturnStatement occurrences="2">
       <code>$course_quizzes</code>
       <code>$url</code>
     </FalsableReturnStatement>
-    <InvalidArgument occurrences="6">
+    <InvalidArgument occurrences="5">
       <code>$lesson_args</code>
       <code>$lesson_args</code>
       <code>$lesson_args</code>
-      <code>uasort( $lessons, [ $this, '_short_course_lessons_callback' ] )</code>
     </InvalidArgument>
     <InvalidDocblock occurrences="2">
       <code>public static function course_archive_filters( $query ) {</code>
@@ -1977,10 +1499,6 @@
       <code>1</code>
       <code>1</code>
     </InvalidPropertyAssignmentValue>
-    <InvalidPropertyFetch occurrences="2">
-      <code>$lesson_1-&gt;course_order</code>
-      <code>$lesson_2-&gt;course_order</code>
-    </InvalidPropertyFetch>
     <InvalidReturnStatement occurrences="2">
       <code>true</code>
       <code>update_post_meta( $post_id, $meta_key, $new_meta_value )</code>
@@ -2043,44 +1561,6 @@
     <MissingPropertyType occurrences="1">
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="36">
-      <code>add_author_support</code>
-      <code>add_course_access_permission_message</code>
-      <code>add_custom_navigation</code>
-      <code>add_legacy_course_hooks</code>
-      <code>add_showcase_courses_upsell</code>
-      <code>allow_course_archive_on_front_page</code>
-      <code>archive_page_content</code>
-      <code>can_access_course_content</code>
-      <code>course_archive_filters</code>
-      <code>course_archive_sorting</code>
-      <code>course_category_title</code>
-      <code>course_notification_meta_box_content</code>
-      <code>disable_log_course_update</code>
-      <code>display_courses_navigation</code>
-      <code>load_single_course_lessons_query</code>
-      <code>log_course_update</code>
-      <code>log_initial_publish_event</code>
-      <code>mark_updating_course_id</code>
-      <code>maybe_redirect_to_login_from_course_completion</code>
-      <code>output_course_enrolment_actions</code>
-      <code>prerequisite_complete_message</code>
-      <code>register_admin_scripts</code>
-      <code>remove_legacy_course_actions</code>
-      <code>save_course_notification_meta_box</code>
-      <code>set_up_meta_fields</code>
-      <code>setup_single_course_page</code>
-      <code>showcase_courses_screen</code>
-      <code>the_course_action_buttons</code>
-      <code>the_course_enrolment_actions</code>
-      <code>the_course_free_lesson_preview</code>
-      <code>the_course_lessons_title</code>
-      <code>the_course_meta</code>
-      <code>the_course_video</code>
-      <code>the_title</code>
-      <code>update_status_after_lesson_change</code>
-      <code>update_status_after_quiz_submission</code>
-    </MissingReturnType>
     <NullArgument occurrences="3">
       <code>null</code>
       <code>null</code>
@@ -2101,20 +1581,15 @@
       <code>get_the_ID()</code>
       <code>get_the_ID()</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="9">
+    <PossiblyInvalidArgument occurrences="7">
       <code>$category_output</code>
       <code>$category_output</code>
       <code>$category_output</code>
       <code>$course</code>
-      <code>$course_id</code>
       <code>$output</code>
-      <code>$progress_percentage</code>
       <code>wp_get_post_terms( $course-&gt;ID, 'module' )</code>
       <code>wp_get_post_terms( $course_id, 'module' )</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignment occurrences="1">
-      <code>$lesson</code>
-    </PossiblyInvalidPropertyAssignment>
     <PossiblyInvalidPropertyFetch occurrences="25">
       <code>$course-&gt;ID</code>
       <code>$course-&gt;ID</code>
@@ -2192,43 +1667,18 @@
       <code>type</code>
       <code>type</code>
     </UndefinedDocblockClass>
-    <UndefinedFunction occurrences="2">
-      <code>'course_single_lessons'</code>
-      <code>sensei_start_course_form( $post-&gt;ID )</code>
-    </UndefinedFunction>
     <UndefinedMagicPropertyFetch occurrences="2">
       <code>$term-&gt;name</code>
       <code>$term-&gt;term_id</code>
     </UndefinedMagicPropertyFetch>
-    <UndefinedPropertyAssignment occurrences="1">
-      <code>$lesson-&gt;course_order</code>
-    </UndefinedPropertyAssignment>
     <UndefinedPropertyFetch occurrences="1">
       <code>$term-&gt;term_id</code>
     </UndefinedPropertyFetch>
   </file>
   <file src="includes/class-sensei-customizer.php">
     <ArgumentTypeCoercion occurrences="2"/>
-    <MissingReturnType occurrences="4">
-      <code>add_customizer_settings</code>
-      <code>enqueue_customizer_helper</code>
-      <code>output_custom_settings</code>
-      <code>output_customizer_helper</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-data-cleaner.php">
-    <MissingReturnType occurrences="10">
-      <code>cleanup_all</code>
-      <code>cleanup_custom_post_types</code>
-      <code>cleanup_options</code>
-      <code>cleanup_pages</code>
-      <code>cleanup_post_meta</code>
-      <code>cleanup_roles_and_caps</code>
-      <code>cleanup_taxonomies</code>
-      <code>cleanup_transients</code>
-      <code>cleanup_user_meta</code>
-      <code>remove_all_sensei_caps</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$item</code>
     </PossiblyInvalidArgument>
@@ -2248,12 +1698,6 @@
     </UndefinedConstant>
   </file>
   <file src="includes/class-sensei-dependency-checker.php">
-    <MissingReturnType occurrences="4">
-      <code>add_assets_notice</code>
-      <code>add_future_php_version_notice</code>
-      <code>add_php_version_notice</code>
-      <code>show_php_notice</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$screen-&gt;id</code>
     </PossiblyNullPropertyFetch>
@@ -2286,12 +1730,6 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="4">
-      <code>get_content</code>
-      <code>init</code>
-      <code>load_template</code>
-      <code>teacher_quiz_submitted</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="3">
       <code>$_from_address</code>
       <code>$_from_name</code>
@@ -2302,9 +1740,6 @@
     </UnresolvableInclude>
   </file>
   <file src="includes/class-sensei-feature-flags.php">
-    <MissingReturnType occurrences="1">
-      <code>register_scripts</code>
-    </MissingReturnType>
     <PossiblyFalseOperand occurrences="1">
       <code>wp_json_encode( $this-&gt;get_feature_flags() )</code>
     </PossiblyFalseOperand>
@@ -2324,28 +1759,6 @@
       <code>$post_id</code>
       <code>$title</code>
     </MissingParamType>
-    <MissingReturnType occurrences="20">
-      <code>lesson_tag_archive_description</code>
-      <code>lesson_tag_archive_filter</code>
-      <code>lesson_tags_display</code>
-      <code>maybe_redirect_to_next_lesson</code>
-      <code>redirect_to_course_completed_page</code>
-      <code>sensei_complete_course</code>
-      <code>sensei_complete_lesson</code>
-      <code>sensei_complete_lesson_button</code>
-      <code>sensei_course_archive_meta</code>
-      <code>sensei_course_archive_pagination</code>
-      <code>sensei_course_category_main_content</code>
-      <code>sensei_course_start</code>
-      <code>sensei_frontend_messages</code>
-      <code>sensei_lesson_meta</code>
-      <code>sensei_lesson_preview_title</code>
-      <code>sensei_lesson_preview_title_tag</code>
-      <code>sensei_lesson_preview_title_text</code>
-      <code>sensei_lesson_video</code>
-      <code>sensei_login_form</code>
-      <code>sensei_reset_lesson_button</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$tags</code>
     </PossibleRawObjectIteration>
@@ -2396,9 +1809,6 @@
     <UndefinedConstant occurrences="1">
       <code>WP_DEBUG</code>
     </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
-    </UndefinedFunction>
     <UndefinedMagicPropertyFetch occurrences="3">
       <code>$tag-&gt;description</code>
       <code>$tag-&gt;term_id</code>
@@ -2424,10 +1834,6 @@
       <code>$user_ids</code>
       <code>$view</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>$search</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -2457,9 +1863,6 @@
       <code>$user_quiz_grade_total</code>
       <code>$user_quiz_grade_total</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>display</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$answer_media_url</code>
     </PossiblyFalseArgument>
@@ -2472,10 +1875,6 @@
       <code>false</code>
       <code>false</code>
     </FalsableReturnStatement>
-    <InvalidArgument occurrences="2">
-      <code>$grade</code>
-      <code>$grade</code>
-    </InvalidArgument>
     <InvalidIterator occurrences="1">
       <code>$lesson_metadata</code>
     </InvalidIterator>
@@ -2510,15 +1909,6 @@
       <code>$name</code>
       <code>$page_slug</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="7">
-      <code>add_grading_notices</code>
-      <code>deprecated_get_lessons_dropdown</code>
-      <code>deprecated_get_redirect_url</code>
-      <code>get_redirect_url</code>
-      <code>grading_admin_menu</code>
-      <code>lessons_drop_down_html</code>
-      <code>sensei_grading_notices</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $args )</code>
     </PossiblyFalseArgument>
@@ -2553,13 +1943,6 @@
       <code>undefined</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="includes/class-sensei-groups-landing-page.php">
-    <MissingReturnType occurrences="3">
-      <code>add_groups_landing_page_menu_item</code>
-      <code>display_student_groups_landing_page</code>
-      <code>wrapper_container</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/class-sensei-guest-user.php">
     <ArgumentTypeCoercion occurrences="1">
       <code>'WP_Role'</code>
@@ -2571,17 +1954,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$user_count</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="9">
-      <code>create_guest_student_role_if_not_exists</code>
-      <code>create_guest_user_and_login_for_open_course</code>
-      <code>enrol_user</code>
-      <code>init</code>
-      <code>is_current_user_guest</code>
-      <code>log_guest_user_out_before_all_actions</code>
-      <code>log_in_guest_user_if_in_open_course</code>
-      <code>login_user</code>
-      <code>recreate_nonce</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$course_id</code>
     </PossiblyInvalidArgument>
@@ -2591,9 +1963,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>Sensei_Utils::get_current_course()</code>
     </PossiblyNullArgument>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $user-&gt;roles</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/class-sensei-learner-profiles.php">
     <InvalidGlobal occurrences="1">
@@ -2602,9 +1971,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$name</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>enqueue_scripts</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-learner.php">
     <DocblockTypeContradiction occurrences="5">
@@ -2621,12 +1987,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$user_id</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
-      <code>add_course_column_data</code>
-      <code>before_enrolled_courses_query</code>
-      <code>init</code>
-      <code>remove_duplicate_progress</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$courses</code>
     </PossiblyInvalidArgument>
@@ -2752,75 +2112,6 @@
       <code>$meta_fields</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="67">
-      <code>add_column_data</code>
-      <code>add_custom_link_to_course</code>
-      <code>add_custom_navigation</code>
-      <code>add_lesson_to_course_order</code>
-      <code>add_video_meta_box</code>
-      <code>all_lessons_edit_fields</code>
-      <code>content_drip_promo_meta_box_content</code>
-      <code>course_signup_link</code>
-      <code>deprecated_get_question_category_limit</code>
-      <code>deprecated_question_get_answer_id</code>
-      <code>disable_log_lesson_update</code>
-      <code>display_lessons_navigation</code>
-      <code>enqueue_lesson_edit_scripts</code>
-      <code>enqueue_scripts</code>
-      <code>enqueue_scripts_meta_box_quiz_editor</code>
-      <code>enqueue_styles</code>
-      <code>footer_quiz_call_to_action</code>
-      <code>get_question_category_limit</code>
-      <code>get_quiz_settings</code>
-      <code>handle_get_prerequisite_meta_box_content</code>
-      <code>lesson_add_existing_questions</code>
-      <code>lesson_add_multiple_questions</code>
-      <code>lesson_course_meta_box_content</code>
-      <code>lesson_info_meta_box_content</code>
-      <code>lesson_prerequisite_meta_box_content</code>
-      <code>lesson_preview_meta_box_content</code>
-      <code>lesson_quiz_meta_box_content</code>
-      <code>lesson_quiz_settings_meta_box_content</code>
-      <code>lesson_remove_multiple_questions</code>
-      <code>lesson_update_grade_type</code>
-      <code>lesson_update_question</code>
-      <code>lesson_update_question_order</code>
-      <code>lesson_update_question_order_random</code>
-      <code>lesson_video_meta_box_content</code>
-      <code>log_initial_publish_event</code>
-      <code>log_lesson_update</code>
-      <code>mark_updating_lesson_id</code>
-      <code>maybe_start_lesson</code>
-      <code>meta_box_setup</code>
-      <code>on_lesson_published</code>
-      <code>output_comments</code>
-      <code>output_prerequisite_meta_box_content</code>
-      <code>prerequisite_complete_message</code>
-      <code>question_get_answer_id</code>
-      <code>quiz_panel</code>
-      <code>quiz_panel_add</code>
-      <code>quiz_panel_add_existing_question</code>
-      <code>quiz_panel_filter_existing_questions</code>
-      <code>quiz_panel_get_existing_questions</code>
-      <code>quiz_panel_question</code>
-      <code>quiz_panel_question_feedback</code>
-      <code>quiz_panel_question_field</code>
-      <code>quiz_panel_questions</code>
-      <code>quiz_settings_panel</code>
-      <code>save_all_lessons_edit_fields</code>
-      <code>save_lesson_featured_video_thumbnail</code>
-      <code>save_post_meta</code>
-      <code>save_quiz_settings</code>
-      <code>set_default_question_order</code>
-      <code>set_quick_edit_admin_defaults</code>
-      <code>the_archive_header</code>
-      <code>the_lesson_image</code>
-      <code>the_lesson_meta</code>
-      <code>the_lesson_thumbnail</code>
-      <code>the_title</code>
-      <code>user_lesson_quiz_status_message</code>
-      <code>user_not_taking_course_message</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="3">
       <code>$this-&gt;get_videopress_thumbnail( $url )</code>
       <code>$this-&gt;get_vimeo_thumbnail( $url )</code>
@@ -2831,7 +2122,7 @@
       <code>$question_cats</code>
       <code>$question_cats</code>
     </PossibleRawObjectIteration>
-    <PossiblyFalseArgument occurrences="18">
+    <PossiblyFalseArgument occurrences="16">
       <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
@@ -2961,10 +2252,6 @@
     <TypeDoesNotContainType occurrences="1">
       <code>! isset( $row_counter )</code>
     </TypeDoesNotContainType>
-    <UndefinedFunction occurrences="2">
-      <code>sensei_complete_lesson_button()</code>
-      <code>sensei_reset_lesson_button()</code>
-    </UndefinedFunction>
     <UndefinedPropertyFetch occurrences="2">
       <code>$cat-&gt;name</code>
       <code>$question_cat-&gt;name</code>
@@ -2985,11 +2272,6 @@
     <MissingPropertyType occurrences="1">
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="3">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-      <code>single_row</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$item</code>
     </MoreSpecificImplementedParamType>
@@ -3057,24 +2339,6 @@
       <code>$post_type</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="16">
-      <code>add_menu_item</code>
-      <code>add_meta_box</code>
-      <code>check_permissions_edit_comments</code>
-      <code>message_login</code>
-      <code>message_reply_received</code>
-      <code>message_rest_insert</code>
-      <code>meta_box_content</code>
-      <code>only_show_messages_to_owner</code>
-      <code>save_new_message</code>
-      <code>send_message_link</code>
-      <code>stop_wp_comment_emails</code>
-      <code>teacher_contact_form</code>
-      <code>the_message_sender</code>
-      <code>the_message_sent_by_title</code>
-      <code>the_message_title</code>
-      <code>the_my_messages_link</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="6">
       <code>get_permalink( $content_post_id )</code>
       <code>get_post_type_archive_link( 'sensei_message' )</code>
@@ -3213,38 +2477,6 @@
       <code>$order_page_slug</code>
       <code>$taxonomy</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="30">
-      <code>add_custom_navigation</code>
-      <code>add_lesson_column_content</code>
-      <code>add_module_admin_hooks</code>
-      <code>add_new_module_term</code>
-      <code>add_submenus</code>
-      <code>add_teacher_id_in_module_meta_when_added_to_course</code>
-      <code>ajax_get_course_modules</code>
-      <code>append_teacher_name_to_module</code>
-      <code>course_module_metabox</code>
-      <code>course_signup_link</code>
-      <code>display_modules_navigation</code>
-      <code>filter_course_selected_terms</code>
-      <code>filter_module_terms</code>
-      <code>handle_get_lesson_module_metabox</code>
-      <code>handle_order_modules</code>
-      <code>module_archive_body_class</code>
-      <code>module_breadcrumb_link</code>
-      <code>output_course_modules_column</code>
-      <code>output_lesson_module_metabox</code>
-      <code>remove_default_modules_box</code>
-      <code>remove_if_unused</code>
-      <code>remove_teacher_id_from_module_meta_when_removed_from_course</code>
-      <code>reset_none_modules_transient</code>
-      <code>sensei_course_preview_titles</code>
-      <code>setup_modules_taxonomy</code>
-      <code>setup_single_course_module_loop</code>
-      <code>teardown_single_course_module_loop</code>
-      <code>track_module_creation</code>
-      <code>update_module_teacher_id_meta_on_post_teacher_update</code>
-      <code>update_module_teacher_meta</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="3">
       <code>$modules</code>
       <code>$modules</code>
@@ -3302,9 +2534,6 @@
       <code>get_post( $post_ID )-&gt;post_type</code>
       <code>get_queried_object()-&gt;name</code>
     </PossiblyNullPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $module_id</code>
-    </RedundantCastGivenDocblockType>
     <RedundantCondition occurrences="2">
       <code>'tax_input[' . $tax_name . ']'</code>
       <code>isset( $course_id )</code>
@@ -3333,9 +2562,6 @@
       <code>$tax_name === 'category'</code>
       <code>empty( $modules )</code>
     </TypeDoesNotContainType>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_module_has_lessons()</code>
-    </UndefinedFunction>
     <UndefinedMagicPropertyFetch occurrences="5">
       <code>$module-&gt;description</code>
       <code>$module-&gt;term_id</code>
@@ -3363,9 +2589,6 @@
     <MissingPropertyType occurrences="1">
       <code>$notices</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>setup_block_notices</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-posttypes.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -3395,21 +2618,6 @@
       <code>$slider_labels</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="13">
-      <code>add_submenus</code>
-      <code>disable_fire_scheduled_initial_publish_actions</code>
-      <code>fire_scheduled_initial_publish_actions</code>
-      <code>is_meta_box_save_request</code>
-      <code>mark_post_already_published</code>
-      <code>maybe_schedule_initial_publish_action</code>
-      <code>protect_feeds</code>
-      <code>reset_scheduled_initial_publish_actions</code>
-      <code>schedule_initial_publish_action</code>
-      <code>setup_initial_publish_action</code>
-      <code>setup_learner_taxonomy</code>
-      <code>setup_post_type_labels_base</code>
-      <code>setup_rest_api</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="4">
       <code>get_permalink( $post_ID )</code>
       <code>get_permalink( $post_ID )</code>
@@ -3461,21 +2669,6 @@
     <InvalidReturnType occurrences="1">
       <code>int</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="9">
-      <code>add_preview_user_filters</code>
-      <code>add_user_switch_to_admin_bar</code>
-      <code>create_role</code>
-      <code>delete_preview_user</code>
-      <code>init</code>
-      <code>override_user</code>
-      <code>set_preview_user</code>
-      <code>switch_off_preview_user</code>
-      <code>switch_to_preview_user</code>
-    </MissingReturnType>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(array) $user-&gt;roles</code>
-      <code>(int) $course_id</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/class-sensei-question.php">
     <DeprecatedMethod occurrences="1">
@@ -3525,28 +2718,6 @@
       <code>$quiz_id</code>
       <code>$quiz_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="20">
-      <code>add_custom_navigation</code>
-      <code>answer_feedback_notes</code>
-      <code>display_question_navigation</code>
-      <code>file_upload_load_question_data</code>
-      <code>gap_fill_load_question_data</code>
-      <code>load_question_template</code>
-      <code>log_initial_publish_event</code>
-      <code>multiple_choice_load_question_data</code>
-      <code>output_result_indication</code>
-      <code>question_edit_panel</code>
-      <code>question_edit_panel_metabox</code>
-      <code>question_lessons_panel</code>
-      <code>question_types</code>
-      <code>save_question</code>
-      <code>the_answer_feedback</code>
-      <code>the_answer_result_indication</code>
-      <code>the_question_description</code>
-      <code>the_question_hidden_fields</code>
-      <code>the_question_media</code>
-      <code>the_question_title</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="3">
       <code>$categories_of_question</code>
       <code>$cats</code>
@@ -3577,7 +2748,7 @@
     <PossiblyInvalidIterator occurrences="1">
       <code>$cats</code>
     </PossiblyInvalidIterator>
-    <PossiblyInvalidPropertyFetch occurrences="10">
+    <PossiblyInvalidPropertyFetch occurrences="9">
       <code>$attachment-&gt;post_content</code>
       <code>$attachment-&gt;post_title</code>
       <code>$question-&gt;ID</code>
@@ -3612,7 +2783,7 @@
     <DeprecatedProperty occurrences="1">
       <code>$this-&gt;file</code>
     </DeprecatedProperty>
-    <DocblockTypeContradiction occurrences="13">
+    <DocblockTypeContradiction occurrences="11">
       <code>! $encoded_feedback</code>
       <code>! $encoded_feedback</code>
       <code>! is_array( $all_feedback )</code>
@@ -3621,9 +2792,7 @@
       <code>! is_array( $unprepared_answers )</code>
       <code>! is_array( $users_answers )</code>
       <code>empty( $lesson_id ) || empty( $user_id ) || ! is_array( $quiz_answers )</code>
-      <code>is_array( $lesson_status )</code>
       <code>is_int( $user_grade )</code>
-      <code>isset( $user_lesson_status-&gt;comment_ID )</code>
     </DocblockTypeContradiction>
     <InvalidDocblock occurrences="1">
       <code>public function reset_button_click_listener() {</code>
@@ -3647,7 +2816,7 @@
     <InvalidReturnType occurrences="1">
       <code>false|int</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="14">
+    <InvalidScalarArgument occurrences="13">
       <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
@@ -3659,7 +2828,6 @@
       <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
-      <code>$lesson_status-&gt;comment_ID</code>
       <code>$this-&gt;get_lesson_id( $quiz_id )</code>
       <code>$this-&gt;get_lesson_id( $quiz_id )</code>
     </InvalidScalarArgument>
@@ -3671,25 +2839,6 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="17">
-      <code>action_buttons</code>
-      <code>delete_quiz_question_meta</code>
-      <code>load_global_quiz_data</code>
-      <code>maybe_delete_quiz</code>
-      <code>output_quiz_hidden_fields</code>
-      <code>page_change_listener</code>
-      <code>redirect_if_lesson_is_protected</code>
-      <code>reset_button_click_listener</code>
-      <code>set_questions</code>
-      <code>start_quiz_questions_loop</code>
-      <code>stop_quiz_questions_loop</code>
-      <code>the_quiz_pagination</code>
-      <code>the_quiz_progress_bar</code>
-      <code>the_title</code>
-      <code>the_user_status_message</code>
-      <code>update_quiz_author</code>
-      <code>user_save_quiz_answers_listener</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="2">
       <code>self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-correct' )</code>
       <code>self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-incorrect' )</code>
@@ -3711,7 +2860,7 @@
       <code>$quiz</code>
       <code>get_post()</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyFetch occurrences="9">
+    <PossiblyInvalidPropertyFetch occurrences="8">
       <code>$lesson-&gt;ID</code>
       <code>$lesson-&gt;post_author</code>
       <code>$lesson-&gt;post_name</code>
@@ -3720,11 +2869,9 @@
       <code>$saved_lesson-&gt;post_author</code>
       <code>$saved_lesson-&gt;post_name</code>
       <code>$saved_lesson-&gt;post_title</code>
-      <code>$user_lesson_status-&gt;comment_ID</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="2">
       <code>$lesson-&gt;ID</code>
-      <code>$lesson_id</code>
       <code>$question-&gt;post_content</code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="6">
@@ -3735,12 +2882,8 @@
       <code>$saved_lesson-&gt;post_name</code>
       <code>$saved_lesson-&gt;post_title</code>
     </PossiblyNullPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $user_id</code>
-    </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>! is_wp_error( $grade )</code>
-      <code>$lesson_status</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedConstant occurrences="6">
       <code>DAY_IN_SECONDS</code>
@@ -3790,15 +2933,6 @@
       <code>$token</code>
       <code>$token_legacy</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="7">
-      <code>determine_method</code>
-      <code>form_field_button</code>
-      <code>register_hook_listener</code>
-      <code>render_additional_section_elements</code>
-      <code>render_content_drip_settings</code>
-      <code>render_promo_banner</code>
-      <code>render_woocommerce_upgrade_settings</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$input[ $k ]</code>
     </PossiblyFalseArgument>
@@ -3824,15 +2958,6 @@
       <code>$new_value</code>
       <code>$setting</code>
     </MissingParamType>
-    <MissingReturnType occurrences="7">
-      <code>flush_rewrite_rules</code>
-      <code>get_learning_mode_template_options</code>
-      <code>log_settings_update</code>
-      <code>mark_section_as_visited</code>
-      <code>render_learning_mode_setting</code>
-      <code>render_learning_mode_templates</code>
-      <code>set</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $inline_data )</code>
     </PossiblyFalseArgument>
@@ -3916,16 +3041,6 @@
       <code>$teacher_role</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="8">
-      <code>add_capabilities</code>
-      <code>archive_title</code>
-      <code>course_column_data</code>
-      <code>filter_queries</code>
-      <code>remove_course_meta_on_teacher_archive</code>
-      <code>teacher_filter_query_modify</code>
-      <code>teacher_meta_box_content</code>
-      <code>update_lesson_teacher</code>
-    </MissingReturnType>
     <ParadoxicalCondition occurrences="1">
       <code>empty( $lesson_id ) || ! $lesson_id</code>
     </ParadoxicalCondition>
@@ -3963,10 +3078,6 @@
       <code>$screen-&gt;id</code>
       <code>$term-&gt;slug</code>
     </PossiblyNullPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(array) $user-&gt;roles</code>
-      <code>(int) $new_author</code>
-    </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>! is_wp_error( $search_term )</code>
       <code>isset( $screen-&gt;id )</code>
@@ -3995,14 +3106,6 @@
       <code>$template_name</code>
       <code>$template_name</code>
     </MissingParamType>
-    <MissingReturnType occurrences="6">
-      <code>fire_frontend_messages_hook</code>
-      <code>fire_sensei_complete_course_hook</code>
-      <code>get_no_permission_template</code>
-      <code>get_template</code>
-      <code>locate_and_load_template_overrides</code>
-      <code>the_title</code>
-    </MissingReturnType>
     <PossiblyFalseOperand occurrences="1">
       <code>get_permalink( $post-&gt;ID )</code>
     </PossiblyFalseOperand>
@@ -4023,10 +3126,6 @@
       <code>$args &amp;&amp; is_array( $args )</code>
       <code>is_array( $args )</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedFunction occurrences="2">
-      <code>get_sensei_footer()</code>
-      <code>get_sensei_header()</code>
-    </UndefinedFunction>
     <UnresolvableInclude occurrences="3">
       <code>include $found_template</code>
       <code>include $found_template</code>
@@ -4042,11 +3141,6 @@
       <code>is_a( $last_week_activities, 'WP_Comment' )</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="3">
-      <code>clean_inactive_guest_users</code>
-      <code>init</code>
-      <code>maybe_schedule_cron_jobs</code>
-    </MissingReturnType>
     <TooManyArguments occurrences="1">
       <code>remove_filter( 'sensei_check_for_activity', [ Sensei_Temporary_User::class, 'filter_sensei_activity' ], 10, 2 )</code>
     </TooManyArguments>
@@ -4059,13 +3153,6 @@
       <code>require_once ABSPATH . '/wp-admin/includes/ms.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/user.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="5">
-      <code>filter_learners_query</code>
-      <code>filter_out_temporary_user_role_tabs</code>
-      <code>filter_out_temporary_user_roles</code>
-      <code>filter_out_temporary_users</code>
-      <code>init</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>get_userdata( $user_id )-&gt;roles</code>
     </PossiblyInvalidPropertyFetch>
@@ -4077,12 +3164,6 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>new Sensei_Unsupported_Themes()</code>
     </InvalidPropertyAssignmentValue>
-    <MissingReturnType occurrences="4">
-      <code>get_instance</code>
-      <code>init</code>
-      <code>maybe_handle_request</code>
-      <code>reset</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-updates.php">
     <DocblockTypeContradiction occurrences="1">
@@ -4094,17 +3175,6 @@
     <InvalidReturnType occurrences="1">
       <code>DateTimeImmutable[]</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="9">
-      <code>assign_role_caps</code>
-      <code>log_update</code>
-      <code>run_updates</code>
-      <code>v3_0_check_legacy_enrolment</code>
-      <code>v3_7_add_comment_indexes</code>
-      <code>v3_7_check_rewrite_front</code>
-      <code>v3_9_fix_question_author</code>
-      <code>v3_9_remove_abandoned_multiple_question</code>
-      <code>v4_10_update_install_time</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="4">
       <code>$this-&gt;current_version</code>
       <code>$this-&gt;current_version</code>
@@ -4179,15 +3249,6 @@
       <code>$fields</code>
       <code>$fields</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="7">
-      <code>get_instance</code>
-      <code>init_event_logging_sources</code>
-      <code>log_update</code>
-      <code>log_wccom_plugin_install</code>
-      <code>set_event_logging_source_data_import</code>
-      <code>set_event_logging_source_frontend</code>
-      <code>set_tracking_enabled</code>
-    </MissingReturnType>
     <TypeDoesNotContainType occurrences="1">
       <code>false</code>
     </TypeDoesNotContainType>
@@ -4199,12 +3260,11 @@
       <code>'WP_Post'</code>
       <code>'WP_Post'</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="7">
+    <DocblockTypeContradiction occurrences="6">
       <code>! is_array( $array_a )</code>
       <code>! is_array( $array_b )</code>
       <code>! is_int( $post_id )</code>
       <code>! is_int( $post_id )</code>
-      <code>is_array( $user_lesson_status )</code>
     </DocblockTypeContradiction>
     <FalsableReturnStatement occurrences="4">
       <code>$activity_value</code>
@@ -4218,9 +3278,6 @@
     <InvalidNullableReturnType occurrences="1">
       <code>bool</code>
     </InvalidNullableReturnType>
-    <InvalidPropertyFetch occurrences="1">
-      <code>$last_lesson_activity-&gt;comment_post_ID</code>
-    </InvalidPropertyFetch>
     <InvalidReturnStatement occurrences="3">
       <code>$activity_logged</code>
       <code>$activity_logged</code>
@@ -4231,12 +3288,10 @@
       <code>boolean</code>
       <code>boolean</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="14">
+    <InvalidScalarArgument occurrences="11">
       <code>$comment_id</code>
       <code>$comment_id</code>
       <code>$data_key</code>
-      <code>$lesson</code>
-      <code>$lesson_status-&gt;comment_ID</code>
       <code>$post_id</code>
       <code>$user_answer_id</code>
       <code>$user_answer_id</code>
@@ -4245,27 +3300,22 @@
       <code>$user_id</code>
       <code>$user_id</code>
       <code>$user_lesson_id</code>
-      <code>$user_lesson_status-&gt;comment_ID</code>
     </InvalidScalarArgument>
     <MissingFile occurrences="3">
       <code>require_once ABSPATH . 'wp-admin/includes/admin.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/image.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/plugin-install.php'</code>
     </MissingFile>
-    <MissingParamType occurrences="28">
+    <MissingParamType occurrences="20">
       <code>$attributes</code>
       <code>$course_id</code>
       <code>$data_key</code>
-      <code>$decimal_places_to_round</code>
-      <code>$decimal_places_to_round</code>
       <code>$denominator</code>
       <code>$denominator</code>
       <code>$file</code>
       <code>$from_course</code>
       <code>$key</code>
-      <code>$lesson_id</code>
       <code>$mode</code>
-      <code>$number</code>
       <code>$numerator</code>
       <code>$numerator</code>
       <code>$options</code>
@@ -4282,21 +3332,6 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="13">
-      <code>as_absolute_rounded_number</code>
-      <code>force_complete_user_course</code>
-      <code>is_plugin_present_and_activated</code>
-      <code>is_preview_lesson</code>
-      <code>output_query_params_as_inputs</code>
-      <code>quotient_as_absolute_rounded_number</code>
-      <code>restore_wp_query</code>
-      <code>sensei_delete_question_grade</code>
-      <code>sensei_get_quiz_questions</code>
-      <code>sensei_get_quiz_total</code>
-      <code>sensei_user_course_status_message</code>
-      <code>upload_file</code>
-      <code>user_passed_quiz</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$attributes</code>
     </PossibleRawObjectIteration>
@@ -4311,30 +3346,19 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>$post</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyFetch occurrences="10">
-      <code>$_user_lesson_status-&gt;comment_approved</code>
-      <code>$lesson_status-&gt;comment_ID</code>
+    <PossiblyInvalidPropertyFetch occurrences="7">
       <code>$plugin_information-&gt;name</code>
       <code>$plugin_information-&gt;short_description</code>
       <code>$plugin_information-&gt;version</code>
       <code>$post-&gt;ID</code>
       <code>$post-&gt;post_content</code>
-      <code>$user_lesson_status-&gt;comment_approved</code>
       <code>get_userdata( $user_id )-&gt;user_login</code>
       <code>get_userdata( $user_id )-&gt;user_login</code>
     </PossiblyInvalidPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(int) $lesson_id</code>
-      <code>(int) $user_id</code>
-    </RedundantCastGivenDocblockType>
     <RedundantCondition occurrences="2">
       <code>is_array( $comments )</code>
       <code>isset( $_GET )</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>isset( $_user_lesson_status-&gt;comment_approved )</code>
-      <code>isset( $user_lesson_status-&gt;comment_approved )</code>
-    </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType occurrences="1">
       <code>'' != $sort_key</code>
     </TypeDoesNotContainType>
@@ -4346,12 +3370,8 @@
       <code>DAY_IN_SECONDS</code>
       <code>WP_PLUGIN_DIR</code>
     </UndefinedConstant>
-    <UndefinedDocblockClass occurrences="1">
-      <code>int|number</code>
-    </UndefinedDocblockClass>
-    <UndefinedFunction occurrences="2">
+    <UndefinedFunction occurrences="1">
       <code>WC()</code>
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
     </UndefinedFunction>
   </file>
   <file src="includes/class-sensei-view-helper.php">
@@ -4373,11 +3393,6 @@
     <MissingPropertyType occurrences="1">
       <code>$allowed_html</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="3">
-      <code>get_default_wp_kses_allowed_html</code>
-      <code>get_source_html_tag_allowed_attributes</code>
-      <code>get_video_html_tag_allowed_attributes</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei.php">
     <DeprecatedMethod occurrences="2">
@@ -4439,28 +3454,6 @@
       <code>$token</code>
       <code>$version</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="20">
-      <code>activate</code>
-      <code>activation</code>
-      <code>activation_flush_rules</code>
-      <code>assign_role_caps</code>
-      <code>disable_sensei_modules_extension</code>
-      <code>flush_comment_counts_cache</code>
-      <code>flush_rewrite_rules</code>
-      <code>init</code>
-      <code>initialize_cache_groups</code>
-      <code>initialize_cli</code>
-      <code>initialize_global_objects</code>
-      <code>initiate_rewrite_rules_flush</code>
-      <code>jetpack_latex_support</code>
-      <code>load_hooks</code>
-      <code>load_modules_class</code>
-      <code>maybe_add_latex_support_via</code>
-      <code>sensei_load_template_functions</code>
-      <code>set_legacy_flag</code>
-      <code>update</code>
-      <code>wp_quicklatex_support</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -4508,12 +3501,6 @@
       <code>Woothemes_Sensei</code>
       <code>Woothemes_Sensei</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="4">
-      <code>(bool) $default</code>
-      <code>(bool) $value</code>
-      <code>(int) $post_id</code>
-      <code>(int) $post_id</code>
-    </RedundantCastGivenDocblockType>
     <RedundantCondition occurrences="1">
       <code>'Sensei_Modules' !== $class</code>
     </RedundantCondition>
@@ -4540,10 +3527,6 @@
     <MissingConstructor occurrences="1">
       <code>$timer_start</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="2">
-      <code>log</code>
-      <code>start_timer</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="4">
       <code>$course_id</code>
       <code>$course_id</code>
@@ -4567,9 +3550,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>the_course_theme_layout</code>
-    </MissingReturnType>
     <UndefinedClass occurrences="1">
       <code>ET_GB_Block_Layout</code>
     </UndefinedClass>
@@ -4587,44 +3567,22 @@
     <MissingParamType occurrences="1">
       <code>$post</code>
     </MissingParamType>
-    <MissingReturnType occurrences="9">
-      <code>add_admin_menu_site_editor_item</code>
-      <code>add_editor_styles</code>
-      <code>add_site_editor_hooks</code>
-      <code>enqueue_site_editor_assets</code>
-      <code>init</code>
-      <code>is_site_editor_request</code>
-      <code>maybe_add_site_editor_hooks</code>
-      <code>maybe_override_lesson_theme</code>
-      <code>substitute_theme_cache</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$post-&gt;ID</code>
       <code>$post-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/course-theme/class-sensei-course-theme-lesson.php">
-    <DocblockTypeContradiction occurrences="4">
-      <code>! $user_answers || empty( $user_answers ) || ! is_array( $user_answers )</code>
-      <code>! is_array( $user_answers )</code>
+    <DocblockTypeContradiction occurrences="2">
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>init</code>
-      <code>intercept_notice</code>
-      <code>maybe_add_lesson_prerequisite_notice</code>
-      <code>maybe_add_quiz_results_notice</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="4">
       <code>$current_link</code>
       <code>$current_link</code>
       <code>get_permalink( $course_id )</code>
       <code>get_permalink( $lesson_prerequisite )</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidPropertyFetch occurrences="1">
-      <code>$lesson_status-&gt;comment_approved</code>
-    </PossiblyInvalidPropertyFetch>
     <PossiblyNullArgument occurrences="1">
       <code>$lesson_id</code>
     </PossiblyNullArgument>
@@ -4643,11 +3601,6 @@
       <code>$meta_key</code>
       <code>$post_id</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="3">
-      <code>ensure_learning_mode_url_prefix</code>
-      <code>init</code>
-      <code>register_post_meta</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="2">
       <code>$prefix</code>
       <code>get_post_type_object( 'lesson' )-&gt;cap-&gt;edit_post</code>
@@ -4661,19 +3614,13 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>init</code>
-      <code>maybe_add_quiz_results_notice</code>
-      <code>render_contact_teacher</code>
-      <code>render_reset_quiz</code>
-    </MissingReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink()</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="1">
       <code>$lesson_id</code>
       <code>$lesson_id</code>
     </PossiblyNullArgument>
@@ -4691,12 +3638,6 @@
     <InvalidParamDefault occurrences="1">
       <code>array</code>
     </InvalidParamDefault>
-    <MissingReturnType occurrences="4">
-      <code>format_css_variables</code>
-      <code>init</code>
-      <code>output_global_styles_colors</code>
-      <code>output_style</code>
-    </MissingReturnType>
     <PossiblyNullArrayAccess occurrences="2">
       <code>$element_colors['background']</code>
       <code>$element_colors['text']</code>
@@ -4711,11 +3652,6 @@
     <InvalidArgument occurrences="1">
       <code>$post</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="3">
-      <code>init</code>
-      <code>maybe_set_block_template_name</code>
-      <code>update_legacy_template_naming</code>
-    </MissingReturnType>
   </file>
   <file src="includes/course-theme/class-sensei-course-theme-template.php">
     <PropertyNotSetInConstructor occurrences="8">
@@ -4741,18 +3677,7 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$post-&gt;post_author</code>
     </InvalidPropertyAssignmentValue>
-    <MissingReturnType occurrences="5">
-      <code>add_learning_mode_template</code>
-      <code>init</code>
-      <code>load_file_templates</code>
-      <code>maybe_add_theme_supports</code>
-      <code>maybe_use_course_theme_templates</code>
-    </MissingReturnType>
-    <PossiblyInvalidPropertyFetch occurrences="1">
-      <code>$post-&gt;post_type</code>
-    </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="2">
-      <code>$lesson_id</code>
+    <PossiblyNullArgument occurrences="1">
       <code>$query['post_type'] ?? null</code>
     </PossiblyNullArgument>
     <RedundantConditionGivenDocblockType occurrences="5">
@@ -4772,17 +3697,6 @@
       <code>self::$instance</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1"/>
-    <MissingReturnType occurrences="9">
-      <code>add_post_type_rewrite_rules</code>
-      <code>add_query_var</code>
-      <code>admin_menu_init</code>
-      <code>enqueue_fonts</code>
-      <code>enqueue_styles</code>
-      <code>init</code>
-      <code>maybe_flush_rewrite_rules</code>
-      <code>maybe_override_theme</code>
-      <code>override_theme</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="2">
       <code>get_permalink( $module_lessons[0] )</code>
       <code>get_post_type()</code>
@@ -4806,14 +3720,8 @@
       <code>get_extension_class_name</code>
       <code>is_supported</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
   </file>
   <file src="includes/course-video/blocks/class-sensei-course-video-blocks-video-extension.php">
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>self::$instance</code>
       <code>self::$instance</code>
@@ -4856,9 +3764,6 @@
       <code>self::$instance</code>
       <code>self::$instance</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>static</code>
     </MoreSpecificReturnType>
@@ -4877,10 +3782,6 @@
       <code>$meta_key</code>
       <code>$post_id</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>register_post_meta</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>get_the_ID()</code>
       <code>get_the_ID()</code>
@@ -4909,16 +3810,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>new $task_class( $this )</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="8">
-      <code>add_log_entry</code>
-      <code>clean_up</code>
-      <code>persist</code>
-      <code>restore_from_json</code>
-      <code>run</code>
-      <code>set_state</code>
-      <code>set_user_id</code>
-      <code>start</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_Data_Port_Task_Interface</code>
     </MoreSpecificReturnType>
@@ -4949,9 +3840,6 @@
       <code>$state</code>
       <code>$user_id</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $level</code>
-    </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$uploads</code>
     </RedundantConditionGivenDocblockType>
@@ -4982,20 +3870,6 @@
     <InvalidStringClass occurrences="1">
       <code>$handler_class::create( $job_id, (int) $user_id )</code>
     </InvalidStringClass>
-    <MissingReturnType occurrences="12">
-      <code>cancel_all_jobs</code>
-      <code>cancel_job</code>
-      <code>clean_old_jobs</code>
-      <code>init</code>
-      <code>log_complete_export_jobs</code>
-      <code>log_complete_import_jobs</code>
-      <code>maybe_schedule_cron_jobs</code>
-      <code>persist</code>
-      <code>redirect_edit_post_link</code>
-      <code>redirect_imported_sample</code>
-      <code>run_data_port_job</code>
-      <code>run_scheduled_data_port_job</code>
-    </MissingReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -5006,13 +3880,6 @@
       <code>get_import_id</code>
       <code>is_complete</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="5">
-      <code>(int) $user_id</code>
-      <code>(int) $user_id</code>
-      <code>(int) $user_id</code>
-      <code>(int) $user_id</code>
-      <code>(string) $job_id</code>
-    </RedundantCastGivenDocblockType>
     <UndefinedClass occurrences="1">
       <code>WP_CLI</code>
     </UndefinedClass>
@@ -5022,17 +3889,6 @@
     <UndefinedMethod occurrences="1">
       <code>get_import_id</code>
     </UndefinedMethod>
-  </file>
-  <file src="includes/data-port/class-sensei-data-port-task-interface.php">
-    <MissingReturnType occurrences="2">
-      <code>run</code>
-      <code>save_state</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/data-port/class-sensei-data-port-task.php">
-    <MissingReturnType occurrences="1">
-      <code>save_state</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/class-sensei-data-port-utilities.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -5108,10 +3964,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>null === $this-&gt;results</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>get_result_counts</code>
-      <code>set_content_types</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$tasks</code>
       <code>Sensei_Export_Job</code>
@@ -5122,12 +3974,6 @@
     <UninitializedProperty occurrences="1">
       <code>$this-&gt;results</code>
     </UninitializedProperty>
-  </file>
-  <file src="includes/data-port/class-sensei-export.php">
-    <MissingReturnType occurrences="2">
-      <code>admin_menu</code>
-      <code>export_page</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/class-sensei-import-block-migrator.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -5155,9 +4001,6 @@
     <MissingClosureParamType occurrences="1">
       <code>$name</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="1">
-      <code>detect_delimiter</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="8">
       <code>$column_names</code>
       <code>$indexed_line</code>
@@ -5187,14 +4030,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>$this-&gt;get_tasks()['associations']</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="6">
-      <code>add_line_warning</code>
-      <code>add_log_entry</code>
-      <code>get_result_counts</code>
-      <code>set_import_id</code>
-      <code>set_is_sample_data</code>
-      <code>set_line_result</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_Import_Associations</code>
     </MoreSpecificReturnType>
@@ -5208,21 +4043,12 @@
       <code>$tasks</code>
       <code>Sensei_Import_Job</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(bool) $is_sample_data</code>
-    </RedundantCastGivenDocblockType>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset( $this-&gt;tasks )</code>
     </RedundantPropertyInitializationCheck>
     <UninitializedProperty occurrences="1">
       <code>$this-&gt;results</code>
     </UninitializedProperty>
-  </file>
-  <file src="includes/data-port/class-sensei-import.php">
-    <MissingReturnType occurrences="2">
-      <code>admin_menu</code>
-      <code>import_page</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/export-tasks/class-sensei-export-courses.php">
     <PossiblyInvalidArgument occurrences="1">
@@ -5244,9 +4070,6 @@
     </UndefinedPropertyFetch>
   </file>
   <file src="includes/data-port/export-tasks/class-sensei-export-package.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$file-&gt;post_title</code>
     </PossiblyInvalidPropertyFetch>
@@ -5277,10 +4100,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/file.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="2">
-      <code>add_file_to_job</code>
-      <code>run</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>get_attached_file( $files[ $type ] )</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -5311,13 +4130,6 @@
       <code>function( $message, $code ) use ( $line_number, $course_id, $post_title ) {</code>
       <code>function( $message, $code ) use ( $line_number, $lesson_id, $post_title ) {</code>
     </MissingClosureReturnType>
-    <MissingReturnType occurrences="5">
-      <code>add_course_lessons</code>
-      <code>add_lesson_module</code>
-      <code>handle_course_lessons</code>
-      <code>run</code>
-      <code>save_state</code>
-    </MissingReturnType>
     <PossiblyInvalidMethodCall occurrences="2">
       <code>get_error_code</code>
       <code>get_error_message</code>
@@ -5329,9 +4141,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$batch_remaining</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $lesson_id</code>
-    </RedundantCastGivenDocblockType>
     <RedundantPropertyInitializationCheck occurrences="3">
       <code>isset( $this-&gt;total_tasks )</code>
       <code>isset( $this-&gt;total_tasks )</code>
@@ -5354,17 +4163,8 @@
     <InvalidReturnType occurrences="1">
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>handle_prerequisite</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/import-tasks/class-sensei-import-file-process-task.php">
-    <MissingReturnType occurrences="4">
-      <code>add_post_process_task</code>
-      <code>run</code>
-      <code>run_post_process_tasks</code>
-      <code>save_state</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_attached_file( $attachment_id )</code>
     </PossiblyFalseArgument>
@@ -5387,15 +4187,8 @@
     <InvalidReturnType occurrences="1">
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>handle_prerequisite</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php">
-    <MissingReturnType occurrences="2">
-      <code>add_prerequisite_task</code>
-      <code>handle_prerequisite_helper</code>
-    </MissingReturnType>
     <UndefinedMethod occurrences="3">
       <code>add_line_warning</code>
       <code>add_line_warning</code>
@@ -5428,10 +4221,6 @@
     <InvalidReturnType occurrences="1">
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="2">
-      <code>delete_course_terms</code>
-      <code>set_course_terms</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="3">
       <code>$post_id</code>
       <code>$post_id</code>
@@ -5468,10 +4257,6 @@
       <code>bool|WP_Error</code>
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="2">
-      <code>set_lesson_terms</code>
-      <code>set_quiz_questions</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="5">
       <code>$post_id</code>
       <code>$post_id</code>
@@ -5506,14 +4291,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$value</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="6">
-      <code>add_line_warning</code>
-      <code>add_warnings_to_job</code>
-      <code>restore_from_source_array</code>
-      <code>set_data</code>
-      <code>set_post_id</code>
-      <code>store_import_id</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="1">
       <code>$post_id</code>
     </NullableReturnStatement>
@@ -5559,9 +4336,6 @@
       <code>null|string</code>
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>sync_meta</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$meta_fields</code>
     </PossibleRawObjectIteration>
@@ -5580,12 +4354,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>enqueue_scripts</code>
-      <code>enqueue_styles</code>
-      <code>init</code>
-      <code>output_modal</code>
-    </MissingReturnType>
   </file>
   <file src="includes/email-signup/template.php">
     <DeprecatedClass occurrences="3">
@@ -5757,21 +4525,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>$this-&gt;get_enrolment_provider_by_id( Sensei_Course_Manual_Enrolment_Provider::instance()-&gt;get_id() )</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="13">
-      <code>add_wcpc_1_notice</code>
-      <code>collect_enrolment_providers</code>
-      <code>defer_course_enrolment_check</code>
-      <code>detect_wcpc_1</code>
-      <code>do_course_enrolment_check</code>
-      <code>init</code>
-      <code>invalidate_learner_result</code>
-      <code>mark_user_as_needing_recalculation</code>
-      <code>recalculate_enrolments</code>
-      <code>recalculate_on_course_post_status_change</code>
-      <code>remove_deferred_enrolment_check</code>
-      <code>run_deferred_course_enrolment_checks</code>
-      <code>trigger_course_enrolment_check</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>false|Sensei_Course_Manual_Enrolment_Provider</code>
     </MoreSpecificReturnType>
@@ -5808,20 +4561,10 @@
       <code>isset( $time ) ? $time : time()</code>
     </PossiblyInvalidPropertyAssignmentValue>
   </file>
-  <file src="includes/enrolment/class-sensei-course-enrolment-stored-status-provider.php">
-    <MissingReturnType occurrences="2">
-      <code>clear_enrolment_status</code>
-      <code>set_enrolment_status</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/enrolment/class-sensei-course-enrolment.php">
     <InvalidClass occurrences="1">
       <code>[ 'Sensei_learner', 'get_learner_id' ]</code>
     </InvalidClass>
-    <MissingReturnType occurrences="2">
-      <code>invalidate_learner_result</code>
-      <code>store_enrolment_results</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="1">
       <code>$is_enrolled</code>
     </NullableReturnStatement>
@@ -5856,9 +4599,6 @@
     <InvalidReturnType occurrences="1">
       <code>int</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>set_migrated_legacy_enrolment_status</code>
-    </MissingReturnType>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset( self::$instance )</code>
     </RedundantPropertyInitializationCheck>
@@ -5870,13 +4610,6 @@
     <InvalidFalsableReturnType occurrences="1">
       <code>string</code>
     </InvalidFalsableReturnType>
-    <MissingReturnType occurrences="5">
-      <code>end</code>
-      <code>modify_user_query_add_user_id</code>
-      <code>run</code>
-      <code>set_last_user_id</code>
-      <code>setup</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>$this-&gt;get_current_job_id()</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -5884,11 +4617,6 @@
       <code>isset( $args['course_id'] ) ? intval( $args['course_id'] ) : null</code>
       <code>isset( $args['job_id'] ) ? sanitize_text_field( $args['job_id'] ) : null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(int) $this-&gt;batch_size</code>
-      <code>(int) $user_id</code>
-      <code>(int) $user_query-&gt;get_total()</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/enrolment/class-sensei-enrolment-job-scheduler.php">
     <DocblockTypeContradiction occurrences="2">
@@ -5898,27 +4626,6 @@
     <MissingClosureReturnType occurrences="1">
       <code>function() {</code>
     </MissingClosureReturnType>
-    <MissingReturnType occurrences="5">
-      <code>cancel_course_calculation_job</code>
-      <code>init</code>
-      <code>maybe_start_learner_calculation</code>
-      <code>run_course_calculation</code>
-      <code>run_learner_calculation</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/enrolment/class-sensei-enrolment-learner-calculation-job.php">
-    <MissingReturnType occurrences="5">
-      <code>end</code>
-      <code>modify_user_query_add_user_id</code>
-      <code>run</code>
-      <code>set_last_user_id</code>
-      <code>setup</code>
-    </MissingReturnType>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(int) $this-&gt;batch_size</code>
-      <code>(int) $user_id</code>
-      <code>(int) $user_query-&gt;get_total()</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/enrolment/class-sensei-enrolment-provider-journal-store.php">
     <DocblockTypeContradiction occurrences="1">
@@ -5927,12 +4634,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$timestamp</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
-      <code>add_provider_log_message</code>
-      <code>persist_all</code>
-      <code>register_possible_enrolment_change</code>
-      <code>restore_from_json</code>
-    </MissingReturnType>
   </file>
   <file src="includes/enrolment/class-sensei-enrolment-provider-journal.php">
     <DocblockTypeContradiction occurrences="1">
@@ -5946,10 +4647,6 @@
     <InvalidFalsableReturnType occurrences="1">
       <code>array</code>
     </InvalidFalsableReturnType>
-    <MissingReturnType occurrences="2">
-      <code>add_log_message</code>
-      <code>add_status</code>
-    </MissingReturnType>
   </file>
   <file src="includes/enrolment/class-sensei-enrolment-provider-state-store.php">
     <DocblockTypeContradiction occurrences="1">
@@ -5961,21 +4658,6 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$provider_states</code>
     </InvalidPropertyAssignmentValue>
-    <MissingReturnType occurrences="5">
-      <code>get_has_changed</code>
-      <code>persist_all</code>
-      <code>restore_from_json</code>
-      <code>set_has_changed</code>
-      <code>set_provider_states</code>
-    </MissingReturnType>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(bool) $has_changed</code>
-    </RedundantCastGivenDocblockType>
-  </file>
-  <file src="includes/enrolment/class-sensei-enrolment-provider-state.php">
-    <MissingReturnType occurrences="1">
-      <code>set_stored_value</code>
-    </MissingReturnType>
   </file>
   <file src="includes/hooks/template.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -5984,14 +4666,8 @@
     <InvalidScope occurrences="1">
       <code>$this</code>
     </InvalidScope>
-    <UndefinedFunction occurrences="1">
-      <code>'sensei_the_single_lesson_meta'</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/internal/emails/class-email-blocks.php">
-    <MissingReturnType occurrences="1">
-      <code>load_admin_assets</code>
-    </MissingReturnType>
     <UndefinedDocblockClass occurrences="2">
       <code>WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg</code>
       <code>WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg</code>
@@ -6002,9 +4678,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>disable_legacy_emails</code>
-    </MissingReturnType>
     <TooManyArguments occurrences="1">
       <code>new Email_Seeder( new Email_Seeder_Data(), $this-&gt;repository, $template_repository )</code>
     </TooManyArguments>
@@ -6018,16 +4691,8 @@
       <code>Email_Generators_Abstract[]</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="includes/internal/emails/class-email-list-table-actions.php">
-    <MissingReturnType occurrences="1">
-      <code>validate_bulk_action_request</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/class-email-list-table.php">
     <ArgumentTypeCoercion occurrences="1"/>
-    <MissingReturnType occurrences="1">
-      <code>prepare_items</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post</code>
     </MoreSpecificImplementedParamType>
@@ -6068,13 +4733,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/emails/class-email-patterns.php">
-    <MissingReturnType occurrences="5">
-      <code>init</code>
-      <code>register_block_patterns_category</code>
-      <code>register_email_block_patterns</code>
-      <code>register_email_editor_block_patterns</code>
-      <code>register_email_preview_block_patterns</code>
-    </MissingReturnType>
     <UndefinedDocblockClass occurrences="1">
       <code>WP_Screen</code>
     </UndefinedDocblockClass>
@@ -6118,25 +4776,13 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $query-&gt;post_count</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/emails/class-email-seeder-data.php">
     <MissingConstructor occurrences="1">
       <code>$emails</code>
     </MissingConstructor>
   </file>
-  <file src="includes/internal/emails/class-email-seeder.php">
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/class-email-sender.php">
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>send_email</code>
-    </MissingReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -6164,33 +4810,14 @@
       <code>$key</code>
       <code>$key</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="3">
-      <code>form_field_hidden</code>
-      <code>init</code>
-      <code>render_tabs</code>
-    </MissingReturnType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$this-&gt;settings-&gt;get_settings()</code>
     </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="includes/internal/emails/class-recreate-emails-tool.php">
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/internal/emails/class-settings-menu.php">
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
   </file>
   <file src="includes/internal/emails/generators/class-course-completed.php">
     <DocblockTypeContradiction occurrences="1">
       <code>get_permalink( $course_id )</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>completed_course_mail_to_student</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>\Sensei_Course::get_course_completed_page_url( $course_id ) ?? get_permalink( $course_id )</code>
     </PossiblyFalseArgument>
@@ -6199,9 +4826,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/internal/emails/generators/class-course-created.php">
-    <MissingReturnType occurrences="1">
-      <code>course_created_to_admin</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$course-&gt;post_author</code>
     </PossiblyInvalidPropertyFetch>
@@ -6211,14 +4835,8 @@
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$course-&gt;post_author</code>
     </PossiblyNullPropertyFetch>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $course_id</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/emails/generators/class-course-welcome.php">
-    <MissingReturnType occurrences="1">
-      <code>welcome_to_course_for_student</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="4">
       <code>$course-&gt;ID</code>
       <code>$course-&gt;post_author</code>
@@ -6226,20 +4844,7 @@
       <code>$course-&gt;post_title</code>
     </PossiblyInvalidPropertyFetch>
   </file>
-  <file src="includes/internal/emails/generators/class-email-generators-abstract.php">
-    <MissingReturnType occurrences="1">
-      <code>send_email_action</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/internal/emails/generators/class-new-course-assigned.php">
-    <MissingReturnType occurrences="1">
-      <code>course_new_teacher_assigned_email</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/generators/class-quiz-graded.php">
-    <MissingReturnType occurrences="1">
-      <code>quiz_graded_mail_to_student</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $quiz_id )</code>
     </PossiblyFalseArgument>
@@ -6248,15 +4853,7 @@
       <code>$lesson-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
   </file>
-  <file src="includes/internal/emails/generators/class-student-completes-course.php">
-    <MissingReturnType occurrences="1">
-      <code>student_completed_course_mail_to_teacher</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/generators/class-student-completes-lesson.php">
-    <MissingReturnType occurrences="1">
-      <code>student_completed_lesson_mail_to_teacher</code>
-    </MissingReturnType>
     <RedundantCast occurrences="2">
       <code>(int) $lesson_id</code>
       <code>(int) $student_id</code>
@@ -6300,9 +4897,6 @@
     </PossiblyNullPropertyFetch>
   </file>
   <file src="includes/internal/emails/generators/class-student-starts-course.php">
-    <MissingReturnType occurrences="1">
-      <code>student_started_course_mail_to_teacher</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="3">
       <code>$course-&gt;post_author</code>
       <code>$course-&gt;post_status</code>
@@ -6310,9 +4904,6 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/emails/generators/class-student-submits-quiz.php">
-    <MissingReturnType occurrences="1">
-      <code>student_submits_quiz_mail_to_teacher</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$course-&gt;ID</code>
       <code>$lesson-&gt;ID</code>
@@ -6338,42 +4929,19 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>install</code>
-    </MissingReturnType>
     <UndefinedConstant occurrences="1">
       <code>MINUTE_IN_SECONDS</code>
     </UndefinedConstant>
-  </file>
-  <file src="includes/internal/installer/class-migration.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
   </file>
   <file src="includes/internal/installer/class-schema.php">
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/upgrade.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>create_tables</code>
-    </MissingReturnType>
   </file>
   <file src="includes/internal/installer/class-updates-factory.php">
     <PossiblyNullArgument occurrences="1">
       <code>$plugin_version</code>
     </PossiblyNullArgument>
-  </file>
-  <file src="includes/internal/installer/migrations/class-student-progress-migration.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_null( $this-&gt;errors )</code>
-    </DocblockTypeContradiction>
-    <InvalidCast occurrences="1">
-      <code>$value_sql</code>
-    </InvalidCast>
-    <UndefinedDocblockClass occurrences="1">
-      <code>strng</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php">
     <PossiblyNullIterator occurrences="1">
@@ -6408,30 +4976,10 @@
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
   </file>
-  <file src="includes/internal/student-progress/course-progress/repositories/class-aggregate-course-progress-repository.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getTimestamp</code>
-      <code>getTimestamp</code>
-    </PossiblyNullReference>
-  </file>
   <file src="includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>Course_Progress</code>
-    </InvalidNullableReturnType>
-    <InvalidPropertyFetch occurrences="3">
-      <code>$comment-&gt;comment_ID</code>
-      <code>$comment-&gt;comment_approved</code>
-      <code>$comment-&gt;comment_date</code>
-    </InvalidPropertyFetch>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;get( $course_id, $user_id )</code>
-    </NullableReturnStatement>
     <PossiblyNullArgument occurrences="1">
       <code>$course_progress-&gt;get_status()</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>format</code>
-    </PossiblyNullReference>
   </file>
   <file src="includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php">
     <PossiblyInvalidPropertyFetch occurrences="8">
@@ -6444,45 +4992,12 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullReference occurrences="2">
-      <code>format</code>
-      <code>format</code>
-    </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
-    </RedundantCastGivenDocblockType>
-  </file>
-  <file src="includes/internal/student-progress/lesson-progress/repositories/class-aggregate-lesson-progress-repository.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getTimestamp</code>
-      <code>getTimestamp</code>
-    </PossiblyNullReference>
   </file>
   <file src="includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>Lesson_Progress</code>
-    </InvalidNullableReturnType>
-    <InvalidPropertyFetch occurrences="3">
-      <code>$comment-&gt;comment_ID</code>
-      <code>$comment-&gt;comment_approved</code>
-      <code>$comment-&gt;comment_date</code>
-    </InvalidPropertyFetch>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;get( $lesson_id, $user_id )</code>
-    </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="1">
-      <code>$lesson_progress-&gt;get_status()</code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="1">
       <code>format</code>
       <code>format</code>
     </PossiblyNullReference>
-    <UndefinedClass occurrences="1">
-      <code>RuntimeException</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
-      <code>RuntimeException</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php">
     <PossiblyInvalidPropertyFetch occurrences="8">
@@ -6495,36 +5010,12 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullReference occurrences="2">
-      <code>format</code>
-      <code>format</code>
-    </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
-    </RedundantCastGivenDocblockType>
-  </file>
-  <file src="includes/internal/student-progress/quiz-progress/repositories/class-aggregate-quiz-progress-repository.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getTimestamp</code>
-      <code>getTimestamp</code>
-    </PossiblyNullReference>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php">
-    <InvalidPropertyFetch occurrences="3">
-      <code>$comment-&gt;comment_ID</code>
-      <code>$comment-&gt;comment_approved</code>
-      <code>$comment-&gt;comment_date</code>
-    </InvalidPropertyFetch>
     <PossiblyInvalidIterator occurrences="2">
       <code>$comments</code>
       <code>$comments</code>
     </PossiblyInvalidIterator>
-    <PossiblyNullArgument occurrences="1">
-      <code>$quiz_progress-&gt;get_status()</code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>format</code>
-    </PossiblyNullReference>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php">
     <PossiblyInvalidPropertyFetch occurrences="8">
@@ -6537,19 +5028,8 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullReference occurrences="2">
-      <code>format</code>
-      <code>format</code>
-    </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/student-progress/services/class-course-deleted-handler.php">
-    <MissingReturnType occurrences="2">
-      <code>handle</code>
-      <code>init</code>
-    </MissingReturnType>
     <UndefinedDocblockClass occurrences="1">
       <code>WP_Post</code>
     </UndefinedDocblockClass>
@@ -6564,12 +5044,6 @@
       <code>WP_Post</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="includes/internal/student-progress/services/class-user-deleted-handler.php">
-    <MissingReturnType occurrences="2">
-      <code>handle</code>
-      <code>init</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/lib/usage-tracking/class-usage-tracking-base.php">
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$callback</code>
@@ -6583,33 +5057,11 @@
     <MissingFile occurrences="1">
       <code>include_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="15">
-      <code>add_usage_tracking_two_week_schedule</code>
-      <code>enqueue_script_deps</code>
-      <code>get_event_prefix</code>
-      <code>get_instance</code>
-      <code>handle_tracking_opt_in</code>
-      <code>hide_tracking_opt_in</code>
-      <code>is_opt_in_hidden</code>
-      <code>maybe_display_tracking_opt_in</code>
-      <code>opt_in_dialog_text_allowed_html</code>
-      <code>output_opt_in_js</code>
-      <code>schedule_tracking_task</code>
-      <code>send_usage_data</code>
-      <code>set_callback</code>
-      <code>set_tracking_enabled</code>
-      <code>unschedule_tracking_task</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$callback</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php">
-    <MissingReturnType occurrences="3">
-      <code>get_instance</code>
-      <code>get_template_data</code>
-      <code>set_tracking_enabled</code>
-    </MissingReturnType>
     <TypeDoesNotContainType occurrences="1">
       <code>false</code>
     </TypeDoesNotContainType>
@@ -6623,10 +5075,6 @@
     <MissingPropertyType occurrences="1">
       <code>$wp_die_args</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>get_wp_die_args</code>
-      <code>set_wp_die_args</code>
-    </MissingReturnType>
   </file>
   <file src="includes/lib/usage-tracking/tests/test-class-usage-tracking.php">
     <UndefinedClass occurrences="1">
@@ -6651,9 +5099,6 @@
       <code>$mail_poet_lists</code>
       <code>$sensei_lists</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(int) $mp_list_id</code>
-    </RedundantCastGivenDocblockType>
     <UndefinedClass occurrences="6">
       <code>$exception</code>
       <code>\MailPoet\API\API</code>
@@ -6706,12 +5151,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/renderers/class-sensei-renderer-single-post.php">
-    <MissingReturnType occurrences="4">
-      <code>backup_global_vars</code>
-      <code>reset_global_vars</code>
-      <code>set_global_vars</code>
-      <code>setup_post_query</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_content</code>
     </PossiblyInvalidPropertyFetch>
@@ -6738,9 +5177,6 @@
     </InvalidGlobal>
   </file>
   <file src="includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php">
-    <MissingReturnType occurrences="1">
-      <code>add_orderby_custom_field_to_query</code>
-    </MissingReturnType>
     <TooManyArguments occurrences="2">
       <code>remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 )</code>
       <code>remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 )</code>
@@ -6750,26 +5186,9 @@
     <InvalidDocblock occurrences="1">
       <code>public function get_is_last_activity_filter_enabled() {</code>
     </InvalidDocblock>
-    <MissingReturnType occurrences="7">
-      <code>add_last_activity_to_user_query</code>
-      <code>add_orderby_custom_field_to_user_query</code>
-      <code>add_pre_user_query_hook</code>
-      <code>filter_users_by_last_activity</code>
-      <code>get_is_last_activity_filter_enabled</code>
-      <code>group_by_users</code>
-      <code>only_course_enrolled_users</code>
-    </MissingReturnType>
   </file>
   <file src="includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php">
     <ArgumentTypeCoercion occurrences="1"/>
-    <MissingReturnType occurrences="6">
-      <code>data_table_footer</code>
-      <code>extra_tablenav</code>
-      <code>output_course_select_input</code>
-      <code>output_top_filters</code>
-      <code>prepare_items</code>
-      <code>search_button</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="4">
       <code>Sensei_Reports_Overview_List_Table_Abstract</code>
       <code>Sensei_Reports_Overview_List_Table_Abstract</code>
@@ -6852,9 +5271,6 @@
     <InvalidClass occurrences="1">
       <code>WP_HTTP</code>
     </InvalidClass>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArrayAssignment occurrences="2">
       <code>$result[ $student_id ][ $course_id ]</code>
       <code>$result[ $student_id ][ $course_id ]</code>
@@ -6879,11 +5295,6 @@
     <InvalidReturnType occurrences="1">
       <code>WP_Post|null</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="3">
-      <code>get_schema_lessons</code>
-      <code>get_schema_modules</code>
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidMethodCall occurrences="2">
       <code>get_error_code</code>
       <code>get_error_message</code>
@@ -6909,9 +5320,6 @@
       <code>WP_HTTP</code>
       <code>WP_HTTP</code>
     </InvalidClass>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArrayAssignment occurrences="2">
       <code>$result[ $user_id ][ $course_id ]</code>
       <code>$result[ $user_id ][ $course_id ]</code>
@@ -6940,9 +5348,6 @@
     <InvalidReturnType occurrences="1">
       <code>boolean</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
@@ -6979,9 +5384,6 @@
     <InvalidStringClass occurrences="1">
       <code>$handler_class::get_file_config()</code>
     </InvalidStringClass>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="4">
       <code>$request-&gt;get_param( 'job_id' )</code>
       <code>$request-&gt;get_param( 'job_id' )</code>
@@ -7033,19 +5435,11 @@
       <code>require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/file.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Sensei_REST_API_Extensions_Controller</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-home-controller.php">
-    <MissingReturnType occurrences="3">
-      <code>register_get_data_route</code>
-      <code>register_mark_tasks_complete_route</code>
-      <code>register_routes</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Sensei_REST_API_Home_Controller</code>
     </PropertyNotSetInConstructor>
@@ -7067,9 +5461,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>sanitize_text_field( $request-&gt;get_param( 'job_id' ) )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$result</code>
     </PossiblyInvalidArgument>
@@ -7083,11 +5474,6 @@
       <code>Sensei_REST_API_Import_Controller</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="includes/rest-api/class-sensei-rest-api-internal.php">
-    <MissingReturnType occurrences="1">
-      <code>register</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php">
     <ArgumentTypeCoercion occurrences="1"/>
     <DocblockTypeContradiction occurrences="1">
@@ -7100,9 +5486,6 @@
     <InvalidReturnType occurrences="1">
       <code>WP_REST_Response|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="6">
       <code>$lesson</code>
       <code>$lesson</code>
@@ -7151,9 +5534,6 @@
       <code>$value</code>
       <code>$value</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="1">
-      <code>init_post_meta</code>
-    </MissingReturnType>
     <ParamNameMismatch occurrences="1">
       <code>$prepared</code>
     </ParamNameMismatch>
@@ -7204,9 +5584,6 @@
     <InvalidArgument occurrences="1">
       <code>$post_args</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="1">
-      <code>migrate_non_editor_question</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$question_categories</code>
     </PossibleRawObjectIteration>
@@ -7247,9 +5624,6 @@
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-question-options-controller.php">
     <ArgumentTypeCoercion occurrences="1"/>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="4">
       <code>$question</code>
       <code>$question</code>
@@ -7335,9 +5709,6 @@
       <code>boolean</code>
       <code>string</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="6">
       <code>$post-&gt;ID</code>
       <code>$post-&gt;ID</code>
@@ -7366,21 +5737,6 @@
       <code>get_json_params</code>
       <code>get_json_params</code>
     </InvalidMethodCall>
-    <MissingReturnType occurrences="13">
-      <code>complete_setup_wizard</code>
-      <code>register_complete_wizard_route</code>
-      <code>register_get_data_route</code>
-      <code>register_get_features_route</code>
-      <code>register_routes</code>
-      <code>register_setup_wizard_settings</code>
-      <code>register_submit_features_installation_route</code>
-      <code>register_submit_features_route</code>
-      <code>register_submit_purpose_route</code>
-      <code>register_submit_theme_route</code>
-      <code>register_submit_tracking_route</code>
-      <code>register_submit_welcome_route</code>
-      <code>update_setup_wizard_settings</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Sensei_REST_API_Setup_Wizard_Controller</code>
     </PropertyNotSetInConstructor>
@@ -7401,9 +5757,6 @@
       <code>include_once ABSPATH . '/wp-admin/includes/theme-install.php'</code>
       <code>include_once ABSPATH . '/wp-admin/includes/theme.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$api-&gt;download_link</code>
     </PossiblyInvalidPropertyFetch>
@@ -7428,11 +5781,6 @@
       <code>$post</code>
       <code>$version</code>
     </MissingParamType>
-    <MissingReturnType occurrences="3">
-      <code>sensei_do_deprecated_action</code>
-      <code>sensei_log_event</code>
-      <code>sensei_log_jetpack_event</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_the_ID()</code>
     </PossiblyFalseArgument>
@@ -7502,9 +5850,6 @@
     <MissingPropertyType occurrences="1">
       <code>$global_product</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>setup_course_query</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyAssignmentValue occurrences="2">
       <code>empty( $exclude ) ? '' : explode( ',', $exclude )</code>
       <code>empty( $ids ) ? '' : explode( ',', $ids )</code>
@@ -7512,11 +5857,6 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$user-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
-  </file>
-  <file src="includes/shortcodes/class-sensei-shortcode-featured-courses.php">
-    <MissingReturnType occurrences="1">
-      <code>setup_course_query</code>
-    </MissingReturnType>
   </file>
   <file src="includes/shortcodes/class-sensei-shortcode-lesson-page.php">
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -7535,10 +5875,6 @@
       <code>$code</code>
       <code>$content</code>
     </MissingParamType>
-    <MissingReturnType occurrences="2">
-      <code>initialize_shortcodes</code>
-      <code>setup_shortcode_class_map</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$shortcode_classes</code>
     </PropertyNotSetInConstructor>
@@ -7562,9 +5898,6 @@
       <code>$users</code>
       <code>$users</code>
     </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>setup_teacher_query</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$exclude</code>
       <code>$include</code>
@@ -7597,23 +5930,6 @@
       <code>$course_status</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="15">
-      <code>active_no_course_message_output</code>
-      <code>add_course_details_wrapper_end</code>
-      <code>add_course_details_wrapper_start</code>
-      <code>attach_course_buttons</code>
-      <code>attach_course_progress</code>
-      <code>attach_shortcode_hooks</code>
-      <code>completed_no_course_message_output</code>
-      <code>course_category</code>
-      <code>course_toggle_actions</code>
-      <code>detach_shortcode_hooks</code>
-      <code>is_my_courses</code>
-      <code>no_course_message_output</code>
-      <code>print_course_toggle_actions_inline_script</code>
-      <code>setup_course_query</code>
-      <code>should_filter_course_by_status</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$category_output</code>
       <code>$course</code>
@@ -7666,30 +5982,6 @@
       <code>$question_type</code>
       <code>$template_name</code>
     </MissingParamType>
-    <MissingReturnType occurrences="22">
-      <code>get_sensei_footer</code>
-      <code>get_sensei_header</code>
-      <code>sensei_courses_per_row</code>
-      <code>sensei_get_template</code>
-      <code>sensei_get_the_question_id</code>
-      <code>sensei_load_template</code>
-      <code>sensei_load_template_part</code>
-      <code>sensei_setup_module</code>
-      <code>sensei_setup_the_question</code>
-      <code>sensei_the_course_results_lessons</code>
-      <code>sensei_the_excerpt</code>
-      <code>sensei_the_lesson_excerpt</code>
-      <code>sensei_the_lesson_status_class</code>
-      <code>sensei_the_module_description</code>
-      <code>sensei_the_module_id</code>
-      <code>sensei_the_module_status</code>
-      <code>sensei_the_my_courses_content</code>
-      <code>sensei_the_question_class</code>
-      <code>sensei_the_question_content</code>
-      <code>sensei_the_single_lesson_meta</code>
-      <code>the_no_permissions_message</code>
-      <code>the_no_permissions_title</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="2">
       <code>get_permalink( $course_id )</code>
       <code>get_the_ID()</code>
@@ -7719,64 +6011,10 @@
       <code>$item-&gt;term_id</code>
     </UndefinedMagicPropertyFetch>
   </file>
-  <file src="includes/theme-integrations/theme-integration-loader.php">
-    <MissingReturnType occurrences="4">
-      <code>get_supported_themes</code>
-      <code>possibly_load_supported_theme_wrappers</code>
-      <code>setup_currently_active_theme</code>
-      <code>setup_themes</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyeleven.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyfifteen.php">
-    <MissingReturnType occurrences="2">
-      <code>print_styles</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyfourteen.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyseventeen.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentythirteen.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentytwelve.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/underscores.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php">
     <DocblockTypeContradiction occurrences="1">
       <code>empty( $post_to_copy )</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7785,10 +6023,6 @@
     </ParamNameMismatch>
   </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php">
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7803,12 +6037,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>true</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
-      <code>add_filter_hide_the_title</code>
-      <code>get_option</code>
-      <code>handle_request</code>
-      <code>remove_filter_hide_the_title</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>get_the_ID()</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -7824,10 +6052,6 @@
       <code>! $learner_user</code>
       <code>$learner_user</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7835,22 +6059,7 @@
       <code>$post_to_copy</code>
     </ParamNameMismatch>
   </file>
-  <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php">
-    <MissingReturnType occurrences="1">
-      <code>handle_request</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php">
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php">
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7881,12 +6090,6 @@
       <code>$this-&gt;dummy_post-&gt;ID === $id</code>
       <code>$this-&gt;original_query</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>do_sensei_pagination</code>
-      <code>output_content_as_page</code>
-      <code>prepare_wp_query</code>
-      <code>setup_original_query</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="2">
       <code>$object_to_copy</code>
       <code>$object_to_copy</code>
@@ -7896,28 +6099,12 @@
     <MissingConstructor occurrences="1">
       <code>$author</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$this-&gt;author</code>
     </PossiblyFalseArgument>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>get_user_by( 'id', get_query_var( 'author' ) )</code>
     </PossiblyFalsePropertyAssignmentValue>
-  </file>
-  <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php">
-    <MissingReturnType occurrences="3">
-      <code>disable_comments</code>
-      <code>disable_theme_pagination</code>
-      <code>reenable_comments</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php">
-    <MissingReturnType occurrences="1">
-      <code>handle_request</code>
-    </MissingReturnType>
   </file>
   <file src="includes/update-tasks/class-sensei-update-fix-question-author.php">
     <PossiblyInvalidPropertyFetch occurrences="2">
@@ -7944,19 +6131,11 @@
     <MissingParamType occurrences="1">
       <code>$email_address</code>
     </MissingParamType>
-    <MissingReturnType occurrences="2">
-      <code>sensei_after_sending_email</code>
-      <code>sensei_before_mail</code>
-    </MissingReturnType>
   </file>
   <file src="sensei-lms.php">
     <InvalidGlobal occurrences="1">
       <code>global $woothemes_sensei;</code>
     </InvalidGlobal>
-    <MissingReturnType occurrences="2">
-      <code>Sensei</code>
-      <code>activate_sensei</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$plugin</code>
     </PossiblyNullArgument>

--- a/includes/admin/tools/class-sensei-tool-enrolment-debug.php
+++ b/includes/admin/tools/class-sensei-tool-enrolment-debug.php
@@ -309,9 +309,9 @@ class Sensei_Tool_Enrolment_Debug implements Sensei_Tool_Interface, Sensei_Tool_
 		$course_lessons = Sensei()->course->course_lessons( $course_id );
 
 		foreach ( $course_lessons as $lesson ) {
-			$lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, $user_id );
-			if ( $lesson_status ) {
-				$dates[] = strtotime( $lesson_status->comment_date_gmt );
+			$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson->ID, $user_id );
+			if ( $lesson_progress ) {
+				$dates[] = $lesson_progress->get_updated_at()->getTimestamp();
 			}
 		}
 

--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -310,9 +310,15 @@ class Course_Navigation {
 		if ( $completed ) {
 			$status = 'completed';
 		} else {
-			$user_lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, $this->user_id );
-			if ( isset( $user_lesson_status->comment_approved ) ) {
-				$status = $user_lesson_status->comment_approved;
+			// If the lesson has a quiz, use the quiz progress.
+			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+			if ( $quiz_id ) {
+				$user_progress = \Sensei()->quiz_progress_repository->get( $quiz_id, $this->user_id );
+			} else {
+				$user_progress = \Sensei()->lesson_progress_repository->get( $lesson_id, $this->user_id );
+			}
+			if ( $user_progress ) {
+				$status = $user_progress->get_status();
 
 				if ( in_array( $status, $in_progress_statuses, true ) ) {
 					$status = 'in-progress';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1932,7 +1932,7 @@ class Sensei_Course {
 
 				$progress_percentage = Sensei_Utils::quotient_as_absolute_rounded_percentage( $lessons_completed, $lesson_count, 0 );
 
-				$active_html .= $this->get_progress_meter( $progress_percentage );
+				$active_html .= $this->get_progress_meter( (int) $progress_percentage );
 
 				$active_html .= '</section>';
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1551,11 +1551,11 @@ class Sensei_Course {
 
 
 	/**
-	 * course_lessons function.
+	 * Get course lessons.
 	 *
 	 * @access public
 	 *
-	 * @param int          $course_id   (default: 0).         The course id.
+	 * @param int|WP_Post  $course_id   (default: 0).         The course id.
 	 * @param string|array $post_status (default: 'publish'). The post status.
 	 * @param string       $fields      (default: 'all').     WP only allows 3 types, but we will limit it to only 'ids' or 'all'.
 	 * @param array        $query_args  Base arguments for the WP query.
@@ -3569,8 +3569,7 @@ class Sensei_Course {
 		// Check if course is completed.
 		$completed_course = false;
 		if ( ! empty( $user_id ) ) {
-			$user_course_status = Sensei_Utils::user_course_status( $course_id, $user_id );
-			$completed_course   = Sensei_Utils::user_completed_course( $user_course_status );
+			$completed_course = Sensei_Utils::user_completed_course( $course_id, $user_id );
 		}
 
 		/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1598,14 +1598,24 @@ class Sensei_Course {
 		// that have been added to the course.
 		if ( count( $lessons ) > 1 ) {
 
+			$lesson_order = array();
 			foreach ( $lessons as $lesson ) {
 
 				$order = intval( get_post_meta( $lesson->ID, '_order_' . $course_id, true ) );
 				// for lessons with no order set it to be 10000 so that it show up at the end
-				$lesson->course_order = $order ? $order : 100000;
+				$lesson_order[ $lesson->ID ] = $order ? $order : 100000;
 			}
 
-			uasort( $lessons, [ $this, '_short_course_lessons_callback' ] );
+			uasort( $lessons, function ( $lesson_1, $lesson_2 ) use ($lesson_order) {
+				$lesson_1_order = $lesson_order[ $lesson_1->ID ];
+				$lesson_2_order = $lesson_order[ $lesson_2->ID ];
+
+				if ( $lesson_1_order == $lesson_2_order ) {
+					return 0;
+				}
+
+				return ( $lesson_1_order < $lesson_2_order ) ? -1 : 1;
+			} );
 		}
 
 		/**
@@ -1632,25 +1642,6 @@ class Sensei_Course {
 
 		return $lessons;
 
-	}
-
-	/**
-	 * Used for the uasort in $this->course_lessons()
-	 *
-	 * @since 1.8.0
-	 * @access protected
-	 *
-	 * @param array $lesson_1
-	 * @param array $lesson_2
-	 * @return int
-	 */
-	protected function _short_course_lessons_callback( $lesson_1, $lesson_2 ) {
-
-		if ( $lesson_1->course_order == $lesson_2->course_order ) {
-			return 0;
-		}
-
-		return ( $lesson_1->course_order < $lesson_2->course_order ) ? -1 : 1;
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1606,16 +1606,19 @@ class Sensei_Course {
 				$lesson_order[ $lesson->ID ] = $order ? $order : 100000;
 			}
 
-			uasort( $lessons, function ( $lesson_1, $lesson_2 ) use ($lesson_order) {
-				$lesson_1_order = $lesson_order[ $lesson_1->ID ];
-				$lesson_2_order = $lesson_order[ $lesson_2->ID ];
+			uasort(
+				$lessons,
+				function ( $lesson_1, $lesson_2 ) use ( $lesson_order ) {
+					$lesson_1_order = $lesson_order[ $lesson_1->ID ];
+					$lesson_2_order = $lesson_order[ $lesson_2->ID ];
 
-				if ( $lesson_1_order == $lesson_2_order ) {
-					return 0;
+					if ( $lesson_1_order == $lesson_2_order ) {
+						return 0;
+					}
+
+					return ( $lesson_1_order < $lesson_2_order ) ? -1 : 1;
 				}
-
-				return ( $lesson_1_order < $lesson_2_order ) ? -1 : 1;
-			} );
+			);
 		}
 
 		/**
@@ -1628,9 +1631,8 @@ class Sensei_Course {
 		 */
 		$lessons = apply_filters( 'sensei_course_get_lessons', $lessons, $course_id );
 
-		// return the requested fields
-		// runs after the sensei_course_get_lessons filter so the filter always give an array of lesson
-		// objects
+		// Return the requested fields.
+		// Runs after the sensei_course_get_lessons filter so the filter always give an array of lesson objects.
 		if ( 'ids' === $fields ) {
 			$lesson_objects = $lessons;
 			$lessons        = [];

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -698,7 +698,6 @@ class Sensei_Grading {
 			return false;
 		}
 
-		$lesson_status   = 'ungraded';
 		$lesson_metadata = [];
 		$quiz_progress->ungrade();
 
@@ -720,10 +719,8 @@ class Sensei_Grading {
 					// Due to our internal logic, we need to complete the lesson first.
 					// This is because in the comments-based version the lesson status is used for both the lesson and the quiz.
 					$lesson_progress->complete();
-					$lesson_status = 'passed';
 					$quiz_progress->pass();
 				} else {
-					$lesson_status = 'failed';
 					$quiz_progress->fail();
 				}
 			}
@@ -731,7 +728,6 @@ class Sensei_Grading {
 			// Student only has to partake the quiz.
 			else {
 				$lesson_progress->complete();
-				$lesson_status = 'graded';
 				$quiz_progress->grade();
 			}
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4731,9 +4731,14 @@ class Sensei_Lesson {
 	 */
 	public static function course_signup_link() {
 
+		$lesson_id = get_the_ID();
+		if ( $lesson_id ) {
+			return;
+		}
+
 		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
 
-		if ( empty( $course_id ) || 'course' !== get_post_type( $course_id ) || sensei_all_access() || Sensei_Utils::is_preview_lesson( get_the_ID() ) ) {
+		if ( empty( $course_id ) || 'course' !== get_post_type( $course_id ) || sensei_all_access() || Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 			return;
 		}
 
@@ -5042,7 +5047,7 @@ class Sensei_Lesson {
 	 */
 	public static function user_lesson_quiz_status_message( $lesson_id = 0, $user_id = 0 ) {
 
-		$lesson_id                 = empty( $lesson_id ) ? get_the_ID() : $lesson_id;
+		$lesson_id                 = empty( $lesson_id ) ? (int) get_the_ID() : $lesson_id;
 		$user_id                   = empty( $user_id ) ? get_current_user_id() : $user_id;
 		$lesson_course_id          = (int) get_post_meta( $lesson_id, '_lesson_course', true );
 		$quiz_id                   = Sensei()->lesson->lesson_quizzes( $lesson_id );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4736,7 +4736,7 @@ class Sensei_Lesson {
 			return;
 		}
 
-		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
 		if ( empty( $course_id ) || 'course' !== get_post_type( $course_id ) || sensei_all_access() || Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 			return;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4732,7 +4732,7 @@ class Sensei_Lesson {
 	public static function course_signup_link() {
 
 		$lesson_id = get_the_ID();
-		if ( $lesson_id ) {
+		if ( ! $lesson_id ) {
 			return;
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1180,7 +1180,6 @@ class Sensei_Core_Modules {
 			'fields'         => 'ids',
 		);
 		$lessons = get_posts( $args );
-
 		if ( is_wp_error( $lessons ) || 0 >= count( $lessons ) ) {
 			return 0;
 		}
@@ -1188,6 +1187,7 @@ class Sensei_Core_Modules {
 		$completed       = false;
 		$lesson_count    = 0;
 		$completed_count = 0;
+		$lessons         = array_map( 'intval', $lessons );
 		foreach ( $lessons as $lesson_id ) {
 			$completed = Sensei_Utils::user_completed_lesson( $lesson_id, $user_id );
 			++$lesson_count;

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -743,13 +743,7 @@ class Sensei_Core_Modules {
 		$title_text = '';
 
 		if ( method_exists( 'Sensei_Utils', 'is_preview_lesson' ) && Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
-			$is_user_taking_course = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'post_id' => $course_id,
-					'user_id' => $current_user->ID,
-					'type'    => 'sensei_course_status',
-				)
-			);
+			$is_user_taking_course = Sensei()->course_progress_repository->has( $course_id, $current_user->ID );
 			if ( ! $is_user_taking_course ) {
 				if ( method_exists( 'Sensei_Frontend', 'sensei_lesson_preview_title_text' ) ) {
 					$title_text = Sensei()->frontend->sensei_lesson_preview_title_text( $course_id );

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -907,10 +907,10 @@ class Sensei_Question {
 			return;
 		}
 
-		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
+		$user_quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, get_current_user_id() );
 		$user_quiz_grade    = Sensei_Quiz::get_user_quiz_grade( $lesson_id, get_current_user_id() );
 		$reset_quiz_allowed = Sensei_Quiz::is_reset_allowed( $lesson_id );
-		$quiz_graded        = isset( $user_lesson_status->comment_approved ) && ! in_array( $user_lesson_status->comment_approved, array( 'ungraded', 'in-progress' ) );
+		$quiz_graded        = $user_quiz_progress && ! in_array( $user_quiz_progress->get_status(), array( 'ungraded', 'in-progress' ) );
 
 		$quiz_required_pass_grade = intval( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
 		$succeeded                = $user_quiz_grade >= $quiz_required_pass_grade;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -265,7 +265,7 @@ class Sensei_Quiz {
 	public function get_lesson_ids( array $quiz_ids ) {
 		$quiz_parents = get_posts(
 			array(
-				'fields'         => 'post_parent',
+				'fields'         => 'id=>post_parent',
 				'post_type'      => 'quiz',
 				'post__in'       => $quiz_ids,
 				'posts_per_page' => -1,

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -272,7 +272,7 @@ class Sensei_Quiz {
 			)
 		);
 
-		return wp_list_pluck( $quiz_parents, 'post_parent' );
+		return array_unique( array_values( $quiz_parents ) );
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -955,16 +955,13 @@ class Sensei_Quiz {
 				if ( $quiz_pass_percentage <= $grade ) {
 					$lesson_progress->complete();
 					$quiz_progress->pass();
-					$lesson_status = 'passed';
 				} else {
 					$quiz_progress->fail();
-					$lesson_status = 'failed';
 				}
 			} else {
 				// Student only has to partake the quiz.
 				$lesson_progress->complete();
 				$quiz_progress->grade();
-				$lesson_status = 'graded';
 			}
 		}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -265,7 +265,7 @@ class Sensei_Quiz {
 	public function get_lesson_ids( array $quiz_ids ) {
 		$quiz_parents = get_posts(
 			array(
-				'fields'         => 'id=>post_parent',
+				'fields'         => 'id=>parent',
 				'post_type'      => 'quiz',
 				'post__in'       => $quiz_ids,
 				'posts_per_page' => -1,

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2018,11 +2018,7 @@ class Sensei_Utils {
 		if ( ! isset( $sensei_user_status->comment_ID ) ) {
 
 			$start_function          = 'user_start_' . $post_type;
-			$sensei_user_activity_id = self::$start_function( $user_id, $post_id );
-
-		} else {
-
-			$sensei_user_activity_id = $sensei_user_status->comment_ID;
+			self::$start_function( $user_id, $post_id );
 
 		}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1471,9 +1471,9 @@ class Sensei_Utils {
 	/**
 	 * Get completion percentage.
 	 *
-	 * @param $numerator
-	 * @param $denominator
-	 * @param int         $decimal_places_to_round
+	 * @param mixed $numerator  Numerator.
+	 * @param int   $denominator Denominator.
+	 * @param int   $decimal_places_to_round Decimal places to round.
 	 * @return float
 	 */
 	public static function quotient_as_absolute_rounded_percentage( $numerator, $denominator, $decimal_places_to_round = 0 ) {
@@ -1483,9 +1483,9 @@ class Sensei_Utils {
 	/**
 	 * Get formatted quotient.
 	 *
-	 * @param mixed $numerator
-	 * @param int   $denominator
-	 * @param int   $decimal_places_to_round
+	 * @param mixed $numerator  Numerator.
+	 * @param int   $denominator Denominator.
+	 * @param int   $decimal_places_to_round Decimal places to round.
 	 * @return float
 	 */
 	public static function quotient_as_absolute_rounded_number( $numerator, $denominator, $decimal_places_to_round = 0 ) {
@@ -1497,10 +1497,10 @@ class Sensei_Utils {
 	}
 
 	/**
-	 * Round a number to a given number of decimal places
+	 * Round a number to a given number of decimal places.
 	 *
-	 * @param mixed $number
-	 * @param int   $decimal_places_to_round
+	 * @param mixed $number Number to round.
+	 * @param int   $decimal_places_to_round Decimal places to round.
 	 * @return float
 	 */
 	public static function as_absolute_rounded_number( $number, $decimal_places_to_round = 0 ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2017,7 +2017,7 @@ class Sensei_Utils {
 		$sensei_user_status = self::$status_function( $post_id, $user_id );
 		if ( ! isset( $sensei_user_status->comment_ID ) ) {
 
-			$start_function          = 'user_start_' . $post_type;
+			$start_function = 'user_start_' . $post_type;
 			self::$start_function( $user_id, $post_id );
 
 		}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1633,10 +1633,9 @@ class Sensei_Utils {
 				// In the tables-based progress we split them. Here is important to use the quiz proress if the quiz pass is required.
 				$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 				if ( $lesson_quiz_id ) {
-					$quiz_progress = Sensei()->quiz_progress_repository->get( $lesson_quiz_id, $user_id );
 					$pass_required = get_post_meta( $lesson_quiz_id, '_pass_required', true );
-
 					if ( $pass_required ) {
+						$quiz_progress = Sensei()->quiz_progress_repository->get( $lesson_quiz_id, $user_id );
 						if ( $quiz_progress ) {
 							$user_lesson_status = $quiz_progress->get_status();
 						} else {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -102,7 +102,6 @@ class Sensei_Utils {
 		}
 	}
 
-
 	/**
 	 * Check for Sensei activity.
 	 *
@@ -517,7 +516,15 @@ class Sensei_Utils {
 			}
 		}
 
-		// Note: When this action runs the lesson status may not yet exist.
+		/**
+		 * Fires when a user starts a lesson.
+		 * When this action runs the lesson status may not yet exist.
+		 *
+		 * @hook sensei_user_lesson_start
+		 *
+		 * @param {int} $user_id ID of user starting lesson.
+		 * @param {int} $lesson_id ID of lesson being started.
+		 */
 		do_action( 'sensei_user_lesson_start', $user_id, $lesson_id );
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
@@ -535,7 +542,17 @@ class Sensei_Utils {
 		}
 
 		if ( $complete ) {
-			// Run this *after* the lesson status has been created/updated.
+			/**
+			 * Fires when a user completes a lesson.
+			 *
+			 * This hook is fired when a user completes a lesson, passes a quiz or their quiz submission was graded.
+			 * Therefore the corresponding lesson is marked as complete.
+			 *
+			 * @since 1.7.0
+			 *
+			 * @param int $user_id
+			 * @param int $lesson_id
+			 */
 			do_action( 'sensei_user_lesson_end', $user_id, $lesson_id );
 		}
 
@@ -952,13 +969,15 @@ class Sensei_Utils {
 				$has_questions = Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson->ID );
 
 				if ( $has_questions ) {
-					$user_lesson_status = self::user_lesson_status( $lesson->ID, $user_id );
+					$quiz_id                = Sensei()->lesson->lesson_quizzes( $lesson->ID );
+					$user_has_quiz_progress = Sensei()->quiz_progress_repository->has( $quiz_id, $user_id );
 
-					if ( empty( $user_lesson_status ) ) {
+					if ( ! $user_has_quiz_progress ) {
 						continue;
 					}
 					// Get user quiz grade
-					$quiz_grade = get_comment_meta( $user_lesson_status->comment_ID, 'grade', true );
+					$submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
+					$quiz_grade = $submission ? $submission->get_final_grade() : 0;
 
 					// Add up total grade
 					$total_grade += intval( $quiz_grade );
@@ -1079,40 +1098,32 @@ class Sensei_Utils {
 		$extra     = '';
 
 		if ( $lesson_id > 0 && $user_id > 0 ) {
-			// Course ID
+			// Course ID.
 			$course_id = absint( get_post_meta( $lesson_id, '_lesson_course', true ) );
 
-			// Has user started course
+			// Has user started course.
 			$started_course = Sensei_Course::is_user_enrolled( $course_id, $user_id );
 
-			// Has user completed lesson
-			$user_lesson_status = self::user_lesson_status( $lesson_id, $user_id );
-			$lesson_complete    = self::user_completed_lesson( $user_lesson_status );
+			// Has user completed lesson.
+			$lesson_complete = self::user_completed_lesson( $lesson_id, $user_id );
 
-			// Quiz ID
+			// Quiz ID.
 			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
-			// Quiz grade
-			$quiz_grade = 0;
-			if ( $user_lesson_status ) {
-				// user lesson status can return as an array.
-				if ( is_array( $user_lesson_status ) ) {
-					$comment_ID = $user_lesson_status[0]->comment_ID;
+			// Quiz progress.
+			$user_quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
 
-				} else {
-					$comment_ID = $user_lesson_status->comment_ID;
-				}
+			// Quiz grade.
+			$submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
+			$quiz_grade = $submission ? $submission->get_final_grade() : 0;
 
-				$quiz_grade = get_comment_meta( $comment_ID, 'grade', true );
-			}
-
-			// Quiz passmark
+			// Quiz passmark.
 			$quiz_passmark = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
 
-			// Pass required
+			// Pass required.
 			$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
 
-			// Quiz questions
+			// Quiz questions.
 			$has_quiz_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 
 			if ( ! $started_course ) {
@@ -1168,7 +1179,14 @@ class Sensei_Utils {
 				$lesson_prerequisite = \Sensei_Lesson::find_first_prerequisite_lesson( $lesson_id, $user_id );
 
 				if ( ! $is_lesson && $lesson_prerequisite > 0 ) {
-					$lesson_status = self::user_lesson_status( $lesson_prerequisite, $user_id );
+					$prerequisite_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_prerequisite );
+					if ( $prerequisite_quiz_id ) {
+						// If there is a quiz for the prerequisite lesson, use the quiz progress.
+						$prerequisite_progress = Sensei()->quiz_progress_repository->get( $prerequisite_quiz_id, $user_id );
+					} else {
+						// If there is no quiz for the prerequisite lesson, use the lesson progress.
+						$prerequisite_progress = Sensei()->lesson_progress_repository->get( $lesson_prerequisite, $user_id );
+					}
 
 					$prerequisite_lesson_link = '<a href="'
 						. esc_url( get_permalink( $lesson_prerequisite ) )
@@ -1179,14 +1197,14 @@ class Sensei_Utils {
 						. esc_html__( 'prerequisites', 'sensei-lms' )
 						. '</a>';
 
-					$message = ! empty( $lesson_status ) && 'ungraded' === $lesson_status->comment_approved
+					$message = ! empty( $prerequisite_progress ) && 'ungraded' === $prerequisite_progress->get_status()
 						// translators: Placeholder is the link to the prerequisite lesson.
 						? sprintf( esc_html__( 'You will be able to access this quiz once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
 						// translators: Placeholder is the link to the prerequisite lesson.
 						: sprintf( esc_html__( 'Please complete the %1$s to access this quiz.', 'sensei-lms' ), $prerequisite_lesson_link );
 
 					// Lesson/Quiz isn't "complete" instead it's ungraded (previously this "state" meant that it *was* complete).
-				} elseif ( isset( $user_lesson_status->comment_approved ) && 'ungraded' == $user_lesson_status->comment_approved ) {
+				} elseif ( $user_quiz_progress && 'ungraded' == $user_quiz_progress->get_status() ) {
 					$status    = 'complete';
 					$box_class = 'info';
 					if ( $is_lesson ) {
@@ -1198,7 +1216,7 @@ class Sensei_Utils {
 					}
 
 					// Lesson status must be "failed".
-				} elseif ( isset( $user_lesson_status->comment_approved ) && 'failed' == $user_lesson_status->comment_approved ) {
+				} elseif ( $user_quiz_progress && 'failed' == $user_quiz_progress->get_status() ) {
 					$status    = 'failed';
 					$box_class = 'alert';
 					if ( $is_lesson ) {
@@ -1394,7 +1412,6 @@ class Sensei_Utils {
 			$course_progress->start();
 		}
 
-		$course_completion  = Sensei()->settings->settings['course_completion'];
 		$lessons_completed  = 0;
 		$lesson_status_args = array(
 			'user_id' => $user_id,
@@ -1415,29 +1432,17 @@ class Sensei_Utils {
 			// ...if all lessons 'passed' then update the course status to complete
 		// The below checks if a lesson is fully completed, though maybe should be Utils::user_completed_lesson()
 		$lesson_status_args['post__in'] = $lesson_ids;
-		$all_lesson_statuses            = self::sensei_check_for_activity( $lesson_status_args, true );
-		// Need to always return an array, even with only 1 item.
-		if ( ! is_array( $all_lesson_statuses ) ) {
-			$all_lesson_statuses = array( $all_lesson_statuses );
-		}
+		$lesson_progress_args           = array(
+			'user_id'   => $user_id,
+			'lesson_id' => $lesson_ids,
+		);
+		$all_lesson_progress            = Sensei()->lesson_progress_repository->find( $lesson_progress_args );
 
-		foreach ( $all_lesson_statuses as $lesson_status ) {
-			// If lessons are complete without needing quizzes to be passed
-			if ( 'passed' !== $course_completion ) {
-				// A user cannot 'complete' a course if a lesson...
-				// ...is still in progress
-				// ...hasn't yet been graded.
-				$lesson_not_complete_stati = array( 'in-progress', 'ungraded' );
-				if ( ! in_array( $lesson_status->comment_approved, $lesson_not_complete_stati, true ) ) {
-					$lessons_completed++;
-				}
-			} else {
-				$lesson_complete_stati = array( 'complete', 'graded', 'passed' );
-				if ( in_array( $lesson_status->comment_approved, $lesson_complete_stati, true ) ) {
-					$lessons_completed++;
-				}
+		foreach ( $all_lesson_progress as $lesson_progress ) {
+			if ( $lesson_progress->is_complete() ) {
+				$lessons_completed++;
 			}
-		} // Each lesson
+		}
 
 		if ( $lessons_completed === $total_lessons ) {
 			$course_progress->complete();
@@ -1598,19 +1603,32 @@ class Sensei_Utils {
 				if ( 0 >= (int) $user_id ) {
 					return false;
 				}
-				$_user_lesson_status = self::user_lesson_status( $lesson, $user_id );
 
-				if ( isset( $_user_lesson_status->comment_approved ) ) {
+				$lesson_id = (int) $lesson;
+				$user_id   = (int) $user_id;
 
-					$user_lesson_status = $_user_lesson_status->comment_approved;
-
+				$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
+				if ( $lesson_progress ) {
+					$user_lesson_status = $lesson_progress->get_status();
 				} else {
-
-					return false; // No status means not complete
-
+					return false; // No progress means not complete
 				}
 
-				$lesson_id = $lesson;
+				// In the comments-based progress we use one entry to store both the lesson progress and the quiz progress.
+				// In the tables-based progress we split them. Here is important to use the quiz proress if the quiz pass is required.
+				$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+				if ( $lesson_quiz_id ) {
+					$quiz_progress = Sensei()->quiz_progress_repository->get( $lesson_quiz_id, $user_id );
+					$pass_required = get_post_meta( $lesson_quiz_id, '_pass_required', true );
+
+					if ( $pass_required ) {
+						if ( $quiz_progress ) {
+							$user_lesson_status = $quiz_progress->get_status();
+						} else {
+							return false;
+						}
+					}
+				}
 			}
 
 			/**
@@ -1624,31 +1642,33 @@ class Sensei_Utils {
 			 */
 			$user_lesson_status = apply_filters( 'sensei_user_completed_lesson', $user_lesson_status, $lesson_id, $user_id );
 
-			if ( 'in-progress' != $user_lesson_status ) {
-				// Check for Passed or Completed Setting
-				// Should we be checking for the Course completion setting? Surely that should only affect the Course completion, not bypass each Lesson setting
-				switch ( $user_lesson_status ) {
-					case 'complete':
-					case 'graded':
-					case 'passed':
-						return true;
+			if ( 'in-progress' === $user_lesson_status ) {
+				return false;
+			}
 
-					case 'failed':
-						// This may be 'completed' depending on...
-						if ( $lesson_id ) {
-							// Get Quiz ID, this won't be needed once all Quiz meta fields are stored on the Lesson
-							$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
-							if ( $lesson_quiz_id ) {
-								// ...the quiz pass setting
-								$pass_required = get_post_meta( $lesson_quiz_id, '_pass_required', true );
-								if ( empty( $pass_required ) ) {
-									// We just require the user to have done the quiz, not to have passed
-									return true;
-								}
+			// Check for Passed or Completed Setting
+			// Should we be checking for the Course completion setting? Surely that should only affect the Course completion, not bypass each Lesson setting
+			switch ( $user_lesson_status ) {
+				case 'complete':
+				case 'graded':
+				case 'passed':
+					return true;
+
+				case 'failed':
+					// This may be 'completed' depending on...
+					if ( $lesson_id ) {
+						// Get Quiz ID, this won't be needed once all Quiz meta fields are stored on the Lesson
+						$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+						if ( $lesson_quiz_id ) {
+							// ...the quiz pass setting
+							$pass_required = get_post_meta( $lesson_quiz_id, '_pass_required', true );
+							if ( empty( $pass_required ) ) {
+								// We just require the user to have done the quiz, not to have passed
+								return true;
 							}
 						}
-						return false;
-				}
+					}
+					return false;
 			}
 		}
 
@@ -1659,6 +1679,8 @@ class Sensei_Utils {
 	 * Returns the requested course status
 	 *
 	 * @since 1.7.0
+	 * @deprecated $$next-version$$ Use course progress repository instead.
+	 *
 	 * @param int $course_id
 	 * @param int $user_id
 	 * @return object
@@ -1714,6 +1736,12 @@ class Sensei_Utils {
 		return false;
 	}
 
+	/**
+	 * Returns if a lesson is a preview lesson or not.
+	 *
+	 * @param int $lesson_id Lesson ID.
+	 * @return bool
+	 */
 	public static function is_preview_lesson( $lesson_id ) {
 		$is_preview = false;
 
@@ -1727,6 +1755,13 @@ class Sensei_Utils {
 		return $is_preview;
 	}
 
+	/**
+	 * Returns if a user has passed a quiz or not.
+	 *
+	 * @param int $quiz_id Quiz ID.
+	 * @param int $user_id User ID.
+	 * @return bool
+	 */
 	public static function user_passed_quiz( $quiz_id = 0, $user_id = 0 ) {
 
 		if ( ! $quiz_id ) {
@@ -1736,11 +1771,10 @@ class Sensei_Utils {
 		if ( ! $user_id ) {
 			$user_id = get_current_user_id();
 		}
-		$lesson_id = get_post_meta( $quiz_id, '_quiz_lesson', true );
 
 		// Quiz Grade
-		$lesson_status = self::user_lesson_status( $lesson_id, $user_id );
-		$quiz_grade    = get_comment_meta( $lesson_status->comment_ID, 'grade', true );
+		$submission = \Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
+		$quiz_grade = $submission ? $submission->get_final_grade() : 0;
 
 		// Check if Grade is greater than or equal to pass percentage
 		$quiz_passmark = self::as_absolute_rounded_number( get_post_meta( $quiz_id, '_quiz_passmark', true ), 2 );
@@ -1749,7 +1783,6 @@ class Sensei_Utils {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -2804,29 +2837,28 @@ class Sensei_Utils {
 			return $course_id;
 		}
 		// First try to get the lesson the user started or updated last.
-		$activity_args = [
-			'post__in' => $course_lessons,
-			'user_id'  => $user_id,
-			'type'     => 'sensei_lesson_status',
-			'number'   => 1,
-			'orderby'  => 'comment_date',
-			'order'    => 'DESC',
-			'status'   => [ 'in-progress', 'ungraded' ],
-		];
+		$progress_args = array(
+			'lesson_id' => $course_lessons,
+			'user_id'   => $user_id,
+			'status'    => array( 'in-progress' ),
+			'orderby'   => 'updated_at',
+			'order'     => 'DESC',
+			'number'    => 1,
+		);
+		$last_progress = Sensei()->lesson_progress_repository->find( $progress_args );
 
-		$last_lesson_activity = self::sensei_check_for_activity( $activity_args, true );
-
-		if ( ! empty( $last_lesson_activity ) ) {
-			return $last_lesson_activity->comment_post_ID;
-		} else {
-			// If there is no such lesson, get the first lesson that the user has not yet started.
-			$completed_lessons     = Sensei()->course->get_completed_lesson_ids( $course_id, $user_id );
-			$not_completed_lessons = array_diff( $course_lessons, $completed_lessons );
-
-			if ( $not_completed_lessons ) {
-				return current( $not_completed_lessons );
-			}
+		if ( count( $last_progress ) > 0 ) {
+			return $last_progress[0]->get_lesson_id();
 		}
+
+		// If there is no such lesson, get the first lesson that the user has not yet started.
+		$completed_lessons     = Sensei()->course->get_completed_lesson_ids( $course_id, $user_id );
+		$not_completed_lessons = array_diff( $course_lessons, $completed_lessons );
+
+		if ( $not_completed_lessons ) {
+			return current( $not_completed_lessons );
+		}
+
 		return $course_id;
 	}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1582,8 +1582,8 @@ class Sensei_Utils {
 	 * Check if a user has completed a lesson or not
 	 *
 	 * @uses  Sensei()
-	 * @param mixed $lesson lesson_id or sensei_lesson_status entry
-	 * @param int   $user_id
+	 * @param int|WP_Comment|string $lesson  lesson id (int), lesson status (string), or sensei_lesson_status entry (WP_Comment).
+	 * @param int                   $user_id User ID.
 	 * @return boolean
 	 */
 	public static function user_completed_lesson( $lesson = 0, $user_id = 0 ): bool {
@@ -2010,6 +2010,16 @@ class Sensei_Utils {
 
 			$sensei_user_activity_id = $sensei_user_status->comment_ID;
 
+		}
+
+		if ( 'course' === $post_type ) {
+			$course_progress_repository = Sensei()->course_progress_repository_factory->create_comments_based_repository();
+			$course_progress            = $course_progress_repository->get( $post_id, $user_id );
+			$sensei_user_activity_id    = $course_progress->get_id();
+		} else {
+			$lesson_progress_repository = Sensei()->lesson_progress_repository_factory->create_comments_based_repository();
+			$lesson_progress            = $lesson_progress_repository->get( $post_id, $user_id );
+			$sensei_user_activity_id    = $lesson_progress->get_id();
 		}
 
 		// store the data

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1469,17 +1469,25 @@ class Sensei_Utils {
 	}
 
 	/**
-	 * Get completion percentage
+	 * Get completion percentage.
 	 *
 	 * @param $numerator
 	 * @param $denominator
 	 * @param int         $decimal_places_to_round
-	 * @return int|number
+	 * @return float
 	 */
 	public static function quotient_as_absolute_rounded_percentage( $numerator, $denominator, $decimal_places_to_round = 0 ) {
 		return self::quotient_as_absolute_rounded_number( $numerator * 100.0, $denominator, $decimal_places_to_round );
 	}
 
+	/**
+	 * Get formatted quotient.
+	 *
+	 * @param mixed $numerator
+	 * @param int   $denominator
+	 * @param int   $decimal_places_to_round
+	 * @return float
+	 */
 	public static function quotient_as_absolute_rounded_number( $numerator, $denominator, $decimal_places_to_round = 0 ) {
 		if ( 0 === $denominator ) {
 			return 0;
@@ -1488,6 +1496,13 @@ class Sensei_Utils {
 		return self::as_absolute_rounded_number( doubleval( $numerator ) / ( $denominator ), $decimal_places_to_round );
 	}
 
+	/**
+	 * Round a number to a given number of decimal places
+	 *
+	 * @param mixed $number
+	 * @param int   $decimal_places_to_round
+	 * @return float
+	 */
 	public static function as_absolute_rounded_number( $number, $decimal_places_to_round = 0 ) {
 		return abs( round( ( doubleval( $number ) ), $decimal_places_to_round ) );
 	}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -273,11 +273,25 @@ class Sensei_Main {
 	public $sensei_wpml;
 
 	/**
+	 * Course progress repository factory.
+	 *
+	 * @var Course_Progress_Repository_Factory
+	 */
+	public $course_progress_repository_factory;
+
+	/**
 	 * Course progress repository.
 	 *
 	 * @var Course_Progress_Repository_Interface
 	 */
 	public $course_progress_repository;
+
+	/**
+	 * Lesson progress repository factory.
+	 *
+	 * @var Lesson_Progress_Repository_Factory
+	 */
+	public $lesson_progress_repository_factory;
 
 	/**
 	 * Lesson progress repository.
@@ -613,11 +627,13 @@ class Sensei_Main {
 		 * @param {bool} $read_from_tables Whether to read student progress from tables. Default false.
 		 * @return {bool} Whether to read student progress from tables.
 		 */
-		$read_from_tables                       = apply_filters( 'sensei_student_progress_read_from_tables', false );
-		$this->course_progress_repository       = ( new Course_Progress_Repository_Factory( $tables_enabled, $read_from_tables ) )->create();
-		$this->lesson_progress_repository       = ( new Lesson_Progress_Repository_Factory( $tables_enabled, $read_from_tables ) )->create();
-		$this->quiz_progress_repository_factory = new Quiz_Progress_Repository_Factory( $tables_enabled, $read_from_tables );
-		$this->quiz_progress_repository         = $this->quiz_progress_repository_factory->create();
+		$read_from_tables                         = apply_filters( 'sensei_student_progress_read_from_tables', false );
+		$this->course_progress_repository_factory = new Course_Progress_Repository_Factory( $tables_enabled, $read_from_tables );
+		$this->course_progress_repository         = $this->course_progress_repository_factory->create();
+		$this->lesson_progress_repository_factory = new Lesson_Progress_Repository_Factory( $tables_enabled, $read_from_tables );
+		$this->lesson_progress_repository         = $this->lesson_progress_repository_factory->create();
+		$this->quiz_progress_repository_factory   = new Quiz_Progress_Repository_Factory( $tables_enabled, $read_from_tables );
+		$this->quiz_progress_repository           = $this->quiz_progress_repository_factory->create();
 
 		if ( class_exists( 'ActionScheduler_Versions' ) ) {
 			$this->action_scheduler = new Action_Scheduler();

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -6,6 +6,9 @@
  * @since 3.15.0
  */
 
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -101,9 +104,9 @@ class Sensei_Course_Theme_Lesson {
 		$notices       = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' );
 		$quiz_id       = Sensei()->lesson->lesson_quizzes( $lesson_id );
 		$user_answers  = Sensei()->quiz->get_user_answers( $lesson_id, $user_id );
-		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
+		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
 
-		if ( $this->maybe_add_lesson_quiz_progress_notice( $user_answers, $lesson_status, $quiz_id, $notices ) ) {
+		if ( $this->maybe_add_lesson_quiz_progress_notice( $user_answers, $quiz_progress, $quiz_id, $notices ) ) {
 			return;
 		}
 
@@ -117,9 +120,9 @@ class Sensei_Course_Theme_Lesson {
 		$passmark_rounded = Sensei_Utils::round( $passmark, 2 );
 		$pass_required    = get_post_meta( $quiz_id, '_pass_required', true );
 
-		if ( 'ungraded' === $lesson_status->comment_approved ) {
+		if ( 'ungraded' === $quiz_progress->get_status() ) {
 			$text = __( 'Awaiting grade', 'sensei-lms' );
-		} elseif ( 'failed' === $lesson_status->comment_approved ) {
+		} elseif ( 'failed' === $quiz_progress->get_status() ) {
 			// translators: Placeholders are the required grade and the actual grade, respectively.
 			$text = sprintf( __( 'You require %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $passmark_rounded . '</strong>', '<strong>' . $grade_rounded . '</strong>' );
 		} else {
@@ -141,15 +144,15 @@ class Sensei_Course_Theme_Lesson {
 	/**
 	 * Maybe add lesson quiz progress notice.
 	 *
-	 * @param array|false            $user_answers  User answers.
-	 * @param object|false           $lesson_status Lesson status.
-	 * @param int                    $quiz_id       Quiz ID.
-	 * @param Sensei_Context_Notices $notices       Notices instance.
+	 * @param array|false                  $user_answers  User answers.
+	 * @param Quiz_Progress_Interface|null $quiz_progress Quiz progress.
+	 * @param int                          $quiz_id       Quiz ID.
+	 * @param Sensei_Context_Notices       $notices       Notices instance.
 	 *
 	 * @return bool Whether notice was added.
 	 */
-	private function maybe_add_lesson_quiz_progress_notice( $user_answers, $lesson_status, $quiz_id, $notices ) {
-		if ( ! $user_answers || empty( $user_answers ) || ! is_array( $user_answers ) || empty( $lesson_status ) || 'in-progress' !== $lesson_status->comment_approved ) {
+	private function maybe_add_lesson_quiz_progress_notice( $user_answers, $quiz_progress, $quiz_id, $notices ) {
+		if ( ! is_array( $user_answers ) || count( $user_answers ) === 0 || empty( $quiz_progress ) || 'in-progress' !== $quiz_progress->get_status() ) {
 			return false;
 		}
 
@@ -213,7 +216,13 @@ class Sensei_Course_Theme_Lesson {
 		$lesson_prerequisite = \Sensei_Lesson::find_first_prerequisite_lesson( $lesson_id, $user_id );
 
 		if ( $lesson_prerequisite > 0 ) {
-			$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_prerequisite, $user_id );
+			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_prerequisite );
+			if ( $quiz_id ) {
+				// If the leesons has a quiz, use the quiz progress instead.
+				$prerequisite_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
+			} else {
+				$prerequisite_progress = Sensei()->lesson_progress_repository->get( $lesson_prerequisite, $user_id );
+			}
 
 			$prerequisite_lesson_link = '<a href="'
 				. esc_url( get_permalink( $lesson_prerequisite ) )
@@ -224,7 +233,7 @@ class Sensei_Course_Theme_Lesson {
 				. esc_html__( 'prerequisites', 'sensei-lms' )
 				. '</a>';
 
-			$text = ! empty( $lesson_status ) && 'ungraded' === $lesson_status->comment_approved
+			$text = ! empty( $prerequisite_progress ) && 'ungraded' === $prerequisite_progress->get_status()
 				// translators: Placeholder is the link to the prerequisite lesson.
 				? sprintf( esc_html__( 'You will be able to view this lesson once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
 				// translators: Placeholder is the link to the prerequisite lesson.
@@ -289,7 +298,7 @@ class Sensei_Course_Theme_Lesson {
 
 			$notice_text = __( 'Please register or sign in to access the course content.', 'sensei-lms' );
 
-			if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
+			if ( $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 				$notice_text  = __( 'Register or sign in to take this lesson.', 'sensei-lms' );
 				$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
 				$notice_icon  = 'eye';
@@ -318,7 +327,7 @@ class Sensei_Course_Theme_Lesson {
 
 		$notice_text = __( 'Please register for this course to access the content.', 'sensei-lms' );
 
-		if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
+		if ( $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 			$notice_text  = __( 'Register for this course to take this lesson.', 'sensei-lms' );
 			$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
 			$notice_icon  = 'eye';

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -65,10 +65,10 @@ class Sensei_Course_Theme_Quiz {
 			return;
 		}
 
-		$lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
+		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
 
 		// If quiz is not submitted, then nothing else to do.
-		if ( ! Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) || empty( $lesson_status ) ) {
+		if ( ! Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) || empty( $quiz_progress ) ) {
 			return;
 		}
 
@@ -80,15 +80,15 @@ class Sensei_Course_Theme_Quiz {
 			__( 'Your Grade: %1$s%%', 'sensei-lms' ),
 			$grade_rounded
 		);
-		if ( 'ungraded' === $lesson_status->comment_approved ) {
+		if ( 'ungraded' === $quiz_progress->get_status() ) {
 			$title = __( 'Awaiting grade', 'sensei-lms' );
 		}
 
 		// Prepare message.
 		$text = __( "You've passed the quiz and can continue to the next lesson.", 'sensei-lms' );
-		if ( 'ungraded' === $lesson_status->comment_approved ) {
+		if ( 'ungraded' === $quiz_progress->get_status() ) {
 			$text = __( 'Your answers have been submitted and your teacher will grade this quiz shortly.', 'sensei-lms' );
-		} elseif ( 'failed' === $lesson_status->comment_approved ) {
+		} elseif ( 'failed' === $quiz_progress->get_status() ) {
 			$passmark         = get_post_meta( $quiz_id, '_quiz_passmark', true );
 			$passmark_rounded = Sensei_Utils::round( $passmark, 2 );
 			$text             = sprintf(

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -157,12 +157,15 @@ class Sensei_Course_Theme_Templates {
 	public function should_use_quiz_template() {
 		$post = get_post();
 
-		$lesson_id = \Sensei_Utils::get_current_lesson();
-		$status    = \Sensei_Utils::user_lesson_status( $lesson_id );
+		if ( ! $post || ! ( $post instanceof WP_Post ) ) {
+			return false;
+		}
 
-		$has_submitted_quiz = $status && in_array( $status->comment_approved, [ 'ungraded', 'graded', 'passed', 'failed' ], true );
+		$progress = Sensei()->quiz_progress_repository->get( $post->ID, get_current_user_id() );
 
-		if ( ! $post || 'quiz' !== $post->post_type || $has_submitted_quiz ) {
+		$has_submitted_quiz = $progress && in_array( $progress->get_status(), [ 'ungraded', 'graded', 'passed', 'failed' ], true );
+
+		if ( 'quiz' !== $post->post_type || $has_submitted_quiz ) {
 			return false;
 		}
 

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -300,6 +300,16 @@ class Student_Progress_Migration extends Migration_Abstract {
 			$lesson_status = 'complete';
 		}
 
+		if ( $comment->comment_approved === 'failed' ) {
+			$quiz_id = Sensei()->lesson->lesson_quizzes( $comment->comment_post_ID );
+			$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
+			if ( empty( $pass_required ) ) {
+				// If pass is not required, we consider the lesson as complete.
+				$completed_at  = $comment->comment_date_gmt;
+				$lesson_status = 'complete';
+			}
+		}
+
 		$started_at = 0;
 		if ( isset( $meta['start'] ) ) {
 			try {

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -300,8 +300,8 @@ class Student_Progress_Migration extends Migration_Abstract {
 			$lesson_status = 'complete';
 		}
 
-		if ( $comment->comment_approved === 'failed' ) {
-			$quiz_id = Sensei()->lesson->lesson_quizzes( $comment->comment_post_ID );
+		if ( 'failed' === $comment->comment_approved ) {
+			$quiz_id       = Sensei()->lesson->lesson_quizzes( $comment->comment_post_ID );
 			$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
 			if ( empty( $pass_required ) ) {
 				// If pass is not required, we consider the lesson as complete.

--- a/includes/internal/student-progress/course-progress/models/class-course-progress-abstract.php
+++ b/includes/internal/student-progress/course-progress/models/class-course-progress-abstract.php
@@ -114,8 +114,9 @@ abstract class Course_Progress_Abstract implements Course_Progress_Interface {
 	 * @param DateTimeInterface|null $started_at Course start date.
 	 */
 	public function start( DateTimeInterface $started_at = null ): void {
-		$this->status     = Course_Progress_Interface::STATUS_IN_PROGRESS;
-		$this->started_at = $started_at ?? current_datetime();
+		$this->status       = Course_Progress_Interface::STATUS_IN_PROGRESS;
+		$this->started_at   = $started_at ?? current_datetime();
+		$this->completed_at = null;
 	}
 
 	/**

--- a/includes/internal/student-progress/course-progress/repositories/class-comment-reading-aggregate-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-comment-reading-aggregate-course-progress-repository.php
@@ -168,4 +168,16 @@ class Comment_Reading_Aggregate_Course_Progress_Repository implements Course_Pro
 		$this->comments_based_repository->delete_for_user( $user_id );
 		$this->tables_based_repository->delete_for_user( $user_id );
 	}
+
+	/**
+	 * Find course progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Course_Progress_Interface[] The course progress.
+	 */
+	public function find( array $args ): array {
+		return $this->comments_based_repository->find( $args );
+	}
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-factory.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-factory.php
@@ -54,7 +54,7 @@ class Course_Progress_Repository_Factory {
 	public function create(): Course_Progress_Repository_Interface {
 		global $wpdb;
 
-		$comments_based = new Comments_Based_Course_Progress_Repository();
+		$comments_based = $this->create_comments_based_repository();
 		$tables_based   = new Tables_Based_Course_Progress_Repository( $wpdb );
 
 		if ( ! $this->tables_enabled ) {
@@ -69,5 +69,16 @@ class Course_Progress_Repository_Factory {
 			$comments_based,
 			$tables_based
 		);
+	}
+
+	/**
+	 * Create a comments based course progress repository.
+	 *
+	 * @internal
+	 *
+	 * @return Comments_Based_Course_Progress_Repository
+	 */
+	public function create_comments_based_repository(): Comments_Based_Course_Progress_Repository {
+		return new Comments_Based_Course_Progress_Repository();
 	}
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-interface.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-interface.php
@@ -89,4 +89,14 @@ interface Course_Progress_Repository_Interface {
 	 * @param int $user_id The user ID.
 	 */
 	public function delete_for_user( int $user_id ): void;
+
+	/**
+	 * Find course progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Course_Progress_Interface[] The course progress.
+	 */
+	public function find( array $args ): array;
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-table-reading-aggregate-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-table-reading-aggregate-course-progress-repository.php
@@ -140,4 +140,16 @@ class Table_Reading_Aggregate_Course_Progress_Repository implements Course_Progr
 		$this->tables_based_repository->delete_for_user( $user_id );
 		$this->comments_based_repository->delete_for_user( $user_id );
 	}
+
+	/**
+	 * Find course progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Course_Progress_Interface[] The course progress.
+	 */
+	public function find( array $args ): array {
+		return $this->tables_based_repository->find( $args );
+	}
 }

--- a/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
@@ -291,17 +291,17 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 
 		$where_clause = array( 'type = %s' );
 		$query_params = array( 'course' );
-		if ( ! is_null( $course_id ) ) {
+		if ( ! empty( $course_id ) ) {
 			$query_params   = array_merge( $query_params, (array) $course_id );
 			$where_clause[] = 'post_id IN (' . $this->get_placeholders( (array) $course_id ) . ')';
 		}
 
-		if ( ! is_null( $user_id ) ) {
+		if ( ! empty( $user_id ) ) {
 			$query_params[] = (int) $user_id;
 			$where_clause[] = 'user_id = %d';
 		}
 
-		if ( ! is_null( $status ) ) {
+		if ( ! empty( $status ) ) {
 			$query_params   = array_merge( $query_params, (array) $status );
 			$where_clause[] = 'status IN (' . $this->get_placeholders( (array) $status ) . ')';
 		}

--- a/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
@@ -273,4 +273,96 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 			throw new \InvalidArgumentException( "Expected Tables_Based_Course_Progress, got {$actual_type}." );
 		}
 	}
+
+	/**
+	 * Find course progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Course_Progress_Interface[] The course progress.
+	 */
+	public function find( array $args ): array {
+		$course_id = $args['course_id'] ?? null;
+		$user_id   = $args['user_id'] ?? null;
+		$status    = $args['status'] ?? null;
+		$limit     = $args['number'] ?? 100;
+		$offset    = $args['offset'] ?? 0;
+
+		$where_clause = array( 'type = %s' );
+		$query_params = array( 'course' );
+		if ( ! is_null( $course_id ) ) {
+			$query_params   = array_merge( $query_params, (array) $course_id );
+			$where_clause[] = 'post_id IN (' . $this->get_placeholders( (array) $course_id ) . ')';
+		}
+
+		if ( ! is_null( $user_id ) ) {
+			$query_params[] = (int) $user_id;
+			$where_clause[] = 'user_id = %d';
+		}
+
+		if ( ! is_null( $status ) ) {
+			$query_params   = array_merge( $query_params, (array) $status );
+			$where_clause[] = 'status IN (' . $this->get_placeholders( (array) $status ) . ')';
+		}
+
+		$table_name = $this->wpdb->prefix . 'sensei_lms_progress';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$query_string = 'SELECT * FROM ' . $table_name . ' ';
+		if ( count( $where_clause ) > 0 ) {
+			$query_string .= 'WHERE ' . implode( ' AND ', $where_clause ) . ' ';
+		}
+
+		$query_string  .= 'ORDER BY id ASC ';
+		$query_string  .= 'LIMIT %d OFFSET %d';
+		$query_params[] = $limit;
+		$query_params[] = $offset;
+
+		$query = $this->wpdb->prepare(
+			$query_string, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			...$query_params
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $this->wpdb->get_results( $query );
+		if ( ! $rows ) {
+			return array();
+		}
+
+		$timezone = new DateTimeZone( 'UTC' );
+
+		$course_progresses = array();
+		foreach ( $rows as $row ) {
+			$course_progresses[] = new Tables_Based_Course_Progress(
+				(int) $row->id,
+				(int) $row->post_id,
+				(int) $row->user_id,
+				$row->status,
+				$row->started_at ? new DateTimeImmutable( $row->started_at, $timezone ) : null,
+				$row->completed_at ? new DateTimeImmutable( $row->completed_at, $timezone ) : null,
+				new DateTimeImmutable( $row->created_at, $timezone ),
+				new DateTimeImmutable( $row->updated_at, $timezone )
+			);
+		}
+
+		return $course_progresses;
+	}
+
+	/**
+	 * Return a string of placeholders for the given values.
+	 *
+	 * @param array $values The values.
+	 * @return string The placeholders.
+	 */
+	private function get_placeholders( array $values ) {
+		if ( empty( $values ) ) {
+			return '';
+		}
+
+		$placeholder  = is_numeric( $values[0] ) ? '%d' : '%s';
+		$placeholders = array_fill( 0, count( $values ), $placeholder );
+
+		return implode( ', ', $placeholders );
+	}
 }

--- a/includes/internal/student-progress/lesson-progress/models/class-lesson-progress-abstract.php
+++ b/includes/internal/student-progress/lesson-progress/models/class-lesson-progress-abstract.php
@@ -111,8 +111,9 @@ abstract class Lesson_Progress_Abstract implements Lesson_Progress_Interface {
 	 * @param DateTimeInterface|null $started_at The start date.
 	 */
 	public function start( ?DateTimeInterface $started_at = null ): void {
-		$this->started_at = $started_at ?? current_datetime();
-		$this->status     = self::STATUS_IN_PROGRESS;
+		$this->started_at   = $started_at ?? current_datetime();
+		$this->completed_at = null;
+		$this->status       = self::STATUS_IN_PROGRESS;
 	}
 
 	/**

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comment-reading-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comment-reading-aggregate-lesson-progress-repository.php
@@ -182,4 +182,16 @@ class Comment_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Pro
 	public function count( int $course_id, int $user_id ): int {
 		return $this->comments_based_repository->count( $course_id, $user_id );
 	}
+
+	/**
+	 * Find lesson progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Lesson_Progress_Interface[]
+	 */
+	public function find( array $args ): array {
+		return $this->comments_based_repository->find( $args );
+	}
 }

--- a/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-factory.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-factory.php
@@ -70,4 +70,15 @@ class Lesson_Progress_Repository_Factory {
 			new Tables_Based_Lesson_Progress_Repository( $wpdb )
 		);
 	}
+
+	/**
+	 * Creates a comments-based lesson progress repository.
+	 *
+	 * @internal
+	 *
+	 * @return Comments_Based_Lesson_Progress_Repository The repository.
+	 */
+	public function create_comments_based_repository(): Comments_Based_Lesson_Progress_Repository {
+		return new Comments_Based_Lesson_Progress_Repository();
+	}
 }

--- a/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
@@ -103,4 +103,14 @@ interface Lesson_Progress_Repository_Interface {
 	 * @return int
 	 */
 	public function count( int $course_id, int $user_id ): int;
+
+	/**
+	 * Find lesson progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Lesson_Progress_Interface[]
+	 */
+	public function find( array $args ): array;
 }

--- a/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
@@ -102,7 +102,7 @@ class Table_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Progr
 		// We can't just use the status of the lesson progress because the comments based lesson lesson_progress
 		// has a different underlying set of statuses.
 		if ( $lesson_progress->get_status() !== $comments_based_progress->get_status() ) {
-			if ( ! $comments_based_progress->is_complete() ) {
+			if ( $lesson_progress->is_complete() ) {
 				$comments_based_progress->complete();
 			} else {
 				$comments_based_progress->start();

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -327,17 +327,17 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 
 		$where_clause = array( 'type = %s' );
 		$query_params = array( 'lesson' );
-		if ( ! is_null( $lesson_id ) ) {
+		if ( ! empty( $lesson_id ) ) {
 			$query_params   = array_merge( $query_params, (array) $lesson_id );
 			$where_clause[] = 'post_id IN (' . $this->get_placeholders( (array) $lesson_id ) . ')';
 		}
 
-		if ( ! is_null( $user_id ) ) {
+		if ( ! empty( $user_id ) ) {
 			$query_params[] = (int) $user_id;
 			$where_clause[] = 'user_id = %d';
 		}
 
-		if ( ! is_null( $status ) ) {
+		if ( ! empty( $status ) ) {
 			$query_params   = array_merge( $query_params, (array) $status );
 			$where_clause[] = 'status IN (' . $this->get_placeholders( (array) $status ) . ')';
 		}

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -309,4 +309,96 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 			throw new InvalidArgumentException( "Expected Tables_Based_Lesson_Progress, got {$actual_type}." );
 		}
 	}
+
+	/**
+	 * Find lesson progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Lesson_Progress_Interface[]
+	 */
+	public function find( array $args ): array {
+		$lesson_id = $args['lesson_id'] ?? null;
+		$user_id   = $args['user_id'] ?? null;
+		$status    = $args['status'] ?? null;
+		$limit     = $args['number'] ?? 100;
+		$offset    = $args['offset'] ?? 0;
+
+		$where_clause = array( 'type = %s' );
+		$query_params = array( 'lesson' );
+		if ( ! is_null( $lesson_id ) ) {
+			$query_params   = array_merge( $query_params, (array) $lesson_id );
+			$where_clause[] = 'post_id IN (' . $this->get_placeholders( (array) $lesson_id ) . ')';
+		}
+
+		if ( ! is_null( $user_id ) ) {
+			$query_params[] = (int) $user_id;
+			$where_clause[] = 'user_id = %d';
+		}
+
+		if ( ! is_null( $status ) ) {
+			$query_params   = array_merge( $query_params, (array) $status );
+			$where_clause[] = 'status IN (' . $this->get_placeholders( (array) $status ) . ')';
+		}
+
+		$table_name = $this->wpdb->prefix . 'sensei_lms_progress';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$query_string = 'SELECT * FROM ' . $table_name . ' ';
+		if ( count( $where_clause ) > 0 ) {
+			$query_string .= 'WHERE ' . implode( ' AND ', $where_clause ) . ' ';
+		}
+
+		$query_string  .= 'ORDER BY id ASC ';
+		$query_string  .= 'LIMIT %d OFFSET %d';
+		$query_params[] = $limit;
+		$query_params[] = $offset;
+
+		$query = $this->wpdb->prepare(
+			$query_string, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			...$query_params
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $this->wpdb->get_results( $query );
+		if ( ! $rows ) {
+			return array();
+		}
+
+		$timezone = new DateTimeZone( 'UTC' );
+
+		$lesson_progresses = array();
+		foreach ( $rows as $row ) {
+			$lesson_progresses[] = new Tables_Based_Lesson_Progress(
+				(int) $row->id,
+				(int) $row->post_id,
+				(int) $row->user_id,
+				$row->status,
+				$row->started_at ? new DateTimeImmutable( $row->started_at, $timezone ) : null,
+				$row->completed_at ? new DateTimeImmutable( $row->completed_at, $timezone ) : null,
+				new DateTimeImmutable( $row->created_at, $timezone ),
+				new DateTimeImmutable( $row->updated_at, $timezone )
+			);
+		}
+
+		return $lesson_progresses;
+	}
+
+	/**
+	 * Return a string of placeholders for the given values.
+	 *
+	 * @param array $values The values.
+	 * @return string The placeholders.
+	 */
+	private function get_placeholders( array $values ) {
+		if ( empty( $values ) ) {
+			return '';
+		}
+
+		$placeholder  = is_numeric( $values[0] ) ? '%d' : '%s';
+		$placeholders = array_fill( 0, count( $values ), $placeholder );
+
+		return implode( ', ', $placeholders );
+	}
 }

--- a/includes/internal/student-progress/quiz-progress/models/class-comments-based-quiz-progress.php
+++ b/includes/internal/student-progress/quiz-progress/models/class-comments-based-quiz-progress.php
@@ -8,6 +8,7 @@
 namespace Sensei\Internal\Student_Progress\Quiz_Progress\Models;
 
 use DateTimeInterface;
+use Sensei\Internal\Student_Progress\Lesson_Progress\Models\Lesson_Progress_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -29,18 +30,17 @@ class Comments_Based_Quiz_Progress extends Quiz_Progress_Abstract {
 	 * @return string|null
 	 */
 	public function get_status(): ?string {
-		$supported_statuses = [
-			self::STATUS_IN_PROGRESS,
-			self::STATUS_FAILED,
-			self::STATUS_GRADED,
-			self::STATUS_PASSED,
-			self::STATUS_UNGRADED,
-		];
-
-		$status = in_array( $this->status, $supported_statuses, true )
-			? $this->status
-			: self::STATUS_IN_PROGRESS;
-
-		return $status;
+		switch ( $this->status ) {
+			case self::STATUS_IN_PROGRESS:
+			case self::STATUS_FAILED:
+			case self::STATUS_GRADED:
+			case self::STATUS_PASSED:
+			case self::STATUS_UNGRADED:
+				return $this->status;
+			case Lesson_Progress_Interface::STATUS_COMPLETE:
+				return self::STATUS_PASSED;
+			default:
+				return self::STATUS_IN_PROGRESS;
+		}
 	}
 }

--- a/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-abstract.php
+++ b/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-abstract.php
@@ -110,8 +110,9 @@ class Quiz_Progress_Abstract implements Quiz_Progress_Interface {
 	 * @param DateTimeInterface|null $started_at Quiz start date.
 	 */
 	public function start( ?DateTimeInterface $started_at = null ): void {
-		$this->status     = self::STATUS_IN_PROGRESS;
-		$this->started_at = $started_at ?? current_datetime();
+		$this->status       = self::STATUS_IN_PROGRESS;
+		$this->started_at   = $started_at ?? current_datetime();
+		$this->completed_at = null;
 	}
 
 	/**

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
@@ -167,4 +167,16 @@ class Comment_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progres
 		$this->comments_based_repository->delete_for_user( $user_id );
 		$this->tables_based_repository->delete_for_user( $user_id );
 	}
+
+	/**
+	 * Find quiz progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Quiz_Progress_Interface[] The course progress.
+	 */
+	public function find( array $args ): array {
+		return $this->comments_based_repository->find( $args );
+	}
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
@@ -174,7 +174,7 @@ class Comment_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progres
 	 * @internal
 	 *
 	 * @param array $args The arguments.
-	 * @return Quiz_Progress_Interface[] The course progress.
+	 * @return Quiz_Progress_Interface[] The quiz progress.
 	 */
 	public function find( array $args ): array {
 		return $this->comments_based_repository->find( $args );

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -11,6 +11,7 @@ use DateTime;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Comments_Based_Quiz_Progress;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
 use Sensei_Utils;
+use WP_Comment;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -69,21 +70,11 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 			'type'    => 'sensei_lesson_status',
 		];
 		$comment       = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
-		if ( ! $comment ) {
+		if ( ! $comment instanceof WP_Comment ) {
 			return null;
 		}
 
-		$comment_date = new DateTime( $comment->comment_date, wp_timezone() );
-		$meta_start   = get_comment_meta( $comment->comment_ID, 'start', true );
-		$started_at   = ! empty( $meta_start ) ? new DateTime( $meta_start, wp_timezone() ) : current_datetime();
-
-		if ( in_array( $comment->comment_approved, [ 'complete', 'passed', 'graded' ], true ) ) {
-			$completed_at = $comment_date;
-		} else {
-			$completed_at = null;
-		}
-
-		return new Comments_Based_Quiz_Progress( (int) $comment->comment_ID, $quiz_id, $user_id, $comment->comment_approved, $started_at, $completed_at, $comment_date, $comment_date );
+		return $this->create_progress_from_comment( $comment, $quiz_id );
 	}
 
 	/**
@@ -204,5 +195,129 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 			$actual_type = get_class( $quiz_progress );
 			throw new \InvalidArgumentException( "Expected Comments_Based_Quiz_Progress, got {$actual_type}." );
 		}
+	}
+
+	/**
+	 * Find course progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Quiz_Progress_Interface[] The course progress.
+	 * @throws \InvalidArgumentException When ordering is not supported.
+	 */
+	public function find( array $args ): array {
+		$comments_args = array(
+			'type'    => 'sensei_lesson_status',
+			'order'   => 'ASC',
+			'orderby' => 'comment_ID',
+		);
+
+		$quiz_id = $args['quiz_id'] ?? null;
+		if ( isset( $args['quiz_id'] ) ) {
+			$lesson_ids = Sensei()->quiz->get_lesson_ids( (array) $args['quiz_id'] );
+			if ( ! empty( $lesson_ids ) ) {
+				$comments_args['post__in'] = $lesson_ids;
+			} else {
+				return array();
+			}
+		}
+
+		if ( isset( $args['user_id'] ) ) {
+			$comments_args['user_id'] = $args['user_id'];
+		}
+
+		if ( isset( $args['status'] ) ) {
+			$comments_args['status'] = $args['status'];
+		}
+
+		if ( isset( $args['order'] ) ) {
+			$comments_args['order'] = $args['order'];
+		}
+
+		if ( isset( $args['orderby'] ) ) {
+			switch ( $args['orderby'] ) {
+				case 'started_at':
+					throw new \InvalidArgumentException( 'Ordering by started_at is not supported in comments-based version.' );
+				case 'completed_at':
+				case 'created_at':
+				case 'updated_at':
+					$comments_args['orderby'] = 'comment_date';
+					break;
+				case 'quiz_id':
+					// We need to order by lesson ID, not quiz ID, as the lesson ID is not reachable from the comment.
+					$comments_args['orderby'] = 'comment_post_ID';
+					break;
+				case 'id':
+					$comments_args['orderby'] = 'comment_ID';
+					break;
+				case 'status':
+					$comments_args['orderby'] = 'comment_approved';
+					break;
+				default:
+					$comments_args['orderby'] = $args['orderby'];
+					break;
+			}
+		}
+
+		if ( isset( $args['order'] ) ) {
+			$comments_args['order'] = $args['order'];
+		}
+
+		if ( isset( $args['offset'] ) ) {
+			$comments_args['offset'] = $args['offset'];
+		}
+
+		if ( isset( $args['number'] ) ) {
+			$comments_args['number'] = $args['number'];
+		}
+
+		$comments = \Sensei_Utils::sensei_check_for_activity( $comments_args, true );
+		if ( empty( $comments ) ) {
+			return array();
+		}
+
+		$comments = is_array( $comments ) ? $comments : array( $comments );
+
+		$quiz_progresses = [];
+		foreach ( $comments as $comment ) {
+			$quiz_progresses[] = $this->create_progress_from_comment( $comment, $quiz_id );
+		}
+
+		return $quiz_progresses;
+	}
+
+	/**
+	 * Create a lesson progress from a comment.
+	 *
+	 * @param WP_Comment $comment The comment.
+	 * @param int|null   $quiz_id The quiz ID that is associated with the status comment.
+	 * @return Comments_Based_Quiz_Progress The course progress.
+	 */
+	private function create_progress_from_comment( WP_Comment $comment, ?int $quiz_id = null ): Comments_Based_Quiz_Progress {
+		$comment_date = new DateTime( $comment->comment_date, wp_timezone() );
+		$meta_start   = get_comment_meta( (int) $comment->comment_ID, 'start', true );
+		$started_at   = ! empty( $meta_start ) ? new DateTime( $meta_start, wp_timezone() ) : current_datetime();
+
+		if ( in_array( $comment->comment_approved, [ 'complete', 'passed', 'graded' ], true ) ) {
+			$completed_at = $comment_date;
+		} else {
+			$completed_at = null;
+		}
+
+		if ( is_null( $quiz_id ) ) {
+			$quiz_id = Sensei()->lesson->lesson_quizzes( $comment->comment_post_ID );
+		}
+
+		return new Comments_Based_Quiz_Progress(
+			(int) $comment->comment_ID,
+			(int) $quiz_id,
+			(int) $comment->user_id,
+			$comment->comment_approved,
+			$started_at,
+			$completed_at,
+			$comment_date,
+			$comment_date
+		);
 	}
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -198,12 +198,12 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	}
 
 	/**
-	 * Find course progress.
+	 * Find quiz progress.
 	 *
 	 * @internal
 	 *
 	 * @param array $args The arguments.
-	 * @return Quiz_Progress_Interface[] The course progress.
+	 * @return Quiz_Progress_Interface[] The quiz progress.
 	 * @throws \InvalidArgumentException When ordering is not supported.
 	 */
 	public function find( array $args ): array {

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Student_Progress\Quiz_Progress\Repositories;
 
+use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comments_Based_Lesson_Progress_Repository;
+
 /**
  * Class Quiz_Progress_Repository_Factory.
  *
@@ -64,7 +66,8 @@ class Quiz_Progress_Repository_Factory {
 
 		return new Table_Reading_Aggregate_Quiz_Progress_Repository(
 			new Comments_Based_Quiz_Progress_Repository(),
-			new Tables_Based_Quiz_Progress_Repository( $wpdb )
+			new Tables_Based_Quiz_Progress_Repository( $wpdb ),
+			new Comments_Based_Lesson_Progress_Repository()
 		);
 	}
 

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
@@ -89,4 +89,14 @@ interface Quiz_Progress_Repository_Interface {
 	 * @param int $user_id User identifier.
 	 */
 	public function delete_for_user( int $user_id ): void;
+
+	/**
+	 * Find course progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Quiz_Progress_Interface[] The course progress.
+	 */
+	public function find( array $args ): array;
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
@@ -7,9 +7,10 @@
 
 namespace Sensei\Internal\Student_Progress\Quiz_Progress\Repositories;
 
+use RuntimeException;
+use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comments_Based_Lesson_Progress_Repository;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Comments_Based_Quiz_Progress;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
-use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Tables_Based_Quiz_Progress;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -30,6 +31,14 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	 */
 	private $comments_based_repository;
 
+
+	/**
+	 * Comments-based lesson progress repository.
+	 *
+	 * @var comments_based_lesson_progress_repository
+	 */
+	private $comments_based_lesson_progress_repository;
+
 	/**
 	 * Tables based quiz progress repository implementation.
 	 *
@@ -40,15 +49,18 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	/**
 	 * Constructor for the Table_Reading_Aggregate_Quiz_Progress_Repository class.
 	 *
-	 * @param Comments_Based_Quiz_Progress_Repository $comments_based_repository Comments based quiz progress repository implementation.
-	 * @param Tables_Based_Quiz_Progress_Repository   $tables_based_repository  Tables based quiz progress repository implementation.
+	 * @param Comments_Based_Quiz_Progress_Repository   $comments_based_repository Comments based quiz progress repository implementation.
+	 * @param Tables_Based_Quiz_Progress_Repository     $tables_based_repository  Tables based quiz progress repository implementation.
+	 * @param Comments_Based_Lesson_Progress_Repository $comments_based_lesson_progress_repository Comments based lesson progress repository.
 	 */
 	public function __construct(
 		Comments_Based_Quiz_Progress_Repository $comments_based_repository,
-		Tables_Based_Quiz_Progress_Repository $tables_based_repository
+		Tables_Based_Quiz_Progress_Repository $tables_based_repository,
+		Comments_Based_Lesson_Progress_Repository $comments_based_lesson_progress_repository
 	) {
-		$this->comments_based_repository = $comments_based_repository;
-		$this->tables_based_repository   = $tables_based_repository;
+		$this->comments_based_repository                 = $comments_based_repository;
+		$this->comments_based_lesson_progress_repository = $comments_based_lesson_progress_repository;
+		$this->tables_based_repository                   = $tables_based_repository;
 	}
 
 	/**
@@ -59,7 +71,17 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	 * @return Quiz_Progress_Interface The quiz progress.
 	 */
 	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
-		$this->comments_based_repository->create( $quiz_id, $user_id );
+		// We don't try to create comments-based quiz progress: it is part of lesson progress.
+		// The attempt to create the comments-based quiz progress will cause an exception.
+		// Try to create the comments-based lesson progress instead.
+		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
+		if ( $lesson_id ) {
+			$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $user_id );
+			if ( ! $lesson_progress_exists ) {
+				$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id );
+			}
+		}
+
 		return $this->tables_based_repository->create( $quiz_id, $user_id );
 	}
 
@@ -89,16 +111,30 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	 * Save quiz progress.
 	 *
 	 * @param Quiz_Progress_Interface $quiz_progress The quiz progress.
+	 * @throws RuntimeException If the comments based quiz progress is not found.
 	 */
 	public function save( Quiz_Progress_Interface $quiz_progress ): void {
 		$this->tables_based_repository->save( $quiz_progress );
+
 		$comments_based_quiz_progress = $this->comments_based_repository->get( $quiz_progress->get_quiz_id(), $quiz_progress->get_user_id() );
 		if ( ! $comments_based_quiz_progress ) {
-			$comments_based_quiz_progress = $this->comments_based_repository->create(
+			$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_progress->get_quiz_id() );
+			if ( $lesson_id ) {
+				$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $quiz_progress->get_user_id() );
+				if ( ! $lesson_progress_exists ) {
+					$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id() );
+				}
+			}
+			$comments_based_quiz_progress = $this->comments_based_repository->get(
 				$quiz_progress->get_quiz_id(),
 				$quiz_progress->get_user_id()
 			);
+
+			if ( ! $comments_based_quiz_progress ) {
+				throw new RuntimeException( 'Comments based quiz progress not found.' );
+			}
 		}
+
 		$updated_comments_based_quiz_progress = new Comments_Based_Quiz_Progress(
 			$comments_based_quiz_progress->get_id(),
 			$quiz_progress->get_quiz_id(),

--- a/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
@@ -9,6 +9,7 @@ namespace Sensei\Internal\Student_Progress\Quiz_Progress\Repositories;
 
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Comments_Based_Quiz_Progress;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Tables_Based_Quiz_Progress;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -142,5 +143,17 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	public function delete_for_user( int $user_id ): void {
 		$this->comments_based_repository->delete_for_user( $user_id );
 		$this->tables_based_repository->delete_for_user( $user_id );
+	}
+
+	/**
+	 * Find quiz progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Quiz_Progress_Interface[] The course progress.
+	 */
+	public function find( array $args ): array {
+		return $this->tables_based_repository->find( $args );
 	}
 }

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -290,17 +290,17 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 
 		$where_clause = array( 'type = %s' );
 		$query_params = array( 'quiz' );
-		if ( ! is_null( $quiz_id ) ) {
+		if ( ! empty( $quiz_id ) ) {
 			$query_params   = array_merge( $query_params, (array) $quiz_id );
 			$where_clause[] = 'post_id IN (' . $this->get_placeholders( (array) $quiz_id ) . ')';
 		}
 
-		if ( ! is_null( $user_id ) ) {
+		if ( ! empty( $user_id ) ) {
 			$query_params[] = (int) $user_id;
 			$where_clause[] = 'user_id = %d';
 		}
 
-		if ( ! is_null( $status ) ) {
+		if ( ! empty( $status ) ) {
 			$query_params   = array_merge( $query_params, (array) $status );
 			$where_clause[] = 'status IN (' . $this->get_placeholders( (array) $status ) . ')';
 		}

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -274,7 +274,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 	}
 
 	/**
-	 * Find lesson progress.
+	 * Find quiz progress.
 	 *
 	 * @internal
 	 *

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -272,4 +272,96 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			throw new \InvalidArgumentException( "Expected Tables_Based_Quiz_Progress, got {$actual_type}." );
 		}
 	}
+
+	/**
+	 * Find lesson progress.
+	 *
+	 * @internal
+	 *
+	 * @param array $args The arguments.
+	 * @return Quiz_Progress_Interface[]
+	 */
+	public function find( array $args ): array {
+		$quiz_id = $args['quiz_id'] ?? null;
+		$user_id = $args['user_id'] ?? null;
+		$status  = $args['status'] ?? null;
+		$limit   = $args['number'] ?? 100;
+		$offset  = $args['offset'] ?? 0;
+
+		$where_clause = array( 'type = %s' );
+		$query_params = array( 'quiz' );
+		if ( ! is_null( $quiz_id ) ) {
+			$query_params   = array_merge( $query_params, (array) $quiz_id );
+			$where_clause[] = 'post_id IN (' . $this->get_placeholders( (array) $quiz_id ) . ')';
+		}
+
+		if ( ! is_null( $user_id ) ) {
+			$query_params[] = (int) $user_id;
+			$where_clause[] = 'user_id = %d';
+		}
+
+		if ( ! is_null( $status ) ) {
+			$query_params   = array_merge( $query_params, (array) $status );
+			$where_clause[] = 'status IN (' . $this->get_placeholders( (array) $status ) . ')';
+		}
+
+		$table_name = $this->wpdb->prefix . 'sensei_lms_progress';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$query_string = 'SELECT * FROM ' . $table_name . ' ';
+		if ( count( $where_clause ) > 0 ) {
+			$query_string .= 'WHERE ' . implode( ' AND ', $where_clause ) . ' ';
+		}
+
+		$query_string  .= 'ORDER BY id ASC ';
+		$query_string  .= 'LIMIT %d OFFSET %d';
+		$query_params[] = $limit;
+		$query_params[] = $offset;
+
+		$query = $this->wpdb->prepare(
+			$query_string, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			...$query_params
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $this->wpdb->get_results( $query );
+		if ( ! $rows ) {
+			return array();
+		}
+
+		$timezone = new DateTimeZone( 'UTC' );
+
+		$course_progresses = array();
+		foreach ( $rows as $row ) {
+			$course_progresses[] = new Tables_Based_Quiz_Progress(
+				(int) $row->id,
+				(int) $row->post_id,
+				(int) $row->user_id,
+				$row->status,
+				$row->started_at ? new DateTimeImmutable( $row->started_at, $timezone ) : null,
+				$row->completed_at ? new DateTimeImmutable( $row->completed_at, $timezone ) : null,
+				new DateTimeImmutable( $row->created_at, $timezone ),
+				new DateTimeImmutable( $row->updated_at, $timezone )
+			);
+		}
+
+		return $course_progresses;
+	}
+
+	/**
+	 * Return a string of placeholders for the given values.
+	 *
+	 * @param array $values The values.
+	 * @return string The placeholders.
+	 */
+	private function get_placeholders( array $values ) {
+		if ( empty( $values ) ) {
+			return '';
+		}
+
+		$placeholder  = is_numeric( $values[0] ) ? '%d' : '%s';
+		$placeholders = array_fill( 0, count( $values ), $placeholder );
+
+		return implode( ', ', $placeholders );
+	}
 }

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -148,7 +148,7 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 	$pre_requisite_complete = Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
 	$is_preview_lesson      = false;
 
-	if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
+	if ( $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 		$is_preview_lesson      = true;
 		$pre_requisite_complete = true;
 	};

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -862,7 +862,7 @@ function sensei_the_single_lesson_meta() {
 	$lesson_id = get_the_ID();
 
 	// Get the meta info
-	$lesson_course_id = absint( get_post_meta( get_the_ID(), '_lesson_course', true ) );
+	$lesson_course_id = absint( get_post_meta( $lesson_id, '_lesson_course', true ) );
 	$is_preview       = $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id );
 
 	// Complete Lesson Logic

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -859,9 +859,11 @@ function sensei_the_single_lesson_meta() {
 
 	}
 
+	$lesson_id = get_the_ID();
+
 	// Get the meta info
 	$lesson_course_id = absint( get_post_meta( get_the_ID(), '_lesson_course', true ) );
-	$is_preview       = Sensei_Utils::is_preview_lesson( get_the_ID() );
+	$is_preview       = $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id );
 
 	// Complete Lesson Logic
 	do_action( 'sensei_complete_lesson' );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -1170,8 +1170,13 @@ function sensei_get_template( $template_name, $args, $path ) {
  */
 function get_the_lesson_status_class() {
 
+	$lesson_id = get_the_ID();
+	if ( ! $lesson_id ) {
+		return '';
+	}
+
 	$status_class     = '';
-	$lesson_completed = Sensei_Utils::user_completed_lesson( get_the_ID(), get_current_user_id() );
+	$lesson_completed = Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() );
 
 	if ( $lesson_completed ) {
 		$status_class = 'completed';

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -864,6 +864,9 @@ function sensei_the_single_lesson_meta() {
 	}
 
 	$lesson_id = get_the_ID();
+	if ( ! $lesson_id ) {
+		return;
+	}
 
 	// Get the meta info
 	$lesson_course_id = absint( get_post_meta( $lesson_id, '_lesson_course', true ) );

--- a/psalm.xml
+++ b/psalm.xml
@@ -30,5 +30,6 @@
 				<referencedProperty name="Sensei_Main::$quiz_progress_repository_factory" />
 			</errorLevel>
 		</PropertyNotSetInConstructor>
+		<RedundantCastGivenDocblockType errorLevel="suppress" />
 	</issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,8 @@
 		<MissingReturnType errorLevel="suppress" />
 		<PropertyNotSetInConstructor>
 			<errorLevel type="suppress">
+				<referencedProperty name="Sensei_Main::$course_progress_repository_factory" />
+				<referencedProperty name="Sensei_Main::$lesson_progress_repository_factory" />
 				<referencedProperty name="Sensei_Main::$quiz_progress_repository_factory" />
 			</errorLevel>
 		</PropertyNotSetInConstructor>

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -72,10 +72,11 @@ global $course;
 					$lesson_grade  = 'n/a';
 					$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson->ID );
 					if ( $has_questions ) {
-						$lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, get_current_user_id() );
-						if ( $lesson_status ) {
+						$sensei_quiz_id    = Sensei()->lesson->lesson_quizzes( $lesson->ID );
+						$sensei_submission = Sensei()->quiz_submission_repository->get( $sensei_quiz_id, get_current_user_id() );
+						if ( $sensei_submission ) {
 							// Get user quiz grade
-							$lesson_grade = get_comment_meta( $lesson_status->comment_ID, 'grade', true );
+							$lesson_grade = $sensei_submission->get_final_grade();
 							if ( $lesson_grade ) {
 								$lesson_grade .= '%';
 							}
@@ -128,11 +129,12 @@ global $course;
 				$lesson_grade  = 'n/a';
 				$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson->ID );
 				if ( $has_questions ) {
-					$lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, get_current_user_id() );
+					$sensei_quiz_id    = Sensei()->lesson->lesson_quizzes( $lesson->ID );
+					$sensei_submission = Sensei()->quiz_submission_repository->get( $sensei_quiz_id, get_current_user_id() );
 					// Get user quiz grade
 					$lesson_grade = '';
-					if ( ! empty( $lesson_status ) ) {
-						$lesson_grade = get_comment_meta( $lesson_status->comment_ID, 'grade', true );
+					if ( ! empty( $sensei_submission ) ) {
+						$lesson_grade = $sensei_submission->get_final_grade();
 						if ( $lesson_grade ) {
 							$lesson_grade .= '%';
 						}

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
@@ -141,7 +141,6 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 
 		$submission = $repository->create( $quiz_id, $user_id, 0 );
 
-
 		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
 
 		/* Act. */

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-comments-based-submission-repository.php
@@ -139,7 +139,8 @@ class Comments_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 
 		$submission_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
 
-		$repository->create( $quiz_id, $user_id, 0 );
+		$submission = $repository->create( $quiz_id, $user_id, 0 );
+
 
 		update_comment_meta( $submission_id, 'questions_asked', '1,2' );
 

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comment-reading-aggregate-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comment-reading-aggregate-course-progress-repository.php
@@ -266,6 +266,45 @@ class Comment_Reading_Aggregate_Course_Progress_Repository_Test extends \WP_Unit
 		$repository->delete_for_user( $user_id );
 	}
 
+	public function testFind_Always_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Comment_Reading_Aggregate_Course_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'find' )
+			->with( $args );
+		$repository->find( $args );
+	}
+
+	public function testFind_Never_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Comment_Reading_Aggregate_Course_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'find' );
+		$repository->find( $args );
+	}
+
 	/**
 	 * Creates a comments-based course progress object.
 	 *

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
@@ -208,6 +208,38 @@ class Comments_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->save( $progress );
 	}
 
+	public function testFind_ArgumentsGiven_ReturnsMatchingProgress(): void {
+		/* Arrange. */
+		$course_ids = $this->factory->course->create_many( 5 );
+		$user_id    = $this->factory->user->create();
+
+		$repository       = new Comments_Based_Course_Progress_Repository();
+		$created_progress = [];
+		foreach ( $course_ids as $course_id ) {
+			$created_progress[] = $repository->create( $course_id, $user_id );
+		}
+
+		$expected = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$progress = $created_progress[ $i ];
+			$progress->complete();
+			$repository->save( $progress );
+			$expected[] = $this->export_progress( $progress );
+		}
+
+		/* Act. */
+		$found_progress = $repository->find(
+			array(
+				'user_id' => $user_id,
+				'status'  => 'complete',
+			)
+		);
+		$actual         = array_map( array( $this, 'export_progress' ), $found_progress );
+
+		/* Assert. */
+		self::assertSame( $expected, $actual );
+	}
+
 	private function export_progress( Course_Progress_Interface $progress ): array {
 		return [
 			'user_id'   => $progress->get_user_id(),

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-table-reading-aggregate-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-table-reading-aggregate-course-progress-repository.php
@@ -339,4 +339,43 @@ class Table_Reading_Aggregate_Course_Progress_Repository_Test extends \WP_UnitTe
 			);
 		$repository->save( $tables_based_progress );
 	}
+
+	public function testFind_Always_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Table_Reading_Aggregate_Course_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'find' )
+			->with( $args );
+		$repository->find( $args );
+	}
+
+	public function testFind_Never_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Course_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Course_Progress_Repository::class );
+
+		$repository = new Table_Reading_Aggregate_Course_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->never() )
+			->method( 'find' );
+		$repository->find( $args );
+	}
 }

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comment-reading-aggregate-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comment-reading-aggregate-lesson-progress-repository.php
@@ -293,6 +293,45 @@ class Comment_Reading_Aggregate_Lesson_Progress_Repository_Test extends \WP_Unit
 		$repository->count( 1, 2 );
 	}
 
+	public function testFind_Always_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Comment_Reading_Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'find' )
+			->with( $args );
+		$repository->find( $args );
+	}
+
+	public function testFind_Never_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Comment_Reading_Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'find' );
+		$repository->find( $args );
+	}
+
 	/**
 	 * Create a comments-baesd lesson progress.
 	 *

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-table-reading-aggregate-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-table-reading-aggregate-lesson-progress-repository.php
@@ -356,4 +356,43 @@ class Table_Reading_Aggregate_Lesson_Progress_Repository_Test extends \WP_UnitTe
 		/* Assert. */
 		$this->assertSame( 3, $actual );
 	}
+
+	public function testFind_Always_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Table_Reading_Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'find' )
+			->with( $args );
+		$repository->find( $args );
+	}
+
+	public function testFind_Never_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Table_Reading_Aggregate_Lesson_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->never() )
+			->method( 'find' );
+		$repository->find( $args );
+	}
 }

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
@@ -15,6 +15,23 @@ use wpdb;
  * @covers \Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Tables_Based_Lesson_Progress_Repository
  */
 class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
+	/**
+	 * Sensei factory.
+	 *
+	 * @var \Sensei_Factory
+	 */
+	protected $factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
 	public function testCreate_ParamsGiven_InsertsToWpdb(): void {
 		/* Arrange. */
 		$wpdb       = $this->createMock( wpdb::class );
@@ -410,6 +427,39 @@ class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertSame( 5, $actual );
 
 		Sensei()->course = $initial_course;
+	}
+
+	public function testIntegrationFind_ArgumentsGiven_ReturnsMatchingProgress(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_ids = $this->factory->lesson->create_many( 5 );
+		$user_id    = $this->factory->user->create();
+
+		$repository       = new Tables_Based_Lesson_Progress_Repository( $wpdb );
+		$created_progress = [];
+		foreach ( $lesson_ids as $lesson_id ) {
+			$created_progress[] = $repository->create( $lesson_id, $user_id );
+		}
+
+		$expected = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$progress = $created_progress[ $i ];
+			$progress->complete();
+			$repository->save( $progress );
+			$expected[] = $this->export_progress( $progress );
+		}
+
+		/* Act. */
+		$found_progress = $repository->find(
+			array(
+				'user_id' => $user_id,
+				'status'  => 'complete',
+			)
+		);
+		$actual         = array_map( array( $this, 'export_progress' ), $found_progress );
+
+		/* Assert. */
+		self::assertSame( $expected, $actual );
 	}
 
 	private function export_progress( Lesson_Progress_Interface $progress ): array {

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comment-reading-aggregate-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comment-reading-aggregate-quiz-progress-repository.php
@@ -270,6 +270,45 @@ class Comment_Reading_Aggregate_Quiz_Progress_Repository_Test extends \WP_UnitTe
 		$repository->delete_for_user( $user_id );
 	}
 
+	public function testFind_Always_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Comment_Reading_Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->once() )
+			->method( 'find' )
+			->with( $args );
+		$repository->find( $args );
+	}
+
+	public function testFind_Never_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Comment_Reading_Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->never() )
+			->method( 'find' );
+		$repository->find( $args );
+	}
+
 	/**
 	 * Create a comments-based quiz progress.
 	 *

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-table-reading-aggregate-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-table-reading-aggregate-quiz-progress-repository.php
@@ -339,4 +339,43 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository_Test extends \WP_UnitTest
 			);
 		$repository->save( $tables_based_progress );
 	}
+
+	public function testFind_Always_CallsTablesBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Table_Reading_Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$tables_based
+			->expects( $this->once() )
+			->method( 'find' )
+			->with( $args );
+		$repository->find( $args );
+	}
+
+	public function testFind_Never_CallsCommentsBasedRepository(): void {
+		/* Arrange. */
+		$comments_based = $this->createMock( Comments_Based_Quiz_Progress_Repository::class );
+		$tables_based   = $this->createMock( Tables_Based_Quiz_Progress_Repository::class );
+
+		$repository = new Table_Reading_Aggregate_Quiz_Progress_Repository( $comments_based, $tables_based );
+
+		$args = array(
+			'a' => 1,
+			'b' => 2,
+		);
+
+		/* Expect & Act. */
+		$comments_based
+			->expects( $this->never() )
+			->method( 'find' );
+		$repository->find( $args );
+	}
 }

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
@@ -14,6 +14,23 @@ use wpdb;
  * @covers \Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Tables_Based_Quiz_Progress_Repository
  */
 class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
+	/**
+	 * Sensei factory.
+	 *
+	 * @var \Sensei_Factory
+	 */
+	protected $factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
 	public function testCreate_ParamsGiven_InsertsToWpdb(): void {
 		/* Arrange. */
 		$wpdb       = $this->createMock( wpdb::class );
@@ -376,6 +393,39 @@ class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 				]
 			);
 		$repository->delete_for_user( 2 );
+	}
+
+	public function testIntegrationFind_ArgumentsGiven_ReturnsMatchingProgress(): void {
+		/* Arrange. */
+		global $wpdb;
+		$quiz_ids = $this->factory->quiz->create_many( 5 );
+		$user_id  = $this->factory->user->create();
+
+		$repository       = new Tables_Based_Quiz_Progress_Repository( $wpdb );
+		$created_progress = [];
+		foreach ( $quiz_ids as $quiz_id ) {
+			$created_progress[] = $repository->create( $quiz_id, $user_id );
+		}
+
+		$expected = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$progress = $created_progress[ $i ];
+			$progress->pass();
+			$repository->save( $progress );
+			$expected[] = $this->export_progress( $progress );
+		}
+
+		/* Act. */
+		$found_progress = $repository->find(
+			array(
+				'user_id' => $user_id,
+				'status'  => 'passed',
+			)
+		);
+		$actual         = array_map( array( $this, 'export_progress' ), $found_progress );
+
+		/* Assert. */
+		self::assertSame( $expected, $actual );
 	}
 
 	private function export_progress( Quiz_Progress_Interface $progress ): array {

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -79,6 +79,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	 * @since 1.8.0
 	 */
 	public function testGetCompletedLessonIds() {
+		$lesson_progress_repository = Sensei()->lesson_progress_repository;
 
 		// does the function exist?
 		$this->assertTrue( method_exists( 'WooThemes_Sensei_Course', 'get_completed_lesson_ids' ), 'The course class get_completed_lesson_ids function does not exist.' );
@@ -98,14 +99,24 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		// complete 3 lessons
 		$i = 0;
 		for ( $i = 0; $i < 3; $i++ ) {
-			WooThemes_Sensei_Utils::update_lesson_status( $test_user_id, $test_lessons[ $i ], 'complete' );
+			$progress = $lesson_progress_repository->get( $test_lessons[ $i ], $test_user_id );
+			if ( ! $progress ) {
+				$progress = $lesson_progress_repository->create( $test_lessons[ $i ], $test_user_id );
+			}
+			$progress->complete();
+			$lesson_progress_repository->save( $progress );
 		}
 
 		$this->assertEquals( 3, count( Sensei()->course->get_completed_lesson_ids( $test_course_id, $test_user_id ) ), 'Course completed lesson count not accurate' );
 
 		// complete all lessons
 		foreach ( $test_lessons as $lesson_id ) {
-			WooThemes_Sensei_Utils::update_lesson_status( $test_user_id, $lesson_id, 'complete' );
+			$progress = $lesson_progress_repository->get( $lesson_id, $test_user_id );
+			if ( ! $progress ) {
+				$progress = $lesson_progress_repository->create( $lesson_id, $test_user_id );
+			}
+			$progress->complete();
+			$lesson_progress_repository->save( $progress );
 		}
 
 		// does it return all lessons
@@ -119,6 +130,8 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	 * @since 1.8.0
 	 */
 	public function testGetCompletionPercentage() {
+		$lesson_progress_repository = Sensei()->lesson_progress_repository;
+
 		// does the function exist?
 		$this->assertTrue( method_exists( 'WooThemes_Sensei_Course', 'get_completion_percentage' ), 'The course class get_completion_percentage function does not exist.' );
 
@@ -137,14 +150,24 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		// complete 3 lessons and check if the correct percentage returns
 		$i = 0;
 		for ( $i = 0; $i < 3; $i++ ) {
-			WooThemes_Sensei_Utils::update_lesson_status( $test_user_id, $test_lessons[ $i ], 'complete' );
+			$progress = $lesson_progress_repository->get( $test_lessons[ $i ], $test_user_id );
+			if ( ! $progress ) {
+				$progress = $lesson_progress_repository->create( $test_lessons[ $i ], $test_user_id );
+			}
+			$progress->complete();
+			$lesson_progress_repository->save( $progress );
 		}
 		$expected_percentage = round( 3 / count( $test_lessons ) * 100, 2 );
 		$this->assertEquals( $expected_percentage, Sensei()->course->get_completion_percentage( $test_course_id, $test_user_id ), 'Course completed percentage is not accurate' );
 
 		// complete all lessons
 		foreach ( $test_lessons as $lesson_id ) {
-			WooThemes_Sensei_Utils::update_lesson_status( $test_user_id, $lesson_id, 'complete' );
+			$progress = $lesson_progress_repository->get( $lesson_id, $test_user_id );
+			if ( ! $progress ) {
+				$progress = $lesson_progress_repository->create( $lesson_id, $test_user_id );
+			}
+			$progress->complete();
+			$lesson_progress_repository->save( $progress );
 		}
 		// all lessons should no be completed
 		$this->assertEquals( 100, Sensei()->course->get_completion_percentage( $test_course_id, $test_user_id ), 'Course completed percentage is not accurate' );

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1950,4 +1950,28 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$actual                   = $quiz_progress_repository->has( $quiz_id, $user_id );
 		$this->assertFalse( $actual );
 	}
+
+	public function testGetLessonIds_QuizIdsGiven_ReturnsMatchingIds(): void {
+		/* Arrange. */
+		$lesson_ids = $this->factory->lesson->create_many( 3 );
+		$quiz_ids   = array();
+		foreach ( $lesson_ids as $lesson_id ) {
+			$quiz_ids[] = $this->factory->quiz->create(
+				array(
+					'post_parent' => $lesson_id,
+					'meta_input'  => array(
+						'_quiz_lesson' => $lesson_id,
+					),
+				)
+			);
+		}
+
+		/* Act. */
+		$actual = Sensei()->quiz->get_lesson_ids( $quiz_ids );
+
+		/* Assert. */
+		sort( $lesson_ids );
+		sort( $actual );
+		$this->assertSame( $lesson_ids, $actual );
+	}
 }


### PR DESCRIPTION
Resolves part of #7150 

- Here I also changed logic for table reading quiz progress repository, to create lesson progress if it doesn't exist yet (creating a quiz progress leads to an error).
- In student progress migration, I added handling for the failed status. It is not very efficient as it performs a query in the loop. Any ideas on how it improve?
- When table reading is enabled, tests fail: we need to update code for quiz submission, then tests themselves to make them green.

## Proposed Changes
* Add a `find` method for progress repositories to get multiple progress entries.
* Adjust client code on the frontend to use new progress storage instead of activity comments.
* Adjust client code to use separated lesson/quiz progress behavior.

## Testing Instructions

1. Create a course with a few lessons with quizzes.
2. Create a few students.
3. Without enabling the feature, complete a course. Make sure frontend looks good (correctly displays the progress), you can see submissions and try to grade them.
4. Enable the tables-based progress feature, complete a course. Make sure frontend looks good (correctly displays the progress), you can see submissions and try to grade them.
5. Run migration.
6. Enable reading from tables. Make sure frontend looks good (correctly displays the progress), you can see submissions and try to grade them.
7. Reset progress. Make sure you don't see progress on the frontend.

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

*

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
