### PR TITLE
Improve support for PHP 8.1

### DIFF
--- a/changelog/add-php-81-support
+++ b/changelog/add-php-81-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve support for PHP 8.1

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
-  <file src="includes/3rd-party/themes/astra.php">
-    <MissingReturnType occurrences="1">
-      <code>sensei_load_learning_mode_styles_for_astra_theme</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/3rd-party/themes/course.php">
-    <MissingReturnType occurrences="3">
-      <code>sensei_admin_load_learning_mode_style_for_course_theme</code>
-      <code>sensei_disable_learning_mode_style_for_course_theme</code>
-      <code>sensei_load_learning_mode_style_for_course_theme</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="3">
       <code>$screen-&gt;base</code>
       <code>$screen-&gt;id</code>
@@ -18,13 +8,6 @@
     </PossiblyNullPropertyFetch>
   </file>
   <file src="includes/3rd-party/themes/divi.php">
-    <MissingReturnType occurrences="5">
-      <code>sensei_admin_load_learning_mode_style_for_divi_theme</code>
-      <code>sensei_fix_divi_learning_mode_video_template_excerpt</code>
-      <code>sensei_fix_divi_theme_builder_and_learning_mode_conflict</code>
-      <code>sensei_fix_divi_yoast_conflict</code>
-      <code>sensei_load_learning_mode_style_for_divi_theme</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="2">
       <code>$course_id</code>
       <code>$course_id</code>
@@ -39,11 +22,6 @@
       <code>'sensei_load_learning_mode_style_for_course_theme'</code>
     </UndefinedFunction>
   </file>
-  <file src="includes/3rd-party/woocommerce.php">
-    <MissingReturnType occurrences="1">
-      <code>sensei_woocommerce_show_admin_bar</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/admin/class-sensei-admin-notices.php">
     <DocblockTypeContradiction occurrences="2">
       <code>! self::$instance</code>
@@ -52,13 +30,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="5">
-      <code>add_admin_notice</code>
-      <code>add_admin_notices</code>
-      <code>handle_notice_dismiss</code>
-      <code>init</code>
-      <code>save_dismissed_notices</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>$plugin_version</code>
       <code>$plugin_version</code>
@@ -78,20 +49,11 @@
       <code>$meta_key</code>
       <code>$post_id</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="3">
-      <code>enqueue_admin_scripts</code>
-      <code>init</code>
-      <code>register_post_metas</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$post_id</code>
     </PossiblyFalseArgument>
   </file>
   <file src="includes/admin/class-sensei-exit-survey.php">
-    <MissingReturnType occurrences="2">
-      <code>enqueue_admin_assets</code>
-      <code>save_exit_survey</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$screen-&gt;id</code>
     </PossiblyNullPropertyFetch>
@@ -115,12 +77,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="4">
-      <code>add_admin_menu_item</code>
-      <code>enqueue_admin_assets</code>
-      <code>init</code>
-      <code>render</code>
-    </MissingReturnType>
     <PossiblyFalseOperand occurrences="1">
       <code>wp_json_encode( $additional_query_args )</code>
     </PossiblyFalseOperand>
@@ -133,14 +89,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="6">
-      <code>add_admin_menu_item</code>
-      <code>enqueue_admin_assets</code>
-      <code>handle_tasks_dismiss</code>
-      <code>init</code>
-      <code>localize_script</code>
-      <code>render</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$screen-&gt;id</code>
     </PossiblyNullPropertyFetch>
@@ -165,27 +113,6 @@
       <code>wp_unslash( $_GET['course_id'] ?? 0 )</code>
       <code>wp_unslash( $_GET['lesson_id'] ?? 0 )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="19">
-      <code>add_custom_navigation</code>
-      <code>add_learner_notices</code>
-      <code>display_students_navigation</code>
-      <code>edit_date_started</code>
-      <code>enqueue_scripts</code>
-      <code>enqueue_styles</code>
-      <code>get_redirect_url</code>
-      <code>handle_learner_actions</code>
-      <code>handle_user_async_action</code>
-      <code>json_search_users</code>
-      <code>learners_admin_menu</code>
-      <code>learners_default_nav</code>
-      <code>learners_headers</code>
-      <code>learners_page</code>
-      <code>load_data_table_files</code>
-      <code>load_screen_options_when_on_bulk_actions</code>
-      <code>remove_user_from_post</code>
-      <code>reset_user_post</code>
-      <code>wrapper_container</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="3">
       <code>$course-&gt;post_author</code>
       <code>$post-&gt;post_author</code>
@@ -205,18 +132,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/admin/class-sensei-learners-admin-bulk-actions-controller.php">
-    <MissingReturnType occurrences="10">
-      <code>add_notices</code>
-      <code>check_nonce</code>
-      <code>do_user_action</code>
-      <code>enqueue_scripts</code>
-      <code>handle_http_post</code>
-      <code>is_current_page</code>
-      <code>learner_admin_page</code>
-      <code>learners_admin_menu</code>
-      <code>redirect_to_learner_admin_index</code>
-      <code>register_hooks</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$edit_course_cap</code>
     </PossiblyNullArgument>
@@ -256,14 +171,6 @@
       <code>$user_id</code>
       <code>Sensei_Learner::get_full_name( $learner-&gt;user_id )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="6">
-      <code>courses_select</code>
-      <code>data_table_header</code>
-      <code>extra_tablenav</code>
-      <code>output_headers</code>
-      <code>prepare_items</code>
-      <code>search_button</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="3">
       <code>$course-&gt;ID</code>
       <code>$course-&gt;post_title</code>
@@ -304,9 +211,6 @@
       <code>$title</code>
       <code>$title</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>extra_tablenav</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$cats</code>
     </PossibleRawObjectIteration>
@@ -376,19 +280,6 @@
       <code>require_once ABSPATH . 'wp-admin/includes/plugin-install.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="11">
-      <code>activate_plugin</code>
-      <code>associate_plugin_file</code>
-      <code>background_installer</code>
-      <code>close_http_connection</code>
-      <code>complete_installation</code>
-      <code>install_plugin</code>
-      <code>install_plugins</code>
-      <code>run_deferred_actions</code>
-      <code>save_error</code>
-      <code>set_installing_plugins</code>
-      <code>set_time_limit</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="4">
       <code>$download</code>
       <code>$download</code>
@@ -414,9 +305,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$page_data</code>
     </ArgumentTypeCoercion>
-    <MissingReturnType occurrences="1">
-      <code>create_pages</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$page-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
@@ -441,22 +329,6 @@
     <InvalidPropertyFetch occurrences="1">
       <code>$extension-&gt;price</code>
     </InvalidPropertyFetch>
-    <MissingReturnType occurrences="14">
-      <code>activation_redirect</code>
-      <code>add_setup_wizard_help_tab</code>
-      <code>close_wccom_install</code>
-      <code>enqueue_scripts</code>
-      <code>enqueue_styles</code>
-      <code>finish_setup_wizard</code>
-      <code>install_extensions</code>
-      <code>prepare_wizard_page</code>
-      <code>redirect_to_setup_wizard</code>
-      <code>register_wizard_page</code>
-      <code>remove_notices_from_setup_wizard</code>
-      <code>render_wizard_page</code>
-      <code>setup_wizard_notice</code>
-      <code>skip_setup_wizard</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$extension</code>
     </PossiblyInvalidArgument>
@@ -475,9 +347,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$installed_time</code>
     </PossiblyFalseArgument>
@@ -490,14 +359,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="6">
-      <code>add_menu_pages</code>
-      <code>get_tool_url</code>
-      <code>init</code>
-      <code>output</code>
-      <code>process</code>
-      <code>trigger_invalid_request</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$tools</code>
     </PropertyNotSetInConstructor>
@@ -518,11 +379,6 @@
     <InvalidReturnType occurrences="1">
       <code>false|object</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="3">
-      <code>init</code>
-      <code>invalid_license_update_disclaimer</code>
-      <code>plugins_loaded</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="18">
       <code>$remote-&gt;author</code>
       <code>$remote-&gt;banners</code>
@@ -578,9 +434,6 @@
     </UndefinedConstant>
   </file>
   <file src="includes/admin/home/class-sensei-home-remote-data-api.php">
-    <MissingReturnType occurrences="1">
-      <code>set_fail_retry</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$response</code>
     </PossiblyInvalidArgument>
@@ -611,9 +464,6 @@
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/update.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$plugin_data-&gt;update-&gt;plugin ?? null</code>
     </PossiblyNullArgument>
@@ -637,11 +487,6 @@
     </InvalidReturnType>
   </file>
   <file src="includes/admin/home/tasks/class-sensei-home-tasks-provider.php">
-    <MissingReturnType occurrences="3">
-      <code>attach_tasks_statuses_hooks</code>
-      <code>mark_as_completed</code>
-      <code>update_tasks_statuses</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_title</code>
     </PossiblyInvalidPropertyFetch>
@@ -674,11 +519,6 @@
     <MissingConstructor occurrences="1">
       <code>$results</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="3">
-      <code>output</code>
-      <code>process</code>
-      <code>return_with_message</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$course</code>
       <code>$course</code>
@@ -699,33 +539,6 @@
       <code>debug</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="includes/admin/tools/class-sensei-tool-ensure-roles.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-export.php">
-    <MissingReturnType occurrences="2">
-      <code>output</code>
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-import.php">
-    <MissingReturnType occurrences="2">
-      <code>output</code>
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-interactive-interface.php">
-    <MissingReturnType occurrences="1">
-      <code>output</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-interface.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php">
     <InvalidReturnStatement occurrences="1">
       <code>$terms</code>
@@ -733,28 +546,11 @@
     <InvalidReturnType occurrences="1">
       <code>\WP_Term[]</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
   </file>
   <file src="includes/admin/tools/class-sensei-tool-recalculate-course-enrolment.php">
-    <MissingReturnType occurrences="2">
-      <code>output</code>
-      <code>process</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$course</code>
     </PossiblyInvalidArgument>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-recalculate-enrolment.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/admin/tools/class-sensei-tool-remove-deleted-user-data.php">
-    <MissingReturnType occurrences="1">
-      <code>process</code>
-    </MissingReturnType>
   </file>
   <file src="includes/admin/tools/views/html-enrolment-debug-form.php">
     <InvalidScalarArgument occurrences="2">
@@ -785,23 +581,7 @@
       <code>empty( $tool )</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="includes/background-jobs/class-sensei-background-job-batch.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/background-jobs/class-sensei-background-job-interface.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/background-jobs/class-sensei-background-job-stateful.php">
-    <MissingReturnType occurrences="4">
-      <code>cleanup</code>
-      <code>persist</code>
-      <code>restore_state</code>
-      <code>set_state</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $this-&gt;get_args() )</code>
     </PossiblyFalseArgument>
@@ -819,31 +599,14 @@
     <MissingConstructor occurrences="1">
       <code>$current_job</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="3">
-      <code>cancel_all_jobs</code>
-      <code>cancel_scheduled_job</code>
-      <code>run</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="includes/background-jobs/class-sensei-scheduler-interface.php">
-    <MissingReturnType occurrences="3">
-      <code>cancel_all_jobs</code>
-      <code>cancel_scheduled_job</code>
-      <code>run</code>
-    </MissingReturnType>
   </file>
   <file src="includes/background-jobs/class-sensei-scheduler-wp-cron.php">
     <InvalidReturnType occurrences="1">
       <code>mixed</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="3">
-      <code>cancel_all_jobs</code>
-      <code>cancel_scheduled_job</code>
-      <code>run</code>
-    </MissingReturnType>
   </file>
   <file src="includes/background-jobs/class-sensei-scheduler.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -862,9 +625,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>self::$instance</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_Scheduler_Interface</code>
     </MoreSpecificReturnType>
@@ -883,24 +643,9 @@
     <MissingClosureParamType occurrences="1">
       <code>$attributes</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="8">
-      <code>enqueue_scripts</code>
-      <code>get_patterns_category_name</code>
-      <code>get_post_content_block_type_name</code>
-      <code>init</code>
-      <code>maybe_register_pattern_block_polyfill</code>
-      <code>register_block_patterns</code>
-      <code>register_block_patterns_category</code>
-      <code>register_course_list_block_patterns</code>
-    </MissingReturnType>
     <UnresolvableInclude occurrences="1">
       <code>require __DIR__ . "/{$post_type}/{$block_pattern}.php"</code>
     </UnresolvableInclude>
-  </file>
-  <file src="includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php">
-    <MissingReturnType occurrences="1">
-      <code>register_course_list_block_patterns</code>
-    </MissingReturnType>
   </file>
   <file src="includes/block-patterns/course/course-default.php">
     <UnresolvableInclude occurrences="1"/>
@@ -923,10 +668,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>absint( $post-&gt;ID )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="2">
-      <code>add_notices</code>
-      <code>register_block</code>
-    </MissingReturnType>
   </file>
   <file src="includes/blocks/class-sensei-block-helpers.php">
     <DocblockTypeContradiction occurrences="1">
@@ -939,9 +680,6 @@
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-block-take-course.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $course_id )</code>
     </PossiblyFalseArgument>
@@ -950,9 +688,6 @@
     </PossiblyNullArgument>
   </file>
   <file src="includes/blocks/class-sensei-block-view-results.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>$course_id</code>
       <code>$course_id</code>
@@ -969,12 +704,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/post.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="4">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-      <code>maybe_initialize_blocks</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_post_type()</code>
     </PossiblyFalseArgument>
@@ -990,10 +719,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$block_content</code>
     </ArgumentTypeCoercion>
-    <MissingReturnType occurrences="2">
-      <code>register_generic_assets</code>
-      <code>register_sensei_block</code>
-    </MissingReturnType>
     <PossiblyInvalidCast occurrences="1">
       <code>$post</code>
     </PossiblyInvalidCast>
@@ -1031,11 +756,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/blocks/class-sensei-course-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignment occurrences="1">
       <code>$post_type_object</code>
     </PossiblyNullPropertyAssignment>
@@ -1047,20 +767,11 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/blocks/class-sensei-course-categories-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$terms</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-outline-block.php">
-    <MissingReturnType occurrences="4">
-      <code>add_block_attributes</code>
-      <code>clear_block_content</code>
-      <code>get_block_structure</code>
-      <code>register_blocks</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -1092,19 +803,11 @@
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-progress-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$course_id</code>
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-results-block.php">
-    <MissingReturnType occurrences="3">
-      <code>clear_block_content</code>
-      <code>register_block</code>
-      <code>render_lesson</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $item['id'] )</code>
     </PossiblyFalseArgument>
@@ -1114,18 +817,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$block_content</code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="includes/blocks/class-sensei-featured-video-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/blocks/class-sensei-global-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
   </file>
   <file src="includes/blocks/class-sensei-learner-courses-block.php">
     <NullArgument occurrences="2">
@@ -1138,10 +829,6 @@
     </PossiblyNullArgument>
   </file>
   <file src="includes/blocks/class-sensei-learner-messages-button-block.php">
-    <MissingReturnType occurrences="2">
-      <code>admin_enqueue_scripts</code>
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_post_type_archive_link( 'sensei_message' )</code>
     </PossiblyFalseArgument>
@@ -1152,12 +839,6 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/blocks/class-sensei-lesson-blocks.php">
-    <MissingReturnType occurrences="4">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-      <code>remove_block_related_content</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignment occurrences="1">
       <code>$post_type_object</code>
     </PossiblyNullPropertyAssignment>
@@ -1176,26 +857,13 @@
       <code>$lesson-&gt;ID</code>
       <code>$lesson-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson-&gt;ID )</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/blocks/class-sensei-page-blocks.php">
     <InvalidArrayAccess occurrences="1">
       <code>$block_parent['blockName']</code>
     </InvalidArrayAccess>
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
   </file>
   <file src="includes/blocks/class-sensei-quiz-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignment occurrences="2">
       <code>$post_type_object</code>
       <code>$post_type_object</code>
@@ -1228,20 +896,7 @@
       <code>$course_categories</code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="includes/blocks/course-list/class-sensei-course-list-filter-block.php">
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/blocks/course-theme/class-course-navigation.php">
-    <MissingClosureParamType occurrences="3">
-      <code>$lesson</code>
-      <code>$lesson</code>
-      <code>$lesson</code>
-    </MissingClosureParamType>
-    <MissingReturnType occurrences="1">
-      <code>register_block</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>get_permalink( $lesson_id )</code>
       <code>get_permalink( $lesson_id )</code>
@@ -1262,13 +917,6 @@
       <code>isset( $user_lesson_status-&gt;comment_approved )</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="includes/blocks/course-theme/class-course-theme-blocks.php">
-    <MissingReturnType occurrences="3">
-      <code>enqueue_block_assets</code>
-      <code>enqueue_block_editor_assets</code>
-      <code>initialize_blocks</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/blocks/course-theme/class-exit-course.php">
     <PossiblyFalseArgument occurrences="1">
       <code>get_the_permalink( $course_id )</code>
@@ -1284,9 +932,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$lesson_id</code>
     </PossiblyNullArgument>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/blocks/course-theme/class-lesson-video.php">
     <MissingClosureParamType occurrences="1">
