### PR TITLE
Update footer design for graded quiz

### DIFF
--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -61,13 +61,13 @@ body {
 	.wp-block-post-content {
 		margin-top: 40px;
 
-		& > *, .wp-block-group__inner-container > * {
+		& > *, & ~ div > *, .wp-block-group__inner-container > * {
 			max-width: var(--content-size) !important;
 			margin-left: auto;
 			margin-right: auto;
 		}
 
-		&, & > & {
+		&, & > &, & ~ div {
 			max-width: unset !important;
 			width: unset !important;
 			padding: 0 !important;

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -203,6 +203,11 @@ $vertical-spacing-desktop: 80px;
 
 .wp-block-sensei-lms-quiz-actions {
 
+	& > div:first-child.sensei-quiz-actions-secondary {
+		flex-grow: 1;
+		justify-content: end;
+	}
+
 	.sensei-course-theme__button.is-primary {
 		width: auto;
 	}

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -202,10 +202,14 @@ $vertical-spacing-desktop: 80px;
 }
 
 .wp-block-sensei-lms-quiz-actions {
+
+	.sensei-course-theme__button.is-primary {
+		width: auto;
+	}
+
 	button:disabled {
 		cursor: not-allowed;
 		pointer-events: none;
-		width: auto;
 	}
 }
 

--- a/changelog/add-footer-design-for-graded-quiz
+++ b/changelog/add-footer-design-for-graded-quiz
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated stylings of graded quizzes footer in learning mode

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -161,10 +161,9 @@ class Lesson_Actions {
 
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
-		$is_learning_mode  = \Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
-		$is_awaiting_grade = \Sensei_Quiz::is_quiz_awaiting_grade_for_user( $lesson_id, $user_id );
+		$is_learning_mode = \Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
 
-		if ( $is_learning_mode && $is_awaiting_grade && 'quiz' === get_post_type() ) {
+		if ( $is_learning_mode && 'quiz' === get_post_type() ) {
 			return '';
 		}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2434,7 +2434,7 @@ class Sensei_Quiz {
 	 *
 	 * @return string|null Next lesson URL if condition holds, null otherwise.
 	 */
-	public static function maybe_get_next_lesson_url_for_quiz_footer( $lesson_id = null, $user_id = null ) {
+	private static function maybe_get_next_lesson_url_for_quiz_footer( $lesson_id = null, $user_id = null ) {
 		if ( empty( $lesson_id ) ) {
 			$lesson_id = Sensei()->quiz->get_lesson_id();
 		}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1905,9 +1905,11 @@ class Sensei_Quiz {
 				</div>
 			<?php endif ?>
 
-			<?php if ( $post_grade_action ) :
-				echo wp_kses_post( $post_grade_action );
-			endif ?>
+			<?php
+				if ( $post_grade_action ) {
+					echo wp_kses_post( $post_grade_action );
+				}
+			?>
 
 			<?php if ( $is_awaiting_grade && $is_learning_mode ) : ?>
 				<button type="button" class="wp-element-button sensei-course-theme__button is-primary" disabled>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2444,7 +2444,7 @@ class Sensei_Quiz {
 		}
 
 		if ( empty( $lesson_id ) || empty( $user_id ) || 'lesson' !== get_post_type( $lesson_id ) || 'quiz' !== get_post_type() ) {
-			return '';
+			return null;
 		}
 
 		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, $user_id );

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1897,7 +1897,7 @@ class Sensei_Quiz {
 							class="wp-block-button__link button quiz-submit complete sensei-course-theme__button sensei-stop-double-submission"
 							style="<?php echo esc_attr( $button_inline_styles ); ?>"
 						>
-							<?php esc_attr_e( 'Complete Quiz', 'sensei-lms' ); ?>
+							<?php esc_html_e( 'Complete Quiz', 'sensei-lms' ); ?>
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
@@ -1907,13 +1907,13 @@ class Sensei_Quiz {
 
 			<?php if ( $next_lesson_url ) : ?>
 				<a class="wp-element-button sensei-course-theme__button is-primary" href="<?php echo esc_url( $next_lesson_url ); ?>">
-					<?php esc_attr_e( 'Continue to next lesson', 'sensei-lms' ); ?>
+					<?php esc_html_e( 'Continue to next lesson', 'sensei-lms' ); ?>
 				</a>
 			<?php endif ?>
 
 			<?php if ( $is_awaiting_grade && $is_learning_mode ) : ?>
 				<button type="button" class="wp-element-button sensei-course-theme__button is-primary" disabled>
-					<?php esc_attr_e( 'Pending teacher grade', 'sensei-lms' ); ?>
+					<?php esc_html_e( 'Pending teacher grade', 'sensei-lms' ); ?>
 				</button>
 			<?php endif ?>
 
@@ -1921,7 +1921,7 @@ class Sensei_Quiz {
 				<?php if ( $is_reset_allowed ) : ?>
 					<div class="sensei-quiz-action">
 						<button type="submit" name="quiz_reset" form="sensei-quiz-form" class="quiz-submit reset sensei-stop-double-submission sensei-course-theme__button is-link">
-							<?php esc_attr_e( 'Restart Quiz', 'sensei-lms' ); ?>
+							<?php esc_html_e( 'Restart Quiz', 'sensei-lms' ); ?>
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
@@ -1931,7 +1931,7 @@ class Sensei_Quiz {
 				<?php if ( ! $is_quiz_completed ) : ?>
 					<div class="sensei-quiz-action">
 						<button type="submit" name="quiz_save" form="sensei-quiz-form" class="quiz-submit save sensei-stop-double-submission">
-							<?php esc_attr_e( 'Save Progress', 'sensei-lms' ); ?>
+							<?php esc_html_e( 'Save Progress', 'sensei-lms' ); ?>
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_save_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1905,11 +1905,9 @@ class Sensei_Quiz {
 				</div>
 			<?php endif ?>
 
-			<?php
-				if ( $post_grade_action ) {
-					echo wp_kses_post( $post_grade_action );
-				}
-			?>
+			<?php if ( $is_learning_mode && $post_grade_action ) : ?>
+				<?php echo wp_kses_post( $post_grade_action ); ?>
+			<?php endif ?>
 
 			<?php if ( $is_awaiting_grade && $is_learning_mode ) : ?>
 				<button type="button" class="wp-element-button sensei-course-theme__button is-primary" disabled>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1859,6 +1859,7 @@ class Sensei_Quiz {
 		$course_id         = Sensei()->lesson->get_course_id( $lesson_id );
 		$is_learning_mode  = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
 		$is_awaiting_grade = self::is_quiz_awaiting_grade_for_user( $lesson_id, get_current_user_id() );
+		$next_lesson_url   = self::maybe_get_next_lesson_url_for_quiz_footer( $lesson_id, get_current_user_id() );
 
 		$show_grade_pending_button = $is_learning_mode && $is_awaiting_grade;
 
@@ -1902,6 +1903,12 @@ class Sensei_Quiz {
 						<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" form="sensei-quiz-form" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
 					</div>
 				</div>
+			<?php endif ?>
+
+			<?php if ( $next_lesson_url ) : ?>
+				<a class="wp-element-button sensei-course-theme__button is-primary" href="<?php echo esc_url( $next_lesson_url ); ?>">
+					<?php esc_attr_e( 'Continue to next lesson', 'sensei-lms' ); ?>
+				</a>
 			<?php endif ?>
 
 			<?php if ( $is_awaiting_grade && $is_learning_mode ) : ?>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1869,7 +1869,7 @@ class Sensei_Quiz {
 			]
 		);
 
-		$has_actions = $is_reset_allowed || ! $is_quiz_completed || $show_grade_pending_button;
+		$has_actions = $is_reset_allowed || ! $is_quiz_completed || $show_grade_pending_button || ! empty( $next_lesson_url );
 
 		if ( ! $has_actions ) {
 			return;
@@ -2462,6 +2462,7 @@ class Sensei_Quiz {
 		}
 
 		$prev_next_urls = sensei_get_prev_next_lessons( $lesson_id );
+
 		return $prev_next_urls['next']['url'] ?? null;
 	}
 

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2097,7 +2097,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Pending teacher grade', $result );
 	}
 
-	public function testQuizFooterActions_WhenPassedInLearningMode_ShowsTheNextLessonButton() {
+	public function testActionButtons_WhenPassedInLearningMode_ShowsTheNextLessonButton() {
 		/* Arrange */
 		$user_id   = $this->factory->user->create();
 		$course_id = $this->factory->course->create();
@@ -2147,7 +2147,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Continue to next lesson', $result );
 	}
 
-	public function testQuizFooterActions_WhenFailedInLearningModeButPassRequired_DoesNotShowTheNextLessonButton() {
+	public function testActionButtons_WhenFailedInLearningModeButPassRequired_DoesNotShowTheNextLessonButton() {
 		/* Arrange */
 		$user_id   = $this->factory->user->create();
 		$course_id = $this->factory->course->create();
@@ -2205,10 +2205,10 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
 
 		/* Assert */
-		$this->assertStringNotContainsString( 'Continue to next lesson', $result );
+		$this->assertStringContainsString( 'Contact teacher', $result );
 	}
 
-	public function testQuizFooterActions_WhenFailedInLearningModeButPassNotRequired_ShowsTheNextLessonButton() {
+	public function testActionButtons_WhenFailedInLearningModeButPassNotRequired_ShowsTheNextLessonButton() {
 		/* Arrange */
 		$user_id   = $this->factory->user->create();
 		$course_id = $this->factory->course->create();
@@ -2269,7 +2269,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Continue to next lesson', $result );
 	}
 
-	public function testQuizFooterActions_WhenPassedButNotInLearningMode_DoesNotShowTheNextLessonButton() {
+	public function testActionButtons_WhenPassedButNotInLearningMode_DoesNotShowTheNextLessonButton() {
 		/* Arrange */
 		$user_id   = $this->factory->user->create();
 		$course_id = $this->factory->course->create();
@@ -2327,7 +2327,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Continue to next lesson', $result );
 	}
 
-	public function testQuizFooterActions_WhenPassedButNextLessonHasLowerOrder_DoesNotShowTheNextLessonButton() {
+	public function testActionButtons_WhenPassedButNextLessonHasLowerOrder_DoesNotShowTheNextLessonButton() {
 		/* Arrange */
 		$user_id   = $this->factory->user->create();
 		$course_id = $this->factory->course->create();
@@ -2388,7 +2388,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Continue to next lesson', $result );
 	}
 
-	public function testQuizFooterActions_WhenQuizPassedButOnLessonPage_DoesNotShowTheNextLessonButton() {
+	public function testActionButtons_WhenQuizPassedButOnLessonPage_DoesNotShowTheNextLessonButton() {
 		/* Arrange */
 		$user_id   = $this->factory->user->create();
 		$course_id = $this->factory->course->create();

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2306,7 +2306,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		wp_set_current_user( $user_id );
 
-		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'failed' );
+		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'passed' );
 		update_comment_meta( $comment_id, 'grade', 2 );
 		update_post_meta( $quiz_id, '_pass_required', 0 );
 
@@ -2324,7 +2324,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
 
 		/* Assert */
-		$this->assertStringContainsString( 'Continue to next lesson', $result );
+		$this->assertStringNotContainsString( 'Continue to next lesson', $result );
 	}
 
 	public function testActionButtons_WhenPassedButNextLessonHasLowerOrder_DoesNotShowTheNextLessonButton() {

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2268,4 +2268,62 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertStringContainsString( 'Continue to next lesson', $result );
 	}
+
+	public function testQuizFooterActions_WhenPassedButNotInLearningMode_DoesNotShowTheNextLessonButton() {
+		/* Arrange */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_1  = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 1,
+					'_quiz_has_questions'  => 1,
+				],
+			]
+		);
+		$this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 2,
+				],
+			]
+		);
+
+		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_1 );
+		$this->factory->question->create(
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [ ' ', ' ', ' ' ],
+				'question_wrong_answers' => [ ' ' ],
+			]
+		);
+
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$course_enrolment->enrol( $user_id );
+
+		wp_set_current_user( $user_id );
+
+		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'failed' );
+		update_comment_meta( $comment_id, 'grade', 2 );
+		update_post_meta( $quiz_id, '_pass_required', 0 );
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		WP_Block_Supports::$block_to_render = [
+			'attrs'     => [],
+			'blockName' => 'sensei-lms/quiz-actions',
+		];
+
+		global $sensei_question_loop;
+		$sensei_question_loop['total_pages'] = 1;
+
+		/* Act */
+		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
+
+		/* Assert */
+		$this->assertStringContainsString( 'Continue to next lesson', $result );
+	}
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2127,7 +2127,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		// Enable course theme;
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
 
-		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'graded' );
+		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'passed' );
 		update_comment_meta( $comment_id, 'grade', 2 );
 
 		$this->go_to( get_permalink( $quiz_id ) );
@@ -2206,5 +2206,66 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		/* Assert */
 		$this->assertStringNotContainsString( 'Continue to next lesson', $result );
+	}
+
+	public function testQuizFooterActions_WhenFailedInLearningModeButPassNotRequired_ShowsTheNextLessonButton() {
+		/* Arrange */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_1  = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 1,
+					'_quiz_has_questions'  => 1,
+				],
+			]
+		);
+		$this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 2,
+				],
+			]
+		);
+
+		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_1 );
+		$this->factory->question->create(
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [ ' ', ' ', ' ' ],
+				'question_wrong_answers' => [ ' ' ],
+			]
+		);
+
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$course_enrolment->enrol( $user_id );
+
+		wp_set_current_user( $user_id );
+
+		// Enable course theme;
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'failed' );
+		update_comment_meta( $comment_id, 'grade', 2 );
+		update_post_meta( $quiz_id, '_pass_required', 0 );
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		WP_Block_Supports::$block_to_render = [
+			'attrs'     => [],
+			'blockName' => 'sensei-lms/quiz-actions',
+		];
+
+		global $sensei_question_loop;
+		$sensei_question_loop['total_pages'] = 1;
+
+		/* Act */
+		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
+
+		/* Assert */
+		$this->assertStringContainsString( 'Continue to next lesson', $result );
 	}
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2113,7 +2113,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			[
 				'meta_input' => [
 					'_lesson_course'       => $course_id,
-					'_order_' . $course_id => 1,
+					'_order_' . $course_id => 2,
 				],
 			]
 		);
