### PR TITLE
Update stylings for footer in awaiting grade quizzes in learning mode

### DIFF
--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -20,7 +20,7 @@
 }
 
 #sensei-quiz-list {
-	margin: 0 0 clamp(3.75rem, 2.5rem + 3.333vw, 5rem) 0
+	margin: 0 0 clamp(3.75rem, 2.5rem + 3.333vw, 5rem) 0;
 }
 
 .quiz {

--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -12,6 +12,13 @@
 		}
 	}
 }
+
+.wp-block-sensei-lms-quiz-actions {
+	button:disabled {
+		opacity: 0.4;
+	}
+}
+
 .quiz {
 	.sensei-course-theme__quiz {
 		&__main-content {

--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -19,6 +19,10 @@
 	}
 }
 
+#sensei-quiz-list {
+	margin: 0 0 clamp(3.75rem, 2.5rem + 3.333vw, 5rem) 0
+}
+
 .quiz {
 	.sensei-course-theme__quiz {
 		&__main-content {

--- a/assets/css/3rd-party/themes/course/quiz.scss
+++ b/assets/css/3rd-party/themes/course/quiz.scss
@@ -30,19 +30,18 @@
 				margin-bottom: 3.75rem;
 			}
 		}
-		&__footer {
-			.sensei-quiz-actions {
-				.sensei-quiz-action {
-					button {
-						padding: 1rem 32px;
-					}
-				}
-				.sensei-quiz-actions-secondary {
-					.sensei-quiz-action {
-						button {
-							font-family: var( --wp--preset--font-family--body );
-						}
-					}
+	}
+
+	.sensei-quiz-actions {
+		.sensei-quiz-action {
+			button {
+				padding: 1rem 32px;
+			}
+		}
+		.sensei-quiz-actions-secondary {
+			.sensei-quiz-action {
+				button {
+					font-family: var( --wp--preset--font-family--body );
 				}
 			}
 		}

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -521,6 +521,11 @@ div.sensei-quiz-actions {
 		.sensei-quiz-action {
 			.button, button {
 				@include button-link;
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: underline;
+				}
 			}
 		}
 	}

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -302,7 +302,6 @@ a.sensei-certificate-link {
 .quiz {
 	form {
 		#sensei-quiz-list {
-			margin: 0 0 1.618em 0;
 			list-style-position: inside;
 			list-style-type: none;
 			padding-inline-start: 0;

--- a/assets/css/sensei-course-theme/quiz-compat.scss
+++ b/assets/css/sensei-course-theme/quiz-compat.scss
@@ -66,7 +66,7 @@ $textColor: #1E1E1E;
 }
 
 #sensei-quiz-list {
-	margin: 0 0 3.75rem 0
+	margin: 0 0 3.75rem 0;
 }
 
 .quiz {

--- a/assets/css/sensei-course-theme/quiz-compat.scss
+++ b/assets/css/sensei-course-theme/quiz-compat.scss
@@ -65,6 +65,10 @@ $textColor: #1E1E1E;
 	}
 }
 
+#sensei-quiz-list {
+	margin: 0 0 3.75rem 0
+}
+
 .quiz {
 	form {
 		#sensei-quiz-list {

--- a/assets/css/sensei-course-theme/quiz-compat.scss
+++ b/assets/css/sensei-course-theme/quiz-compat.scss
@@ -53,6 +53,12 @@ $textColor: #1E1E1E;
 	}
 }
 
+.wp-block-sensei-lms-quiz-actions {
+	button:disabled {
+		opacity: 0.6;
+	}
+}
+
 .quiz {
 	form {
 		#sensei-quiz-list {

--- a/assets/css/sensei-course-theme/quiz-compat.scss
+++ b/assets/css/sensei-course-theme/quiz-compat.scss
@@ -57,6 +57,12 @@ $textColor: #1E1E1E;
 	button:disabled {
 		opacity: 0.6;
 	}
+
+	.sensei-quiz-actions-secondary {
+		.sensei-course-theme__button.is-link {
+			color: var(--sensei-primary-color);
+		}
+	}
 }
 
 .quiz {

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -201,6 +201,14 @@ $vertical-spacing-desktop: 80px;
 	text-decoration: none;
 }
 
+.wp-block-sensei-lms-quiz-actions {
+	button:disabled {
+		cursor: not-allowed;
+		pointer-events: none;
+		width: auto;
+	}
+}
+
 .sensei-progress-bar {
 	&__bar {
 		height: 12px;

--- a/changelog/add-stylings-for-footer-in-awaiting-grade-quiz-lm
+++ b/changelog/add-stylings-for-footer-in-awaiting-grade-quiz-lm
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed footer style for quizzes awaiting grading

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -162,15 +162,8 @@ class Lesson_Actions {
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
 		$is_learning_mode  = \Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
-		$is_awaiting_grade = false;
-
-		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
-
-		if ( $lesson_status ) {
-			$lesson_status = is_array( $lesson_status ) ? $lesson_status[0] : $lesson_status;
-
-			$is_awaiting_grade = 'ungraded' === $lesson_status->comment_approved;
-		}
+		$lesson_status     = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
+		$is_awaiting_grade = $lesson_status && 'ungraded' === $lesson_status->comment_approved;
 
 		if ( $is_learning_mode && $is_awaiting_grade && 'quiz' === get_post_type() ) {
 			return '';

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -161,6 +161,21 @@ class Lesson_Actions {
 
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
+		$is_learning_mode  = \Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
+		$is_awaiting_grade = false;
+
+		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
+
+		if ( $lesson_status ) {
+			$lesson_status = is_array( $lesson_status ) ? $lesson_status[0] : $lesson_status;
+
+			$is_awaiting_grade = 'ungraded' === $lesson_status->comment_approved;
+		}
+
+		if ( $is_learning_mode && $is_awaiting_grade && 'quiz' === get_post_type() ) {
+			return '';
+		}
+
 		if (
 			! Sensei_Course::is_user_enrolled( $course_id )
 		) {

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -162,8 +162,7 @@ class Lesson_Actions {
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
 		$is_learning_mode  = \Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
-		$lesson_status     = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
-		$is_awaiting_grade = $lesson_status && 'ungraded' === $lesson_status->comment_approved;
+		$is_awaiting_grade = \Sensei_Quiz::is_quiz_awaiting_grade_for_user( $lesson_id, $user_id );
 
 		if ( $is_learning_mode && $is_awaiting_grade && 'quiz' === get_post_type() ) {
 			return '';

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2402,14 +2402,14 @@ class Sensei_Quiz {
 	 */
 	public static function is_quiz_awaiting_grade_for_user( $lesson_id = null, $user_id = null ) {
 		if ( empty( $lesson_id ) ) {
-			$quiz_id = Sensei()->quiz->get_lesson_id();
+			$lesson_id = Sensei()->quiz->get_lesson_id();
 		}
 
 		if ( empty( $user_id ) ) {
 			$user_id = get_current_user_id();
 		}
 
-		if ( empty( $quiz_id ) || empty( $user_id ) || 'quiz' !== get_post_type( $quiz_id ) ) {
+		if ( empty( $lesson_id ) || empty( $user_id ) || 'lesson' !== get_post_type( $lesson_id ) ) {
 			return false;
 		}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1856,7 +1856,6 @@ class Sensei_Quiz {
 		$lesson_id         = Sensei()->quiz->get_lesson_id();
 		$is_quiz_completed = self::is_quiz_completed();
 		$is_reset_allowed  = self::is_reset_allowed( $lesson_id );
-		$has_actions       = $is_reset_allowed || ! $is_quiz_completed;
 		$course_id         = Sensei()->lesson->get_course_id( $lesson_id );
 		$is_learning_mode  = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
 		$is_awaiting_grade = false;
@@ -1869,11 +1868,15 @@ class Sensei_Quiz {
 			$is_awaiting_grade = 'ungraded' === $lesson_status->comment_approved;
 		}
 
+		$show_grade_pending_button = $is_learning_mode && $is_awaiting_grade;
+
 		$wrapper_attributes = get_block_wrapper_attributes(
 			[
 				'class' => 'sensei-quiz-actions',
 			]
 		);
+
+		$has_actions = $is_reset_allowed || ! $is_quiz_completed || $show_grade_pending_button;
 
 		if ( ! $has_actions ) {
 			return;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1857,6 +1857,17 @@ class Sensei_Quiz {
 		$is_quiz_completed = self::is_quiz_completed();
 		$is_reset_allowed  = self::is_reset_allowed( $lesson_id );
 		$has_actions       = $is_reset_allowed || ! $is_quiz_completed;
+		$course_id         = Sensei()->lesson->get_course_id( $lesson_id );
+		$is_learning_mode  = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
+		$is_awaiting_grade = false;
+
+		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
+
+		if ( $lesson_status ) {
+			$lesson_status = is_array( $lesson_status ) ? $lesson_status[0] : $lesson_status;
+
+			$is_awaiting_grade = 'ungraded' === $lesson_status->comment_approved;
+		}
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			[
@@ -1896,6 +1907,12 @@ class Sensei_Quiz {
 						<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
 					</div>
 				</div>
+			<?php endif ?>
+
+			<?php if ( $is_awaiting_grade && $is_learning_mode ) : ?>
+				<button type="button" class="wp-element-button sensei-course-theme__button is-primary" disabled>
+					<?php esc_attr_e( 'Pending teacher grade', 'sensei-lms' ); ?>
+				</button>
 			<?php endif ?>
 
 			<div class="sensei-quiz-actions-secondary">

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1858,8 +1858,7 @@ class Sensei_Quiz {
 		$is_reset_allowed  = self::is_reset_allowed( $lesson_id );
 		$course_id         = Sensei()->lesson->get_course_id( $lesson_id );
 		$is_learning_mode  = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
-		$lesson_status     = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
-		$is_awaiting_grade = $lesson_status && 'ungraded' === $lesson_status->comment_approved;
+		$is_awaiting_grade = self::is_quiz_awaiting_grade_for_user( $lesson_id, get_current_user_id() );
 
 		$show_grade_pending_button = $is_learning_mode && $is_awaiting_grade;
 
@@ -2391,6 +2390,32 @@ class Sensei_Quiz {
 		}
 
 		$quiz_progress_repository->create( $quiz_id, $user_id );
+	}
+
+	/**
+	 * Check if the quiz is in ungraded state for a user.
+	 *
+	 * @param ?int $lesson_id The lesson ID.
+	 * @param ?int $user_id   The user ID.
+	 *
+	 * @return bool True if the quiz is in ungraded state for the user, false otherwise.
+	 */
+	public static function is_quiz_awaiting_grade_for_user( $lesson_id = null, $user_id = null ) {
+		if ( empty( $lesson_id ) ) {
+			$quiz_id = Sensei()->quiz->get_lesson_id();
+		}
+
+		if ( empty( $user_id ) ) {
+			$user_id = get_current_user_id();
+		}
+
+		if ( empty( $quiz_id ) || empty( $user_id ) || 'quiz' !== get_post_type( $quiz_id ) ) {
+			return false;
+		}
+
+		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
+
+		return $lesson_status && 'ungraded' === $lesson_status->comment_approved;
 	}
 }
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1918,8 +1918,8 @@ class Sensei_Quiz {
 			<div class="sensei-quiz-actions-secondary">
 				<?php if ( $is_reset_allowed ) : ?>
 					<div class="sensei-quiz-action">
-						<button type="submit" name="quiz_reset" form="sensei-quiz-form" class="quiz-submit reset sensei-stop-double-submission">
-							<?php esc_attr_e( 'Reset Quiz', 'sensei-lms' ); ?>
+						<button type="submit" name="quiz_reset" form="sensei-quiz-form" class="quiz-submit reset sensei-stop-double-submission sensei-course-theme__button is-link">
+							<?php esc_attr_e( 'Restart Quiz', 'sensei-lms' ); ?>
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1858,15 +1858,8 @@ class Sensei_Quiz {
 		$is_reset_allowed  = self::is_reset_allowed( $lesson_id );
 		$course_id         = Sensei()->lesson->get_course_id( $lesson_id );
 		$is_learning_mode  = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
-		$is_awaiting_grade = false;
-
-		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
-
-		if ( $lesson_status ) {
-			$lesson_status = is_array( $lesson_status ) ? $lesson_status[0] : $lesson_status;
-
-			$is_awaiting_grade = 'ungraded' === $lesson_status->comment_approved;
-		}
+		$lesson_status     = \Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
+		$is_awaiting_grade = $lesson_status && 'ungraded' === $lesson_status->comment_approved;
 
 		$show_grade_pending_button = $is_learning_mode && $is_awaiting_grade;
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1690,7 +1690,7 @@ class Sensei_Utils {
 	 * @since 1.7.0
 	 * @param int $lesson_id
 	 * @param int $user_id
-	 * @return WP_Comment|WP_Comment[]|false
+	 * @return WP_Comment|false
 	 */
 	public static function user_lesson_status( $lesson_id = 0, $user_id = 0 ) {
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1690,7 +1690,7 @@ class Sensei_Utils {
 	 * @since 1.7.0
 	 * @param int $lesson_id
 	 * @param int $user_id
-	 * @return WP_Comment|false
+	 * @return WP_Comment|WP_Comment[]|false
 	 */
 	public static function user_lesson_status( $lesson_id = 0, $user_id = 0 ) {
 

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -60,7 +60,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		foreach ( $quizzes as $index => $quiz ) {
 			wp_delete_post( $quiz->ID, true );
 		}
-
+		WP_Block_Supports::$block_to_render = null;
 	}
 
 	/**
@@ -1949,5 +1949,43 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$quiz_progress_repository = new Tables_Based_Quiz_Progress_Repository( $wpdb );
 		$actual                   = $quiz_progress_repository->has( $quiz_id, $user_id );
 		$this->assertFalse( $actual );
+	}
+
+	public function testQuizFooterActions_WhenAwaitingGradeInLearningMode_RendersAwaitingGradeButton() {
+		/* Arrange */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+
+		$quiz_id          = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$course_enrolment->enrol( $user_id );
+
+		wp_set_current_user( $user_id );
+
+		// Enable course theme;
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		WP_Block_Supports::$block_to_render = [
+			'attrs'     => [],
+			'blockName' => 'sensei-lms/quiz-actions',
+		];
+
+		/* Act */
+		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
+
+		/* Assert */
+		$this->assertStringContainsString( 'Pending teacher grade', $result );
 	}
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2023,4 +2023,41 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertStringNotContainsString( 'Pending teacher grade', $result );
 	}
+
+	public function testQuizFooterActions_WhenPassedButInLearningMode_DoesNotRenderAwaitingGradeButton() {
+		/* Arrange */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+
+		$quiz_id          = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$course_enrolment->enrol( $user_id );
+
+		wp_set_current_user( $user_id );
+
+		// Enable course theme;
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed' );
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		WP_Block_Supports::$block_to_render = [
+			'attrs'     => [],
+			'blockName' => 'sensei-lms/quiz-actions',
+		];
+
+		/* Act */
+		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
+
+		/* Assert */
+		$this->assertStringNotContainsString( 'Pending teacher grade', $result );
+	}
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2007,7 +2007,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		wp_set_current_user( $user_id );
 
-
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
 
 		$this->go_to( get_permalink( $quiz_id ) );

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1972,7 +1972,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		// Enable course theme;
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
 
-
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
 
 		$this->go_to( get_permalink( $quiz_id ) );

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1988,4 +1988,39 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertStringContainsString( 'Pending teacher grade', $result );
 	}
+
+	public function testQuizFooterActions_WhenAwaitingGradeButNotInLearningMode_DoesNotRenderAwaitingGradeButton() {
+		/* Arrange */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+
+		$quiz_id          = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$course_enrolment->enrol( $user_id );
+
+		wp_set_current_user( $user_id );
+
+
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		WP_Block_Supports::$block_to_render = [
+			'attrs'     => [],
+			'blockName' => 'sensei-lms/quiz-actions',
+		];
+
+		/* Act */
+		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
+
+		/* Assert */
+		$this->assertStringNotContainsString( 'Pending teacher grade', $result );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7101

## Proposed Changes
* Updated block markups and stylings for the footer of quizzes awaiting grading

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with a lesson with a quiz
2. Make sure you have LM enabled for the course and auto grading disabled (or have at least one question in the quiz that is not auto-gradable, like the multi-line question) for that quiz
3. Take the quiz
4. Make sure the footer matches the design
5. Try enabling and disabling retakes for the quiz and make sure the design matches in those cases as well
6. Check for All variations of the Course theme and other themes as well, especially Divi and Astra
7. Check on mobile view as well for those states
8. Check that the footer of the lesson looks as it used to do
9. Check that the non-LM design isn't broken

In the design, the variations of Course theme have 0.6 opacity, but the default variation has 0.4, so I only set the 0.4, and didn't add 0.6 for the variations because it'd require adding CSS as string in all the JSON files of the variations which is not very manageable. 0.2 difference in opacity hopefully shouldn't feel too different in the variations.

Desktop:
![Screenshot 2023-09-27 at 5 50 42 PM](https://github.com/Automattic/sensei/assets/6820724/a5df908b-5235-45c1-99f9-313d10c2e550)

Desktop - without retakes:
![Screenshot 2023-09-27 at 5 28 16 PM](https://github.com/Automattic/sensei/assets/6820724/cb994f75-7b2d-483e-a8de-a935c2e67bb6)

Mobile:
![Screenshot 2023-09-27 at 5 51 02 PM](https://github.com/Automattic/sensei/assets/6820724/570e35b3-3c6b-41b3-8631-fd41de2df017)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