@@ -1300,23 +945,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$aria_label</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
-    </UndefinedFunction>
-  </file>
-  <file src="includes/blocks/course-theme/class-quiz-content.php">
-    <MissingReturnType occurrences="1">
-      <code>render_questions_loop</code>
-    </MissingReturnType>
-    <UndefinedFunction occurrences="7">
-      <code>sensei_get_the_question_id()</code>
-      <code>sensei_get_the_question_id()</code>
-      <code>sensei_get_the_question_number()</code>
-      <code>sensei_quiz_has_questions()</code>
-      <code>sensei_setup_the_question()</code>
-      <code>sensei_the_question_class()</code>
-      <code>sensei_the_question_content()</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/class-sensei-admin.php">
     <ArgumentTypeCoercion occurrences="3">
@@ -1367,28 +995,6 @@
       <code>$course_order_page_slug</code>
       <code>$lesson_order_page_slug</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="20">
-      <code>add_course_order</code>
-      <code>add_lesson_order</code>
-      <code>admin_styles_global</code>
-      <code>ajax_log_event</code>
-      <code>get_course_order</code>
-      <code>handle_order_courses</code>
-      <code>handle_order_lessons</code>
-      <code>install_pages</code>
-      <code>notify_if_admin_email_not_real_admin_user</code>
-      <code>output_cpt_block_editor_workaround</code>
-      <code>register_scripts</code>
-      <code>remove_trashed_course_from_course_order</code>
-      <code>render_settings</code>
-      <code>save_course_order</code>
-      <code>save_lesson_order</code>
-      <code>sensei_add_custom_menu_items</code>
-      <code>sensei_set_plugin_url</code>
-      <code>update_lesson_order_on_course</code>
-      <code>update_lesson_order_on_lesson</code>
-      <code>wp_nav_menu_item_sensei_links_meta_box</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="2">
       <code>$new_post</code>
       <code>null</code>
@@ -1469,11 +1075,6 @@
       <code>$report</code>
       <code>$text</code>
     </MissingParamType>
-    <MissingReturnType occurrences="3">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-      <code>output_top_filters</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="2">
       <code>$search</code>
       <code>$search</code>
@@ -1535,10 +1136,6 @@
       <code>$lesson_id</code>
       <code>$page_slug</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="2">
       <code>$search</code>
       <code>$search</code>
@@ -1606,17 +1203,6 @@
       <code>$page_slug</code>
       <code>$type</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="6">
-      <code>add_last_activity_to_user_query</code>
-      <code>add_orderby_custom_field_to_non_user_query</code>
-      <code>add_orderby_custom_field_to_query</code>
-      <code>filter_users_by_last_activity</code>
-      <code>output_course_select_input</code>
-      <code>output_top_filters</code>
-    </MissingReturnType>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>wp_get_object_terms( $lessons, 'module', $default_args )</code>
-    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="8">
       <code>Sensei_Analysis_Overview_List_Table</code>
       <code>Sensei_Analysis_Overview_List_Table</code>
@@ -1627,9 +1213,6 @@
       <code>WooThemes_Sensei_Analysis_Overview_List_Table</code>
       <code>WooThemes_Sensei_Analysis_Overview_List_Table</code>
     </PropertyNotSetInConstructor>
-    <RedundantCondition occurrences="1">
-      <code>'lessons'</code>
-    </RedundantCondition>
     <TooManyArguments occurrences="1">
       <code>remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_non_user_query' ), 10, 2 )</code>
     </TooManyArguments>
@@ -1655,10 +1238,6 @@
       <code>$page_slug</code>
       <code>$user_id</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="2">
       <code>$search</code>
       <code>$search</code>
@@ -1700,14 +1279,6 @@
       <code>$type</code>
       <code>$which</code>
     </MissingParamType>
-    <MissingReturnType occurrences="6">
-      <code>add_custom_navigation</code>
-      <code>check_course_lesson</code>
-      <code>display_nav</code>
-      <code>display_report_page</code>
-      <code>display_reports_navigation</code>
-      <code>enqueue_scripts</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_List_Table</code>
     </MoreSpecificReturnType>
@@ -1724,17 +1295,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/class-sensei-assets.php">
-    <MissingReturnType occurrences="9">
-      <code>call_wp</code>
-      <code>disable_frontend_styles</code>
-      <code>enqueue</code>
-      <code>enqueue_script</code>
-      <code>enqueue_style</code>
-      <code>override_script</code>
-      <code>preload_data</code>
-      <code>register</code>
-      <code>wp_compat</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $preload_data )</code>
     </PossiblyFalseArgument>
@@ -1748,30 +1308,15 @@
       <code>$handle</code>
     </PossiblyNullArgument>
   </file>
-  <file src="includes/class-sensei-autoloader.php">
-    <MissingReturnType occurrences="2">
-      <code>autoload</code>
-      <code>initialize_class_file_map</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/class-sensei-bootstrap.php">
     <DocblockTypeContradiction occurrences="1">
       <code>null === self::$instance</code>
     </DocblockTypeContradiction>
   </file>
   <file src="includes/class-sensei-cli.php">
-    <MissingReturnType occurrences="2">
-      <code>load</code>
-      <code>register</code>
-    </MissingReturnType>
     <UndefinedClass occurrences="1">
       <code>WP_CLI</code>
     </UndefinedClass>
-  </file>
-  <file src="includes/class-sensei-context-notices.php">
-    <MissingReturnType occurrences="1">
-      <code>add_notice</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-core-lesson-modules.php">
     <MissingParamType occurrences="1">
@@ -1780,10 +1325,6 @@
     <MissingPropertyType occurrences="1">
       <code>$lesson_id</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>modules_taxonomy</code>
-      <code>set_module</code>
-    </MissingReturnType>
     <ParadoxicalCondition occurrences="2">
       <code>! $module_id || empty( $module_id ) || ! $module_exists_in_course</code>
       <code>$module_id || ! empty( $module_id )</code>
@@ -1796,9 +1337,6 @@
     <InvalidReturnStatement occurrences="1">
       <code>$title</code>
     </InvalidReturnStatement>
-    <MissingReturnType occurrences="1">
-      <code>fire_sensei_message_hook</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$course-&gt;post_name</code>
       <code>$course-&gt;post_name</code>
@@ -1853,11 +1391,6 @@
       <code>$teacher_user_id</code>
       <code>get_post( $this-&gt;course_id )-&gt;post_author</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="3">
-      <code>clear_lesson_associations</code>
-      <code>create_quiz</code>
-      <code>save_module_order</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="2">
       <code>$lesson-&gt;ID</code>
       <code>$term-&gt;term_id</code>
@@ -2043,44 +1576,6 @@
     <MissingPropertyType occurrences="1">
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="36">
-      <code>add_author_support</code>
-      <code>add_course_access_permission_message</code>
-      <code>add_custom_navigation</code>
-      <code>add_legacy_course_hooks</code>
-      <code>add_showcase_courses_upsell</code>
-      <code>allow_course_archive_on_front_page</code>
-      <code>archive_page_content</code>
-      <code>can_access_course_content</code>
-      <code>course_archive_filters</code>
-      <code>course_archive_sorting</code>
-      <code>course_category_title</code>
-      <code>course_notification_meta_box_content</code>
-      <code>disable_log_course_update</code>
-      <code>display_courses_navigation</code>
-      <code>load_single_course_lessons_query</code>
-      <code>log_course_update</code>
-      <code>log_initial_publish_event</code>
-      <code>mark_updating_course_id</code>
-      <code>maybe_redirect_to_login_from_course_completion</code>
-      <code>output_course_enrolment_actions</code>
-      <code>prerequisite_complete_message</code>
-      <code>register_admin_scripts</code>
-      <code>remove_legacy_course_actions</code>
-      <code>save_course_notification_meta_box</code>
-      <code>set_up_meta_fields</code>
-      <code>setup_single_course_page</code>
-      <code>showcase_courses_screen</code>
-      <code>the_course_action_buttons</code>
-      <code>the_course_enrolment_actions</code>
-      <code>the_course_free_lesson_preview</code>
-      <code>the_course_lessons_title</code>
-      <code>the_course_meta</code>
-      <code>the_course_video</code>
-      <code>the_title</code>
-      <code>update_status_after_lesson_change</code>
-      <code>update_status_after_quiz_submission</code>
-    </MissingReturnType>
     <NullArgument occurrences="3">
       <code>null</code>
       <code>null</code>
@@ -2101,7 +1596,7 @@
       <code>get_the_ID()</code>
       <code>get_the_ID()</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="9">
+    <PossiblyInvalidArgument occurrences="7">
       <code>$category_output</code>
       <code>$category_output</code>
       <code>$category_output</code>
@@ -2109,8 +1604,6 @@
       <code>$course_id</code>
       <code>$output</code>
       <code>$progress_percentage</code>
-      <code>wp_get_post_terms( $course-&gt;ID, 'module' )</code>
-      <code>wp_get_post_terms( $course_id, 'module' )</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidPropertyAssignment occurrences="1">
       <code>$lesson</code>
@@ -2192,10 +1685,6 @@
       <code>type</code>
       <code>type</code>
     </UndefinedDocblockClass>
-    <UndefinedFunction occurrences="2">
-      <code>'course_single_lessons'</code>
-      <code>sensei_start_course_form( $post-&gt;ID )</code>
-    </UndefinedFunction>
     <UndefinedMagicPropertyFetch occurrences="2">
       <code>$term-&gt;name</code>
       <code>$term-&gt;term_id</code>
@@ -2209,26 +1698,8 @@
   </file>
   <file src="includes/class-sensei-customizer.php">
     <ArgumentTypeCoercion occurrences="2"/>
-    <MissingReturnType occurrences="4">
-      <code>add_customizer_settings</code>
-      <code>enqueue_customizer_helper</code>
-      <code>output_custom_settings</code>
-      <code>output_customizer_helper</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-data-cleaner.php">
-    <MissingReturnType occurrences="10">
-      <code>cleanup_all</code>
-      <code>cleanup_custom_post_types</code>
-      <code>cleanup_options</code>
-      <code>cleanup_pages</code>
-      <code>cleanup_post_meta</code>
-      <code>cleanup_roles_and_caps</code>
-      <code>cleanup_taxonomies</code>
-      <code>cleanup_transients</code>
-      <code>cleanup_user_meta</code>
-      <code>remove_all_sensei_caps</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$item</code>
     </PossiblyInvalidArgument>
@@ -2248,12 +1719,6 @@
     </UndefinedConstant>
   </file>
   <file src="includes/class-sensei-dependency-checker.php">
-    <MissingReturnType occurrences="4">
-      <code>add_assets_notice</code>
-      <code>add_future_php_version_notice</code>
-      <code>add_php_version_notice</code>
-      <code>show_php_notice</code>
-    </MissingReturnType>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$screen-&gt;id</code>
     </PossiblyNullPropertyFetch>
@@ -2286,12 +1751,6 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="4">
-      <code>get_content</code>
-      <code>init</code>
-      <code>load_template</code>
-      <code>teacher_quiz_submitted</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="3">
       <code>$_from_address</code>
       <code>$_from_name</code>
@@ -2302,9 +1761,6 @@
     </UnresolvableInclude>
   </file>
   <file src="includes/class-sensei-feature-flags.php">
-    <MissingReturnType occurrences="1">
-      <code>register_scripts</code>
-    </MissingReturnType>
     <PossiblyFalseOperand occurrences="1">
       <code>wp_json_encode( $this-&gt;get_feature_flags() )</code>
     </PossiblyFalseOperand>
@@ -2324,28 +1780,6 @@
       <code>$post_id</code>
       <code>$title</code>
     </MissingParamType>
-    <MissingReturnType occurrences="20">
-      <code>lesson_tag_archive_description</code>
-      <code>lesson_tag_archive_filter</code>
-      <code>lesson_tags_display</code>
-      <code>maybe_redirect_to_next_lesson</code>
-      <code>redirect_to_course_completed_page</code>
-      <code>sensei_complete_course</code>
-      <code>sensei_complete_lesson</code>
-      <code>sensei_complete_lesson_button</code>
-      <code>sensei_course_archive_meta</code>
-      <code>sensei_course_archive_pagination</code>
-      <code>sensei_course_category_main_content</code>
-      <code>sensei_course_start</code>
-      <code>sensei_frontend_messages</code>
-      <code>sensei_lesson_meta</code>
-      <code>sensei_lesson_preview_title</code>
-      <code>sensei_lesson_preview_title_tag</code>
-      <code>sensei_lesson_preview_title_text</code>
-      <code>sensei_lesson_video</code>
-      <code>sensei_login_form</code>
-      <code>sensei_reset_lesson_button</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$tags</code>
     </PossibleRawObjectIteration>
@@ -2367,10 +1801,9 @@
       <code>get_the_ID()</code>
       <code>wp_get_referer()</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="6">
+    <PossiblyInvalidArgument occurrences="5">
       <code>$category_output</code>
       <code>$tag_link</code>
-      <code>$tags</code>
       <code>$user_id</code>
       <code>$user_id</code>
       <code>$user_id</code>
@@ -2389,16 +1822,12 @@
       <code>WooThemes_Sensei_Frontend</code>
       <code>WooThemes_Sensei_Frontend</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>$tags &amp;&amp; count( $tags ) &gt; 0</code>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>isset( $post_item-&gt;ID )</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedConstant occurrences="1">
       <code>WP_DEBUG</code>
     </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
-    </UndefinedFunction>
     <UndefinedMagicPropertyFetch occurrences="3">
       <code>$tag-&gt;description</code>
       <code>$tag-&gt;term_id</code>
@@ -2424,10 +1853,6 @@
       <code>$user_ids</code>
       <code>$view</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>$search</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -2457,9 +1882,6 @@
       <code>$user_quiz_grade_total</code>
       <code>$user_quiz_grade_total</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>display</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$answer_media_url</code>
     </PossiblyFalseArgument>
@@ -2510,15 +1932,6 @@
       <code>$name</code>
       <code>$page_slug</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="7">
-      <code>add_grading_notices</code>
-      <code>deprecated_get_lessons_dropdown</code>
-      <code>deprecated_get_redirect_url</code>
-      <code>get_redirect_url</code>
-      <code>grading_admin_menu</code>
-      <code>lessons_drop_down_html</code>
-      <code>sensei_grading_notices</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $args )</code>
     </PossiblyFalseArgument>
@@ -2553,13 +1966,6 @@
       <code>undefined</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="includes/class-sensei-groups-landing-page.php">
-    <MissingReturnType occurrences="3">
-      <code>add_groups_landing_page_menu_item</code>
-      <code>display_student_groups_landing_page</code>
-      <code>wrapper_container</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/class-sensei-guest-user.php">
     <ArgumentTypeCoercion occurrences="1">
       <code>'WP_Role'</code>
@@ -2571,17 +1977,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$user_count</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="9">
-      <code>create_guest_student_role_if_not_exists</code>
-      <code>create_guest_user_and_login_for_open_course</code>
-      <code>enrol_user</code>
-      <code>init</code>
-      <code>is_current_user_guest</code>
-      <code>log_guest_user_out_before_all_actions</code>
-      <code>log_in_guest_user_if_in_open_course</code>
-      <code>login_user</code>
-      <code>recreate_nonce</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$course_id</code>
     </PossiblyInvalidArgument>
@@ -2602,9 +1997,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$name</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>enqueue_scripts</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-learner.php">
     <DocblockTypeContradiction occurrences="5">
@@ -2621,19 +2013,9 @@
     <InvalidScalarArgument occurrences="1">
       <code>$user_id</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
-      <code>add_course_column_data</code>
-      <code>before_enrolled_courses_query</code>
-      <code>init</code>
-      <code>remove_duplicate_progress</code>
-    </MissingReturnType>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$courses</code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidIterator occurrences="1">
-      <code>$courses</code>
-    </PossiblyInvalidIterator>
-    <PossiblyInvalidPropertyFetch occurrences="3">
+    <PossiblyInvalidPropertyFetch occurrences="5">
+      <code>$course-&gt;ID</code>
+      <code>$course-&gt;post_title</code>
       <code>$user-&gt;display_name</code>
       <code>$user-&gt;first_name</code>
       <code>$user-&gt;last_name</code>
@@ -2752,84 +2134,16 @@
       <code>$meta_fields</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="67">
-      <code>add_column_data</code>
-      <code>add_custom_link_to_course</code>
-      <code>add_custom_navigation</code>
-      <code>add_lesson_to_course_order</code>
-      <code>add_video_meta_box</code>
-      <code>all_lessons_edit_fields</code>
-      <code>content_drip_promo_meta_box_content</code>
-      <code>course_signup_link</code>
-      <code>deprecated_get_question_category_limit</code>
-      <code>deprecated_question_get_answer_id</code>
-      <code>disable_log_lesson_update</code>
-      <code>display_lessons_navigation</code>
-      <code>enqueue_lesson_edit_scripts</code>
-      <code>enqueue_scripts</code>
-      <code>enqueue_scripts_meta_box_quiz_editor</code>
-      <code>enqueue_styles</code>
-      <code>footer_quiz_call_to_action</code>
-      <code>get_question_category_limit</code>
-      <code>get_quiz_settings</code>
-      <code>handle_get_prerequisite_meta_box_content</code>
-      <code>lesson_add_existing_questions</code>
-      <code>lesson_add_multiple_questions</code>
-      <code>lesson_course_meta_box_content</code>
-      <code>lesson_info_meta_box_content</code>
-      <code>lesson_prerequisite_meta_box_content</code>
-      <code>lesson_preview_meta_box_content</code>
-      <code>lesson_quiz_meta_box_content</code>
-      <code>lesson_quiz_settings_meta_box_content</code>
-      <code>lesson_remove_multiple_questions</code>
-      <code>lesson_update_grade_type</code>
-      <code>lesson_update_question</code>
-      <code>lesson_update_question_order</code>
-      <code>lesson_update_question_order_random</code>
-      <code>lesson_video_meta_box_content</code>
-      <code>log_initial_publish_event</code>
-      <code>log_lesson_update</code>
-      <code>mark_updating_lesson_id</code>
-      <code>maybe_start_lesson</code>
-      <code>meta_box_setup</code>
-      <code>on_lesson_published</code>
-      <code>output_comments</code>
-      <code>output_prerequisite_meta_box_content</code>
-      <code>prerequisite_complete_message</code>
-      <code>question_get_answer_id</code>
-      <code>quiz_panel</code>
-      <code>quiz_panel_add</code>
-      <code>quiz_panel_add_existing_question</code>
-      <code>quiz_panel_filter_existing_questions</code>
-      <code>quiz_panel_get_existing_questions</code>
-      <code>quiz_panel_question</code>
-      <code>quiz_panel_question_feedback</code>
-      <code>quiz_panel_question_field</code>
-      <code>quiz_panel_questions</code>
-      <code>quiz_settings_panel</code>
-      <code>save_all_lessons_edit_fields</code>
-      <code>save_lesson_featured_video_thumbnail</code>
-      <code>save_post_meta</code>
-      <code>save_quiz_settings</code>
-      <code>set_default_question_order</code>
-      <code>set_quick_edit_admin_defaults</code>
-      <code>the_archive_header</code>
-      <code>the_lesson_image</code>
-      <code>the_lesson_meta</code>
-      <code>the_lesson_thumbnail</code>
-      <code>the_title</code>
-      <code>user_lesson_quiz_status_message</code>
-      <code>user_not_taking_course_message</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="3">
       <code>$this-&gt;get_videopress_thumbnail( $url )</code>
       <code>$this-&gt;get_vimeo_thumbnail( $url )</code>
       <code>$this-&gt;get_youtube_thumbnail( $url )</code>
     </NullableReturnStatement>
-    <PossibleRawObjectIteration occurrences="3">
+    <PossibleRawObjectIteration occurrences="4">
       <code>$question_cats</code>
       <code>$question_cats</code>
       <code>$question_cats</code>
+      <code>$questions_array</code>
     </PossibleRawObjectIteration>
     <PossiblyFalseArgument occurrences="18">
       <code>$lesson_id</code>
@@ -2927,23 +2241,8 @@
     <PossiblyNullReference occurrences="1">
       <code>is_block_editor</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedVariable occurrences="16">
-      <code>$nonce</code>
-      <code>$nonce</code>
-      <code>$nonce</code>
-      <code>$nonce</code>
-      <code>$question_grade</code>
-      <code>$question_grade</code>
-      <code>$question_grade</code>
-      <code>$question_media</code>
-      <code>$question_media_add_button</code>
-      <code>$question_media_delete_class</code>
-      <code>$question_media_link</code>
-      <code>$question_media_link_class</code>
-      <code>$question_media_thumb</code>
-      <code>$question_media_thumb_class</code>
+    <PossiblyUndefinedVariable occurrences="1">
       <code>$question_wrong_answers_array</code>
-      <code>$random_order</code>
     </PossiblyUndefinedVariable>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$lesson_id_updating</code>
@@ -2961,10 +2260,6 @@
     <TypeDoesNotContainType occurrences="1">
       <code>! isset( $row_counter )</code>
     </TypeDoesNotContainType>
-    <UndefinedFunction occurrences="2">
-      <code>sensei_complete_lesson_button()</code>
-      <code>sensei_reset_lesson_button()</code>
-    </UndefinedFunction>
     <UndefinedPropertyFetch occurrences="2">
       <code>$cat-&gt;name</code>
       <code>$question_cat-&gt;name</code>
@@ -2985,11 +2280,6 @@
     <MissingPropertyType occurrences="1">
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="3">
-      <code>extra_tablenav</code>
-      <code>get_row_data</code>
-      <code>single_row</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$item</code>
     </MoreSpecificImplementedParamType>
@@ -3057,24 +2347,6 @@
       <code>$post_type</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="16">
-      <code>add_menu_item</code>
-      <code>add_meta_box</code>
-      <code>check_permissions_edit_comments</code>
-      <code>message_login</code>
-      <code>message_reply_received</code>
-      <code>message_rest_insert</code>
-      <code>meta_box_content</code>
-      <code>only_show_messages_to_owner</code>
-      <code>save_new_message</code>
-      <code>send_message_link</code>
-      <code>stop_wp_comment_emails</code>
-      <code>teacher_contact_form</code>
-      <code>the_message_sender</code>
-      <code>the_message_sent_by_title</code>
-      <code>the_message_title</code>
-      <code>the_my_messages_link</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="6">
       <code>get_permalink( $content_post_id )</code>
       <code>get_post_type_archive_link( 'sensei_message' )</code>
@@ -3122,10 +2394,9 @@
       <code>$post-&gt;post_author</code>
       <code>$post-&gt;post_type</code>
     </PossiblyNullPropertyFetch>
-    <PossiblyUndefinedVariable occurrences="3">
+    <PossiblyUndefinedVariable occurrences="2">
       <code>$description</code>
       <code>$label</code>
-      <code>$user_login</code>
     </PossiblyUndefinedVariable>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>! is_wp_error( $message_id )</code>
@@ -3213,38 +2484,6 @@
       <code>$order_page_slug</code>
       <code>$taxonomy</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="30">
-      <code>add_custom_navigation</code>
-      <code>add_lesson_column_content</code>
-      <code>add_module_admin_hooks</code>
-      <code>add_new_module_term</code>
-      <code>add_submenus</code>
-      <code>add_teacher_id_in_module_meta_when_added_to_course</code>
-      <code>ajax_get_course_modules</code>
-      <code>append_teacher_name_to_module</code>
-      <code>course_module_metabox</code>
-      <code>course_signup_link</code>
-      <code>display_modules_navigation</code>
-      <code>filter_course_selected_terms</code>
-      <code>filter_module_terms</code>
-      <code>handle_get_lesson_module_metabox</code>
-      <code>handle_order_modules</code>
-      <code>module_archive_body_class</code>
-      <code>module_breadcrumb_link</code>
-      <code>output_course_modules_column</code>
-      <code>output_lesson_module_metabox</code>
-      <code>remove_default_modules_box</code>
-      <code>remove_if_unused</code>
-      <code>remove_teacher_id_from_module_meta_when_removed_from_course</code>
-      <code>reset_none_modules_transient</code>
-      <code>sensei_course_preview_titles</code>
-      <code>setup_modules_taxonomy</code>
-      <code>setup_single_course_module_loop</code>
-      <code>teardown_single_course_module_loop</code>
-      <code>track_module_creation</code>
-      <code>update_module_teacher_id_meta_on_post_teacher_update</code>
-      <code>update_module_teacher_meta</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="3">
       <code>$modules</code>
       <code>$modules</code>
@@ -3333,9 +2572,6 @@
       <code>$tax_name === 'category'</code>
       <code>empty( $modules )</code>
     </TypeDoesNotContainType>
-    <UndefinedFunction occurrences="1">
-      <code>sensei_module_has_lessons()</code>
-    </UndefinedFunction>
     <UndefinedMagicPropertyFetch occurrences="5">
       <code>$module-&gt;description</code>
       <code>$module-&gt;term_id</code>
@@ -3363,9 +2599,6 @@
     <MissingPropertyType occurrences="1">
       <code>$notices</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>setup_block_notices</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-posttypes.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -3395,21 +2628,6 @@
       <code>$slider_labels</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="13">
-      <code>add_submenus</code>
-      <code>disable_fire_scheduled_initial_publish_actions</code>
-      <code>fire_scheduled_initial_publish_actions</code>
-      <code>is_meta_box_save_request</code>
-      <code>mark_post_already_published</code>
-      <code>maybe_schedule_initial_publish_action</code>
-      <code>protect_feeds</code>
-      <code>reset_scheduled_initial_publish_actions</code>
-      <code>schedule_initial_publish_action</code>
-      <code>setup_initial_publish_action</code>
-      <code>setup_learner_taxonomy</code>
-      <code>setup_post_type_labels_base</code>
-      <code>setup_rest_api</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="4">
       <code>get_permalink( $post_ID )</code>
       <code>get_permalink( $post_ID )</code>
@@ -3461,17 +2679,6 @@
     <InvalidReturnType occurrences="1">
       <code>int</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="9">
-      <code>add_preview_user_filters</code>
-      <code>add_user_switch_to_admin_bar</code>
-      <code>create_role</code>
-      <code>delete_preview_user</code>
-      <code>init</code>
-      <code>override_user</code>
-      <code>set_preview_user</code>
-      <code>switch_off_preview_user</code>
-      <code>switch_to_preview_user</code>
-    </MissingReturnType>
     <RedundantCastGivenDocblockType occurrences="2">
       <code>(array) $user-&gt;roles</code>
       <code>(int) $course_id</code>
@@ -3525,28 +2732,6 @@
       <code>$quiz_id</code>
       <code>$quiz_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="20">
-      <code>add_custom_navigation</code>
-      <code>answer_feedback_notes</code>
-      <code>display_question_navigation</code>
-      <code>file_upload_load_question_data</code>
-      <code>gap_fill_load_question_data</code>
-      <code>load_question_template</code>
-      <code>log_initial_publish_event</code>
-      <code>multiple_choice_load_question_data</code>
-      <code>output_result_indication</code>
-      <code>question_edit_panel</code>
-      <code>question_edit_panel_metabox</code>
-      <code>question_lessons_panel</code>
-      <code>question_types</code>
-      <code>save_question</code>
-      <code>the_answer_feedback</code>
-      <code>the_answer_result_indication</code>
-      <code>the_question_description</code>
-      <code>the_question_hidden_fields</code>
-      <code>the_question_media</code>
-      <code>the_question_title</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="3">
       <code>$categories_of_question</code>
       <code>$cats</code>
@@ -3671,25 +2856,6 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="17">
-      <code>action_buttons</code>
-      <code>delete_quiz_question_meta</code>
-      <code>load_global_quiz_data</code>
-      <code>maybe_delete_quiz</code>
-      <code>output_quiz_hidden_fields</code>
-      <code>page_change_listener</code>
-      <code>redirect_if_lesson_is_protected</code>
-      <code>reset_button_click_listener</code>
-      <code>set_questions</code>
-      <code>start_quiz_questions_loop</code>
-      <code>stop_quiz_questions_loop</code>
-      <code>the_quiz_pagination</code>
-      <code>the_quiz_progress_bar</code>
-      <code>the_title</code>
-      <code>the_user_status_message</code>
-      <code>update_quiz_author</code>
-      <code>user_save_quiz_answers_listener</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="2">
       <code>self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-correct' )</code>
       <code>self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-incorrect' )</code>
@@ -3790,15 +2956,6 @@
       <code>$token</code>
       <code>$token_legacy</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="7">
-      <code>determine_method</code>
-      <code>form_field_button</code>
-      <code>register_hook_listener</code>
-      <code>render_additional_section_elements</code>
-      <code>render_content_drip_settings</code>
-      <code>render_promo_banner</code>
-      <code>render_woocommerce_upgrade_settings</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$input[ $k ]</code>
     </PossiblyFalseArgument>
@@ -3824,15 +2981,6 @@
       <code>$new_value</code>
       <code>$setting</code>
     </MissingParamType>
-    <MissingReturnType occurrences="7">
-      <code>flush_rewrite_rules</code>
-      <code>get_learning_mode_template_options</code>
-      <code>log_settings_update</code>
-      <code>mark_section_as_visited</code>
-      <code>render_learning_mode_setting</code>
-      <code>render_learning_mode_templates</code>
-      <code>set</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $inline_data )</code>
     </PossiblyFalseArgument>
@@ -3916,16 +3064,6 @@
       <code>$teacher_role</code>
       <code>$token</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="8">
-      <code>add_capabilities</code>
-      <code>archive_title</code>
-      <code>course_column_data</code>
-      <code>filter_queries</code>
-      <code>remove_course_meta_on_teacher_archive</code>
-      <code>teacher_filter_query_modify</code>
-      <code>teacher_meta_box_content</code>
-      <code>update_lesson_teacher</code>
-    </MissingReturnType>
     <ParadoxicalCondition occurrences="1">
       <code>empty( $lesson_id ) || ! $lesson_id</code>
     </ParadoxicalCondition>
@@ -3995,14 +3133,6 @@
       <code>$template_name</code>
       <code>$template_name</code>
     </MissingParamType>
-    <MissingReturnType occurrences="6">
-      <code>fire_frontend_messages_hook</code>
-      <code>fire_sensei_complete_course_hook</code>
-      <code>get_no_permission_template</code>
-      <code>get_template</code>
-      <code>locate_and_load_template_overrides</code>
-      <code>the_title</code>
-    </MissingReturnType>
     <PossiblyFalseOperand occurrences="1">
       <code>get_permalink( $post-&gt;ID )</code>
     </PossiblyFalseOperand>
@@ -4023,10 +3153,6 @@
       <code>$args &amp;&amp; is_array( $args )</code>
       <code>is_array( $args )</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedFunction occurrences="2">
-      <code>get_sensei_footer()</code>
-      <code>get_sensei_header()</code>
-    </UndefinedFunction>
     <UnresolvableInclude occurrences="3">
       <code>include $found_template</code>
       <code>include $found_template</code>
@@ -4042,11 +3168,6 @@
       <code>is_a( $last_week_activities, 'WP_Comment' )</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="3">
-      <code>clean_inactive_guest_users</code>
-      <code>init</code>
-      <code>maybe_schedule_cron_jobs</code>
-    </MissingReturnType>
     <TooManyArguments occurrences="1">
       <code>remove_filter( 'sensei_check_for_activity', [ Sensei_Temporary_User::class, 'filter_sensei_activity' ], 10, 2 )</code>
     </TooManyArguments>
@@ -4059,13 +3180,6 @@
       <code>require_once ABSPATH . '/wp-admin/includes/ms.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/user.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="5">
-      <code>filter_learners_query</code>
-      <code>filter_out_temporary_user_role_tabs</code>
-      <code>filter_out_temporary_user_roles</code>
-      <code>filter_out_temporary_users</code>
-      <code>init</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>get_userdata( $user_id )-&gt;roles</code>
     </PossiblyInvalidPropertyFetch>
@@ -4077,12 +3191,6 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>new Sensei_Unsupported_Themes()</code>
     </InvalidPropertyAssignmentValue>
-    <MissingReturnType occurrences="4">
-      <code>get_instance</code>
-      <code>init</code>
-      <code>maybe_handle_request</code>
-      <code>reset</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei-updates.php">
     <DocblockTypeContradiction occurrences="1">
@@ -4094,17 +3202,6 @@
     <InvalidReturnType occurrences="1">
       <code>DateTimeImmutable[]</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="9">
-      <code>assign_role_caps</code>
-      <code>log_update</code>
-      <code>run_updates</code>
-      <code>v3_0_check_legacy_enrolment</code>
-      <code>v3_7_add_comment_indexes</code>
-      <code>v3_7_check_rewrite_front</code>
-      <code>v3_9_fix_question_author</code>
-      <code>v3_9_remove_abandoned_multiple_question</code>
-      <code>v4_10_update_install_time</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="4">
       <code>$this-&gt;current_version</code>
       <code>$this-&gt;current_version</code>
@@ -4179,15 +3276,6 @@
       <code>$fields</code>
       <code>$fields</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="7">
-      <code>get_instance</code>
-      <code>init_event_logging_sources</code>
-      <code>log_update</code>
-      <code>log_wccom_plugin_install</code>
-      <code>set_event_logging_source_data_import</code>
-      <code>set_event_logging_source_frontend</code>
-      <code>set_tracking_enabled</code>
-    </MissingReturnType>
     <TypeDoesNotContainType occurrences="1">
       <code>false</code>
     </TypeDoesNotContainType>
@@ -4282,21 +3370,6 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="13">
-      <code>as_absolute_rounded_number</code>
-      <code>force_complete_user_course</code>
-      <code>is_plugin_present_and_activated</code>
-      <code>is_preview_lesson</code>
-      <code>output_query_params_as_inputs</code>
-      <code>quotient_as_absolute_rounded_number</code>
-      <code>restore_wp_query</code>
-      <code>sensei_delete_question_grade</code>
-      <code>sensei_get_quiz_questions</code>
-      <code>sensei_get_quiz_total</code>
-      <code>sensei_user_course_status_message</code>
-      <code>upload_file</code>
-      <code>user_passed_quiz</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$attributes</code>
     </PossibleRawObjectIteration>
@@ -4349,9 +3422,8 @@
     <UndefinedDocblockClass occurrences="1">
       <code>int|number</code>
     </UndefinedDocblockClass>
-    <UndefinedFunction occurrences="2">
+    <UndefinedFunction occurrences="1">
       <code>WC()</code>
-      <code>sensei_get_prev_next_lessons( $lesson_id )</code>
     </UndefinedFunction>
   </file>
   <file src="includes/class-sensei-view-helper.php">
@@ -4373,11 +3445,6 @@
     <MissingPropertyType occurrences="1">
       <code>$allowed_html</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="3">
-      <code>get_default_wp_kses_allowed_html</code>
-      <code>get_source_html_tag_allowed_attributes</code>
-      <code>get_video_html_tag_allowed_attributes</code>
-    </MissingReturnType>
   </file>
   <file src="includes/class-sensei.php">
     <DeprecatedMethod occurrences="2">
@@ -4439,28 +3506,6 @@
       <code>$token</code>
       <code>$version</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="20">
-      <code>activate</code>
-      <code>activation</code>
-      <code>activation_flush_rules</code>
-      <code>assign_role_caps</code>
-      <code>disable_sensei_modules_extension</code>
-      <code>flush_comment_counts_cache</code>
-      <code>flush_rewrite_rules</code>
-      <code>init</code>
-      <code>initialize_cache_groups</code>
-      <code>initialize_cli</code>
-      <code>initialize_global_objects</code>
-      <code>initiate_rewrite_rules_flush</code>
-      <code>jetpack_latex_support</code>
-      <code>load_hooks</code>
-      <code>load_modules_class</code>
-      <code>maybe_add_latex_support_via</code>
-      <code>sensei_load_template_functions</code>
-      <code>set_legacy_flag</code>
-      <code>update</code>
-      <code>wp_quicklatex_support</code>
-    </MissingReturnType>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -4540,10 +3585,6 @@
     <MissingConstructor occurrences="1">
       <code>$timer_start</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="2">
-      <code>log</code>
-      <code>start_timer</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="4">
       <code>$course_id</code>
       <code>$course_id</code>
@@ -4567,9 +3608,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>the_course_theme_layout</code>
-    </MissingReturnType>
     <UndefinedClass occurrences="1">
       <code>ET_GB_Block_Layout</code>
     </UndefinedClass>
@@ -4587,17 +3625,6 @@
     <MissingParamType occurrences="1">
       <code>$post</code>
     </MissingParamType>
-    <MissingReturnType occurrences="9">
-      <code>add_admin_menu_site_editor_item</code>
-      <code>add_editor_styles</code>
-      <code>add_site_editor_hooks</code>
-      <code>enqueue_site_editor_assets</code>
-      <code>init</code>
-      <code>is_site_editor_request</code>
-      <code>maybe_add_site_editor_hooks</code>
-      <code>maybe_override_lesson_theme</code>
-      <code>substitute_theme_cache</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$post-&gt;ID</code>
       <code>$post-&gt;post_type</code>
@@ -4610,12 +3637,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>init</code>
-      <code>intercept_notice</code>
-      <code>maybe_add_lesson_prerequisite_notice</code>
-      <code>maybe_add_quiz_results_notice</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="4">
       <code>$current_link</code>
       <code>$current_link</code>
@@ -4643,11 +3664,6 @@
       <code>$meta_key</code>
       <code>$post_id</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="3">
-      <code>ensure_learning_mode_url_prefix</code>
-      <code>init</code>
-      <code>register_post_meta</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="2">
       <code>$prefix</code>
       <code>get_post_type_object( 'lesson' )-&gt;cap-&gt;edit_post</code>
@@ -4661,12 +3677,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>init</code>
-      <code>maybe_add_quiz_results_notice</code>
-      <code>render_contact_teacher</code>
-      <code>render_reset_quiz</code>
-    </MissingReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -4691,12 +3701,6 @@
     <InvalidParamDefault occurrences="1">
       <code>array</code>
     </InvalidParamDefault>
-    <MissingReturnType occurrences="4">
-      <code>format_css_variables</code>
-      <code>init</code>
-      <code>output_global_styles_colors</code>
-      <code>output_style</code>
-    </MissingReturnType>
     <PossiblyNullArrayAccess occurrences="2">
       <code>$element_colors['background']</code>
       <code>$element_colors['text']</code>
@@ -4711,11 +3715,6 @@
     <InvalidArgument occurrences="1">
       <code>$post</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="3">
-      <code>init</code>
-      <code>maybe_set_block_template_name</code>
-      <code>update_legacy_template_naming</code>
-    </MissingReturnType>
   </file>
   <file src="includes/course-theme/class-sensei-course-theme-template.php">
     <PropertyNotSetInConstructor occurrences="8">
@@ -4741,13 +3740,6 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$post-&gt;post_author</code>
     </InvalidPropertyAssignmentValue>
-    <MissingReturnType occurrences="5">
-      <code>add_learning_mode_template</code>
-      <code>init</code>
-      <code>load_file_templates</code>
-      <code>maybe_add_theme_supports</code>
-      <code>maybe_use_course_theme_templates</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
@@ -4772,17 +3764,6 @@
       <code>self::$instance</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1"/>
-    <MissingReturnType occurrences="9">
-      <code>add_post_type_rewrite_rules</code>
-      <code>add_query_var</code>
-      <code>admin_menu_init</code>
-      <code>enqueue_fonts</code>
-      <code>enqueue_styles</code>
-      <code>init</code>
-      <code>maybe_flush_rewrite_rules</code>
-      <code>maybe_override_theme</code>
-      <code>override_theme</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="2">
       <code>get_permalink( $module_lessons[0] )</code>
       <code>get_post_type()</code>
@@ -4806,14 +3787,8 @@
       <code>get_extension_class_name</code>
       <code>is_supported</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
   </file>
   <file src="includes/course-video/blocks/class-sensei-course-video-blocks-video-extension.php">
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>self::$instance</code>
       <code>self::$instance</code>
@@ -4856,9 +3831,6 @@
       <code>self::$instance</code>
       <code>self::$instance</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>static</code>
     </MoreSpecificReturnType>
@@ -4877,10 +3849,6 @@
       <code>$meta_key</code>
       <code>$post_id</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>register_post_meta</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="3">
       <code>get_the_ID()</code>
       <code>get_the_ID()</code>
@@ -4909,16 +3877,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>new $task_class( $this )</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="8">
-      <code>add_log_entry</code>
-      <code>clean_up</code>
-      <code>persist</code>
-      <code>restore_from_json</code>
-      <code>run</code>
-      <code>set_state</code>
-      <code>set_user_id</code>
-      <code>start</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_Data_Port_Task_Interface</code>
     </MoreSpecificReturnType>
@@ -4982,20 +3940,6 @@
     <InvalidStringClass occurrences="1">
       <code>$handler_class::create( $job_id, (int) $user_id )</code>
     </InvalidStringClass>
-    <MissingReturnType occurrences="12">
-      <code>cancel_all_jobs</code>
-      <code>cancel_job</code>
-      <code>clean_old_jobs</code>
-      <code>init</code>
-      <code>log_complete_export_jobs</code>
-      <code>log_complete_import_jobs</code>
-      <code>maybe_schedule_cron_jobs</code>
-      <code>persist</code>
-      <code>redirect_edit_post_link</code>
-      <code>redirect_imported_sample</code>
-      <code>run_data_port_job</code>
-      <code>run_scheduled_data_port_job</code>
-    </MissingReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -5022,17 +3966,6 @@
     <UndefinedMethod occurrences="1">
       <code>get_import_id</code>
     </UndefinedMethod>
-  </file>
-  <file src="includes/data-port/class-sensei-data-port-task-interface.php">
-    <MissingReturnType occurrences="2">
-      <code>run</code>
-      <code>save_state</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/data-port/class-sensei-data-port-task.php">
-    <MissingReturnType occurrences="1">
-      <code>save_state</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/class-sensei-data-port-utilities.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -5108,10 +4041,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>null === $this-&gt;results</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>get_result_counts</code>
-      <code>set_content_types</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$tasks</code>
       <code>Sensei_Export_Job</code>
@@ -5122,12 +4051,6 @@
     <UninitializedProperty occurrences="1">
       <code>$this-&gt;results</code>
     </UninitializedProperty>
-  </file>
-  <file src="includes/data-port/class-sensei-export.php">
-    <MissingReturnType occurrences="2">
-      <code>admin_menu</code>
-      <code>export_page</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/class-sensei-import-block-migrator.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -5155,18 +4078,8 @@
     <MissingClosureParamType occurrences="1">
       <code>$name</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="1">
-      <code>detect_delimiter</code>
-    </MissingReturnType>
-    <PossiblyInvalidArgument occurrences="8">
+    <PossiblyInvalidArgument occurrences="1">
       <code>$column_names</code>
-      <code>$indexed_line</code>
-      <code>$indexed_line</code>
-      <code>$indexed_line</code>
-      <code>$indexed_line</code>
-      <code>$indexed_line</code>
-      <code>$second_line</code>
-      <code>$this-&gt;file-&gt;current()</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="includes/data-port/class-sensei-import-job-cli.php">
@@ -5187,14 +4100,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>$this-&gt;get_tasks()['associations']</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="6">
-      <code>add_line_warning</code>
-      <code>add_log_entry</code>
-      <code>get_result_counts</code>
-      <code>set_import_id</code>
-      <code>set_is_sample_data</code>
-      <code>set_line_result</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>Sensei_Import_Associations</code>
     </MoreSpecificReturnType>
@@ -5218,12 +4123,6 @@
       <code>$this-&gt;results</code>
     </UninitializedProperty>
   </file>
-  <file src="includes/data-port/class-sensei-import.php">
-    <MissingReturnType occurrences="2">
-      <code>admin_menu</code>
-      <code>import_page</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/data-port/export-tasks/class-sensei-export-courses.php">
     <PossiblyInvalidArgument occurrences="1">
       <code>$categories</code>
@@ -5244,9 +4143,6 @@
     </UndefinedPropertyFetch>
   </file>
   <file src="includes/data-port/export-tasks/class-sensei-export-package.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$file-&gt;post_title</code>
     </PossiblyInvalidPropertyFetch>
@@ -5277,10 +4173,6 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/file.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="2">
-      <code>add_file_to_job</code>
-      <code>run</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>get_attached_file( $files[ $type ] )</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -5311,13 +4203,6 @@
       <code>function( $message, $code ) use ( $line_number, $course_id, $post_title ) {</code>
       <code>function( $message, $code ) use ( $line_number, $lesson_id, $post_title ) {</code>
     </MissingClosureReturnType>
-    <MissingReturnType occurrences="5">
-      <code>add_course_lessons</code>
-      <code>add_lesson_module</code>
-      <code>handle_course_lessons</code>
-      <code>run</code>
-      <code>save_state</code>
-    </MissingReturnType>
     <PossiblyInvalidMethodCall occurrences="2">
       <code>get_error_code</code>
       <code>get_error_message</code>
@@ -5354,17 +4239,8 @@
     <InvalidReturnType occurrences="1">
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>handle_prerequisite</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/import-tasks/class-sensei-import-file-process-task.php">
-    <MissingReturnType occurrences="4">
-      <code>add_post_process_task</code>
-      <code>run</code>
-      <code>run_post_process_tasks</code>
-      <code>save_state</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_attached_file( $attachment_id )</code>
     </PossiblyFalseArgument>
@@ -5387,15 +4263,8 @@
     <InvalidReturnType occurrences="1">
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>handle_prerequisite</code>
-    </MissingReturnType>
   </file>
   <file src="includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php">
-    <MissingReturnType occurrences="2">
-      <code>add_prerequisite_task</code>
-      <code>handle_prerequisite_helper</code>
-    </MissingReturnType>
     <UndefinedMethod occurrences="3">
       <code>add_line_warning</code>
       <code>add_line_warning</code>
@@ -5428,10 +4297,6 @@
     <InvalidReturnType occurrences="1">
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="2">
-      <code>delete_course_terms</code>
-      <code>set_course_terms</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="3">
       <code>$post_id</code>
       <code>$post_id</code>
@@ -5468,10 +4333,6 @@
       <code>bool|WP_Error</code>
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="2">
-      <code>set_lesson_terms</code>
-      <code>set_quiz_questions</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="5">
       <code>$post_id</code>
       <code>$post_id</code>
@@ -5506,14 +4367,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$value</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="6">
-      <code>add_line_warning</code>
-      <code>add_warnings_to_job</code>
-      <code>restore_from_source_array</code>
-      <code>set_data</code>
-      <code>set_post_id</code>
-      <code>store_import_id</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="1">
       <code>$post_id</code>
     </NullableReturnStatement>
@@ -5559,9 +4412,6 @@
       <code>null|string</code>
       <code>true|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>sync_meta</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$meta_fields</code>
     </PossibleRawObjectIteration>
@@ -5580,12 +4430,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>enqueue_scripts</code>
-      <code>enqueue_styles</code>
-      <code>init</code>
-      <code>output_modal</code>
-    </MissingReturnType>
   </file>
   <file src="includes/email-signup/template.php">
     <DeprecatedClass occurrences="3">
@@ -5757,21 +4601,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>$this-&gt;get_enrolment_provider_by_id( Sensei_Course_Manual_Enrolment_Provider::instance()-&gt;get_id() )</code>
     </LessSpecificReturnStatement>
-    <MissingReturnType occurrences="13">
-      <code>add_wcpc_1_notice</code>
-      <code>collect_enrolment_providers</code>
-      <code>defer_course_enrolment_check</code>
-      <code>detect_wcpc_1</code>
-      <code>do_course_enrolment_check</code>
-      <code>init</code>
-      <code>invalidate_learner_result</code>
-      <code>mark_user_as_needing_recalculation</code>
-      <code>recalculate_enrolments</code>
-      <code>recalculate_on_course_post_status_change</code>
-      <code>remove_deferred_enrolment_check</code>
-      <code>run_deferred_course_enrolment_checks</code>
-      <code>trigger_course_enrolment_check</code>
-    </MissingReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>false|Sensei_Course_Manual_Enrolment_Provider</code>
     </MoreSpecificReturnType>
@@ -5808,20 +4637,10 @@
       <code>isset( $time ) ? $time : time()</code>
     </PossiblyInvalidPropertyAssignmentValue>
   </file>
-  <file src="includes/enrolment/class-sensei-course-enrolment-stored-status-provider.php">
-    <MissingReturnType occurrences="2">
-      <code>clear_enrolment_status</code>
-      <code>set_enrolment_status</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/enrolment/class-sensei-course-enrolment.php">
     <InvalidClass occurrences="1">
       <code>[ 'Sensei_learner', 'get_learner_id' ]</code>
     </InvalidClass>
-    <MissingReturnType occurrences="2">
-      <code>invalidate_learner_result</code>
-      <code>store_enrolment_results</code>
-    </MissingReturnType>
     <NullableReturnStatement occurrences="1">
       <code>$is_enrolled</code>
     </NullableReturnStatement>
@@ -5856,9 +4675,6 @@
     <InvalidReturnType occurrences="1">
       <code>int</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>set_migrated_legacy_enrolment_status</code>
-    </MissingReturnType>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset( self::$instance )</code>
     </RedundantPropertyInitializationCheck>
@@ -5870,13 +4686,6 @@
     <InvalidFalsableReturnType occurrences="1">
       <code>string</code>
     </InvalidFalsableReturnType>
-    <MissingReturnType occurrences="5">
-      <code>end</code>
-      <code>modify_user_query_add_user_id</code>
-      <code>run</code>
-      <code>set_last_user_id</code>
-      <code>setup</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>$this-&gt;get_current_job_id()</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -5898,22 +4707,8 @@
     <MissingClosureReturnType occurrences="1">
       <code>function() {</code>
     </MissingClosureReturnType>
-    <MissingReturnType occurrences="5">
-      <code>cancel_course_calculation_job</code>
-      <code>init</code>
-      <code>maybe_start_learner_calculation</code>
-      <code>run_course_calculation</code>
-      <code>run_learner_calculation</code>
-    </MissingReturnType>
   </file>
   <file src="includes/enrolment/class-sensei-enrolment-learner-calculation-job.php">
-    <MissingReturnType occurrences="5">
-      <code>end</code>
-      <code>modify_user_query_add_user_id</code>
-      <code>run</code>
-      <code>set_last_user_id</code>
-      <code>setup</code>
-    </MissingReturnType>
     <RedundantCastGivenDocblockType occurrences="3">
       <code>(int) $this-&gt;batch_size</code>
       <code>(int) $user_id</code>
@@ -5927,12 +4722,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$timestamp</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
-      <code>add_provider_log_message</code>
-      <code>persist_all</code>
-      <code>register_possible_enrolment_change</code>
-      <code>restore_from_json</code>
-    </MissingReturnType>
   </file>
   <file src="includes/enrolment/class-sensei-enrolment-provider-journal.php">
     <DocblockTypeContradiction occurrences="1">
@@ -5946,10 +4735,6 @@
     <InvalidFalsableReturnType occurrences="1">
       <code>array</code>
     </InvalidFalsableReturnType>
-    <MissingReturnType occurrences="2">
-      <code>add_log_message</code>
-      <code>add_status</code>
-    </MissingReturnType>
   </file>
   <file src="includes/enrolment/class-sensei-enrolment-provider-state-store.php">
     <DocblockTypeContradiction occurrences="1">
@@ -5961,21 +4746,9 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$provider_states</code>
     </InvalidPropertyAssignmentValue>
-    <MissingReturnType occurrences="5">
-      <code>get_has_changed</code>
-      <code>persist_all</code>
-      <code>restore_from_json</code>
-      <code>set_has_changed</code>
-      <code>set_provider_states</code>
-    </MissingReturnType>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $has_changed</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="includes/enrolment/class-sensei-enrolment-provider-state.php">
-    <MissingReturnType occurrences="1">
-      <code>set_stored_value</code>
-    </MissingReturnType>
   </file>
   <file src="includes/hooks/template.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -5984,14 +4757,8 @@
     <InvalidScope occurrences="1">
       <code>$this</code>
     </InvalidScope>
-    <UndefinedFunction occurrences="1">
-      <code>'sensei_the_single_lesson_meta'</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/internal/emails/class-email-blocks.php">
-    <MissingReturnType occurrences="1">
-      <code>load_admin_assets</code>
-    </MissingReturnType>
     <UndefinedDocblockClass occurrences="2">
       <code>WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg</code>
       <code>WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg</code>
@@ -6002,9 +4769,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>disable_legacy_emails</code>
-    </MissingReturnType>
     <TooManyArguments occurrences="1">
       <code>new Email_Seeder( new Email_Seeder_Data(), $this-&gt;repository, $template_repository )</code>
     </TooManyArguments>
@@ -6018,16 +4782,8 @@
       <code>Email_Generators_Abstract[]</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="includes/internal/emails/class-email-list-table-actions.php">
-    <MissingReturnType occurrences="1">
-      <code>validate_bulk_action_request</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/class-email-list-table.php">
     <ArgumentTypeCoercion occurrences="1"/>
-    <MissingReturnType occurrences="1">
-      <code>prepare_items</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post</code>
     </MoreSpecificImplementedParamType>
@@ -6068,13 +4824,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/emails/class-email-patterns.php">
-    <MissingReturnType occurrences="5">
-      <code>init</code>
-      <code>register_block_patterns_category</code>
-      <code>register_email_block_patterns</code>
-      <code>register_email_editor_block_patterns</code>
-      <code>register_email_preview_block_patterns</code>
-    </MissingReturnType>
     <UndefinedDocblockClass occurrences="1">
       <code>WP_Screen</code>
     </UndefinedDocblockClass>
@@ -6127,19 +4876,7 @@
       <code>$emails</code>
     </MissingConstructor>
   </file>
-  <file src="includes/internal/emails/class-email-seeder.php">
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/class-email-sender.php">
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>send_email</code>
-    </MissingReturnType>
-    <NullArgument occurrences="1">
-      <code>null</code>
-    </NullArgument>
     <PossiblyNullArgument occurrences="1">
       <code>get_block_template( Email_Page_Template::ID, 'wp_template' )-&gt;content</code>
     </PossiblyNullArgument>
@@ -6164,33 +4901,14 @@
       <code>$key</code>
       <code>$key</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="3">
-      <code>form_field_hidden</code>
-      <code>init</code>
-      <code>render_tabs</code>
-    </MissingReturnType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$this-&gt;settings-&gt;get_settings()</code>
     </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="includes/internal/emails/class-recreate-emails-tool.php">
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>process</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/internal/emails/class-settings-menu.php">
-    <MissingReturnType occurrences="1">
-      <code>init</code>
-    </MissingReturnType>
   </file>
   <file src="includes/internal/emails/generators/class-course-completed.php">
     <DocblockTypeContradiction occurrences="1">
       <code>get_permalink( $course_id )</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>completed_course_mail_to_student</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>\Sensei_Course::get_course_completed_page_url( $course_id ) ?? get_permalink( $course_id )</code>
     </PossiblyFalseArgument>
@@ -6199,9 +4917,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/internal/emails/generators/class-course-created.php">
-    <MissingReturnType occurrences="1">
-      <code>course_created_to_admin</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$course-&gt;post_author</code>
     </PossiblyInvalidPropertyFetch>
@@ -6216,9 +4931,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/emails/generators/class-course-welcome.php">
-    <MissingReturnType occurrences="1">
-      <code>welcome_to_course_for_student</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="4">
       <code>$course-&gt;ID</code>
       <code>$course-&gt;post_author</code>
@@ -6226,20 +4938,7 @@
       <code>$course-&gt;post_title</code>
     </PossiblyInvalidPropertyFetch>
   </file>
-  <file src="includes/internal/emails/generators/class-email-generators-abstract.php">
-    <MissingReturnType occurrences="1">
-      <code>send_email_action</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/internal/emails/generators/class-new-course-assigned.php">
-    <MissingReturnType occurrences="1">
-      <code>course_new_teacher_assigned_email</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/generators/class-quiz-graded.php">
-    <MissingReturnType occurrences="1">
-      <code>quiz_graded_mail_to_student</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $quiz_id )</code>
     </PossiblyFalseArgument>
@@ -6248,15 +4947,7 @@
       <code>$lesson-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
   </file>
-  <file src="includes/internal/emails/generators/class-student-completes-course.php">
-    <MissingReturnType occurrences="1">
-      <code>student_completed_course_mail_to_teacher</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/internal/emails/generators/class-student-completes-lesson.php">
-    <MissingReturnType occurrences="1">
-      <code>student_completed_lesson_mail_to_teacher</code>
-    </MissingReturnType>
     <RedundantCast occurrences="2">
       <code>(int) $lesson_id</code>
       <code>(int) $student_id</code>
@@ -6300,9 +4991,6 @@
     </PossiblyNullPropertyFetch>
   </file>
   <file src="includes/internal/emails/generators/class-student-starts-course.php">
-    <MissingReturnType occurrences="1">
-      <code>student_started_course_mail_to_teacher</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="3">
       <code>$course-&gt;post_author</code>
       <code>$course-&gt;post_status</code>
@@ -6310,9 +4998,6 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/emails/generators/class-student-submits-quiz.php">
-    <MissingReturnType occurrences="1">
-      <code>student_submits_quiz_mail_to_teacher</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$course-&gt;ID</code>
       <code>$lesson-&gt;ID</code>
@@ -6338,42 +5023,19 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>init</code>
-      <code>install</code>
-    </MissingReturnType>
     <UndefinedConstant occurrences="1">
       <code>MINUTE_IN_SECONDS</code>
     </UndefinedConstant>
-  </file>
-  <file src="includes/internal/installer/class-migration.php">
-    <MissingReturnType occurrences="1">
-      <code>run</code>
-    </MissingReturnType>
   </file>
   <file src="includes/internal/installer/class-schema.php">
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/upgrade.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>create_tables</code>
-    </MissingReturnType>
   </file>
   <file src="includes/internal/installer/class-updates-factory.php">
     <PossiblyNullArgument occurrences="1">
       <code>$plugin_version</code>
     </PossiblyNullArgument>
-  </file>
-  <file src="includes/internal/installer/migrations/class-student-progress-migration.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_null( $this-&gt;errors )</code>
-    </DocblockTypeContradiction>
-    <InvalidCast occurrences="1">
-      <code>$value_sql</code>
-    </InvalidCast>
-    <UndefinedDocblockClass occurrences="1">
-      <code>strng</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php">
     <PossiblyNullIterator occurrences="1">
@@ -6408,30 +5070,15 @@
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
   </file>
-  <file src="includes/internal/student-progress/course-progress/repositories/class-aggregate-course-progress-repository.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getTimestamp</code>
-      <code>getTimestamp</code>
-    </PossiblyNullReference>
-  </file>
   <file src="includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>Course_Progress</code>
-    </InvalidNullableReturnType>
     <InvalidPropertyFetch occurrences="3">
       <code>$comment-&gt;comment_ID</code>
       <code>$comment-&gt;comment_approved</code>
       <code>$comment-&gt;comment_date</code>
     </InvalidPropertyFetch>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;get( $course_id, $user_id )</code>
-    </NullableReturnStatement>
     <PossiblyNullArgument occurrences="1">
       <code>$course_progress-&gt;get_status()</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>format</code>
-    </PossiblyNullReference>
   </file>
   <file src="includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php">
     <PossiblyInvalidPropertyFetch occurrences="8">
@@ -6444,45 +5091,19 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullReference occurrences="2">
-      <code>format</code>
-      <code>format</code>
-    </PossiblyNullReference>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="includes/internal/student-progress/lesson-progress/repositories/class-aggregate-lesson-progress-repository.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getTimestamp</code>
-      <code>getTimestamp</code>
-    </PossiblyNullReference>
-  </file>
   <file src="includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>Lesson_Progress</code>
-    </InvalidNullableReturnType>
     <InvalidPropertyFetch occurrences="3">
       <code>$comment-&gt;comment_ID</code>
       <code>$comment-&gt;comment_approved</code>
       <code>$comment-&gt;comment_date</code>
     </InvalidPropertyFetch>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;get( $lesson_id, $user_id )</code>
-    </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="1">
-      <code>$lesson_progress-&gt;get_status()</code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
-      <code>format</code>
+    <PossiblyNullReference occurrences="1">
       <code>format</code>
     </PossiblyNullReference>
-    <UndefinedClass occurrences="1">
-      <code>RuntimeException</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
-      <code>RuntimeException</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php">
     <PossiblyInvalidPropertyFetch occurrences="8">
@@ -6495,19 +5116,9 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullReference occurrences="2">
-      <code>format</code>
-      <code>format</code>
-    </PossiblyNullReference>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="includes/internal/student-progress/quiz-progress/repositories/class-aggregate-quiz-progress-repository.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getTimestamp</code>
-      <code>getTimestamp</code>
-    </PossiblyNullReference>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php">
     <InvalidPropertyFetch occurrences="3">
@@ -6519,12 +5130,6 @@
       <code>$comments</code>
       <code>$comments</code>
     </PossiblyInvalidIterator>
-    <PossiblyNullArgument occurrences="1">
-      <code>$quiz_progress-&gt;get_status()</code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>format</code>
-    </PossiblyNullReference>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php">
     <PossiblyInvalidPropertyFetch occurrences="8">
@@ -6537,19 +5142,11 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullReference occurrences="2">
-      <code>format</code>
-      <code>format</code>
-    </PossiblyNullReference>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(int) $this-&gt;wpdb-&gt;insert_id</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="includes/internal/student-progress/services/class-course-deleted-handler.php">
-    <MissingReturnType occurrences="2">
-      <code>handle</code>
-      <code>init</code>
-    </MissingReturnType>
     <UndefinedDocblockClass occurrences="1">
       <code>WP_Post</code>
     </UndefinedDocblockClass>
@@ -6564,12 +5161,6 @@
       <code>WP_Post</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="includes/internal/student-progress/services/class-user-deleted-handler.php">
-    <MissingReturnType occurrences="2">
-      <code>handle</code>
-      <code>init</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/lib/usage-tracking/class-usage-tracking-base.php">
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$callback</code>
@@ -6583,33 +5174,11 @@
     <MissingFile occurrences="1">
       <code>include_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="15">
-      <code>add_usage_tracking_two_week_schedule</code>
-      <code>enqueue_script_deps</code>
-      <code>get_event_prefix</code>
-      <code>get_instance</code>
-      <code>handle_tracking_opt_in</code>
-      <code>hide_tracking_opt_in</code>
-      <code>is_opt_in_hidden</code>
-      <code>maybe_display_tracking_opt_in</code>
-      <code>opt_in_dialog_text_allowed_html</code>
-      <code>output_opt_in_js</code>
-      <code>schedule_tracking_task</code>
-      <code>send_usage_data</code>
-      <code>set_callback</code>
-      <code>set_tracking_enabled</code>
-      <code>unschedule_tracking_task</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$callback</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php">
-    <MissingReturnType occurrences="3">
-      <code>get_instance</code>
-      <code>get_template_data</code>
-      <code>set_tracking_enabled</code>
-    </MissingReturnType>
     <TypeDoesNotContainType occurrences="1">
       <code>false</code>
     </TypeDoesNotContainType>
@@ -6623,10 +5192,6 @@
     <MissingPropertyType occurrences="1">
       <code>$wp_die_args</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>get_wp_die_args</code>
-      <code>set_wp_die_args</code>
-    </MissingReturnType>
   </file>
   <file src="includes/lib/usage-tracking/tests/test-class-usage-tracking.php">
     <UndefinedClass occurrences="1">
@@ -6706,12 +5271,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/renderers/class-sensei-renderer-single-post.php">
-    <MissingReturnType occurrences="4">
-      <code>backup_global_vars</code>
-      <code>reset_global_vars</code>
-      <code>set_global_vars</code>
-      <code>setup_post_query</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_content</code>
     </PossiblyInvalidPropertyFetch>
@@ -6738,9 +5297,6 @@
     </InvalidGlobal>
   </file>
   <file src="includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php">
-    <MissingReturnType occurrences="1">
-      <code>add_orderby_custom_field_to_query</code>
-    </MissingReturnType>
     <TooManyArguments occurrences="2">
       <code>remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 )</code>
       <code>remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 )</code>
@@ -6750,26 +5306,9 @@
     <InvalidDocblock occurrences="1">
       <code>public function get_is_last_activity_filter_enabled() {</code>
     </InvalidDocblock>
-    <MissingReturnType occurrences="7">
-      <code>add_last_activity_to_user_query</code>
-      <code>add_orderby_custom_field_to_user_query</code>
-      <code>add_pre_user_query_hook</code>
-      <code>filter_users_by_last_activity</code>
-      <code>get_is_last_activity_filter_enabled</code>
-      <code>group_by_users</code>
-      <code>only_course_enrolled_users</code>
-    </MissingReturnType>
   </file>
   <file src="includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php">
     <ArgumentTypeCoercion occurrences="1"/>
-    <MissingReturnType occurrences="6">
-      <code>data_table_footer</code>
-      <code>extra_tablenav</code>
-      <code>output_course_select_input</code>
-      <code>output_top_filters</code>
-      <code>prepare_items</code>
-      <code>search_button</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="4">
       <code>Sensei_Reports_Overview_List_Table_Abstract</code>
       <code>Sensei_Reports_Overview_List_Table_Abstract</code>
@@ -6802,9 +5341,6 @@
     <PossibleRawObjectIteration occurrences="1">
       <code>$modules_terms</code>
     </PossibleRawObjectIteration>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>wp_get_object_terms( $lessons, 'module', $default_args )</code>
-    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="4">
       <code>Sensei_Reports_Overview_List_Table_Lessons</code>
       <code>Sensei_Reports_Overview_List_Table_Lessons</code>
@@ -6852,9 +5388,6 @@
     <InvalidClass occurrences="1">
       <code>WP_HTTP</code>
     </InvalidClass>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArrayAssignment occurrences="2">
       <code>$result[ $student_id ][ $course_id ]</code>
       <code>$result[ $student_id ][ $course_id ]</code>
@@ -6879,11 +5412,6 @@
     <InvalidReturnType occurrences="1">
       <code>WP_Post|null</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="3">
-      <code>get_schema_lessons</code>
-      <code>get_schema_modules</code>
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidMethodCall occurrences="2">
       <code>get_error_code</code>
       <code>get_error_message</code>
@@ -6909,9 +5437,6 @@
       <code>WP_HTTP</code>
       <code>WP_HTTP</code>
     </InvalidClass>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArrayAssignment occurrences="2">
       <code>$result[ $user_id ][ $course_id ]</code>
       <code>$result[ $user_id ][ $course_id ]</code>
@@ -6940,9 +5465,6 @@
     <InvalidReturnType occurrences="1">
       <code>boolean</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
@@ -6979,9 +5501,6 @@
     <InvalidStringClass occurrences="1">
       <code>$handler_class::get_file_config()</code>
     </InvalidStringClass>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="4">
       <code>$request-&gt;get_param( 'job_id' )</code>
       <code>$request-&gt;get_param( 'job_id' )</code>
@@ -7033,19 +5552,11 @@
       <code>require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/file.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Sensei_REST_API_Extensions_Controller</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-home-controller.php">
-    <MissingReturnType occurrences="3">
-      <code>register_get_data_route</code>
-      <code>register_mark_tasks_complete_route</code>
-      <code>register_routes</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Sensei_REST_API_Home_Controller</code>
     </PropertyNotSetInConstructor>
@@ -7067,9 +5578,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>sanitize_text_field( $request-&gt;get_param( 'job_id' ) )</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$result</code>
     </PossiblyInvalidArgument>
@@ -7083,11 +5591,6 @@
       <code>Sensei_REST_API_Import_Controller</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="includes/rest-api/class-sensei-rest-api-internal.php">
-    <MissingReturnType occurrences="1">
-      <code>register</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php">
     <ArgumentTypeCoercion occurrences="1"/>
     <DocblockTypeContradiction occurrences="1">
@@ -7100,9 +5603,6 @@
     <InvalidReturnType occurrences="1">
       <code>WP_REST_Response|WP_Error</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="6">
       <code>$lesson</code>
       <code>$lesson</code>
@@ -7151,9 +5651,6 @@
       <code>$value</code>
       <code>$value</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="1">
-      <code>init_post_meta</code>
-    </MissingReturnType>
     <ParamNameMismatch occurrences="1">
       <code>$prepared</code>
     </ParamNameMismatch>
@@ -7204,9 +5701,6 @@
     <InvalidArgument occurrences="1">
       <code>$post_args</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="1">
-      <code>migrate_non_editor_question</code>
-    </MissingReturnType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$question_categories</code>
     </PossibleRawObjectIteration>
@@ -7247,9 +5741,6 @@
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-question-options-controller.php">
     <ArgumentTypeCoercion occurrences="1"/>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="4">
       <code>$question</code>
       <code>$question</code>
@@ -7335,9 +5826,6 @@
       <code>boolean</code>
       <code>string</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="6">
       <code>$post-&gt;ID</code>
       <code>$post-&gt;ID</code>
@@ -7366,21 +5854,6 @@
       <code>get_json_params</code>
       <code>get_json_params</code>
     </InvalidMethodCall>
-    <MissingReturnType occurrences="13">
-      <code>complete_setup_wizard</code>
-      <code>register_complete_wizard_route</code>
-      <code>register_get_data_route</code>
-      <code>register_get_features_route</code>
-      <code>register_routes</code>
-      <code>register_setup_wizard_settings</code>
-      <code>register_submit_features_installation_route</code>
-      <code>register_submit_features_route</code>
-      <code>register_submit_purpose_route</code>
-      <code>register_submit_theme_route</code>
-      <code>register_submit_tracking_route</code>
-      <code>register_submit_welcome_route</code>
-      <code>update_setup_wizard_settings</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Sensei_REST_API_Setup_Wizard_Controller</code>
     </PropertyNotSetInConstructor>
@@ -7401,9 +5874,6 @@
       <code>include_once ABSPATH . '/wp-admin/includes/theme-install.php'</code>
       <code>include_once ABSPATH . '/wp-admin/includes/theme.php'</code>
     </MissingFile>
-    <MissingReturnType occurrences="1">
-      <code>register_routes</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$api-&gt;download_link</code>
     </PossiblyInvalidPropertyFetch>
@@ -7428,11 +5898,6 @@
       <code>$post</code>
       <code>$version</code>
     </MissingParamType>
-    <MissingReturnType occurrences="3">
-      <code>sensei_do_deprecated_action</code>
-      <code>sensei_log_event</code>
-      <code>sensei_log_jetpack_event</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_the_ID()</code>
     </PossiblyFalseArgument>
@@ -7502,9 +5967,6 @@
     <MissingPropertyType occurrences="1">
       <code>$global_product</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>setup_course_query</code>
-    </MissingReturnType>
     <PossiblyInvalidPropertyAssignmentValue occurrences="2">
       <code>empty( $exclude ) ? '' : explode( ',', $exclude )</code>
       <code>empty( $ids ) ? '' : explode( ',', $ids )</code>
@@ -7512,11 +5974,6 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$user-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
-  </file>
-  <file src="includes/shortcodes/class-sensei-shortcode-featured-courses.php">
-    <MissingReturnType occurrences="1">
-      <code>setup_course_query</code>
-    </MissingReturnType>
   </file>
   <file src="includes/shortcodes/class-sensei-shortcode-lesson-page.php">
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -7535,10 +5992,6 @@
       <code>$code</code>
       <code>$content</code>
     </MissingParamType>
-    <MissingReturnType occurrences="2">
-      <code>initialize_shortcodes</code>
-      <code>setup_shortcode_class_map</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$shortcode_classes</code>
     </PropertyNotSetInConstructor>
@@ -7562,9 +6015,6 @@
       <code>$users</code>
       <code>$users</code>
     </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>setup_teacher_query</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$exclude</code>
       <code>$include</code>
@@ -7597,23 +6047,6 @@
       <code>$course_status</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingReturnType occurrences="15">
-      <code>active_no_course_message_output</code>
-      <code>add_course_details_wrapper_end</code>
-      <code>add_course_details_wrapper_start</code>
-      <code>attach_course_buttons</code>
-      <code>attach_course_progress</code>
-      <code>attach_shortcode_hooks</code>
-      <code>completed_no_course_message_output</code>
-      <code>course_category</code>
-      <code>course_toggle_actions</code>
-      <code>detach_shortcode_hooks</code>
-      <code>is_my_courses</code>
-      <code>no_course_message_output</code>
-      <code>print_course_toggle_actions_inline_script</code>
-      <code>setup_course_query</code>
-      <code>should_filter_course_by_status</code>
-    </MissingReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$category_output</code>
       <code>$course</code>
@@ -7666,30 +6099,6 @@
       <code>$question_type</code>
       <code>$template_name</code>
     </MissingParamType>
-    <MissingReturnType occurrences="22">
-      <code>get_sensei_footer</code>
-      <code>get_sensei_header</code>
-      <code>sensei_courses_per_row</code>
-      <code>sensei_get_template</code>
-      <code>sensei_get_the_question_id</code>
-      <code>sensei_load_template</code>
-      <code>sensei_load_template_part</code>
-      <code>sensei_setup_module</code>
-      <code>sensei_setup_the_question</code>
-      <code>sensei_the_course_results_lessons</code>
-      <code>sensei_the_excerpt</code>
-      <code>sensei_the_lesson_excerpt</code>
-      <code>sensei_the_lesson_status_class</code>
-      <code>sensei_the_module_description</code>
-      <code>sensei_the_module_id</code>
-      <code>sensei_the_module_status</code>
-      <code>sensei_the_my_courses_content</code>
-      <code>sensei_the_question_class</code>
-      <code>sensei_the_question_content</code>
-      <code>sensei_the_single_lesson_meta</code>
-      <code>the_no_permissions_message</code>
-      <code>the_no_permissions_title</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="2">
       <code>get_permalink( $course_id )</code>
       <code>get_the_ID()</code>
@@ -7719,64 +6128,10 @@
       <code>$item-&gt;term_id</code>
     </UndefinedMagicPropertyFetch>
   </file>
-  <file src="includes/theme-integrations/theme-integration-loader.php">
-    <MissingReturnType occurrences="4">
-      <code>get_supported_themes</code>
-      <code>possibly_load_supported_theme_wrappers</code>
-      <code>setup_currently_active_theme</code>
-      <code>setup_themes</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyeleven.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyfifteen.php">
-    <MissingReturnType occurrences="2">
-      <code>print_styles</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyfourteen.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentyseventeen.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentythirteen.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/twentytwelve.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/theme-integrations/underscores.php">
-    <MissingReturnType occurrences="2">
-      <code>wrapper_end</code>
-      <code>wrapper_start</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php">
     <DocblockTypeContradiction occurrences="1">
       <code>empty( $post_to_copy )</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7785,10 +6140,6 @@
     </ParamNameMismatch>
   </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php">
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7803,12 +6154,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>true</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
-      <code>add_filter_hide_the_title</code>
-      <code>get_option</code>
-      <code>handle_request</code>
-      <code>remove_filter_hide_the_title</code>
-    </MissingReturnType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>get_the_ID()</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -7824,10 +6169,6 @@
       <code>! $learner_user</code>
       <code>$learner_user</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7835,22 +6176,7 @@
       <code>$post_to_copy</code>
     </ParamNameMismatch>
   </file>
-  <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php">
-    <MissingReturnType occurrences="1">
-      <code>handle_request</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php">
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
-  </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php">
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -7881,12 +6207,6 @@
       <code>$this-&gt;dummy_post-&gt;ID === $id</code>
       <code>$this-&gt;original_query</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
-      <code>do_sensei_pagination</code>
-      <code>output_content_as_page</code>
-      <code>prepare_wp_query</code>
-      <code>setup_original_query</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="2">
       <code>$object_to_copy</code>
       <code>$object_to_copy</code>
@@ -7896,28 +6216,12 @@
     <MissingConstructor occurrences="1">
       <code>$author</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="2">
-      <code>handle_request</code>
-      <code>prepare_wp_query</code>
-    </MissingReturnType>
     <PossiblyFalseArgument occurrences="1">
       <code>$this-&gt;author</code>
     </PossiblyFalseArgument>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>get_user_by( 'id', get_query_var( 'author' ) )</code>
     </PossiblyFalsePropertyAssignmentValue>
-  </file>
-  <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php">
-    <MissingReturnType occurrences="3">
-      <code>disable_comments</code>
-      <code>disable_theme_pagination</code>
-      <code>reenable_comments</code>
-    </MissingReturnType>
-  </file>
-  <file src="includes/unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php">
-    <MissingReturnType occurrences="1">
-      <code>handle_request</code>
-    </MissingReturnType>
   </file>
   <file src="includes/update-tasks/class-sensei-update-fix-question-author.php">
     <PossiblyInvalidPropertyFetch occurrences="2">
@@ -7944,19 +6248,11 @@
     <MissingParamType occurrences="1">
       <code>$email_address</code>
     </MissingParamType>
-    <MissingReturnType occurrences="2">
-      <code>sensei_after_sending_email</code>
-      <code>sensei_before_mail</code>
-    </MissingReturnType>
   </file>
   <file src="sensei-lms.php">
     <InvalidGlobal occurrences="1">
       <code>global $woothemes_sensei;</code>
     </InvalidGlobal>
-    <MissingReturnType occurrences="2">
-      <code>Sensei</code>
-      <code>activate_sensei</code>
-    </MissingReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$plugin</code>
     </PossiblyNullArgument>

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -391,7 +391,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$course_enrolment       = Sensei_Course_Enrolment::get_course_instance( $this->course_id );
 				$enrolment_results      = $course_enrolment->get_enrolment_check_results( $user_activity->user_id );
 				$provider_results       = $enrolment_results ? $enrolment_results->get_provider_results() : [];
-				$enrolment_tooltip_html = '';
+				$enrolment_tooltip_html = array();
 
 				if ( Sensei()->feature_flags->is_enabled( 'enrolment_provider_tooltip' ) ) {
 					if ( ! empty( $provider_results ) ) {

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -391,24 +391,24 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$course_enrolment       = Sensei_Course_Enrolment::get_course_instance( $this->course_id );
 				$enrolment_results      = $course_enrolment->get_enrolment_check_results( $user_activity->user_id );
 				$provider_results       = $enrolment_results ? $enrolment_results->get_provider_results() : [];
-				$enrolment_tooltip_html = array();
+				$enrolment_tooltip_html = '';
 
 				if ( Sensei()->feature_flags->is_enabled( 'enrolment_provider_tooltip' ) ) {
 					if ( ! empty( $provider_results ) ) {
-						$enrolment_tooltip_html = [ '<ul class="enrolment-helper">' ];
+						$tooltip_html_parts = [ '<ul class="enrolment-helper">' ];
 
 						foreach ( $provider_results as $id => $result ) {
 							$name       = Sensei_Course_Enrolment_Manager::instance()->get_enrolment_provider_name_by_id( $id ) ?? $id;
 							$item_class = $result ? 'provides-enrolment' : 'does-not-provide-enrolment';
 
-							$enrolment_tooltip_html[] =
+							$tooltip_html_parts[] =
 								'<li class="' . esc_attr( $item_class ) . '">' .
 									esc_html( $name ) .
 								'</li>';
 						}
 
-						$enrolment_tooltip_html[] = '</ul>';
-						$enrolment_tooltip_html   = implode( '', $enrolment_tooltip_html );
+						$tooltip_html_parts[]   = '</ul>';
+						$enrolment_tooltip_html = implode( '', $tooltip_html_parts );
 					} else {
 						$enrolment_tooltip_html = esc_html__( 'No enrollment data was found.', 'sensei-lms' );
 					}

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -222,15 +222,13 @@ class Sensei_Course_Results_Block {
 
 		}
 
-		if ( $item['lessons'] ) {
-			$section_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons">';
+		$section_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons">';
 
-			foreach ( $item['lessons'] as $lesson ) {
-				$section_content[] = $this->render_lesson( $lesson );
-			}
-
-			$section_content[] = '</ul>';
+		foreach ( $item['lessons'] as $lesson ) {
+			$section_content[] = $this->render_lesson( $lesson );
 		}
+
+		$section_content[] = '</ul>';
 
 		$section_content[] = '</section>';
 

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -222,7 +222,7 @@ class Sensei_Course_Results_Block {
 
 		}
 
-		if ( 0 < count( $item['lessons'] ) ) {
+		if ( $item['lessons'] ) {
 			$section_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons">';
 
 			foreach ( $item['lessons'] as $lesson ) {

--- a/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
@@ -52,7 +52,7 @@ class Sensei_Course_List_Categories_Filter extends Sensei_Course_List_Filter_Abs
 
 		return '<select data-param-key="' . esc_attr( $filter_param_key ) . '">
 			<option value="' . esc_attr( $default_option ) . '">' . esc_html__( 'All Categories', 'sensei-lms' ) . '</option>' .
-			join(
+			implode(
 				'',
 				array_map(
 					function ( $category ) use ( $category_id ) {

--- a/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
@@ -57,7 +57,7 @@ class Sensei_Course_List_Featured_Filter extends Sensei_Course_List_Filter_Abstr
 		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 
 		return '<select data-param-key="' . esc_attr( $filter_param_key ) . '">' .
-			join(
+			implode(
 				'',
 				array_map(
 					function ( $key ) use ( $selected_option ) {

--- a/includes/blocks/course-list/class-sensei-course-list-filter-abstract.php
+++ b/includes/blocks/course-list/class-sensei-course-list-filter-abstract.php
@@ -49,7 +49,7 @@ abstract class Sensei_Course_List_Filter_Abstract {
 		$filter_param_key = static::PARAM_KEY . $query_id;
 		$default_option   = $default_options[ static::FILTER_NAME ] ?? '';
 
-		if ( ! key_exists( $filter_param_key, $_GET ) && ! empty( $default_option ) ) { // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
+		if ( ! array_key_exists( $filter_param_key, $_GET ) && ! empty( $default_option ) ) { // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 			$_GET[ $filter_param_key ] = $default_option;
 		}
 	}

--- a/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
@@ -61,7 +61,7 @@ class Sensei_Course_List_Student_Course_Filter extends Sensei_Course_List_Filter
 		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 
 		return '<select data-param-key="' . esc_attr( $filter_param_key ) . '">' .
-			join(
+			implode(
 				'',
 				array_map(
 					function ( $key ) use ( $selected_option ) {

--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -173,7 +173,7 @@ class Course_Navigation {
 
 		$current_lesson_id  = \Sensei_Utils::get_current_lesson();
 		$has_current_lesson = count(
-			(array) array_filter(
+			array_filter(
 				$lessons,
 				function( $lesson ) use ( $current_lesson_id ) {
 					return $current_lesson_id === $lesson['id'];
@@ -184,7 +184,7 @@ class Course_Navigation {
 
 		$lesson_count = count( $lessons );
 		$quiz_count   = count(
-			(array) array_filter(
+			array_filter(
 				$lessons,
 				function( $lesson ) {
 					return \Sensei_Lesson::lesson_quiz_has_questions( $lesson['id'] );

--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -158,7 +158,7 @@ class Course_Navigation {
 	private function render_module( $module ) {
 		$module_id  = $module['id'];
 		$title      = esc_html( $module['title'] );
-		$lessons    = $module['lessons'];
+		$lessons    = is_array( $module['lessons'] ) ? $module['lessons'] : [];
 		$module_url = add_query_arg( 'course_id', $this->course_id, get_term_link( $module_id, 'module' ) );
 
 		$lessons_html = implode(
@@ -173,7 +173,7 @@ class Course_Navigation {
 
 		$current_lesson_id  = \Sensei_Utils::get_current_lesson();
 		$has_current_lesson = count(
-			array_filter(
+			(array) array_filter(
 				$lessons,
 				function( $lesson ) use ( $current_lesson_id ) {
 					return $current_lesson_id === $lesson['id'];
@@ -184,7 +184,7 @@ class Course_Navigation {
 
 		$lesson_count = count( $lessons );
 		$quiz_count   = count(
-			array_filter(
+			(array) array_filter(
 				$lessons,
 				function( $lesson ) {
 					return \Sensei_Lesson::lesson_quiz_has_questions( $lesson['id'] );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -766,7 +766,7 @@ class Sensei_Admin {
 		}
 
 		// Persist new lesson order to course meta.
-		$new_lesson_order_string = join( ',', $new_lesson_order );
+		$new_lesson_order_string = implode( ',', $new_lesson_order );
 		update_post_meta( $course_id, '_lesson_order', $new_lesson_order_string );
 	}
 
@@ -884,7 +884,7 @@ class Sensei_Admin {
 		if ( ! is_wp_error( $new_post_id ) ) {
 
 			$post_meta = get_post_custom( $post->ID );
-			if ( $post_meta && count( $post_meta ) > 0 ) {
+			if ( $post_meta ) {
 
 				/**
 				 * Ignored meta fields when duplicating a post.
@@ -1088,7 +1088,7 @@ class Sensei_Admin {
 
 		$html = '';
 
-		if ( 0 == count( $settings ) ) {
+		if ( ! $settings ) {
 			return $html;
 		}
 
@@ -1379,7 +1379,7 @@ class Sensei_Admin {
 
 								$courses = Sensei()->course->get_all_courses();
 
-								if ( 0 < count( $courses ) ) {
+								if ( $courses ) {
 
 									// order the courses as set by the users
 									$all_course_ids = array();

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -498,7 +498,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 						remove_filter( 'comments_clauses', array( 'Sensei_Utils', 'comment_total_sum_meta_value_filter' ) );
 
 						$grade_count          = ! empty( $lesson_grades->total ) ? $lesson_grades->total : 1;
-						$grade_total          = ! empty( $lesson_grades->meta_sum ) ? doubleval( $lesson_grades->meta_sum ) : 0;
+						$grade_total          = ! empty( $lesson_grades->meta_sum ) ? floatval( $lesson_grades->meta_sum ) : 0;
 						$lesson_average_grade = Sensei_Utils::quotient_as_absolute_rounded_number( $grade_total, $grade_count, 2 );
 					}
 					// Output lesson data

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1884,7 +1884,7 @@ class Sensei_Course {
 				// Get Course Categories
 				$category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
 
-				$active_html .= '<article class="' . esc_attr( join( ' ', get_post_class( [ 'course', 'post' ], $course_item->ID ) ) ) . '">';
+				$active_html .= '<article class="' . esc_attr( implode( ' ', get_post_class( [ 'course', 'post' ], $course_item->ID ) ) ) . '">';
 
 				// Image
 				$active_html .= Sensei()->course->course_image( absint( $course_item->ID ), '100', '100', true );
@@ -2025,7 +2025,7 @@ class Sensei_Course {
 				// Get Course Categories
 				$category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
 
-				$complete_html .= '<article class="' . esc_attr( join( ' ', get_post_class( [ 'course', 'post' ], $course_item->ID ) ) ) . '">';
+				$complete_html .= '<article class="' . esc_attr( implode( ' ', get_post_class( [ 'course', 'post' ], $course_item->ID ) ) ) . '">';
 
 				// Image
 				$complete_html .= Sensei()->course->course_image( absint( $course_item->ID ), 100, 100, true );
@@ -4056,9 +4056,10 @@ class Sensei_Course {
 	public function log_initial_publish_event( $course ) {
 		$product_ids   = get_post_meta( $course->ID, '_course_woocommerce_product', false );
 		$product_count = empty( $product_ids ) ? 0 : count( array_filter( $product_ids, 'is_numeric' ) );
+		$modules       = wp_get_post_terms( $course->ID, 'module' );
 
 		$event_properties = [
-			'module_count'  => count( wp_get_post_terms( $course->ID, 'module' ) ),
+			'module_count'  => is_countable( $modules ) ? count( $modules ) : 0,
 			'lesson_count'  => $this->course_lesson_count( $course->ID ),
 			'product_count' => $product_count,
 			'sample_course' => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG === $course->post_name ? 1 : 0,
@@ -4148,6 +4149,7 @@ class Sensei_Course {
 		$content       = $post->post_content;
 		$product_ids   = get_post_meta( $course_id, '_course_woocommerce_product', false );
 		$product_count = empty( $product_ids ) ? 0 : count( array_filter( $product_ids, 'is_numeric' ) );
+		$modules       = wp_get_post_terms( $course_id, 'module' );
 
 		$event_properties = [
 			'course_id'                     => $course_id,
@@ -4156,7 +4158,7 @@ class Sensei_Course {
 			'has_take_course_block'         => has_block( 'sensei-lms/button-take-course', $content ) ? 1 : 0,
 			'has_contact_teacher_block'     => has_block( 'sensei-lms/button-contact-teacher', $content ) ? 1 : 0,
 			'has_conditional_content_block' => has_block( 'sensei-lms/conditional-content', $content ) ? 1 : 0,
-			'module_count'                  => count( wp_get_post_terms( $course_id, 'module' ) ),
+			'module_count'                  => is_countable( $modules ) ? count( $modules ) : 0,
 			'lesson_count'                  => $this->course_lesson_count( $course_id ),
 			'product_count'                 => $product_count,
 			'sample_course'                 => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG === $post->post_name ? 1 : 0,

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -563,7 +563,7 @@ class Sensei_Frontend {
 	public function lesson_tags_display( $lesson_id = 0 ) {
 		if ( $lesson_id ) {
 			$tags = wp_get_post_terms( $lesson_id, 'lesson-tag' );
-			if ( $tags && count( $tags ) > 0 ) {
+			if ( $tags ) {
 				$tag_list = '';
 				foreach ( $tags as $tag ) {
 					$tag_link = get_term_link( $tag, 'lesson-tag' );
@@ -998,7 +998,7 @@ class Sensei_Frontend {
 					the_post();
 					?>
 
-					<article class="<?php echo esc_attr( join( ' ', get_post_class( array( 'course', 'post' ), get_the_ID() ) ) ); ?>">
+					<article class="<?php echo esc_attr( implode( ' ', get_post_class( array( 'course', 'post' ), get_the_ID() ) ) ); ?>">
 
 						<?php do_action( 'sensei_course_archive_meta' ); ?>
 

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -246,7 +246,7 @@ class Sensei_Grading_User_Quiz {
 				 */
 				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id, $right_answer, $user_answer_content );
 
-				if ( null !== $possibly_new_args && 0 < count( $possibly_new_args ) ) {
+				if ( null !== $possibly_new_args && $possibly_new_args ) {
 					$type_name           = $possibly_new_args['type_name'] ?? $type_name;
 					$right_answer        = $possibly_new_args['right_answer'] ?? $right_answer;
 					$user_answer_content = $possibly_new_args['user_answer_content'] ?? $user_answer_content;

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -523,7 +523,7 @@ class Sensei_Grading {
 		$courses     = get_posts( apply_filters( 'sensei_grading_filter_courses', $course_args ) );
 
 		$html .= '<option value="">' . __( 'Select a course', 'sensei-lms' ) . '</option>';
-		if ( count( $courses ) > 0 ) {
+		if ( $courses ) {
 			foreach ( $courses as $course_id ) {
 				$html .= '<option value="' . esc_attr( absint( $course_id ) ) . '" ' . selected( $course_id, $selected_course_id, false ) . '>' . esc_html( get_the_title( $course_id ) ) . '</option>' . "\n";
 			}
@@ -614,7 +614,7 @@ class Sensei_Grading {
 			$lessons     = get_posts( apply_filters( 'sensei_grading_filter_lessons', $lesson_args ) );
 
 			$html .= '<option value="">' . esc_html__( 'Select a lesson', 'sensei-lms' ) . '</option>';
-			if ( count( $lessons ) > 0 ) {
+			if ( $lessons ) {
 				foreach ( $lessons as $lesson_id ) {
 					$html .= '<option value="' . esc_attr( absint( $lesson_id ) ) . '" ' . selected( $lesson_id, $selected_lesson_id, false ) . '>' . esc_html( get_the_title( $lesson_id ) ) . '</option>' . "\n";
 				}
@@ -1287,7 +1287,7 @@ class Sensei_Grading {
 			) averages_by_course"
 		);
 
-		return doubleval( $result->courses_average );
+		return floatval( $result->courses_average );
 	}
 }
 

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -161,7 +161,7 @@ class Sensei_Guest_User {
 	public function log_guest_user_out_before_all_actions() {
 		if (
 			is_user_logged_in() &&
-			$this->is_current_user_guest()
+			self::is_current_user_guest()
 		) {
 			$this->guest_user_id = get_current_user_id();
 			wp_set_current_user( 0 );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -756,7 +756,7 @@ class Sensei_Learner {
 		}
 
 		$html_items = [];
-		if ( count( $courses ) > 0 ) {
+		if ( $courses ) {
 			foreach ( $courses as $course ) {
 				$html_items[] = '<a href="' . esc_url( $controller->get_learner_management_course_url( $course->ID ) ) .
 								'" class="sensei-students__enrolled-course" data-course-id="' . esc_attr( $course->ID ) . '">' .

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -748,21 +748,17 @@ class Sensei_Learner {
 		$learner_manager = self::instance();
 		$controller      = new Sensei_Learners_Admin_Bulk_Actions_Controller( new Sensei_Learner_Management( '' ), $learner_manager );
 		$base_query_args = [ 'posts_per_page' => -1 ];
-		$posts           = $learner_manager->get_enrolled_courses_query( $user_id, $base_query_args )->posts;
-		$courses         = 0;
-		if ( $posts ) {
-			// We only want to show courses after the third one in the UI.
-			$courses = array_slice( $posts, 3 );
-		}
+		$courses_query   = $learner_manager->get_enrolled_courses_query( $user_id, $base_query_args );
+
+		// We only want to show courses after the third one in the UI.
+		$courses = array_slice( $courses_query->posts, 3 );
 
 		$html_items = [];
-		if ( $courses ) {
-			foreach ( $courses as $course ) {
-				$html_items[] = '<a href="' . esc_url( $controller->get_learner_management_course_url( $course->ID ) ) .
-								'" class="sensei-students__enrolled-course" data-course-id="' . esc_attr( $course->ID ) . '">' .
-								esc_html( $course->post_title ) .
-								'</a>';
-			}
+		foreach ( $courses as $course ) {
+			$html_items[] = '<a href="' . esc_url( $controller->get_learner_management_course_url( $course->ID ) ) .
+							'" class="sensei-students__enrolled-course" data-course-id="' . intval( $course->ID ) . '">' .
+							esc_html( $course->post_title ) .
+							'</a>';
 		}
 		wp_send_json_success( $html_items );
 		exit();

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1457,13 +1457,13 @@ class Sensei_Lesson {
 
 		$random_order                = null;
 		$question_grade              = null;
-		$question_media_add_button   = null;
-		$question_media_delete_class = null;
-		$question_media_link_class   = null;
-		$question_media_link         = null;
-		$question_media_thumb_class  = null;
-		$question_media_thumb        = null;
-		$question_media              = null;
+		$question_media_add_button   = '';
+		$question_media_delete_class = '';
+		$question_media_link_class   = '';
+		$question_media_link         = '';
+		$question_media_thumb_class  = '';
+		$question_media_thumb        = '';
+		$question_media              = '';
 		$html                        = '';
 		$question_class              = '';
 
@@ -1534,7 +1534,7 @@ class Sensei_Lesson {
 					$question                = get_post( $question_id );
 					$html                   .= '<td class="table-count question-number question-count-column"><span class="number">' . esc_html( $question_counter ) . '</span></td>';
 					$html                   .= '<td>' . esc_html( $question->post_title ) . '</td>';
-					$html                   .= '<td class="question-grade-column">' . esc_html( $question_grade ) . '</td>';
+					$html                   .= '<td class="question-grade-column">' . esc_html( (string) $question_grade ) . '</td>';
 					$question_types_filtered = ucwords( str_replace( array( 'boolean', 'multiple-choice', 'gap-fill', 'single-line', 'multi-line', 'file-upload' ), array( __( 'True/False', 'sensei-lms' ), __( 'Multiple Choice', 'sensei-lms' ), __( 'Gap Fill', 'sensei-lms' ), __( 'Single Line', 'sensei-lms' ), __( 'Multi Line', 'sensei-lms' ), __( 'File Upload', 'sensei-lms' ) ), $question_type ) );
 					$html                   .= '<td>' . esc_html( $question_types_filtered ) . '</td>';
 
@@ -1592,7 +1592,7 @@ class Sensei_Lesson {
 							// Question grade
 							$html     .= '<div>';
 								$html .= '<label for="question_' . esc_attr( $question_counter ) . '_grade">' . esc_html__( 'Grade:', 'sensei-lms' ) . '</label> ';
-								$html .= '<input type="number" id="question_' . esc_attr( $question_counter ) . '_grade" class="question_grade small-text" name="question_grade" min="0" value="' . esc_attr( $question_grade ) . '" />';
+								$html .= '<input type="number" id="question_' . esc_attr( $question_counter ) . '_grade" class="question_grade small-text" name="question_grade" min="0" value="' . esc_attr( (string) $question_grade ) . '" />';
 							$html     .= '</div>';
 
 							// Random order
@@ -1608,7 +1608,7 @@ class Sensei_Lesson {
 								$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button" class="upload_media_file_button button-secondary" data-uploader-title="' . esc_attr__( 'Add file to question', 'sensei-lms' ) . '" data-uploader-button-text="' . esc_attr__( 'Add to question', 'sensei-lms' ) . '">' . esc_html( $question_media_add_button ) . '</button>';
 								$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button_delete" class="delete_media_file_button button-secondary ' . esc_attr( $question_media_delete_class ) . '">' . esc_html__( 'Delete file', 'sensei-lms' ) . '</button><br/>';
 								$html .= '<span id="question_' . esc_attr( $question_counter ) . '_media_link" class="question_media_link ' . esc_attr( $question_media_link_class ) . '">' . wp_kses_post( $question_media_link ) . '</span>';
-								$html .= '<br/><img id="question_' . esc_attr( $question_counter ) . '_media_preview" class="question_media_preview ' . esc_attr( $question_media_thumb_class ) . '" src="' . esc_url( $question_media_thumb ) . '" /><br/>';
+								$html .= '<br/><img id="question_' . esc_attr( $question_counter ) . '_media_preview" class="question_media_preview ' . esc_attr( $question_media_thumb_class ) . '" src="' . esc_url( (string) $question_media_thumb ) . '" /><br/>';
 								$html .= '<input type="hidden" id="question_' . esc_attr( $question_counter ) . '_media" class="question_media" name="question_media" value="' . esc_attr( $question_media ) . '" />';
 							$html     .= '</div>';
 
@@ -2876,7 +2876,7 @@ class Sensei_Lesson {
 	 * @access public
 	 */
 	public function lesson_update_question() {
-		$nonce = null;
+		$nonce = '';
 		// Add nonce security to the request.
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -3161,7 +3161,7 @@ class Sensei_Lesson {
 	}
 
 	public function lesson_update_grade_type() {
-		$nonce = null;
+		$nonce = '';
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_grade_type_nonce'] ) ) {
 
@@ -3186,7 +3186,7 @@ class Sensei_Lesson {
 	}
 
 	public function lesson_update_question_order() {
-		$nonce = null;
+		$nonce = '';
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -3220,7 +3220,7 @@ class Sensei_Lesson {
 	}
 
 	public function lesson_update_question_order_random() {
-		$nonce = null;
+		$nonce = '';
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_random_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -3676,7 +3676,7 @@ class Sensei_Lesson {
 		// If viewing quiz on the frontend then show questions in random order if set.
 		if ( ! is_admin() ) {
 			$random_order = get_post_meta( $quiz_id, '_random_question_order', true );
-			if ( $random_order && 'yes' === $random_order ) {
+			if ( 'yes' === $random_order ) {
 				$orderby = 'rand';
 			}
 		}
@@ -3808,8 +3808,10 @@ class Sensei_Lesson {
 						$show_questions > $questions_count ? $questions_count : $show_questions
 					);
 
-					// Loop through all questions and pick the the ones to be shown based on the random key selection.
+					// Loop through all questions and pick the ones to be shown based on the random key selection.
 					$questions = [];
+
+					// @psalm-suppress PossibleRawObjectIteration -- For some reason, Psalm thinks that $questions_array is an object.
 					foreach ( $questions_array as $k => $question ) {
 
 						// Random keys will always be an array, unless only one question is to be shown.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -817,7 +817,7 @@ class Sensei_Lesson {
 		$post   = get_post( $post_id );
 		$blocks = parse_blocks( $post->post_content );
 
-		if ( 0 === count( $blocks ) || 'sensei-lms/featured-video' !== $blocks[0]['blockName'] ) {
+		if ( ! $blocks || 'sensei-lms/featured-video' !== $blocks[0]['blockName'] ) {
 			return null;
 		}
 
@@ -1024,7 +1024,7 @@ class Sensei_Lesson {
 		update_post_meta( $post_id, '_lesson_quiz', $quiz_id );
 		// Mark if the Lesson Quiz has questions
 		$quiz_questions = Sensei()->lesson->lesson_quiz_questions( $quiz_id );
-		if ( 0 < count( $quiz_questions ) ) {
+		if ( $quiz_questions ) {
 			update_post_meta( $post_id, '_quiz_has_questions', '1' );
 		} else {
 			delete_post_meta( $post_id, '_quiz_has_questions' );
@@ -1405,7 +1405,7 @@ class Sensei_Lesson {
 
 		$html = '';
 
-		if ( count( $questions ) > 0 ) {
+		if ( $questions ) {
 			$question_counter = 1;
 
 			foreach ( $questions as $question ) {
@@ -1455,9 +1455,18 @@ class Sensei_Lesson {
 	public function quiz_panel_question( $question_type = '', $question_counter = 0, $question_id = 0, $context = 'quiz', $multiple_data = array() ) {
 		global $row_counter;
 
-		$html = '';
+		$random_order                = null;
+		$question_grade              = null;
+		$question_media_add_button   = null;
+		$question_media_delete_class = null;
+		$question_media_link_class   = null;
+		$question_media_link         = null;
+		$question_media_thumb_class  = null;
+		$question_media_thumb        = null;
+		$question_media              = null;
+		$html                        = '';
+		$question_class              = '';
 
-		$question_class = '';
 		if ( 'quiz' == $context ) {
 			if ( ! $row_counter || ! isset( $row_counter ) ) {
 				$row_counter = 1;
@@ -2867,6 +2876,7 @@ class Sensei_Lesson {
 	 * @access public
 	 */
 	public function lesson_update_question() {
+		$nonce = null;
 		// Add nonce security to the request.
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -3151,6 +3161,7 @@ class Sensei_Lesson {
 	}
 
 	public function lesson_update_grade_type() {
+		$nonce = null;
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_grade_type_nonce'] ) ) {
 
@@ -3175,6 +3186,7 @@ class Sensei_Lesson {
 	}
 
 	public function lesson_update_question_order() {
+		$nonce = null;
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -3208,6 +3220,7 @@ class Sensei_Lesson {
 	}
 
 	public function lesson_update_question_order_random() {
+		$nonce = null;
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_random_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -3244,6 +3257,7 @@ class Sensei_Lesson {
 		$question_wrong_answers = $question_right_answers = array();
 		$question_type          = 'multiple-choice';
 		$question_category      = '';
+		$question_grade         = null;
 
 		// Handle Question Type
 		if ( isset( $data['question_type'] ) && ( '' != $data['question_type'] ) ) {
@@ -3365,7 +3379,7 @@ class Sensei_Lesson {
 			}
 		}
 
-		$wrong_answer_count = count( $question_wrong_answers );
+		$wrong_answer_count = is_countable( $question_wrong_answers ) ? count( $question_wrong_answers ) : 0;
 
 		// Only save if there is a valid title
 		if ( $post_title != '' ) {
@@ -3788,9 +3802,10 @@ class Sensei_Lesson {
 				// Negative amount is considered as All (same as zero).
 				if ( $show_questions > 0 ) {
 					// Get random set of array keys from selected questions array.
+					$questions_count    = is_countable( $questions_array ) ? count( $questions_array ) : 0;
 					$selected_questions = array_rand(
 						$questions_array,
-						$show_questions > count( $questions_array ) ? count( $questions_array ) : $show_questions
+						$show_questions > $questions_count ? $questions_count : $show_questions
 					);
 
 					// Loop through all questions and pick the the ones to be shown based on the random key selection.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3811,7 +3811,6 @@ class Sensei_Lesson {
 					// Loop through all questions and pick the ones to be shown based on the random key selection.
 					$questions = [];
 
-					// @psalm-suppress PossibleRawObjectIteration -- For some reason, Psalm thinks that $questions_array is an object.
 					foreach ( $questions_array as $k => $question ) {
 
 						// Random keys will always be an array, unless only one question is to be shown.

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -604,6 +604,7 @@ class Sensei_Messages {
 			return false;
 		}
 
+		$user_login = null;
 		if ( $user_id == 0 ) {
 			global $current_user;
 			wp_get_current_user();

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1187,7 +1187,7 @@ class Sensei_Core_Modules {
 		);
 		$lessons = get_posts( $args );
 
-		if ( is_wp_error( $lessons ) || 0 >= count( $lessons ) ) {
+		if ( is_wp_error( $lessons ) || ! $lessons ) {
 			return 0;
 		}
 
@@ -2546,10 +2546,12 @@ class Sensei_Core_Modules {
 	 */
 	public function filter_course_selected_terms( $terms, $course_ids_array, $taxonomies ) {
 
+		$taxonomies_count = is_countable( $taxonomies ) ? count( $taxonomies ) : 0;
+
 		// dont limit for admins and other taxonomies. This should also only apply to admin
 		if ( current_user_can( 'manage_options' ) || ! is_admin() || empty( $terms )
 			// only apply this to module only taxonomy queries so 1 taxonomy only:
-			|| count( $taxonomies ) > 1 || ! in_array( 'module', $taxonomies ) ) {
+			|| $taxonomies_count > 1 || ! in_array( 'module', $taxonomies ) ) {
 			return $terms;
 		}
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -384,7 +384,7 @@ class Sensei_Question {
 			$quizzes = array_unique( array_filter( $quizzes ) );
 		}
 
-		if ( 0 == count( $quizzes ) ) {
+		if ( ! $quizzes ) {
 			echo wp_kses_post( $no_lessons );
 			return;
 		}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1673,7 +1673,7 @@ class Sensei_Quiz {
 		}
 
 		$sensei_question_loop['questions_asked'] = wp_list_pluck( $all_questions, 'ID' );
-		$sensei_question_loop['total']           = count( $all_questions );
+		$sensei_question_loop['total']           = is_countable( $all_questions ) ? count( $all_questions ) : 0;
 
 		// Paginate the questions.
 		if ( $sensei_question_loop['posts_per_page'] > 0 ) {
@@ -2365,7 +2365,7 @@ class Sensei_Quiz {
 			return;
 		}
 
-		$quiz_available = $this->is_quiz_available( $quiz_id, $user_id );
+		$quiz_available = static::is_quiz_available($quiz_id, $user_id);
 		if ( ! $quiz_available ) {
 			return;
 		}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2365,7 +2365,7 @@ class Sensei_Quiz {
 			return;
 		}
 
-		$quiz_available = static::is_quiz_available($quiz_id, $user_id);
+		$quiz_available = static::is_quiz_available( $quiz_id, $user_id );
 		if ( ! $quiz_available ) {
 			return;
 		}

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -264,7 +264,7 @@ class Sensei_Settings_API {
 	 * @return void
 	 */
 	private function create_tabs() {
-		if ( count( $this->sections ) > 0 ) {
+		if ( $this->sections ) {
 			$tabs = array();
 			foreach ( $this->sections as $k => $v ) {
 				$tabs[ $k ] = $v;
@@ -281,7 +281,7 @@ class Sensei_Settings_API {
 	 * @return void
 	 */
 	public function create_sections() {
-		if ( count( $this->sections ) > 0 ) {
+		if ( $this->sections ) {
 			foreach ( $this->sections as $k => $v ) {
 				add_settings_section( $k, $v['name'], array( $this, 'section_description' ), $this->token );
 			}
@@ -296,7 +296,7 @@ class Sensei_Settings_API {
 	 * @return void
 	 */
 	public function create_fields() {
-		if ( count( $this->sections ) > 0 ) {
+		if ( $this->sections ) {
 
 			foreach ( $this->fields as $k => $v ) {
 				$method = $this->determine_method( $v, 'form' );
@@ -1130,7 +1130,7 @@ class Sensei_Settings_API {
 	 * @return  void
 	 */
 	protected function parse_errors() {
-		if ( count( $this->errors ) > 0 ) {
+		if ( $this->errors ) {
 			foreach ( $this->errors as $k => $v ) {
 				add_settings_error( $this->token . '-errors', $k, $v, 'error' );
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1480,11 +1480,11 @@ class Sensei_Utils {
 			return 0;
 		}
 
-		return self::as_absolute_rounded_number( doubleval( $numerator ) / ( $denominator ), $decimal_places_to_round );
+		return self::as_absolute_rounded_number( floatval( $numerator ) / ( $denominator ), $decimal_places_to_round );
 	}
 
 	public static function as_absolute_rounded_number( $number, $decimal_places_to_round = 0 ) {
-		return abs( round( ( doubleval( $number ) ), $decimal_places_to_round ) );
+		return abs( round( ( floatval( $number ) ), $decimal_places_to_round ) );
 	}
 
 	/**
@@ -2131,8 +2131,7 @@ class Sensei_Utils {
 			$drop_down_element .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>';
 		}
 
-		if ( count( $options ) > 0 ) {
-
+		if ( $options ) {
 			foreach ( $options as $value => $option ) {
 
 				$element  = '';

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -114,7 +114,7 @@ class Sensei_Course_Theme_Editor {
 	 */
 	public function maybe_add_site_editor_hooks() {
 
-		if ( $this->is_site_editor_request() ) {
+		if ( static::is_site_editor_request() ) {
 			$this->add_site_editor_hooks();
 		}
 	}

--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -140,14 +140,14 @@ class Sensei_Import_CSV_Reader {
 	 */
 	private function get_columns_number() {
 		$this->file->seek( 0 );
-		$first_line_columns = count( $this->file->current() );
+		$first_line_columns = is_countable( $this->file->current() ) ? count( $this->file->current() ) : 0;
 
 		// Skip the header.
 		$this->file->next();
 
 		while ( ! $this->file->eof() ) {
 			$second_line         = $this->file->current();
-			$second_line_columns = count( $second_line );
+			$second_line_columns = is_countable( $second_line ) ? count( $second_line ) : 0;
 
 			// SplFileObject->current() returns [ 0 => null ] on empty lines.
 			if ( 1 === $second_line_columns && empty( $second_line[0] ) ) {
@@ -197,7 +197,7 @@ class Sensei_Import_CSV_Reader {
 		while ( $lines_processed < $this->lines_per_batch ) {
 			$lines_processed++;
 
-			$indexed_line = $this->file->current();
+			$indexed_line = is_array( $this->file->current() ) ? $this->file->current() : [];
 
 			// SplFileObject->current() returns [ 0 => null ] on empty lines.
 			if ( 1 < count( $indexed_line ) || ( 1 === count( $indexed_line ) && ! empty( $indexed_line[0] ) ) ) {

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -130,8 +130,7 @@ class Email_Sender {
 					$recipient,
 					$subject,
 					$message,
-					$this->get_email_headers(),
-					null
+					$this->get_email_headers()
 				);
 				sensei_log_event( 'email_send', [ 'type' => $usage_tracking_type ] );
 			}

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -91,7 +91,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			? Sensei_Utils::quotient_as_absolute_rounded_percentage( $total_counts->lesson_completed_count, $total_counts->lesson_start_count ) . '%'
 			: '0%';
 		foreach ( $column_value_map as $key => $value ) {
-			if ( key_exists( $key, $columns ) ) {
+			if ( array_key_exists( $key, $columns ) ) {
 				$columns[ $key ] = $columns[ $key ] . ' (' . esc_html( $value ) . ')';
 			}
 		}
@@ -276,7 +276,8 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 		$default_args  = array(
 			'fields' => 'ids',
 		);
-		$modules_count = count( wp_get_object_terms( $lessons, 'module', $default_args ) );
+		$modules       = wp_get_object_terms( $lessons, 'module', $default_args );
+		$modules_count = is_countable( $modules ) ? count( $modules ) : 0;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
 		$lesson_completion_info                      = $wpdb->get_row(
 			$wpdb->prepare(

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -125,7 +125,7 @@ class Sensei_Reports_Overview_Service_Courses {
 		) averages_by_course'
 		);
 
-		return doubleval( $result->courses_average );
+		return floatval( $result->courses_average );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -152,7 +152,7 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function request_get_job( $request ) {
-		$job_id = $this->get_job_id_param( $request );
+		$job_id = static::get_job_id_param($request);
 		$job    = $this->resolve_job( $job_id, true );
 
 		if ( ! $job ) {
@@ -180,7 +180,7 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function request_process_job( $request ) {
-		$job = $this->get_job( $this->get_job_id_param( $request ) );
+		$job = $this->get_job( static::get_job_id_param($request) );
 
 		if ( ! $job ) {
 			return new WP_Error(

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -152,7 +152,7 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function request_get_job( $request ) {
-		$job_id = static::get_job_id_param($request);
+		$job_id = static::get_job_id_param( $request );
 		$job    = $this->resolve_job( $job_id, true );
 
 		if ( ! $job ) {
@@ -180,7 +180,7 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function request_process_job( $request ) {
-		$job = $this->get_job( static::get_job_id_param($request) );
+		$job = $this->get_job( static::get_job_id_param( $request ) );
 
 		if ( ! $job ) {
 			return new WP_Error(

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -615,7 +615,7 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 			sensei_log_event(
 				'setup_wizard_purpose_continue',
 				[
-					'purpose'         => join( ',', $setup_purpose_data['selected'] ?? [] ),
+					'purpose'         => implode( ',', $setup_purpose_data['selected'] ?? [] ),
 					'purpose_details' => $setup_purpose_data['other'] ?? '',
 				]
 			);

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -154,7 +154,7 @@ function sensei_get_modules_and_lessons( $course_id ) {
 		foreach ( (array) $course_modules as $module ) {
 			$module_lessons = Sensei()->modules->get_lessons( $course_id, $module->term_id );
 
-			if ( count( $module_lessons ) === 0 ) {
+			if ( ! $module_lessons ) {
 				continue;
 			}
 
@@ -683,7 +683,11 @@ function sensei_quiz_has_questions() {
 
 	global $sensei_question_loop;
 
-	$questions_count = count( $sensei_question_loop['questions'] );
+	if ( empty( $sensei_question_loop['questions'] ) ) {
+		return false;
+	}
+
+	$questions_count = is_countable( $sensei_question_loop['questions'] ) ? count( $sensei_question_loop['questions'] ) : 0;
 
 	if ( 0 === $questions_count ) {
 		return false;

--- a/templates/content-lesson.php
+++ b/templates/content-lesson.php
@@ -81,5 +81,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	</section> <!-- article .lesson-content -->
 
-</article> <!-- article .(<?php echo esc_attr( join( ' ', get_post_class( array( 'lesson', 'post' ) ) ) ); ?>  -->
+</article> <!-- article .(<?php echo esc_attr( implode( ' ', get_post_class( array( 'lesson', 'post' ) ) ) ); ?>  -->
 

--- a/templates/content-message.php
+++ b/templates/content-message.php
@@ -80,4 +80,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	</section> <!-- article .message-content -->
 
-</article> <!-- article .(<?php echo esc_attr( join( ' ', get_post_class( array( 'sensei_message', 'post' ) ) ) ); ?>  -->
+</article> <!-- article .(<?php echo esc_attr( implode( ' ', get_post_class( array( 'sensei_message', 'post' ) ) ) ); ?>  -->

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -57,7 +57,7 @@ global $course;
 			$lessons_query = Sensei()->modules->get_lessons_query( $course->ID, $module->term_id );
 			$lessons       = $lessons_query->get_posts();
 
-			if ( count( $lessons ) > 0 ) {
+			if ( $lessons ) {
 
 				$course_has_lessons_in_modules = true;
 
@@ -112,7 +112,7 @@ global $course;
 		<?php
 
 		$lessons = Sensei()->modules->get_none_module_lessons( $course->ID );
-		if ( 0 < count( $lessons ) ) :
+		if ( $lessons ) :
 			?>
 
 			<?php

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -195,7 +195,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 
 		$posts_array = get_posts( $post_args );
 
-		if ( count( $posts_array ) > 0 ) {
+		if ( $posts_array ) {
 			?>
 			<ul>
 			<?php

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -222,6 +222,8 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 			$courses = apply_filters( 'sensei_widget_course_component_get_courses_' . $component, array(), $instance );
 		}
 
+		$courses = is_array( $courses ) ? $courses : [];
+
 		// course_query() is buggy, it doesn't honour the 1st arg if includes are provided, so instead slice the includes.
 		if ( ! empty( $instance['limit'] ) && intval( $instance['limit'] ) >= 1 && intval( $instance['limit'] ) < count( $courses ) ) {
 			$courses = array_slice( $courses, 0, intval( $instance['limit'] ) );

--- a/widgets/class-sensei-lesson-component-widget.php
+++ b/widgets/class-sensei-lesson-component-widget.php
@@ -188,7 +188,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 		);
 		$posts_array = get_posts( $post_args );
 
-		if ( count( $posts_array ) > 0 ) {
+		if ( $posts_array ) {
 			?>
 			<ul>
 			<?php


### PR DESCRIPTION
Resolves #7177

This PR improves the PHP 8.1 support by following the WP.com PHP 8.1 migration guidelines (p5TWut-OG-p2). 

## Proposed Changes

* Improve PHP 8.1 support by applying fixes generated by [wpcom-php-migration](https://github.com/Automattic/wpcom-php-migration). I think some of the Rector suggestions were false positive, so I've skipped those. 
* Fix an 8.1 deprecation warning that happens when sending emails.

## Testing Instructions
1. Set up the plugin on PHP 8.1.
2. Test the main features and make sure there are no errors.
3. (optional) Run the [wpcom-php-migration](https://github.com/Automattic/wpcom-php-migration) on the repository and check if something is a miss.
  
## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues