### PR TITLE
Improve styles for sensei login page

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -721,16 +721,6 @@ section.entry span.course-lesson-progress {
 		clear: both;
 	}
 
-	form#loginform {
-		label {
-			display: block;
-		}
-
-		input[type='text'], input[type='password'] {
-			width: 90%;
-		}
-	}
-
 	&.ui-tabs {
 		position: relative;
 		zoom: 1;

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -131,3 +131,9 @@
 		}
 	}
 }
+
+body.theme-Divi {
+	.sensei-message.alert {
+		margin-top: 80px;
+	}
+}

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -131,3 +131,13 @@
 		}
 	}
 }
+
+.theme-twentytwentyone {
+	#customer_login {
+		.remember_me,
+		.sensei-login-submit,
+		.form-row:last-child {
+			margin-top: 1rem;
+		}
+	}
+}

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -85,7 +85,7 @@
 	}
 }
 
-.wp-block-sensei-lms-learner-courses {
+#my-courses {
 	#customer_login {
 		column-gap: 1.5rem;
 		display: flex;

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -131,9 +131,3 @@
 		}
 	}
 }
-
-body.theme-Divi {
-	.sensei-message.alert {
-		margin-top: 80px;
-	}
-}

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -66,6 +66,23 @@
 			}
 		}
 	}
+
+	&.alert {
+		background: #ffd9c8;
+
+		&:before {
+			color: $error;
+			content: '\f071';
+		}
+
+		a {
+			color: darken($error, 10%);
+
+			&:hover {
+				color: darken($error, 15%);
+			}
+		}
+	}
 }
 
 .wp-block-sensei-lms-learner-courses {

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -3,6 +3,7 @@
  */
 @import 'fontawesome';
 @import 'mixins';
+@import "~@wordpress/base-styles/breakpoints";
 
 /**
  * Course Completed Page
@@ -62,6 +63,53 @@
 
 			&:hover {
 				color: darken($color_body, 15%);
+			}
+		}
+	}
+}
+
+.wp-block-sensei-lms-learner-courses {
+	#customer_login {
+		column-gap: 1.5rem;
+		display: flex;
+
+		@media screen and (max-width: $break-medium) {
+			flex-direction: column;
+		}
+
+		label {
+			display: block;
+			margin-bottom: 0.7rem;
+		}
+
+		input.input-text {
+			box-sizing: border-box;
+			font-size: var(--wp--preset--font-size--small);
+			line-height: normal;
+			margin: 0;
+			outline: 0;
+			padding: 0.9rem 1.1rem;
+			width: 100%;
+		}
+
+		& > div {
+			display: flex;
+			flex: 1 1 0;
+			flex-direction: column;
+		}
+
+		form {
+			border: 1px solid #d3ced2;
+			border-radius: 5px;
+			flex: 1 1 0;
+			margin: 0 0 2em 0;
+			padding: 20px;
+			text-align: left;
+		}
+
+		.sensei-login-submit {
+			.button {
+				margin-right: 1em;
 			}
 		}
 	}

--- a/changelog/add-styles-for-sensei-login-page
+++ b/changelog/add-styles-for-sensei-login-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated the login page style and fixed issue of "My Messages" button rendering when logged out

--- a/changelog/add-styles-for-sensei-login-page-dev
+++ b/changelog/add-styles-for-sensei-login-page-dev
@@ -1,0 +1,4 @@
+Significance: minor
+Type: development
+
+Updated the "login-form" template

--- a/includes/blocks/class-sensei-learner-messages-button-block.php
+++ b/includes/blocks/class-sensei-learner-messages-button-block.php
@@ -63,7 +63,7 @@ class Sensei_Learner_Messages_Button_Block {
 	 * @return string Link to the learner messages button.
 	 */
 	public function render_learner_messages_block( $attributes, $content ): string {
-		if ( Sensei()->settings->settings['messages_disable'] ?? false ) {
+		if ( ! is_user_logged_in() || Sensei()->settings->settings['messages_disable'] ?? false ) {
 			return '';
 		}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1541,10 +1541,10 @@ class Sensei_Frontend {
 	 */
 	public function login_message_process() {
 
-			// setup the message variables.
-			$message = '';
+		// setup the message variables.
+		$message = '';
 
-			// only output message if the url contains login=failed and login=emptyfields.
+		// only output message if the url contains login=failed and login=emptyfields.
 		if ( $_GET['login'] == 'failed' ) {
 
 			$message = __( 'Incorrect login details', 'sensei-lms' );
@@ -1554,7 +1554,14 @@ class Sensei_Frontend {
 			$message = __( 'Please enter your username and password', 'sensei-lms' );
 		}
 
-			Sensei()->notices->add_notice( $message, 'alert' );
+		if ( '' !== $message ) {
+			// If it's a login failure, don't print the notices from the wp_body_open hook. Because on non-block
+			// themes, the notices are printed in the top, even above the header or nav, which breaks it.
+			// We show the notice on the login form instead.
+			remove_action( 'wp_body_open', [ Sensei()->notices, 'maybe_print_notices' ] );
+		}
+
+		Sensei()->notices->add_notice( $message, 'alert' );
 
 	}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1076,7 +1076,7 @@ class Sensei_Frontend {
 						<?php wp_nonce_field( 'sensei-register' ); ?>
 
 						<p class="form-row">
-							<input type="submit" class="button" name="register" value="<?php esc_attr_e( 'Register', 'sensei-lms' ); ?>" />
+							<input type="submit" class="button wp-element-button" name="register" value="<?php esc_attr_e( 'Register', 'sensei-lms' ); ?>" />
 						</p>
 
 						<?php do_action( 'sensei_register_form_end' ); ?>

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1029,7 +1029,7 @@ class Sensei_Frontend {
 		 */
 
 		?>
-		<div id="my-courses">
+		<div id="my-courses" class="alignwide">
 			<?php Sensei()->notices->maybe_print_notices(); ?>
 			<div class="col2-set" id="customer_login">
 

--- a/templates/user/login-form.php
+++ b/templates/user/login-form.php
@@ -39,7 +39,7 @@ do_action( 'sensei_login_form_before' );
 
 				<label for="sensei_user_login"><?php esc_html_e( 'Username or Email', 'sensei-lms' ); ?> </label>
 
-				<input type="text" name="log" id="sensei_user_login" class="input" value="" size="20">
+				<input type="text" name="log" id="sensei_user_login" class="input input-text" value="" size="20">
 
 	</p>
 
@@ -47,7 +47,7 @@ do_action( 'sensei_login_form_before' );
 
 				<label for="sensei_user_pass"> <?php esc_html_e( 'Password', 'sensei-lms' ); ?>  </label>
 
-				<input type="password" name="pwd" id="sensei_user_pass" class="input txt text" value="" size="20">
+				<input type="password" name="pwd" id="sensei_user_pass" class="input txt text input-text" value="" size="20">
 
 	</p>
 
@@ -64,7 +64,7 @@ do_action( 'sensei_login_form_before' );
 
 	<p class='sensei-login-submit'>
 
-		<input type="submit" class="button" name="login" value="<?php esc_attr_e( 'Login', 'sensei-lms' ); ?>" />
+		<input type="submit" class="button wp-element-button" name="login" value="<?php esc_attr_e( 'Login', 'sensei-lms' ); ?>" />
 
 		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'sensei-lms' ); ?></a>
 

--- a/templates/user/login-form.php
+++ b/templates/user/login-form.php
@@ -7,7 +7,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     2.0.0
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/6368

## Proposed Changes
* Improved the style of the login page following the Woocommerce login
* Improved the alert message shown when there's a login error
* Fixed the issue of "My Messages" button getting rendered even for logged-out users

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Log out
2. Go to My Courses page from frontend
3. It should look better than before and nothing should be broken
4. Try with all variations of the Course theme, Divi and Astra
5. Enable registration from Settings -> General -> Anyone can Register
6. Make sure it looks better with the Registration form too
7. Check in mobile view as well for all the above
8. Check the error alert with a wrong password

#### Course theme:
<img width="1113" alt="Screenshot 2023-10-05 at 4 32 17 PM" src="https://github.com/Automattic/sensei/assets/6820724/6f39930b-8265-418b-82c1-873d7e4f336e">
<img width="1113" alt="Screenshot 2023-10-05 at 4 32 37 PM" src="https://github.com/Automattic/sensei/assets/6820724/88c6eaf3-79ab-4fde-a779-49ace8df16e2">
<img width="1113" alt="Screenshot 2023-10-05 at 4 32 52 PM" src="https://github.com/Automattic/sensei/assets/6820724/4e722634-f628-422d-98f9-b23b5073ed68">
<img width="1113" alt="Screenshot 2023-10-05 at 4 33 09 PM" src="https://github.com/Automattic/sensei/assets/6820724/ac70dfcc-90fa-4601-9c49-ba0b64c7b823">

#### Divi
<img width="1191" alt="Screenshot 2023-10-05 at 4 34 43 PM" src="https://github.com/Automattic/sensei/assets/6820724/dc9bc27f-993e-49ed-8af3-913f1f749c02">

#### Astra
<img width="1249" alt="Screenshot 2023-10-05 at 4 34 07 PM" src="https://github.com/Automattic/sensei/assets/6820724/a5a4fb6a-ef42-429d-a508-84c10958af21">

#### Mobile
<img width="523" alt="Screenshot 2023-10-05 at 4 35 34 PM" src="https://github.com/Automattic/sensei/assets/6820724/cc1b83ad-b6a3-4be1-98a0-160b3b47ed0d">

#### Error message
![image (2)](https://github.com/Automattic/sensei/assets/6820724/0029010f-b3b0-4fea-a504-ce4774935912)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