@@ -2145,6 +2145,66 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		/* Assert */
 		$this->assertStringContainsString( 'Continue to next lesson', $result );
-		echo $result;
+	}
+
+	public function testQuizFooterActions_WhenFailedInLearningModeButPassRequired_DoesNotShowTheNextLessonButton() {
+		/* Arrange */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_1  = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 1,
+					'_quiz_has_questions'  => 1,
+				],
+			]
+		);
+		$this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 2,
+				],
+			]
+		);
+
+		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_1 );
+		$this->factory->question->create(
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [ ' ', ' ', ' ' ],
+				'question_wrong_answers' => [ ' ' ],
+			]
+		);
+
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$course_enrolment->enrol( $user_id );
+
+		wp_set_current_user( $user_id );
+
+		// Enable course theme;
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'failed' );
+		update_comment_meta( $comment_id, 'grade', 2 );
+		update_post_meta( $quiz_id, '_pass_required', 'on' );
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		WP_Block_Supports::$block_to_render = [
+			'attrs'     => [],
+			'blockName' => 'sensei-lms/quiz-actions',
+		];
+
+		global $sensei_question_loop;
+		$sensei_question_loop['total_pages'] = 1;
+
+		/* Act */
+		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
+
+		/* Assert */
+		$this->assertStringNotContainsString( 'Continue to next lesson', $result );
 	}
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2387,4 +2387,65 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertStringNotContainsString( 'Continue to next lesson', $result );
 	}
+
+	public function testQuizFooterActions_WhenQuizPassedButOnLessonPage_DoesNotShowTheNextLessonButton() {
+		/* Arrange */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_1  = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 1,
+					'_quiz_has_questions'  => 1,
+				],
+			]
+		);
+		$this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'       => $course_id,
+					'_order_' . $course_id => 2,
+				],
+			]
+		);
+
+		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_1 );
+		$this->factory->question->create(
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [ ' ', ' ', ' ' ],
+				'question_wrong_answers' => [ ' ' ],
+			]
+		);
+
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$course_enrolment->enrol( $user_id );
+
+		wp_set_current_user( $user_id );
+
+		// Enable course theme;
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		$comment_id = Sensei_Utils::update_lesson_status( $user_id, $lesson_1, 'passed' );
+		update_comment_meta( $comment_id, 'grade', 2 );
+		update_post_meta( $quiz_id, '_pass_required', 0 );
+
+		$this->go_to( get_permalink( $lesson_1 ) );
+
+		WP_Block_Supports::$block_to_render = [
+			'attrs'     => [],
+			'blockName' => 'sensei-lms/quiz-actions',
+		];
+
+		global $sensei_question_loop;
+		$sensei_question_loop['total_pages'] = 1;
+
+		/* Act */
+		$result = ( new \Sensei\Blocks\Course_Theme\Quiz_Actions() )->render();
+
+		/* Assert */
+		$this->assertStringNotContainsString( 'Continue to next lesson', $result );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7116

## Proposed Changes
* Update footer design to match the new design
* Fixed extra lateral spacing issue in footer in Divi, Twenty Twenty Three and some other themes

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with some lessons with quizzes
2. Apply different quiz settings on different quizzes, for example, mark one as pass required, one with auto grade enabled, one with reset enabled, and different combinations of these. The last lesson should have a quiz to check if the next lesson button renders unintentionally when there is no more lesson after that.
3. Take those quizzes as a student. keep some of the quizzes incomplete, some awaiting grade, some passed, some failed, some just graded
4. Check that the style holds in different scenarios
5. Check for mobile view
6. Check for different themes
7. Check the lesson view as well to make sure nothing is broken there
8. Check with the learning mode turned off as well to make sure nothing is broken there.

Passed:
<img width="1154" alt="Screenshot 2023-10-03 at 6 38 45 PM" src="https://github.com/Automattic/sensei/assets/6820724/d992d96b-208a-482c-86dd-8ed03bbdba12">

Failed with reset:
<img width="1154" alt="Screenshot 2023-10-03 at 6 40 40 PM" src="https://github.com/Automattic/sensei/assets/6820724/a40bd658-3773-401d-8589-7c0a9e767d0f">

Last lesson passed with no reset:
<img width="1154" alt="Screenshot 2023-10-03 at 6 41 27 PM" src="https://github.com/Automattic/sensei/assets/6820724/efd8ef5e-612b-4e57-9af4-60eaeb31fb28">


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues