### PR TITLE
Update filters documentation

### DIFF
--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -189,7 +189,6 @@ class Sensei_Admin_Notices {
 		 *
 		 * @param {array}    $notices The admin notices.
 		 * @param {int|null} $max_age The max age (seconds) of the source data.
-		 *
 		 * @return {array} The admin notices.
 		 */
 		$notices = apply_filters( 'sensei_admin_notices', $notices, $max_age );
@@ -489,6 +488,7 @@ class Sensei_Admin_Notices {
 		 * Filter the array of screen IDs that are part of Sensei, and where we should show Sensei notices on.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_notices_screen_ids
 		 *
 		 * @param {array} Array of Screen IDs that are part of Sensei.

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -395,6 +395,14 @@ class Sensei_Learner_Management {
 			<h2 class="sensei-students__subheading">
 				<?php
 				echo wp_kses(
+					/**
+					 * Filters the title of the Learners page.
+					 *
+					 * @hook sensei_learners_nav_title
+					 *
+					 * @param {string} $title Title of the Learners page.
+					 * @return {string} Filtered title of the Learners page.
+					 */
 					apply_filters( 'sensei_learners_nav_title', $title ),
 					array(
 						'span' => array(
@@ -512,10 +520,11 @@ class Sensei_Learner_Management {
 		 *
 		 * This filter should return false if there was no update in the learner row.
 		 *
+		 * @hook sensei_learners_learner_updated
+		 *
 		 * @param {bool} $updated    A flag indicating if there was an update in the learner row.
 		 * @param {int}  $post_id    Lesson or course id.
 		 * @param {int}  $comment_id The comment id which tracks the progress of the learner.
-		 *
 		 * @return {bool} False if there were no updates.
 		 */
 		$updated = apply_filters( 'sensei_learners_learner_updated', $updated, $post_id, $comment_id );
@@ -830,6 +839,14 @@ class Sensei_Learner_Management {
 			$query_args['message'] .= '_multiple';
 		}
 
+		/**
+		 * Filter the redirect URL after adding a learner.
+		 *
+		 * @hook sensei_learners_add_learner_redirect_url
+		 *
+		 * @param {string} $redirect_url URL to redirect to after adding a learner.
+		 * @return {string} Filtered URL to redirect to after adding a learner.
+		 */
 		$redirect_url = apply_filters( 'sensei_learners_add_learner_redirect_url', add_query_arg( $query_args, admin_url( 'admin.php' ) ) );
 
 		wp_safe_redirect( esc_url_raw( $redirect_url ) );

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -192,6 +192,14 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	public function get_known_bulk_actions() {
 		$known_bulk_actions = $this->known_bulk_actions;
 
+		/**
+		 * Filter the known bulk actions.
+		 *
+		 * @hook sensei_learners_admin_get_known_bulk_actions
+		 *
+		 * @param {array} $known_bulk_actions The known bulk actions.
+		 * @return {array} Filtered known bulk actions.
+		 */
 		return (array) apply_filters( 'sensei_learners_admin_get_known_bulk_actions', $known_bulk_actions );
 	}
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -103,6 +103,14 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
+		/**
+		 * Filter the search button text.
+		 *
+		 * @hook sensei_list_table_search_button_text
+		 *
+		 * @param {string} $text The search button text.
+		 * @return {string} The filtered text.
+		 */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 
@@ -141,6 +149,13 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			'actions'            => '',
 		);
 
+		/**
+		 * Filter columns for the learners admin table.
+		 *
+		 * @param {array}                                   $columns The Columns.
+		 * @param {Sensei_Learners_Admin_Bulk_Actions_View} $view The View.
+		 * @return {array} Filtered columns.
+		 */
 		return apply_filters( 'sensei_learners_admin_default_columns', $columns, $this );
 	}
 
@@ -153,6 +168,14 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		$columns = array(
 			'learner' => array( 'learner', false ),
 		);
+
+		/**
+		 * Filter sortable columns for the learners admin table.
+		 *
+		 * @param {array}                                   $columns The sortable columns.
+		 * @param {Sensei_Learners_Admin_Bulk_Actions_View} $view The View.
+		 * @return {array} Filtered columns.
+		 */
 		return apply_filters( 'sensei_learner_admin_default_columns_sortable', $columns, $this );
 	}
 
@@ -218,11 +241,12 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		/**
 		 * Filter sensei_learner_admin_get_row_data, for adding/removing row data.
 		 *
-		 * @param array                                   $row_data The Row Data.
-		 * @param mixed|object                            $item The Item (learner query row).
-		 * @param Sensei_Learners_Admin_Bulk_Actions_View $view The View.
+		 * @hook sensei_learner_admin_get_row_data
 		 *
-		 * @return array
+		 * @param {array}                                   $row_data The Row Data.
+		 * @param {mixed|object}                            $item The Item (learner query row).
+		 * @param {Sensei_Learners_Admin_Bulk_Actions_View} $view The View.
+		 * @return {array} Filtered row data.
 		 */
 		$row_data         = apply_filters( 'sensei_learner_admin_get_row_data', $row_data, $item, $this );
 		$escaped_row_data = array();
@@ -319,6 +343,14 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			$text    = '<div class="sensei-students__call-to-action"><div>' . $message . '</div><div>' . $button . '</div></div>';
 		}
 
+		/**
+		 * Filter the text displayed when no items are found.
+		 *
+		 * @hook sensei_learners_no_items_text
+		 *
+		 * @param {string} $text The text.
+		 * @return {string} The filtered text.
+		 */
 		echo wp_kses_post( apply_filters( 'sensei_learners_no_items_text', $text ) );
 	}
 
@@ -538,6 +570,15 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			}
 		} else {
 			$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
+			/**
+			 * Filter the number of items per page for the comments list table.
+			 *
+			 * @hook sensei_comments_per_page
+			 *
+			 * @param {int} $per_page The number of items to be displayed.
+			 * @param {string} $type The type of items to be displayed.
+			 * @return {int} The filtered number of items to be displayed.
+			 */
 			$per_page = absint( apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' ) );
 		}
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -207,12 +207,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		 *
 		 * Filters the columns that are displayed in learner management
 		 *
+		 * @hook sensei_learners_default_columns
+		 *
 		 * @param {array}   $columns              The default columns.
 		 * @param {object}  $sensei_learners_main Sensei_Learners_Main instance.
-		 *
 		 * @return {array} The modified default columns
 		 */
 		$columns = apply_filters( 'sensei_learners_default_columns', $columns, $this );
+
 		return $columns;
 	}
 
@@ -248,7 +250,17 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			);
 		}
 
+		/**
+		 * Filter the columns that are sortable in learner management.
+		 *
+		 * @hook sensei_learners_default_columns_sortable
+		 *
+		 * @param {array}   $columns    The sortable columns.
+		 * @param {object}  $list_table Sensei_Learners_Main instance.
+		 * @return {array} The modified sortable columns
+		 */
 		$columns = apply_filters( 'sensei_learners_default_columns_sortable', $columns, $this );
+
 		return $columns;
 	}
 
@@ -290,6 +302,15 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		// phpcs:enable WordPress.Security.NonceVerification
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
+		/**
+		 * Filter the number of items per page in learner management.
+		 *
+		 * @hook sensei_comments_per_page
+		 *
+		 * @param {int} $per_page The number of items per page.
+		 * @param {string} $type The type of items to display.
+		 * @return {int} The modified number of items per page.
+		 */
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
 
 		$paged  = $this->get_pagenum();
@@ -770,6 +791,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			$course_args['s'] = $args['search'];
 		}
 
+		/**
+		 * Filter arguments for the course query on the student management screen.
+		 *
+		 * @hook sensei_learners_filter_courses
+		 *
+		 * @param {array} $course_args Course query arguments.
+		 * @return {array} The modified arguments.
+		 */
 		$courses_query = new WP_Query( apply_filters( 'sensei_learners_filter_courses', $course_args ) );
 
 		$this->total_items = $courses_query->found_posts;
@@ -806,6 +835,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			$lesson_args['s'] = $args['search'];
 		}
 
+		/**
+		 * Filter arguments for the lesson query on the student management screen.
+		 *
+		 * @hook sensei_learners_filter_lessons
+		 *
+		 * @param {array} $lesson_args Lesson query arguments.
+		 * @return {array} The modified arguments.
+		 */
 		$lessons_query = new WP_Query( apply_filters( 'sensei_learners_filter_lessons', $lesson_args ) );
 
 		$this->total_items = $lessons_query->found_posts;
@@ -859,6 +896,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			$activity_args['user_id'] = $user_ids;
 		}
 
+		/**
+		 * Filter arguments for the learners activity on the student management screen.
+		 *
+		 * @hook sensei_learners_filter_users
+		 *
+		 * @param {array} $activity_args Activity query arguments.
+		 * @return {array} The modified arguments.
+		 */
 		$activity_args = apply_filters( 'sensei_learners_filter_users', $activity_args );
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice.
@@ -904,9 +949,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		/**
 		 * Allows user search arguments modification in learner management.
 		 *
-		 * @param array $user_args {
+		 * @hook sensei_learners_search_users
+		 *
+		 * @param {array} $user_args {
 		 *     @type string 'search' The search argument as used in WP_User_Query.
 		 * }
+		 * @return {array} The modified arguments.
 		 */
 		$user_args = apply_filters( 'sensei_learners_search_users', $user_args );
 
@@ -973,6 +1021,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$text = __( 'No courses found.', 'sensei-lms' );
 				break;
 		}
+		/**
+		 * Filter the text displayed when no items are found.
+		 *
+		 * @hook sensei_learners_no_items_text
+		 *
+		 * @param {string} $text The text to display.
+		 * @return {string} The modified text.
+		 */
 		echo wp_kses_post( apply_filters( 'sensei_learners_no_items_text', $text ) );
 	}
 
@@ -1035,6 +1091,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			$menu['lessons'] = $this->lessons_link();
 		}
 
+		/**
+		 * Filter the sub menu items for the learner management screen.
+		 *
+		 * @hook sensei_learners_sub_menu
+		 *
+		 * @param {array} $menu The menu items.
+		 * @return {array} The modified menu items.
+		 */
 		return apply_filters( 'sensei_learners_sub_menu', $menu );
 	}
 
@@ -1065,6 +1129,15 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
+
+		/**
+		 * Filter the search box button text on the learner management screen.
+		 *
+		 * @hook sensei_list_table_search_button_text
+		 *
+		 * @param {string} $text The text to display.
+		 * @return {string} The modified text.
+		 */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -951,8 +951,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		 *
 		 * @hook sensei_learners_search_users
 		 *
-		 * @param {array} $user_args Search user arguments.
-		 * @property {string} search The search string, used as in WP_User_Query.
+		 * @param    {array}   $user_args             Search user arguments.
+		 * @property {string} `$user_args['search']` The search string, used as in WP_User_Query.
 		 * @return {array} The modified arguments.
 		 */
 		$user_args = apply_filters( 'sensei_learners_search_users', $user_args );

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -951,9 +951,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		 *
 		 * @hook sensei_learners_search_users
 		 *
-		 * @param {array} $user_args {
-		 *     @type string 'search' The search argument as used in WP_User_Query.
-		 * }
+		 * @param {array} $user_args Search user arguments.
+		 * @property {string} search The search string, used as in WP_User_Query.
 		 * @return {array} The modified arguments.
 		 */
 		$user_args = apply_filters( 'sensei_learners_search_users', $user_args );

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -81,11 +81,11 @@ class Sensei_Tools {
 			 * Array of the tools available to Sensei LMS.
 			 *
 			 * @since 3.7.0
+			 *
 			 * @hook sensei_tools
 			 *
 			 * @param {Sensei_Tool_Interface[]} $tools Tool objects for Sensei LMS.
-			 *
-			 * @return {array}
+			 * @return {array} Filtered tools.
 			 */
 			$tools = apply_filters( 'sensei_tools', $tools );
 

--- a/includes/admin/home/class-sensei-home-remote-data-api.php
+++ b/includes/admin/home/class-sensei-home-remote-data-api.php
@@ -67,10 +67,10 @@ class Sensei_Home_Remote_Data_API {
 		 * Filter if we should retry errors when fetching remote data.
 		 *
 		 * @since 4.8.0
+		 *
 		 * @hook sensei_home_remote_data_retry_error
 		 *
 		 * @param {bool} $retry_error If we should retry errors. Default true.
-		 *
 		 * @return {bool} If we should retry errors.
 		 */
 		$retry_error = apply_filters( 'sensei_home_remote_data_retry_error', true );
@@ -186,10 +186,10 @@ class Sensei_Home_Remote_Data_API {
 		 * Filter the primary plugin slug.
 		 *
 		 * @since 4.8.0
+		 *
 		 * @hook sensei_home_remote_data_primary_plugin_slug
 		 *
 		 * @param {string} $primary_plugin_slug The primary plugin slug.
-		 *
 		 * @return {string} The filtered primary plugin slug.
 		 */
 		return apply_filters( 'sensei_home_remote_data_primary_plugin_slug', $this->primary_plugin_slug );
@@ -205,10 +205,10 @@ class Sensei_Home_Remote_Data_API {
 		 * Filter the other plugins used for Sensei Home.
 		 *
 		 * @since 4.8.0
+		 *
 		 * @hook sensei_home_remote_data_other_plugins
 		 *
 		 * @param {array} $other_plugins The other plugins.
-		 *
 		 * @return {array} The filtered other plugins.
 		 */
 		return array_diff( apply_filters( 'sensei_home_remote_data_other_plugins', [] ), [ $this->get_primary_plugin_slug() ] );

--- a/includes/admin/home/help/class-sensei-home-help-provider.php
+++ b/includes/admin/home/help/class-sensei-home-help-provider.php
@@ -91,12 +91,12 @@ class Sensei_Home_Help_Provider {
 		/**
 		 * Filter to disable upsell to Sensei Pro in Sensei Home's action to create support tickets.
 		 *
-		 * @hook sensei_home_support_ticket_creation_upsell_show
 		 * @since 4.8.0
 		 *
-		 * @param {bool} $show_upsell True if upsell must be shown.
+		 * @hook sensei_home_support_ticket_creation_upsell_show
 		 *
-		 * @return {bool}
+		 * @param {bool} $show_upsell True if upsell must be shown.
+		 * @return {bool} Filtered value.
 		 */
 		if ( apply_filters( 'sensei_home_support_ticket_creation_upsell_show', true ) ) {
 			$extra_link = $this->create_extra_link( __( 'Upgrade to Sensei Pro', 'sensei-lms' ), 'https://senseilms.com/pricing/' );

--- a/includes/admin/home/notices/class-sensei-home-notices-provider.php
+++ b/includes/admin/home/notices/class-sensei-home-notices-provider.php
@@ -47,7 +47,13 @@ class Sensei_Home_Notices_Provider {
 	 */
 	private function local_only( $max_age = null ) : array {
 		/**
-		 * This filter is documented in `class-sensei-admin-notices.php`.
+		 * Filters the admin notices.
+		 *
+		 * @hook sensei_admin_notices
+		 *
+		 * @param {array}    $notices The admin notices.
+		 * @param {int|null} $max_age The max age (seconds) of the source data.
+		 * @return {array} The admin notices.
 		 */
 		$notices = apply_filters( 'sensei_admin_notices', [], $max_age );
 

--- a/includes/admin/home/notices/class-sensei-home-notices.php
+++ b/includes/admin/home/notices/class-sensei-home-notices.php
@@ -216,11 +216,11 @@ class Sensei_Home_Notices {
 			 *
 			 * Defaults to true for plugins that don't need a license.
 			 *
-			 * @hook sensei_home_is_plugin_licensed_{$plugin_slug}
 			 * @since 4.8.0
 			 *
-			 * @param {bool} $is_licensed Whether the plugin has an active license.
+			 * @hook sensei_home_is_plugin_licensed_{$plugin_slug}
 			 *
+			 * @param {bool} $is_licensed Whether the plugin has an active license.
 			 * @return {bool} Whether the plugin has an active license.
 			 */
 			$has_license = apply_filters( 'sensei_home_is_plugin_licensed_' . $plugin_slug, ! $plugin_data['licensed'] );

--- a/includes/admin/home/promo-banner/class-sensei-home-promo-banner-provider.php
+++ b/includes/admin/home/promo-banner/class-sensei-home-promo-banner-provider.php
@@ -22,12 +22,12 @@ class Sensei_Home_Promo_Banner_Provider {
 			/**
 			 * Filter to disable the promotional banner in Sensei Home.
 			 *
-			 * @hook sensei_home_promo_banner_show
 			 * @since 4.8.0
 			 *
-			 * @param {bool} $show_promo_banner True if promotional banner must be shown.
+			 * @hook sensei_home_promo_banner_show
 			 *
-			 * @return {bool}
+			 * @param {bool} $show_promo_banner True if promotional banner must be shown.
+			 * @return {bool} Filtered value.
 			 */
 			'is_visible' => apply_filters( 'sensei_home_promo_banner_show', true ),
 		];

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -92,13 +92,13 @@ class Sensei_Home_Tasks_Provider {
 		 *
 		 * @hook sensei_home_tasks
 		 *
-		 * @param {array} $tasks A dictionary of tasks indexed by task ID.
-		 * @property {string} id The task ID. Must be unique.
-		 * @property {string} title The task title.
-		 * @property {int}    priority Number used in frontend to sort tasks in ascending order.
-		 * @property {string} url Optional. Destination URL for users when clicking on the task.
-		 * @property {string} image Optional. Source url or path for the featured image when this task is the first pending one.
-		 * @property {bool}   done Whether the task is considered done or not.
+		 * @param    {array[]} $tasks                A dictionary of tasks indexed by task ID.
+		 * @property {string} `$tasks[]['id']`       The task ID. Must be unique.
+		 * @property {string} `$tasks[]['title']`    The task title.
+		 * @property {int}    `$tasks[]['priority']` Number used in frontend to sort tasks in ascending order.
+		 * @property {string} `$tasks[]['url']`      Optional. Destination URL for users when clicking on the task.
+		 * @property {string} `$tasks[]['image']`    Optional. Source url or path for the featured image when this task is the first pending one.
+		 * @property {bool}   `$tasks[]['done']`     Whether the task is considered done or not.
 		 * @return {array} Filtered tasks.
 		 */
 		return apply_filters( 'sensei_home_tasks', $tasks );

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -90,7 +90,9 @@ class Sensei_Home_Tasks_Provider {
 		 *
 		 * @since 4.8.0
 		 *
-		 * @param array $tasks {
+		 * @hook sensei_home_tasks
+		 *
+		 * @param {array} $tasks {
 		 *  A dictionary of tasks indexed by task ID.
 		 *
 		 *  @type string $id The task ID. Must be unique.
@@ -100,6 +102,7 @@ class Sensei_Home_Tasks_Provider {
 		 *  @type string $image Optional. Source url or path for the featured image when this task is the first pending one.
 		 *  @type bool $done Whether the task is considered done or not.
 		 * }
+		 * @return {array} Filtered tasks.
 		 */
 		return apply_filters( 'sensei_home_tasks', $tasks );
 	}

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -86,22 +86,22 @@ class Sensei_Home_Tasks_Provider {
 		}
 
 		/**
+		*/
+
+		/**
 		 * Filters the list of tasks that will be later displayed in the Sensei Home header.
 		 *
 		 * @since 4.8.0
 		 *
 		 * @hook sensei_home_tasks
 		 *
-		 * @param {array} $tasks {
-		 *  A dictionary of tasks indexed by task ID.
-		 *
-		 *  @type string $id The task ID. Must be unique.
-		 *  @type string $title The task title.
-		 *  @type int $priority Number used in frontend to sort tasks in ascending order.
-		 *  @type string $url Optional. Destination URL for users when clicking on the task.
-		 *  @type string $image Optional. Source url or path for the featured image when this task is the first pending one.
-		 *  @type bool $done Whether the task is considered done or not.
-		 * }
+		 * @param {array} $tasks A dictionary of tasks indexed by task ID.
+		 * @property {string} id The task ID. Must be unique.
+		 * @property {string} title The task title.
+		 * @property {int}    priority Number used in frontend to sort tasks in ascending order.
+		 * @property {string} url Optional. Destination URL for users when clicking on the task.
+		 * @property {string} image Optional. Source url or path for the featured image when this task is the first pending one.
+		 * @property {bool}   done Whether the task is considered done or not.
 		 * @return {array} Filtered tasks.
 		 */
 		return apply_filters( 'sensei_home_tasks', $tasks );

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -86,9 +86,6 @@ class Sensei_Home_Tasks_Provider {
 		}
 
 		/**
-		*/
-
-		/**
 		 * Filters the list of tasks that will be later displayed in the Sensei Home header.
 		 *
 		 * @since 4.8.0

--- a/includes/admin/tools/class-sensei-tool-enrolment-debug.php
+++ b/includes/admin/tools/class-sensei-tool-enrolment-debug.php
@@ -401,13 +401,13 @@ class Sensei_Tool_Enrolment_Debug implements Sensei_Tool_Interface, Sensei_Tool_
 		 * Show the enrolment debug button on learner management.
 		 *
 		 * @since 3.7.0
+		 *
 		 * @hook sensei_show_enrolment_debug_button
 		 *
 		 * @param {bool} $show_button Whether to show the button.
 		 * @param {int}  $user_id     User ID.
 		 * @param {int}  $course_id   Course ID.
-		 *
-		 * @return {bool}
+		 * @return {bool} Filtered value.
 		 */
 		$show_button = apply_filters( 'sensei_show_enrolment_debug_button', false, $item->user_id, $course_id );
 		if (

--- a/includes/background-jobs/class-sensei-scheduler-wp-cron.php
+++ b/includes/background-jobs/class-sensei-scheduler-wp-cron.php
@@ -70,7 +70,10 @@ class Sensei_Scheduler_WP_Cron implements Sensei_Scheduler_Interface {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param array $actions Scheduled actions that are handled by this class.
+		 * @hook sensei_background_job_actions
+		 *
+		 * @param {array} $actions Scheduled actions that are handled by this class.
+		 * @return {array} Filtered actions.
 		 */
 		$actions = apply_filters( 'sensei_background_job_actions', [] );
 		foreach ( $actions as $action_name ) {

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -98,7 +98,10 @@ class Sensei_Scheduler {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param string $class_name Class for the scheduler that should be used by Sensei.
+		 * @hook sensei_scheduler_class
+		 *
+		 * @param {string} $class_name Class for the scheduler that should be used by Sensei.
+		 * @return {string} Filtered class name.
 		 */
 		$class_name = apply_filters( 'sensei_scheduler_class', $default_class_name );
 		if ( ! is_subclass_of( $class_name, Sensei_Scheduler_Interface::class, true ) ) {

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -40,9 +40,10 @@ class Sensei_Course_List_Block_Patterns {
 			 *
 			 * @since 4.10.0
 			 *
+			 * @hook sensei_course_list_block_patterns_extra_links
+			 *
 			 * @param {array}  $course_list_extra_links The extra links.
 			 * @param {string} $pattern                 The pattern name.
-			 *
 			 * @return {array} The extra links.
 			 */
 			$course_list_extra_links[ $pattern ] = apply_filters( 'sensei_course_list_block_patterns_extra_links', [], $pattern );

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -159,14 +159,15 @@ class Sensei_Blocks {
 		 * Notice that for blocks being registered using the `$file_or_folder`, this filter runs before the
 		 * `register_block_type_from_metadata`.
 		 *
-		 * @since 3.6.0
-		 * @hook sensei_block_type_args
 		 * @see register_block_type
 		 * @see register_block_type_from_metadata
 		 *
+		 * @since 3.6.0
+		 *
+		 * @hook sensei_block_type_args
+		 *
 		 * @param {array}  $block_args The block arguments as defined by register_block_type.
 		 * @param {string} $block_name Block name.
-		 *
 		 * @return {array} Block args.
 		 */
 		$block_args = apply_filters( 'sensei_block_type_args', $block_args, $block_name );

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -75,12 +75,12 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 		/**
 		 * Customize the course block template.
 		 *
-		 * @hook  sensei_course_block_template
 		 * @since 3.9.0
+		 *
+		 * @hook  sensei_course_block_template
 		 *
 		 * @param {string[][]} $template          Array of blocks to use as the default initial state for a course.
 		 * @param {string[][]} $original_template Original block template.
-		 *
 		 * @return {string[][]} Array of blocks to use as the default initial state for a course.
 		 */
 		$post_type_object->template = apply_filters( 'sensei_course_block_template', $block_template, $post_type_object->template ?? [] );

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -89,12 +89,12 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		/**
 		 * Customize the lesson block template.
 		 *
-		 * @hook  sensei_lesson_block_template
 		 * @since 3.9.0
+		 *
+		 * @hook  sensei_lesson_block_template
 		 *
 		 * @param {string[][]} $template          Array of blocks to use as the default initial state for a lesson.
 		 * @param {string[][]} $original_template Original block template.
-		 *
 		 * @return {string[][]} Array of blocks to use as the default initial state for a lesson.
 		 */
 		$post_type_object->template = apply_filters( 'sensei_lesson_block_template', $block_template, $post_type_object->template ?? [] );

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -37,8 +37,9 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 		/**
 		 * Filters the quiz ordering type promo toggle.
 		 *
-		 * @hook  sensei_quiz_ordering_question_type_hide
 		 * @since 4.1.0
+		 *
+		 * @hook  sensei_quiz_ordering_question_type_hide
 		 *
 		 * @param  {bool} $ordering_question_type_hide Whether to hide the ordering question type promo.
 		 * @return {bool} Whether to hide the ordering question type promo.

--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -282,6 +282,15 @@ class Course_Navigation {
 	private function lesson_status_icon( $status ) {
 		$icon = Sensei()->assets->get_icon( self::ICONS[ $status ], 'sensei-lms-course-navigation-lesson__status' );
 
+		/**
+		 * Filter the lesson status icon.
+		 *
+		 * @hook sensei_learning_mode_lesson_status_icon
+		 *
+		 * @param {string} $icon   The icon HTML.
+		 * @param {string} $status The lesson status.
+		 * @return {string} The icon HTML.
+		 */
 		return apply_filters( 'sensei_learning_mode_lesson_status_icon', $icon, $status );
 	}
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -363,7 +363,7 @@ class Sensei_Admin {
 		 * @param {array} $allowed_post_types The list of post types where the admin custom styles should be loaded.
 		 * @return {array} Filtered list of allowed post types.
 		 */
-		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
+		$allowed_post_types = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
 
 		/**
 		 * Filter the list of admin pages where the admin custom styles should be loaded.

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -355,8 +355,34 @@ class Sensei_Admin {
 	 * @return bool Returns true if admin custom styles are allowed.
 	 */
 	private function are_custom_admin_styles_allowed( $post_type, $hook_suffix, $screen ) {
+		/**
+		 * Filter the list of post types where the admin custom styles should be loaded.
+		 *
+		 * @hook sensei_scripts_allowed_post_types
+		 *
+		 * @param {array} $allowed_post_types The list of post types where the admin custom styles should be loaded.
+		 * @return {array} Filtered list of allowed post types.
+		 */
 		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
+
+		/**
+		 * Filter the list of admin pages where the admin custom styles should be loaded.
+		 *
+		 * @hook sensei_scripts_allowed_post_type_pages
+		 *
+		 * @param {array} $allowed_post_type_pages The list of admin pages where the admin custom styles should be loaded.
+		 * @return {array} Filtered list of allowed admin pages.
+		 */
 		$allowed_post_type_pages = apply_filters( 'sensei_scripts_allowed_post_type_pages', array( 'edit.php', 'post-new.php', 'post.php', 'edit-tags.php' ) );
+
+		/**
+		 * Filter the list of admin pages slugs where the admin custom styles should be loaded.
+		 *
+		 * @hook sensei_scripts_allowed_pages
+		 *
+		 * @param {array} $allowed_pages The list of admin pages slugs where the admin custom styles should be loaded.
+		 * @return {array} Filtered list of allowed admin pages.
+		 */
 		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei_Analysis::PAGE_SLUG, 'sensei_learners', 'sensei_updates', 'sensei-settings', 'sensei_learners', Sensei_Course::SHOWCASE_COURSES_SLUG, $this->lesson_order_page_slug, $this->course_order_page_slug ) );
 		$module_pages_screen_ids = [ 'edit-module' ];
 
@@ -869,12 +895,12 @@ class Sensei_Admin {
 		 * Filter arguments for `wp_insert_post` when duplicating a Sensei
 		 * post. This may be a Course, Lesson, or Quiz.
 		 *
-		 * @hook  sensei_duplicate_post_args
 		 * @since 3.11.0
+		 *
+		 * @hook  sensei_duplicate_post_args
 		 *
 		 * @param {array}   $new_post The arguments for duplicating the post.
 		 * @param {WP_Post} $post     The original post being duplicated.
-		 *
 		 * @return {array}  The new arguments to be handed to `wp_insert_post`.
 		 */
 		$new_post = apply_filters( 'sensei_duplicate_post_args', $new_post, $post );
@@ -889,13 +915,13 @@ class Sensei_Admin {
 				/**
 				 * Ignored meta fields when duplicating a post.
 				 *
-				 * @hook  sensei_duplicate_post_ignore_meta
 				 * @since 3.7.0
+				 *
+				 * @hook  sensei_duplicate_post_ignore_meta
 				 *
 				 * @param {array}   $meta_keys The meta keys to be ignored.
 				 * @param {WP_Post} $new_post  The new duplicate post.
 				 * @param {WP_Post} $post      The original post that's being duplicated.
-				 *
 				 * @return {array} $meta_keys The meta keys to be ignored.
 				 */
 				$ignore_meta = apply_filters( 'sensei_duplicate_post_ignore_meta', [ '_quiz_lesson', '_quiz_id', '_lesson_quiz', '_lesson_prerequisite' ], $new_post, $post );

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -133,10 +133,30 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 				}
 				break;
 		}
-		// Backwards compatible
+
+		/**
+		 * Filter the columns that are going to be used in the Course Analysis list table.
+		 * Backwards compatible filter. Use sensei_analysis_course_columns instead.
+		 *
+		 * @hook sensei_analysis_course_{view}_columns
+		 *
+		 * @param {array}                             $columns The array of columns to use in the table.
+		 * @param {Sensei_Analysis_Course_List_Table} $this    The current instance of the class.
+		 * @return {array} $columns The array of columns to use with the table.
+		*/
 		$columns = apply_filters( 'sensei_analysis_course_' . $this->view . '_columns', $columns, $this );
-		// Moving forward, single filter with args
+
+		/**
+		 * Filter the columns that are going to be used in the Course Analysis list table.
+		 *
+		 * @hook sensei_analysis_course_columns
+		 *
+		 * @param {array}                             $columns The array of columns to use in the table.
+		 * @param {Sensei_Analysis_Course_List_Table} $this    The current instance of the class.
+		 * @return {array} $columns The array of columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_course_columns', $columns, $this );
+
 		return $columns;
 	}
 
@@ -168,10 +188,30 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 				}
 				break;
 		}
-		// Backwards compatible
+
+		/**
+		 * Filter the sortable columns that are going to be used in the Course Analysis list table.
+		 * Backwards compatible filter. Use sensei_analysis_course_columns_sortable instead.
+		 *
+		 * @hook sensei_analysis_course_{view}_columns_sortable
+		 *
+		 * @param {array}                             $columns The array of sortable columns to use in the table.
+		 * @param {Sensei_Analysis_Course_List_Table} $this    The current instance of the class.
+		 * @return {array} The array of sortable columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_course_' . $this->view . '_columns_sortable', $columns, $this );
-		// Moving forward, single filter with args
+
+		/**
+		 * Filter the sortable columns that are going to be used in the Course Analysis list table.
+		 *
+		 * @hook sensei_analysis_course_columns_sortable
+		 *
+		 * @param {array}                             $columns The array of sortable columns to use in the table.
+		 * @param {Sensei_Analysis_Course_List_Table} $this    The current instance of the class.
+		 * @return {array} The array of sortable columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_course_columns_sortable', $columns, $this );
+
 		return $columns;
 	}
 
@@ -204,6 +244,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
+		/**
+		 * Filter the number of items per page for the Course Analysis list table.
+		 *
+		 * @hook sensei_comments_per_page
+		 *
+		 * @param {int} $per_page The number of items per page.
+		 * @param {string} $screen The current screen.
+		 * @return {int} The number of items per page.
+		 */
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
 
 		$paged  = $this->get_pagenum();
@@ -397,6 +446,16 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 						'type'    => 'sensei_lesson_status',
 						'status'  => 'any',
 					);
+					/**
+					 * Filter the lesson status arguments for the Course Analysis list table.
+					 *
+					 * @hook sensei_analysis_course_user_lesson
+					 *
+					 * @param {array}  $lesson_args The lesson status arguments.
+					 * @param {object} $item The current item.
+					 * @param {int}    $user_id The user ID.
+					 * @return {array} The lesson status arguments.
+					 */
 					$lesson_status = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_user_lesson', $lesson_args, $item, $this->user_id ), true );
 
 					if ( ! empty( $lesson_status ) ) {
@@ -472,6 +531,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 						'type'    => 'sensei_lesson_status',
 						'status'  => 'any',
 					);
+					/**
+					 * Filter the lesson learners activity arguments for the Course Analysis list table.
+					 *
+					 * @hook sensei_analysis_lesson_learners
+					 *
+					 * @param {array}  $lesson_args The lesson learners activity arguments.
+					 * @param {object} $item The current item.
+					 * @return {array} The lesson learners activity arguments.
+					 */
 					$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
 
 					// Get Course Completions
@@ -481,6 +549,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 						'status'  => array( 'complete', 'graded', 'passed', 'failed' ),
 						'count'   => true,
 					);
+					/**
+					 * Filter the lesson completions activity arguments for the Course Analysis list table.
+					 *
+					 * @hook sensei_analysis_lesson_completions
+					 *
+					 * @param {array}  $lesson_args The lesson completions activity arguments.
+					 * @param {object} $item The current item.
+					 * @return {array} The lesson completions activity arguments.
+					 */
 					$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
 
 					$lesson_average_grade = __( 'N/A', 'sensei-lms' );
@@ -494,6 +571,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 							'meta_key' => 'grade',
 						);
 						add_filter( 'comments_clauses', array( 'Sensei_Utils', 'comment_total_sum_meta_value_filter' ) );
+						/**
+						 * Filter the lesson grades activity arguments for the Course Analysis list table.
+						 *
+						 * @hook sensei_analysis_lesson_grades
+						 *
+						 * @param {array}  $grade_args The lesson grades activity arguments.
+						 * @param {object} $item The current item.
+						 * @return {array} The lesson grades activity arguments.
+						 */
 						$lesson_grades = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_grades', $grade_args, $item ), true );
 						remove_filter( 'comments_clauses', array( 'Sensei_Utils', 'comment_total_sum_meta_value_filter' ) );
 
@@ -562,7 +648,14 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 				'search' => '*' . $this->search . '*',
 				'fields' => 'ID',
 			);
-			// Filter for extending
+			/**
+			 * Filter the user arguments for the Course Analysis list table.
+			 *
+			 * @hook sensei_analysis_course_search_users
+			 *
+			 * @param {array} $user_args The user arguments.
+			 * @return {array} The user arguments.
+			 */
 			$user_args = apply_filters( 'sensei_analysis_course_search_users', $user_args );
 			if ( ! empty( $user_args ) ) {
 				$learners_search = new WP_User_Query( $user_args );
@@ -571,6 +664,14 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			}
 		}
 
+		/**
+		 * Filter the course activity arguments for the Course Analysis list table.
+		 *
+		 * @hook sensei_analysis_course_filter_statuses
+		 *
+		 * @param {array} $activity_args The course statuses arguments.
+		 * @return {array} The course statuses arguments.
+		 */
 		$activity_args = apply_filters( 'sensei_analysis_course_filter_statuses', $activity_args );
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice
@@ -627,8 +728,17 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		}
 
 		// Using WP_Query as get_posts() doesn't support 'found_posts'
+		/**
+		 * Filter the lessons arguments for the Course Analysis list table.
+		 *
+		 * @hook sensei_analysis_course_filter_lessons
+		 *
+		 * @param {array} $lessons_args The lessons arguments.
+		 * @return {array} The lessons arguments.
+		 */
 		$lessons_query     = new WP_Query( apply_filters( 'sensei_analysis_course_filter_lessons', $lessons_args ) );
 		$this->total_items = $lessons_query->found_posts;
+
 		return $lessons_query->posts;
 	}
 
@@ -650,6 +760,14 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 				$text = __( 'No lessons found.', 'sensei-lms' );
 				break;
 		}
+		/**
+		 * Filter the text to display when no items are found in the Course Analysis list table.
+		 *
+		 * @hook sensei_analysis_course_no_items_text
+		 *
+		 * @param {string} $text The text to display.
+		 * @return {string} Filtered text.
+		 */
 		echo wp_kses_post( apply_filters( 'sensei_analysis_course_no_items_text', $text ) );
 	}
 
@@ -699,6 +817,14 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$menu['lesson'] = sprintf( '<a href="%s" class="%s">%s</a>', esc_url( $lessons_url ), esc_attr( $lessons_class ), esc_html( $lessons_text ) );
 		$menu['user']   = sprintf( '<a href="%s" class="%s">%s</a>', esc_url( $learners_url ), esc_attr( $learners_class ), esc_html( $learners_text ) );
 
+		/**
+		 * Filter the sub menu for the Course Analysis list table.
+		 *
+		 * @hook sensei_analysis_course_sub_menu
+		 *
+		 * @param {array} $menu The sub menu.
+		 * @return {array} The filtered sub menu.
+		 */
 		return apply_filters( 'sensei_analysis_course_sub_menu', $menu );
 	}
 
@@ -724,6 +850,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
+
+		/**
+		 * Filter the search button text for the Course Analysis list table.
+		 *
+		 * @hook sensei_list_table_search_button_text
+		 *
+		 * @param {string} $text The search button text.
+		 * @return {string} The filtered search button text.
+		 */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -440,7 +440,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 					$status          = __( 'Not started', 'sensei-lms' );
 					$user_start_date = $user_end_date = $status_class = $grade = '';
 
-					$lesson_args   = array(
+					$lesson_args = array(
 						'post_id' => $item->ID,
 						'user_id' => $this->user_id,
 						'type'    => 'sensei_lesson_status',
@@ -526,7 +526,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 				// Display lessons for this Course regardless of users
 				else {
 					// Get Learners (i.e. those who have started)
-					$lesson_args     = array(
+					$lesson_args = array(
 						'post_id' => $item->ID,
 						'type'    => 'sensei_lesson_status',
 						'status'  => 'any',
@@ -543,7 +543,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 					$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
 
 					// Get Course Completions
-					$lesson_args        = array(
+					$lesson_args = array(
 						'post_id' => $item->ID,
 						'type'    => 'sensei_lesson_status',
 						'status'  => array( 'complete', 'graded', 'passed', 'failed' ),

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -52,6 +52,15 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 			'status'    => __( 'Status', 'sensei-lms' ),
 			'grade'     => __( 'Grade', 'sensei-lms' ),
 		);
+		/**
+		 * Filter the columns that are going to be used in the table
+		 *
+		 * @hook sensei_analysis_lesson_columns
+		 *
+		 * @param {array}                             $columns    The array of columns to use with the table.
+		 * @param {Sensei_Analysis_Lesson_List_Table} $list_table The current instance of the class
+		 * @return {array} The array of columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_lesson_columns', $columns, $this );
 		return $columns;
 	}
@@ -66,6 +75,16 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$columns = array(
 			'completed' => array( 'comment_date', false ),
 		);
+
+		/**
+		 * Filter the sortable columns that are going to be used in the table
+		 *
+		 * @hook sensei_analysis_lesson_columns_sortable
+		 *
+		 * @param {array}                             $columns    The array of sortable columns to use with the table.
+		 * @param {Sensei_Analysis_Lesson_List_Table} $list_table The current instance of the class
+		 * @return {array} The array of soratable columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_lesson_columns_sortable', $columns, $this );
 		return $columns;
 	}
@@ -99,6 +118,15 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
+		/**
+		 * Filter the number of items per page that are going to be used in the table
+		 *
+		 * @hook sensei_comments_per_page
+		 *
+		 * @param {int} $per_page The number of items per page to use with the table.
+		 * @param {string} $type The type of items to display.
+		 * @return {int} The number of items per page to use with the table.
+		 */
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
 
 		$paged  = $this->get_pagenum();
@@ -287,7 +315,14 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 				'search' => '*' . $this->search . '*',
 				'fields' => 'ID',
 			);
-			// Filter for extending
+			/**
+			 * Filter the user arguments used to search for users
+			 *
+			 * @hook sensei_analysis_lesson_search_users
+			 *
+			 * @param {array} $user_args The arguments to find users.
+			 * @return {array} The array of user argument.
+			 */
 			$user_args = apply_filters( 'sensei_analysis_lesson_search_users', $user_args );
 			if ( ! empty( $user_args ) ) {
 				$learners_search = new WP_User_Query( $user_args );
@@ -296,6 +331,14 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 			}
 		}
 
+		/**
+		 * Filter the arguments used to search for activity
+		 *
+		 * @hook sensei_analysis_lesson_filter_statuses
+		 *
+		 * @param {array} $activity_args The arguments to find activity.
+		 * @return {array} The array of activity argument.
+		 */
 		$activity_args = apply_filters( 'sensei_analysis_lesson_filter_statuses', $activity_args );
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice
@@ -366,6 +409,15 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
+
+		/**
+		 * Filter the search button text for the list table.
+		 *
+		 * @hook sensei_list_table_search_button_text
+		 *
+		 * @param {string} $text The text for the search button.
+		 * @return {string} The text for the search button.
+		 */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -428,7 +428,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				}
 
 				// Get Course Completions.
-				$course_args        = array(
+				$course_args = array(
 					'post_id' => $item->ID,
 					'type'    => 'sensei_course_status',
 					'status'  => 'complete',
@@ -511,7 +511,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
 				 * @return {array} Filtered array of column data for the report table.
 				 */
-				$column_data             = apply_filters(
+				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
 						'title'              => $course_title,
@@ -528,7 +528,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 			case 'lessons':
 				// Get Learners (i.e. those who have started).
-				$lesson_args     = array(
+				$lesson_args = array(
 					'post_id' => $item->ID,
 					'type'    => 'sensei_lesson_status',
 					'status'  => 'any',
@@ -548,7 +548,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$lesson_students = Sensei_Utils::sensei_check_for_activity( $lesson_args );
 
 				// Get Course Completions.
-				$lesson_args        = array(
+				$lesson_args = array(
 					'post_id' => $item->ID,
 					'type'    => 'sensei_lesson_status',
 					'status'  => array( 'complete', 'graded', 'passed', 'failed', 'ungraded' ),
@@ -605,7 +605,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			case 'users':
 			default:
 				// Get Started Courses.
-				$course_args          = array(
+				$course_args = array(
 					'user_id' => $item->ID,
 					'type'    => 'sensei_course_status',
 					'status'  => 'any',
@@ -625,7 +625,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$user_courses_started = Sensei_Utils::sensei_check_for_activity( $course_args );
 
 				// Get Completed Courses.
-				$course_args        = array(
+				$course_args = array(
 					'user_id' => $item->ID,
 					'type'    => 'sensei_course_status',
 					'status'  => 'complete',
@@ -661,7 +661,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				 * @param {WP_User} $item Current user object.
 				 * @return {array} Filtered array of query arguments for graded user lessons.
 				 */
-				$grade_args         = apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item );
+				$grade_args = apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item );
 
 				$grade_count        = Sensei_Utils::sensei_check_for_activity( $grade_args, false );
 				$grade_total        = Sensei_Grading::get_user_graded_lessons_sum( $item->ID );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -144,7 +144,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
 		 * @return {array} Filtered array of columns for the report table.
 		 */
-		$columns = apply_filters( 'sensei_analysis_overview_' . $this->type . '_columns', $columns, $this );
+		$columns = apply_filters_deprecated(
+			'sensei_analysis_overview_' . $this->type . '_columns',
+			array( $columns, $this ),
+			'$$next-version$$',
+			'sensei_analysis_overview_columns'
+		);
 
 		/**
 		 * Filter the columns that are going to be used in the Analysis Overview list table.
@@ -243,7 +248,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
 		 * @return {array} Filtered array of sortable columns for the report table.
 		 */
-		$columns = apply_filters( 'sensei_analysis_overview_' . $this->type . '_columns_sortable', $columns, $this );
+		$columns = apply_filters_deprecated(
+			'sensei_analysis_overview_' . $this->type . '_columns_sortable',
+			array( $columns, $this ),
+			'$$next-version$$',
+			'sensei_analysis_overview_columns_sortable'
+		);
 
 		/**
 		 * Filter the sortable columns that are going to be used in the Analysis Overview list table.

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -284,7 +284,15 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
 
-		/* Filter documented in includes/class-sensei-grading-main.php */
+		/**
+		 * Filter the number of items per page.
+		 *
+		 * @hook sensei_comments_per_page
+		 *
+		 * @param {int} $per_page The number of items per page.
+		 * @param {string} $type The type of items.
+		 * @return {int} The number of items per page.
+		 */
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
 
 		$paged  = $this->get_pagenum();
@@ -586,7 +594,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 				}
 
-				/** This filter is documented in includes/class-sensei-analysis-overview-list-table.php */
+				/**
+				 * Filter the row data for the Analysis Overview list table.
+				 *
+				 * @hook sensei_analysis_overview_column_data
+				 *
+				 * @param {array} $column_data Array of column data for the report table.
+				 * @param {object|WP_Post|WP_User} $item Current row object.
+				 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
+				 * @return {array} Filtered array of column data for the report table.
+				 */
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
@@ -692,7 +709,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					$last_activity_date = $this->csv_output ? $item->last_activity_date : Sensei_Utils::format_last_activity_date( $item->last_activity_date );
 				}
 
-				/** This filter is documented in includes/class-sensei-analysis-overview-list-table.php */
+				/**
+				 * Filter the row data for the Analysis Overview list table.
+				 *
+				 * @hook sensei_analysis_overview_column_data
+				 *
+				 * @param {array} $column_data Array of column data for the report table.
+				 * @param {object|WP_Post|WP_User} $item Current row object.
+				 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
+				 * @return {array} Filtered array of column data for the report table.
+				 */
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -136,9 +136,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		 *
 		 * Backwards compatible filter name, moving forward should have single filter name.
 		 *
-		 * @hook sensei_analysis_overview_{type}_columns
-		 *
 		 * @deprecated $$next-version$$ Use sensei_analysis_overview_columns instead.
+		 *
+		 * @hook sensei_analysis_overview_{type}_columns
 		 *
 		 * @param {array} $columns Array of columns for the report table.
 		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
@@ -235,9 +235,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		 *
 		 * Backwards compatible filter name, moving forward should have single filter name.
 		 *
-		 * @hook sensei_analysis_overview_{type}_columns_sortable
-		 *
 		 * @deprecated $$next-version$$ Use sensei_analysis_overview_columns_sortable instead.
+		 *
+		 * @hook sensei_analysis_overview_{type}_columns_sortable
 		 *
 		 * @param {array} $columns Array of sortable columns for the report table.
 		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -131,8 +131,30 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				break;
 		}
 
-		// Backwards compatible filter name, moving forward should have single filter name
+		/**
+		 * Filter the columns that are going to be used in the Analysis Overview list table.
+		 *
+		 * Backwards compatible filter name, moving forward should have single filter name.
+		 *
+		 * @hook sensei_analysis_overview_{type}_columns
+		 *
+		 * @deprecated $$next-version$$ Use sensei_analysis_overview_columns instead.
+		 *
+		 * @param {array} $columns Array of columns for the report table.
+		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
+		 * @return {array} Filtered array of columns for the report table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_' . $this->type . '_columns', $columns, $this );
+
+		/**
+		 * Filter the columns that are going to be used in the Analysis Overview list table.
+		 *
+		 * @hook sensei_analysis_overview_columns
+		 *
+		 * @param {array} $columns Array of columns for the report table.
+		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
+		 * @return {array} Filtered array of columns for the report table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns', $columns, $this );
 
 		$this->columns = $columns;
@@ -207,9 +229,33 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				);
 				break;
 		}
-		// Backwards compatible filter name, moving forward should have single filter name.
+
+		/**
+		 * Filter the sortable columns that are going to be used in the Analysis Overview list table.
+		 *
+		 * Backwards compatible filter name, moving forward should have single filter name.
+		 *
+		 * @hook sensei_analysis_overview_{type}_columns_sortable
+		 *
+		 * @deprecated $$next-version$$ Use sensei_analysis_overview_columns_sortable instead.
+		 *
+		 * @param {array} $columns Array of sortable columns for the report table.
+		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
+		 * @return {array} Filtered array of sortable columns for the report table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_' . $this->type . '_columns_sortable', $columns, $this );
+
+		/**
+		 * Filter the sortable columns that are going to be used in the Analysis Overview list table.
+		 *
+		 * @hook sensei_analysis_overview_columns_sortable
+		 *
+		 * @param {array} $columns Array of sortable columns for the report table.
+		 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
+		 * @return {array} Filtered array of sortable columns for the report table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns_sortable', $columns, $this );
+
 		return $columns;
 	}
 
@@ -237,6 +283,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
+
+		/* Filter documented in includes/class-sensei-grading-main.php */
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
 
 		$paged  = $this->get_pagenum();
@@ -385,7 +433,19 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'type'    => 'sensei_course_status',
 					'status'  => 'complete',
 				);
-				$course_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_completions', $course_args, $item ) );
+
+				/**
+				 * Filter the course completions query arguments.
+				 *
+				 * @hook sensei_analysis_course_completions
+				 *
+				 * @param {array} $course_args Array of query arguments for course completions.
+				 * @param {WP_Post} $item Current course post object.
+				 * @return {array} Filtered array of query arguments for course completions.
+				 */
+				$course_args = apply_filters( 'sensei_analysis_course_completions', $course_args, $item );
+
+				$course_completions = Sensei_Utils::sensei_check_for_activity( $course_args );
 
 				// Average Grade will be N/A if the course has no lessons or quizzes, if none of the lessons
 				// have a status of 'graded', 'passed' or 'failed', or if none of the quizzes have grades.
@@ -400,7 +460,18 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						'meta_key' => 'grade',
 					);
 
-					$percent_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_percentage', $grade_args, $item ), false );
+					/**
+					 * Filter the course completion percentage query arguments.
+					 *
+					 * @hook sensei_analysis_course_percentage
+					 *
+					 * @param {array} $grade_args Array of query arguments for course percentage.
+					 * @param {WP_Post} $item Current course post object.
+					 * @return {array} Filtered array of query arguments for course percentage.
+					 */
+					$grade_args = apply_filters( 'sensei_analysis_course_percentage', $grade_args, $item );
+
+					$percent_count = Sensei_Utils::sensei_check_for_activity( $grade_args, false );
 					$percent_total = Sensei_Grading::get_course_users_grades_sum( $item->ID );
 
 					if ( $percent_count > 0 && $percent_total >= 0 ) {
@@ -429,6 +500,17 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				}
 
 				$average_course_progress = $this->get_average_progress_for_courses_table( $item->ID );
+
+				/**
+				 * Filter the row data for the Analysis Overview list table.
+				 *
+				 * @hook sensei_analysis_overview_column_data
+				 *
+				 * @param {array} $column_data Array of column data for the report table.
+				 * @param {object|WP_Post|WP_User} $item Current row object.
+				 * @param {Sensei_Analysis_Overview_List_Table} $this Current instance of the list table.
+				 * @return {array} Filtered array of column data for the report table.
+				 */
 				$column_data             = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
@@ -451,7 +533,19 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'type'    => 'sensei_lesson_status',
 					'status'  => 'any',
 				);
-				$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
+
+				/**
+				 * Filter the lesson learners progress query arguments.
+				 *
+				 * @hook sensei_analysis_lesson_learners
+				 *
+				 * @param {array} $lesson_args Array of query arguments for lesson learners.
+				 * @param {WP_Post} $item Current lesson post object.
+				 * @return {array} Filtered array of query arguments for lesson learners.
+				 */
+				$lesson_args = apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item );
+
+				$lesson_students = Sensei_Utils::sensei_check_for_activity( $lesson_args );
 
 				// Get Course Completions.
 				$lesson_args        = array(
@@ -460,7 +554,20 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'status'  => array( 'complete', 'graded', 'passed', 'failed', 'ungraded' ),
 					'count'   => true,
 				);
-				$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
+
+				/**
+				 * Filter the lesson completions query arguments.
+				 *
+				 * @hook sensei_analysis_lesson_completions
+				 *
+				 * @param {array} $lesson_args Array of query arguments for lesson completions.
+				 * @param {WP_Post} $item Current lesson post object.
+				 * @return {array} Filtered array of query arguments for lesson completions.
+				 */
+				$lesson_args = apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item );
+
+				$lesson_completions = Sensei_Utils::sensei_check_for_activity( $lesson_args );
+
 				// Taking the ceiling value for the average.
 				$average_completion_days = $lesson_completions > 0 ? ceil( $item->days_to_complete / $lesson_completions ) : __( 'N/A', 'sensei-lms' );
 
@@ -478,6 +585,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					$lesson_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 
 				}
+
+				/** This filter is documented in includes/class-sensei-analysis-overview-list-table.php */
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
@@ -501,7 +610,19 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'type'    => 'sensei_course_status',
 					'status'  => 'any',
 				);
-				$user_courses_started = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item ) );
+
+				/**
+				 * Filter user progress query arguments for courses: find started courses.
+				 *
+				 * @hook sensei_analysis_user_courses_started
+				 *
+				 * @param {array} $course_args Array of query arguments for started user courses.
+				 * @param {WP_User} $item Current user object.
+				 * @return {array} Filtered array of query arguments for started user courses.
+				 */
+				$course_args = apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item );
+
+				$user_courses_started = Sensei_Utils::sensei_check_for_activity( $course_args );
 
 				// Get Completed Courses.
 				$course_args        = array(
@@ -509,7 +630,19 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'type'    => 'sensei_course_status',
 					'status'  => 'complete',
 				);
-				$user_courses_ended = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_ended', $course_args, $item ) );
+
+				/**
+				 * Filter user progress query arguments for courses: find completed courses.
+				 *
+				 * @hook sensei_analysis_user_courses_ended
+				 *
+				 * @param {array} $course_args Array of query arguments for ended user courses.
+				 * @param {WP_User} $item Current user object.
+				 * @return {array} Filtered array of query arguments for ended user courses.
+				 */
+				$course_args = apply_filters( 'sensei_analysis_user_courses_ended', $course_args, $item );
+
+				$user_courses_ended = Sensei_Utils::sensei_check_for_activity( $course_args );
 
 				// Get Quiz Grades.
 				$grade_args = array(
@@ -519,7 +652,18 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'meta_key' => 'grade',
 				);
 
-				$grade_count        = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item ), false );
+				/**
+				 * Filter user progress query arguments for lessons: find graded lessons.
+				 *
+				 * @hook sensei_analysis_user_lesson_grades
+				 *
+				 * @param {array} $grade_args Array of query arguments for graded user lessons.
+				 * @param {WP_User} $item Current user object.
+				 * @return {array} Filtered array of query arguments for graded user lessons.
+				 */
+				$grade_args         = apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item );
+
+				$grade_count        = Sensei_Utils::sensei_check_for_activity( $grade_args, false );
 				$grade_total        = Sensei_Grading::get_user_graded_lessons_sum( $item->ID );
 				$user_average_grade = 0;
 
@@ -547,6 +691,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				if ( $item->last_activity_date ) {
 					$last_activity_date = $this->csv_output ? $item->last_activity_date : Sensei_Utils::format_last_activity_date( $item->last_activity_date );
 				}
+
+				/** This filter is documented in includes/class-sensei-analysis-overview-list-table.php */
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
@@ -687,7 +833,19 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		if ( isset( $args['orderby'] ) && ( 'count_of_completions' === $args['orderby'] ) ) {
 			add_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_non_user_query' ), 10, 2 );
 		}
-		$courses_query = new WP_Query( apply_filters( 'sensei_analysis_overview_filter_courses', $course_args ) );
+
+		/**
+		 * Filter the query arguments for courses in the Analysis Overview list table.
+		 *
+		 * @hook sensei_analysis_overview_filter_courses
+		 *
+		 * @param {array} $course_args Array of query arguments for courses.
+		 * @return {array} Filtered array of query arguments for courses.
+		 */
+		$course_args = apply_filters( 'sensei_analysis_overview_filter_courses', $course_args );
+
+		$courses_query = new WP_Query( $course_args );
+
 		remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_non_user_query' ), 10, 2 );
 		remove_filter( 'posts_clauses', [ $this, 'filter_courses_by_last_activity' ] );
 		remove_filter( 'posts_clauses', [ $this, 'add_days_to_completion_to_courses_queries' ] );
@@ -731,8 +889,19 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 
 		add_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );
+
+		/**
+		 * Filter the query arguments for lessons in the Analysis Overview list table.
+		 *
+		 * @hook sensei_analysis_overview_filter_lessons
+		 *
+		 * @param {array} $lessons_args Array of query arguments for lessons.
+		 * @return {array} Filtered array of query arguments for lessons.
+		 */
+		$lessons_args = apply_filters( 'sensei_analysis_overview_filter_lessons', $lessons_args );
+
 		// Using WP_Query as get_posts() doesn't support 'found_posts'.
-		$lessons_query = new WP_Query( apply_filters( 'sensei_analysis_overview_filter_lessons', $lessons_args ) );
+		$lessons_query = new WP_Query( $lessons_args );
 		remove_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );
 		$this->total_items = $lessons_query->found_posts;
 		return $lessons_query->posts;
@@ -756,10 +925,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$args['fields'] = array( 'ID', 'user_login', 'user_email', 'user_registered', 'display_name' );
 
 		/**
-		 * Filter the WP_User_Query arguments
+		 * Filter the query arguments for users in the Analysis Overview list table.
 		 *
-		 * @since 1.6.0
-		 * @param $args
+		 * @hook sensei_analysis_overview_filter_users
+		 *
+		 * @param {array} $args Array of query arguments for users.
+		 * @return {array} Filtered array of query arguments for users.
 		 */
 		$args = apply_filters( 'sensei_analysis_overview_filter_users', $args );
 

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -51,7 +51,16 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 			'status'    => __( 'Status', 'sensei-lms' ),
 			'percent'   => __( 'Percent Complete', 'sensei-lms' ),
 		);
+		/**
+		 * Filter the columns that are going to be used in the table.
+		 *
+		 * @hook sensei_analysis_user_profile_columns
+		 *
+		 * @param {array} $columns The array of columns to use with the table.
+		 * @return {array} The filtered array of columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_user_profile_columns', $columns );
+
 		return $columns;
 	}
 
@@ -59,13 +68,23 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 	 * Define the columns that are going to be used in the table
 	 *
 	 * @since  1.7.0
-	 * @return array $columns, the array of columns to use with the table
+	 * @return array $columns the array of columns to use with the table
 	 */
 	function get_sortable_columns() {
 		$columns = array(
 			'completed' => array( 'comment_date', false ),
 		);
+
+		/**
+		 * Filter sortable columns that are going to be used in the table.
+		 *
+		 * @hook sensei_analysis_user_profile_columns_sortable
+		 *
+		 * @param {array} $columns The array of sortable columns to use with the table.
+		 * @return {array} The filtered array of sortable columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_user_profile_columns_sortable', $columns );
+
 		return $columns;
 	}
 
@@ -98,6 +117,15 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
+		/**
+		 * Filter the number of items per page that are going to be used in the table.
+		 *
+		 * @hook sensei_comments_per_page
+		 *
+		 * @param {int}    $per_page The number of items per page to use with the table.
+		 * @param {string} $type     The type of items per page to use with the table.
+		 * @return {int} The filtered number of items per page to use with the table.
+		 */
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
 
 		$paged  = $this->get_pagenum();
@@ -274,6 +302,14 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 			$activity_args['post_author'] = get_current_user_id();
 		}
 
+		/**
+		 * Filter the activity args for the user profile statuses.
+		 *
+		 * @hook sensei_analysis_user_profile_filter_statuses
+		 *
+		 * @param {array} $activity_args The array of activity args.
+		 * @return {array} The filtered array of activity args.
+		 */
 		$activity_args = apply_filters( 'sensei_analysis_user_profile_filter_statuses', $activity_args );
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice
@@ -348,6 +384,14 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
+		/**
+		 * Filter the search button text for the list table.
+		 *
+		 * @hook sensei_list_table_search_button_text
+		 *
+		 * @param {string} $text The text for the search button.
+		 * @return {string} The filtered text for the search button.
+		 */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -643,7 +643,8 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<h1><?php
+			<h1>
+			<?php
 			/**
 			 * Filter the Reports page title.
 			 *
@@ -655,7 +656,8 @@ class Sensei_Analysis {
 			 * @return {string} Returns filtered page title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
-			?></h1>
+			?>
+			</h1>
 		<?php
 	}
 

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -127,6 +127,7 @@ class Sensei_Analysis {
 		 * Filter the Reports navigation menu items.
 		 *
 		 * @since 4.2.0
+		 *
 		 * @hook sensei_analysis_sub_menu
 		 *
 		 * @param {array} $menu The menu items.
@@ -137,6 +138,7 @@ class Sensei_Analysis {
 		 * Filter the Reports page title.
 		 *
 		 * @since 4.2.0
+		 *
 		 * @hook sensei_analysis_nav_title
 		 *
 		 * @param {string} $title The page title.
@@ -543,7 +545,17 @@ class Sensei_Analysis {
 		$title = $this->name;
 		?>
 			<h1>
-				<?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?>
+				<?php
+				/**
+				 * Filter the Reports page title.
+				 *
+				 * @hook sensei_analysis_nav_title
+				 *
+				 * @param {string} $title The page title.
+				 * @return {string} Returns filtered page title.
+				 */
+				echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
+				?>
 			</h1>
 		<?php
 	}
@@ -576,6 +588,7 @@ class Sensei_Analysis {
 
 		}
 		?>
+			<?php /** This filter is documented earlier in this file. */ ?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
 	}
@@ -617,6 +630,7 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
+			<?php /** This filter is documented earlier in this file. */ ?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
 	}
@@ -645,6 +659,7 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
+			<?php /** This filter is documented earlier in this file. */ ?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
 	}
@@ -673,6 +688,7 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
+			<?php /** This filter is documented earlier in this file. */ ?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
 	}
@@ -710,6 +726,7 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $lesson_id ) );
 		}
 		?>
+			<?php /** This filter is documented earlier in this file. */ ?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
 	}
@@ -732,6 +749,14 @@ class Sensei_Analysis {
 			}
 
 			// Setup the variables we might need
+			/**
+			 * Filter the filename for the CSV export.
+			 *
+			 * @hook sensei_csv_export_filename
+			 *
+			 * @param {string} $filename The filename.
+			 * @return {string} Filtered filename.
+			 */
 			$filename  = apply_filters( 'sensei_csv_export_filename', $report );
 			$course_id = 0;
 			$lesson_id = 0;

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -643,8 +643,7 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<h1>
-			<?php
+			<h1><?php
 			/**
 			 * Filter the Reports page title.
 			 *
@@ -656,8 +655,7 @@ class Sensei_Analysis {
 			 * @return {string} Returns filtered page title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
-			?>
-			</h1>
+			?></h1>
 		<?php
 	}
 

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -588,8 +588,19 @@ class Sensei_Analysis {
 
 		}
 		?>
-			<?php /** This filter is documented earlier in this file. */ ?>
-			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
+			<h1><?php
+			/**
+			 * Filter the Reports page title.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @hook sensei_analysis_nav_title
+			 *
+			 * @param {string} $title The page title.
+			 * @return {string} Returns filtered page title.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
+			?></h1>
 		<?php
 	}
 
@@ -630,8 +641,19 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<?php /** This filter is documented earlier in this file. */ ?>
-			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
+			<h1><?php
+			/**
+			 * Filter the Reports page title.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @hook sensei_analysis_nav_title
+			 *
+			 * @param {string} $title The page title.
+			 * @return {string} Returns filtered page title.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
+			?></h1>
 		<?php
 	}
 
@@ -659,8 +681,19 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<?php /** This filter is documented earlier in this file. */ ?>
-			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
+			<h1><?php
+			/**
+			 * Filter the Reports page title.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @hook sensei_analysis_nav_title
+			 *
+			 * @param {string} $title The page title.
+			 * @return {string} Returns filtered page title.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
+			?></h1>
 		<?php
 	}
 
@@ -688,8 +721,19 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<?php /** This filter is documented earlier in this file. */ ?>
-			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
+			<h1><?php
+			/**
+			 * Filter the Reports page title.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @hook sensei_analysis_nav_title
+			 *
+			 * @param {string} $title The page title.
+			 * @return {string} Returns filtered page title.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
+			?></h1>
 		<?php
 	}
 
@@ -726,8 +770,19 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $lesson_id ) );
 		}
 		?>
-			<?php /** This filter is documented earlier in this file. */ ?>
-			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
+			<h1><?php
+			/**
+			 * Filter the Reports page title.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @hook sensei_analysis_nav_title
+			 *
+			 * @param {string} $title The page title.
+			 * @return {string} Returns filtered page title.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
+			?></h1>
 		<?php
 	}
 

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -588,7 +588,8 @@ class Sensei_Analysis {
 
 		}
 		?>
-			<h1><?php
+			<h1>
+			<?php
 			/**
 			 * Filter the Reports page title.
 			 *
@@ -600,7 +601,8 @@ class Sensei_Analysis {
 			 * @return {string} Returns filtered page title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
-			?></h1>
+			?>
+			</h1>
 		<?php
 	}
 
@@ -641,7 +643,8 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<h1><?php
+			<h1>
+			<?php
 			/**
 			 * Filter the Reports page title.
 			 *
@@ -653,7 +656,8 @@ class Sensei_Analysis {
 			 * @return {string} Returns filtered page title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
-			?></h1>
+			?>
+			</h1>
 		<?php
 	}
 
@@ -681,7 +685,8 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<h1><?php
+			<h1>
+			<?php
 			/**
 			 * Filter the Reports page title.
 			 *
@@ -693,7 +698,8 @@ class Sensei_Analysis {
 			 * @return {string} Returns filtered page title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
-			?></h1>
+			?>
+			</h1>
 		<?php
 	}
 
@@ -721,7 +727,8 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
 		?>
-			<h1><?php
+			<h1>
+			<?php
 			/**
 			 * Filter the Reports page title.
 			 *
@@ -733,7 +740,8 @@ class Sensei_Analysis {
 			 * @return {string} Returns filtered page title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
-			?></h1>
+			?>
+			</h1>
 		<?php
 	}
 
@@ -770,7 +778,8 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $lesson_id ) );
 		}
 		?>
-			<h1><?php
+			<h1>
+			<?php
 			/**
 			 * Filter the Reports page title.
 			 *
@@ -782,7 +791,8 @@ class Sensei_Analysis {
 			 * @return {string} Returns filtered page title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) );
-			?></h1>
+			?>
+			</h1>
 		<?php
 	}
 

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -284,12 +284,12 @@ class Sensei_Assets {
 		 * Filters the icon href for the svg.
 		 *
 		 * @since 4.4.0
+		 *
 		 * @hook sensei_icon_href
 		 *
 		 * @param {string} $icon_href   The icon href.
 		 * @param {string} $sprite_file The sprite file URL.
 		 * @param {string} $name        The icon name.
-		 *
 		 * @return {string} The icon href.
 		 */
 		$icon_href = apply_filters( 'sensei_icon_href', "{$sprite_file}#sensei-sprite-{$name}", $sprite_file, $name );

--- a/includes/class-sensei-context-notices.php
+++ b/includes/class-sensei-context-notices.php
@@ -114,11 +114,11 @@ class Sensei_Context_Notices {
 		 * Filter the Course Theme notices.
 		 *
 		 * @since 3.15.0
+		 *
 		 * @hook sensei_context_notices
 		 *
 		 * @param {array}  $notices Course Theme notices.
 		 * @param {string} $context  The context.
-		 *
 		 * @return {array} Filtered Course Theme notices.
 		 */
 		return apply_filters( 'sensei_context_notices', $this->notices, $this->context );

--- a/includes/class-sensei-course-results.php
+++ b/includes/class-sensei-course-results.php
@@ -47,6 +47,14 @@ class Sensei_Course_Results {
 	 */
 	public function setup_permastruct() {
 		// Setup course results URL base.
+		/**
+		 * Filter the course slug.
+		 *
+		 * @hook sensei_course_slug
+		 *
+		 * @param {string} $course_slug The course slug.
+		 * @return {string} Filtered course slug.
+		 */
 		$this->courses_url_base = apply_filters( 'sensei_course_slug', _x( 'course', 'post type single url slug', 'sensei-lms' ) );
 
 		// Setup permalinks structure.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2117,8 +2117,15 @@ class Sensei_Course {
 				}
 
 				/**
-				* Filter documented in Sensei_Course::the_course_action_buttons
-				*/
+				 * Filter results links.
+				 *
+				 * @hook sensei_results_links
+				 *
+				 * @param {string} $results_links HTML for results links.
+				 * @param {int}    $course_id     Course ID.
+				 * @param {int}    $user_id       User ID.
+				 * @return {string} HTML for results links.
+				 */
 				$results_links = apply_filters( 'sensei_results_links', $results_link, $course_item->ID, $user->ID );
 				if ( $results_links ) {
 						$complete_html .= '<p class="sensei-results-links">';
@@ -3499,7 +3506,13 @@ class Sensei_Course {
 		}
 
 		/**
-		 * hook document in class-woothemes-sensei-message.php
+		 * Filter Sensei single title
+		 *
+		 * @hook sensei_single_title
+		 *
+		 * @param {string} $title     The title.
+		 * @param {string} $post_type The post type.
+		 * @return {string} Filtered title.
 		 */
 		$title = apply_filters( 'sensei_single_title', $title, $post->post_type );
 
@@ -3676,7 +3689,13 @@ class Sensei_Course {
 						}
 
 						/**
-						 * Filter documented in Sensei_Course::the_course_action_buttons
+						 * Filter results links.
+						 *
+						 * @hook sensei_results_links
+						 *
+						 * @param {string} $results_links HTML for results links.
+						 * @param {int}    $course_id     Course ID.
+						 * @return {string} HTML for results links.
 						 */
 						$results_link = apply_filters( 'sensei_results_links', $results_link, $course_id );
 						echo wp_kses_post( $results_link );
@@ -3859,7 +3878,13 @@ class Sensei_Course {
 
 				<?php
 				/**
-				 * Filter documented in class-sensei-messages.php the_title
+				 * Filter Sensei single title
+				 *
+				 * @hook sensei_single_title
+				 *
+				 * @param {string} $title     The title.
+				 * @param {string} $post_type The post type.
+				 * @return {string} Filtered title.
 				 */
 				echo wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type ) );
 				?>

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -360,10 +360,10 @@ class Sensei_Course {
 		 * Filters the tabs that the user can see on the Courses page.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_course_custom_navigation_tabs
 		 *
 		 * @param {Array} $tabs The list of tabs that the user should see on the Courses page.
-		 *
 		 * @return {Array} The list of tabs to render for the user on the Courses page.
 		 */
 		$tabs = apply_filters( 'sensei_course_custom_navigation_tabs', $tabs );
@@ -393,12 +393,12 @@ class Sensei_Course {
 		/**
 		 * Filter courses navigation sidebar content.
 		 *
-		 * @hook  sensei_courses_navigation_sidebar
 		 * @since 4.12.0
+		*
+		 * @hook  sensei_courses_navigation_sidebar
 		 *
 		 * @param {string}    $content The content to be displayed in the sidebar.
 		 * @param {WP_Screen} $screen  The current screen.
-		 *
 		 * @return {string} The content to be displayed in the sidebar.
 		 */
 		$navigation_sidebar = apply_filters( 'sensei_courses_navigation_sidebar', '', $screen );
@@ -493,6 +493,14 @@ class Sensei_Course {
 			'nonce_name'  => Sensei()->teacher::NONCE_FIELD_NAME,
 			'teachers'    => Sensei()->teacher->get_teachers_and_authors_with_fields( [ 'ID', 'display_name' ] ),
 			'features'    => [
+				/**
+				 * Filters whether the course feature to allow students to preview lessons is enabled.
+				 *
+				 * @hook sensei_feature_course_preview_lessons
+				 *
+				 * @param {bool} $enabled Whether the feature is enabled.
+				 * @return {bool} Whether the feature is enabled.
+				 */
 				'open_access' => apply_filters( 'sensei_feature_open_access_courses', true ),
 			],
 			'courses'     => get_posts(
@@ -570,6 +578,7 @@ class Sensei_Course {
 		 * Filters if a visitor can view course content.
 		 *
 		 * @since 3.0.0
+		 *
 		 * @hook sensei_can_access_course_content
 		 *
 		 * @param {bool}   $can_view_course_content True if they can view the course content.
@@ -688,7 +697,10 @@ class Sensei_Course {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param string[] $course_meta_fields Array of meta field key names to save on course save.
+		 * @hook sensei_course_meta_fields
+		 *
+		 * @param {string[]} $course_meta_fields Array of meta field key names to save on course save.
+		 * @return {string[]} Filtered meta field key names.
 		 */
 		$this->meta_fields = apply_filters( 'sensei_course_meta_fields', [ 'course_prerequisite', 'course_featured', 'course_video_embed' ] );
 	}
@@ -1013,10 +1025,13 @@ class Sensei_Course {
 		 *
 		 * @since 2.2.0
 		 *
-		 * @param bool   $do_save        Whether or not to do the default save.
-		 * @param int    $post_id        The course ID.
-		 * @param string $meta_key       The meta to be saved.
-		 * @param mixed  $new_meta_value The meta value to be saved.
+		 * @hook sensei_course_meta_default_save
+		 *
+		 * @param {bool}   $do_save        Whether or not to do the default save.
+		 * @param {int}    $post_id        The course ID.
+		 * @param {string} $meta_key       The meta to be saved.
+		 * @param {mixed}  $new_meta_value The meta value to be saved.
+		 * @return {bool} Whether or not to do the default save.
 		 */
 		if ( apply_filters( 'sensei_course_meta_default_save', true, $post_id, $meta_key, $new_meta_value ) ) {
 			// Update meta field with the new value
@@ -1481,10 +1496,13 @@ class Sensei_Course {
 					 * @since 1.1.0
 					 * @since 1.12.0 Added $course_id, $width, and $height.
 					 *
-					 * @param string $img_html  Course image HTML.
-					 * @param int    $course_id Course ID.
-					 * @param int    $width     Requested image width.
-					 * @param int    $height    Requested image height.
+					 * @hook sensei_course_placeholder_image_url
+					 *
+					 * @param {string} $img_html  Course image HTML.
+					 * @param {int}    $course_id Course ID.
+					 * @param {int}    $width     Requested image width.
+					 * @param {int}    $height    Requested image height.
+					 * @return {string} Course image HTML.
 					 */
 					$img_html         = apply_filters( 'sensei_course_placeholder_image_url', '<img src="//via.placeholder.com/' . $width . 'x' . $height . '" class="' . esc_attr( $classes ) . '" />', $course_id, $width, $height );
 					$used_placeholder = true;
@@ -1498,11 +1516,14 @@ class Sensei_Course {
 		 *
 		 * @since 1.12.0
 		 *
-		 * @param string $img_html         Course image HTML.
-		 * @param int    $course_id        Course ID.
-		 * @param int    $width            Requested image width.
-		 * @param int    $height           Requested image height.
-		 * @param bool   $used_placeholder True if placeholder was used in the generation of the image HTML.
+		 * @hook sensei_course_image_html
+		 *
+		 * @param {string} $img_html         Course image HTML.
+		 * @param {int}    $course_id        Course ID.
+		 * @param {int}    $width            Requested image width.
+		 * @param {int}    $height           Requested image height.
+		 * @param {bool}   $used_placeholder True if placeholder was used in the generation of the image HTML.
+		 * @return {string} Course image HTML.
 		 */
 		$img_html = apply_filters( 'sensei_course_image_html', $img_html, $course_id, $width, $height, $used_placeholder );
 
@@ -1544,6 +1565,14 @@ class Sensei_Course {
 		];
 
 		// Allow WP to generate the complex final query, just shortcut to only do an overall count
+		/**
+		 * Filter course count query arguments.
+		 *
+		 * @hook sensei_course_count
+		 *
+		 * @param {array} $post_args Query arguments.
+		 * @return {array} Filtered query arguments.
+		 */
 		$courses_query = new WP_Query( apply_filters( 'sensei_course_count', $post_args ) );
 
 		return count( $courses_query->posts );
@@ -1613,8 +1642,11 @@ class Sensei_Course {
 		 *
 		 * Returns all lessons for a given course
 		 *
-		 * @param array $lessons
-		 * @param int $course_id
+		 * @hook sensei_course_get_lessons
+		 *
+		 * @param {array} $lessons   Array of lesson objects.
+		 * @param {int}   $course_id The course ID.
+		 * @return {array} Array of lesson objects.
 		 */
 		$lessons = apply_filters( 'sensei_course_get_lessons', $lessons, $course_id );
 
@@ -1806,6 +1838,15 @@ class Sensei_Course {
 	 * @return boolean
 	 */
 	private static function has_results_links( $course_id ) {
+		/**
+		 * Filter results links.
+		 *
+		 * @hook sensei_results_links
+		 *
+		 * @param {string} $results_links HTML for results links.
+		 * @param {int}    $course_id     Course ID.
+		 * @return {string} HTML for results links.
+		 */
 		return has_filter( 'sensei_results_links' ) && ! empty( apply_filters( 'sensei_results_links', '', $course_id ) );
 	}
 
@@ -2279,14 +2320,12 @@ class Sensei_Course {
 		$wp_query_obj = new WP_Query( $args );
 
 		/**
-		 * sensei_get_all_courses filter
+		 * Filter courses in Sensei_Course::get_all_courses.
 		 *
-		 * This filter runs inside Sensei_Course::get_all_courses.
+		 * @hook sensei_get_all_courses
 		 *
-		 * @param array $courses{
-		 *  @type WP_Post
-		 * }
-		 * @param array $attributes
+		 * @param {WP_Post[]} Array of courses.
+		 * @return {WP_Post[]} Filtered courses.
 		 */
 		return apply_filters( 'sensei_get_all_courses', $wp_query_obj->posts );
 
@@ -2344,7 +2383,10 @@ class Sensei_Course {
 		 * Filter the course completion statement.
 		 * Default Currently completed $var lesson($plural) of $var in total
 		 *
-		 * @param string $statement
+		 * @hook sensei_course_completion_statement
+		 *
+		 * @param {string} $statement The course completion statement.
+		 * @return {string} Filtered course completion statement.
 		 */
 		return apply_filters( 'sensei_course_completion_statement', $statement );
 
@@ -2373,11 +2415,15 @@ class Sensei_Course {
 		 * Filter the course progress stats.
 		 *
 		 * @since 3.14.4
-		 * @param array $stat An array of course progress stats.
-		 *              $stats['lessons_count'] The total number of lessons in the course.
-		 *              $stats['completed_lessons_count'] The total number of completed lessons of the course by the user.
-		 *              $stats['completed_lessons_percentage'] The completed lessons percentage relative to total number of lessons.
-		 * @param int   $course_id The id of the course.
+		 *
+		 * @hook sensei_course_progress_stats
+		 *
+		 * @param {array} $stat An array of course progress stats.
+		 *                $stats['lessons_count'] The total number of lessons in the course.
+		 *                $stats['completed_lessons_count'] The total number of completed lessons of the course by the user.
+		 *                $stats['completed_lessons_percentage'] The completed lessons percentage relative to total number of lessons.
+		 * @param {int}   $course_id The id of the course.
+		 * @return {array} Filtered course progress stats.
 		 */
 		return apply_filters( 'sensei_course_progress_stats', $stats, $course_id );
 	}
@@ -2496,10 +2542,14 @@ class Sensei_Course {
 		 *
 		 * Filter the percentage returned for a users course.
 		 *
-		 * @param $percentage
-		 * @param $course_id
-		 * @param $user_id
 		 * @since 1.8.0
+		 *
+		 * @hook sensei_course_completion_percentage
+		 *
+		 * @param {float} $percentage The percentage of the course completed.
+		 * @param {int}   $course_id  The ID of the course.
+		 * @param {int}   $user_id    The ID of the user.
+		 * @return {float} Filtered percentage.
 		 */
 		return apply_filters( 'sensei_course_completion_percentage', $percentage, $course_id, $user_id );
 
@@ -2800,8 +2850,11 @@ class Sensei_Course {
 				/**
 				 * Filter the results links
 				 *
-				 * @param string $results_links_html
-				 * @param integer $course_id
+				 * @hook sensei_results_links
+				 *
+				 * @param {string} $results_links_html The HTML for the results links.
+				 * @param {int}    $course_id          The ID of the course.
+				 * @return {string} Filtered results links HTML.
 				 */
 				echo wp_kses_post( apply_filters( 'sensei_results_links', $results_link, $course->ID ) );
 				?>
@@ -2842,13 +2895,14 @@ class Sensei_Course {
 		// for the course archive page
 		if ( $query->is_main_query() && is_post_type_archive( 'course' ) ) {
 			/**
-			 * sensei_archive_courses_per_page
-			 *
-			 * Sensei courses per page on the course
-			 * archive
+			 * Filter courses per page on the course archive.
 			 *
 			 * @since 1.9.0
-			 * @param integer $posts_per_page defaults to the value of get_option( 'posts_per_page' )
+			 *
+			 * @hook sensei_archive_courses_per_page
+			 *
+			 * @param {int} $posts_per_page defaults to the value of get_option( 'posts_per_page' )
+			 * @return {int} Filtered posts per page.
 			 */
 			$query->set( 'posts_per_page', apply_filters( 'sensei_archive_courses_per_page', get_option( 'posts_per_page' ) ) );
 			if ( isset( $query->query ) && isset( $query->query['paged'] ) && false === $query->get( 'paged', false ) ) {
@@ -2858,13 +2912,13 @@ class Sensei_Course {
 		// for the my courses page
 		elseif ( isset( $post ) && is_page() && Sensei()->settings->get( 'my_course_page' ) == $post->ID ) {
 			/**
-			 * sensei_my_courses_per_page
-			 *
-			 * Sensei courses per page on the my courses page
-			 * as set in the settings
+			 * Filters number of courses per page on the my courses page as set in the settings.
 			 *
 			 * @since 1.9.0
-			 * @param integer $posts_per_page default 10
+			 *
+			 * @hook sensei_my_courses_per_page
+			 * @param {int} $posts_per_page Number of courses per page, default 10.
+			 * @return {int} Filtered posts per page.
 			 */
 			$query->set( 'posts_per_page', apply_filters( 'sensei_my_courses_per_page', $query->get( 'posts_per_page', 10 ) ) );
 
@@ -2921,11 +2975,11 @@ class Sensei_Course {
 		 * which is called from the course loop content-course.php.
 		 *
 		 * @since 1.9.0
+		*
 		 * @hook sensei_course_loop_content_class
 		 *
 		 * @param {array} $extra_classes
 		 * @param {WP_Post} $loop_current_course
-		 *
 		 * @return {array} Additional CSS classes.
 		 */
 		return apply_filters( 'sensei_course_loop_content_class', $extra_classes, get_post() );
@@ -2944,7 +2998,11 @@ class Sensei_Course {
 		 * Filter the number of columns on the course archive page.
 		 *
 		 * @since 1.9.0
-		 * @param int $number_of_columns default 1
+		 *
+		 * @hook sensei_course_loop_number_of_columns
+		 *
+		 * @param {int} $number_of_columns Number of columns, default 1.
+		 * @return {int} Filtered number of columns.
 		 */
 		return apply_filters( 'sensei_course_loop_number_of_columns', 1 );
 
@@ -3254,7 +3312,10 @@ class Sensei_Course {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param string $course_page_url Course archive page URL.
+		 * @hook sensei_course_archive_page_url
+		 *
+		 * @param {string} $course_page_url Course archive page URL.
+		 * @return {string} Course archive page URL.
 		 */
 		return apply_filters( 'sensei_course_archive_page_url', $course_page_url );
 	}
@@ -3276,11 +3337,11 @@ class Sensei_Course {
 		 * Filter the course completed page URL.
 		 *
 		 * @since 3.13.0
+		*
 		 * @hook sensei_course_completed_page_url
 		 *
 		 * @param {string} $url       Course completed page URL.
 		 * @param {int}    $course_id ID of the course that was completed.
-		 *
 		 * @return {string} Course completed page URL.
 		 */
 		return apply_filters( 'sensei_course_completed_page_url', $url, $course_id );
@@ -3389,8 +3450,11 @@ class Sensei_Course {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param bool $has_access_to_content Filtered variable for if the visitor has access to view the content.
-		 * @param int  $course_id             Post ID for the course.
+		 * @hook sensei_course_content_has_access
+		 *
+		 * @param {bool} $has_access_to_content Filtered variable for if the visitor has access to view the content.
+		 * @param {int}  $course_id             Post ID for the course.
+		 * @return {bool} Filtered variable for if the visitor has access to view the content.
 		 */
 		if ( apply_filters( 'sensei_course_content_has_access', true, get_the_ID() ) ) {
 			if ( empty( $content ) ) {
@@ -3667,8 +3731,11 @@ class Sensei_Course {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool $can_user_manually_enrol True if they can manually enrol themselves, false if not.
-		 * @param int  $course_id               Course post ID.
+		 * @hook sensei_can_user_manually_enrol
+		 *
+		 * @param {bool} $can_user_manually_enrol True if they can manually enrol themselves, false if not.
+		 * @param {int}  $course_id               Course post ID.
+		 * @return {bool} Filtered value.
 		 */
 		return (bool) apply_filters( 'sensei_can_user_manually_enrol', $can_user_manually_enrol, $course_id );
 	}
@@ -3910,8 +3977,12 @@ class Sensei_Course {
 		 * Filter course prerequisite complete
 		 *
 		 * @since 1.9.10
-		 * @param bool $prerequisite_complete
-		 * @param int $course_id
+		 *
+		 * @hook sensei_course_is_prerequisite_complete
+		 *
+		 * @param {bool} $prerequisite_complete Whether the prerequisite is complete.
+		 * @param {int}  $course_id             Course ID.
+		 * @return {bool} Whether the prerequisite is complete.
 		 */
 		return apply_filters( 'sensei_course_is_prerequisite_complete', $prerequisite_complete, $course_id );
 
@@ -4038,9 +4109,12 @@ class Sensei_Course {
 		/**
 		 * Filter sensei_course_complete_prerequisite_message.
 		 *
-		 * @param string $complete_prerequisite_message the message to filter
-		 *
 		 * @since 1.9.10
+		 *
+		 * @hook sensei_course_complete_prerequisite_message
+		 *
+		 * @param {string} $complete_prerequisite_message The message to filter
+		 * @return {string} The filtered message.
 		 */
 		return apply_filters( 'sensei_course_complete_prerequisite_message', $complete_prerequisite_message );
 	}

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -231,11 +231,11 @@ class Sensei_Db_Query_Learners {
 		/**
 		 * Filter the query to get learners based on the current search arguments.
 		 *
-		 * @hook sensei_learners_query
 		 * @since 4.11.0
 		 *
-		 * @param {string} $sql SQL query
+		 * @hook sensei_learners_query
 		 *
+		 * @param {string} $sql SQL query.
 		 * @return {Sensei_Db_Query_Learners} Query builder instance.
 		 */
 		$sql = apply_filters( 'sensei_learners_query', $sql, $this );

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -75,7 +75,7 @@ class Sensei_Emails {
 		 * @param {array} $emails Array of email classes.
 		 * @return {array} Filtered array of email classes.
 		 */
-		$this->emails                             = apply_filters( 'sensei_email_classes', $this->emails );
+		$this->emails = apply_filters( 'sensei_email_classes', $this->emails );
 	}
 
 	/**

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -67,6 +67,14 @@ class Sensei_Emails {
 		$this->emails['teacher-quiz-submitted']   = new Sensei_Email_Teacher_Quiz_Submitted();
 		$this->emails['teacher-new-message']      = new Sensei_Email_Teacher_New_Message();
 		$this->emails['new-message-reply']        = new Sensei_Email_New_Message_Reply();
+		/**
+		 * Filter Sensei's email classes.
+		 *
+		 * @hook sensei_email_classes
+		 *
+		 * @param {array} $emails Array of email classes.
+		 * @return {array} Filtered array of email classes.
+		 */
 		$this->emails                             = apply_filters( 'sensei_email_classes', $this->emails );
 	}
 
@@ -171,10 +179,14 @@ class Sensei_Emails {
 		 * Filter Sensei's ability to send out emails.
 		 *
 		 * @since 1.8.0
-		 * @param bool $send_email Whether to send the email or not.
-		 * @param mixed $to The email address(es) to send the email to.
-		 * @param mixed $subject The subject of the email.
-		 * @param mixed $message The message of the email.
+		 *
+		 * @hook sensei_send_emails
+		 *
+		 * @param {bool} $send_email Whether to send the email or not.
+		 * @param {mixed} $to The email address(es) to send the email to.
+		 * @param {mixed} $subject The subject of the email.
+		 * @param {mixed} $message The message of the email.
+		 * @return {bool} Whether to send the email or not.
 		 */
 		if ( apply_filters( 'sensei_send_emails', true, $to, $subject, $message ) ) {
 
@@ -194,6 +206,15 @@ class Sensei_Emails {
 
 		$html = $this->wrap_message( $message );
 
+		/**
+		 * Filter the email content.
+		 *
+		 * @hook sensei_email
+		 *
+		 * @param {string} $html The email content.
+		 * @param {string} $email_template The email template.
+		 * @return {string} Filtered email content.
+		 */
 		return apply_filters( 'sensei_email', $html, $email_template );
 	}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -539,7 +539,7 @@ class Sensei_Frontend {
 		 * @param {string} $separator Breadcrumb separator.
 		 * @return {string} Filtered separator.
 		 */
-		$separator                = apply_filters( 'sensei_breadcrumb_separator', '&gt;' );
+		$separator = apply_filters( 'sensei_breadcrumb_separator', '&gt;' );
 
 		$html = '<section class="sensei-breadcrumb">' . esc_html( $sensei_breadcrumb_prefix );
 		// Lesson.

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -376,7 +376,10 @@ class Sensei_Frontend {
 						 *
 						 * With this filter you can alter the login / login menu item title string
 						 *
-						 * @param $menu_title
+						 * @hook sensei_login_logout_menu_title
+						 *
+						 * @param {string} $menu_title The menu title.
+						 * @return {string} The filtered menu title.
 						 */
 						$item->title = apply_filters( 'sensei_login_logout_menu_title', $menu_title );
 
@@ -528,6 +531,14 @@ class Sensei_Frontend {
 		}
 
 		$sensei_breadcrumb_prefix = __( 'Back to: ', 'sensei-lms' );
+		/**
+		 * Filter the breadcrumb separator.
+		 *
+		 * @hook sensei_breadcrumb_separator
+		 *
+		 * @param {string} $separator Breadcrumb separator.
+		 * @return {string} Filtered separator.
+		 */
 		$separator                = apply_filters( 'sensei_breadcrumb_separator', '&gt;' );
 
 		$html = '<section class="sensei-breadcrumb">' . esc_html( $sensei_breadcrumb_prefix );
@@ -548,7 +559,15 @@ class Sensei_Frontend {
 			 $html .= '<a href="' . esc_url( get_permalink( $lesson_id ) ) . '" title="' . esc_attr__( 'Back to the lesson', 'sensei-lms' ) . '">' . esc_html( get_the_title( $lesson_id ) ) . '</a>';
 		}
 
-		// Allow other plugins to filter html.
+		/**
+		 * Filter the breadcrumb HTML.
+		 *
+		 * @hook sensei_breadcrumb_output
+		 *
+		 * @param {string} $html      Breadcrumb HTML.
+		 * @param {string} $separator Breadcrumb separator.
+		 * @return {string} Filtered HTML.
+		 */
 		$html  = apply_filters( 'sensei_breadcrumb_output', $html, $separator );
 		$html .= '</section>';
 
@@ -612,8 +631,17 @@ class Sensei_Frontend {
 	 */
 	public function lesson_tag_archive_header( $title ) {
 		if ( is_tax( 'lesson-tag' ) ) {
+			/**
+			 * Filters the lesson tag archive title.
+			 *
+			 * @hook sensei_lesson_tag_archive_title
+			 *
+			 * @param {string} $title Lesson tag archive title.
+			 * @return {string} Filtered title.
+			 */
+			$lesson_tag_archive_title = apply_filters( 'sensei_lesson_tag_archive_title', get_queried_object()->name );
 			// translators: Placeholder is the filtered tag name.
-			$title = sprintf( __( 'Lesson tag: %1$s', 'sensei-lms' ), apply_filters( 'sensei_lesson_tag_archive_title', get_queried_object()->name ) );
+			$title = sprintf( __( 'Lesson tag: %1$s', 'sensei-lms' ), $lesson_tag_archive_title );
 		}
 		return $title;
 	}
@@ -624,6 +652,15 @@ class Sensei_Frontend {
 	public function lesson_tag_archive_description() {
 		if ( is_tax( 'lesson-tag' ) ) {
 			$tag = get_queried_object();
+			/**
+			 * Filters the lesson tag archive description.
+			 *
+			 * @hook sensei_lesson_tag_archive_description
+			 *
+			 * @param {string} $description Lesson tag archive description.
+			 * @param {int}    $tag_id      Lesson tag ID.
+			 * @return {string} Filtered description.
+			 */
 			echo '<p class="archive-description lesson-description">' . wp_kses_post( apply_filters( 'sensei_lesson_tag_archive_description', nl2br( $tag->description ), $tag->term_id ) ) . '</p>';
 		}
 	}
@@ -696,9 +733,12 @@ class Sensei_Frontend {
 		 *
 		 * @since 1.12.0
 		 *
-		 * @param string|bool $redirect_url URL to redirect students to after completing a lesson. False to skip redirect.
-		 * @param int         $lesson_id    Current lesson ID.
-		 * @param array       $nav_links    Navigation links found for the current lesson.
+		 * @hook sensei_complete_lesson_redirect_url
+		 *
+		 * @param {string|bool} $redirect_url URL to redirect students to after completing a lesson. False to skip redirect.
+		 * @param {int}         $lesson_id    Current lesson ID.
+		 * @param {array}       $nav_links    Navigation links found for the current lesson.
+		 * @return {string|bool} Filtered URL to redirect students to after completing a lesson. False to skip redirect.
 		 */
 		$redirect_url = apply_filters( 'sensei_complete_lesson_redirect_url', $redirect_url, $lesson_id, $nav_links );
 
@@ -1129,8 +1169,11 @@ class Sensei_Frontend {
 		 *
 		 * @since 1.11.0
 		 *
-		 * @param string $preview_text
-		 * @param int    $course_id
+		 * @hook sensei_lesson_preview_title_text
+		 *
+		 * @param {string} $preview_text
+		 * @param {int}    $course_id
+		 * @return {string} Filtered text.
 		 */
 		return apply_filters( 'sensei_lesson_preview_title_text', $preview_text, $course_id );
 	}
@@ -1181,14 +1224,17 @@ class Sensei_Frontend {
 			 *
 			 * @since 3.0.0
 			 *
-			 * @param callable $handler {
+			 * @hook sensei_frontend_course_signup_handler
+			 *
+			 * @param {callable} $handler {
 			 *     Frontend enrolment handler. Returns `true` if successful; `false` if not.
 			 *
 			 *     @type int $user_id   User ID.
 			 *     @type int $course_id Course post ID.
 			 * }
-			 * @param int      $user_id          User ID.
-			 * @param int      $course_id        Course post ID.
+			 * @param {int}      $user_id          User ID.
+			 * @param {int}      $course_id        Course post ID.
+			 * @return {callable} Filtered handler.
 			 */
 			$learner_enrollment_handler = apply_filters( 'sensei_frontend_learner_enrolment_handler', [ $this, 'manually_enrol_learner' ], $current_user->ID, $post->ID );
 
@@ -1208,8 +1254,11 @@ class Sensei_Frontend {
 				 *
 				 * @since 1.10.0
 				 *
-				 * @param string|bool  $redirect_url URL to redirect students to after starting course. Return `false` to prevent redirect.
-				 * @param WP_Post      $post         Post object for course.
+				 * @hook sensei_start_course_redirect_url
+				 *
+				 * @param {string|bool}  $redirect_url URL to redirect students to after starting course. Return `false` to prevent redirect.
+				 * @param {WP_Post}      $post         Post object for course.
+				 * @return {string|bool} Filtered URL to redirect students to after starting course. Return `false` to prevent redirect.
 				 */
 				$redirect_url = apply_filters( 'sensei_start_course_redirect_url', get_permalink( $post->ID ), $post );
 
@@ -1403,12 +1452,14 @@ class Sensei_Frontend {
 					/**
 					 * Change the redirect url programatically.
 					 *
-					 * @hook sensei_login_success_redirect_url
+					 * The redirect URL if login is successful. Note that if this URL points to an external domain, it may need to be whitelisted using the `allowed_redirect_hosts` filter.
+					 *
 					 * @since 3.15.0
 					 *
-					 * @param {string} $referrer The page where the current url wheresensei login form was posted from.
+					 * @hook sensei_login_success_redirect_url
 					 *
-					 * The redirect URL if login is successful. Note that if this URL points to an external domain, it may need to be whitelisted using the `allowed_redirect_hosts` filter.
+					 * @param {string} $referrer The page where the current url wheresensei login form was posted from.
+					 * @return {string} The redirect URL.
 					 */
 					$success_redirect_url = apply_filters( 'sensei_login_success_redirect_url', $success_redirect_url );
 
@@ -1528,6 +1579,14 @@ class Sensei_Frontend {
 
 		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : $redirect;
 
+		/**
+		 * Filter the URL that students are redirected to after registering.
+		 *
+		 * @hook sensei_registration_redirect
+		 *
+		 * @param {string} $redirect_to URL to redirect students to after registering.
+		 * @return {string} Filtered URL to redirect students to after registering.
+		 */
 		wp_safe_redirect( apply_filters( 'sensei_registration_redirect', $redirect_to ) );
 		exit;
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1229,8 +1229,8 @@ class Sensei_Frontend {
 			 * @param {callable} $handler {
 			 *     Frontend enrolment handler. Returns `true` if successful; `false` if not.
 			 *
-			 *     @type int $user_id   User ID.
-			 *     @type int $course_id Course post ID.
+			 *     @property {int} $user_id   User ID.
+			 *     @property {int} $course_id Course post ID.
 			 * }
 			 * @param {int}      $user_id          User ID.
 			 * @param {int}      $course_id        Course post ID.

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1224,17 +1224,12 @@ class Sensei_Frontend {
 			 *
 			 * @since 3.0.0
 			 *
-			 * @hook sensei_frontend_course_signup_handler
+			 * @hook sensei_frontend_learner_enrolment_handler
 			 *
-			 * @param {callable} $handler {
-			 *     Frontend enrolment handler. Returns `true` if successful; `false` if not.
-			 *
-			 *     @property {int} $user_id   User ID.
-			 *     @property {int} $course_id Course post ID.
-			 * }
-			 * @param {int}      $user_id          User ID.
-			 * @param {int}      $course_id        Course post ID.
-			 * @return {callable} Filtered handler.
+			 * @param    {callback(int, int):bool} $handler   Frontend enrolment handler. Takes two arguments: $user_id and $course_id. Returns `true` if successful; `false` if not.
+			 * @param    {int}                     $user_id   User ID.
+			 * @param    {int}                     $course_id Course post ID.
+			 * @return   {callback(int, int):bool} Filtered handler.
 			 */
 			$learner_enrollment_handler = apply_filters( 'sensei_frontend_learner_enrolment_handler', [ $this, 'manually_enrol_learner' ], $current_user->ID, $post->ID );
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -70,7 +70,17 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			'action'      => '',
 		);
 
+		/**
+		 * Filter columns for the grading list table.
+		 *
+		 * @hook sensei_grading_default_columns
+		 *
+		 * @param {array} Columns.
+		 * @param {Sensei_Grading_Main} The grading list table.
+		 * @return {array} Filtered columns.
+		 */
 		$columns = apply_filters( 'sensei_grading_default_columns', $columns, $this );
+
 		return $columns;
 	}
 
@@ -89,7 +99,18 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			'user_status' => array( 'user_status', false ),
 			'user_grade'  => array( 'user_grade', false ),
 		);
+
+		/**
+		 * Filter sortable columns for the grading list table.
+		 *
+		 * @hook sensei_grading_default_columns_sortable
+		 *
+		 * @param {array} Sortable columns.
+		 * @param {Sensei_Grading_Main} The grading list table.
+		 * @return {array} Filtered sortable columns.
+		 */
 		$columns = apply_filters( 'sensei_grading_default_columns_sortable', $columns, $this );
+
 		return $columns;
 	}
 
@@ -127,8 +148,17 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				'search' => '*' . $this->search . '*',
 				'fields' => 'ID',
 			);
-			// Filter for extending
+
+			/**
+			 * Filter user searching arguments in Grading.
+			 *
+			 * @hook sensei_grading_search_users
+			 *
+			 * @param {array} $user_args User search arguments.
+			 * @return {array} Filtered user search arguments.
+			 */
 			$user_args = apply_filters( 'sensei_grading_search_users', $user_args );
+
 			if ( ! empty( $user_args ) ) {
 				$learners_search = new WP_User_Query( $user_args );
 				// Store for reuse on counts
@@ -137,6 +167,16 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		}
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
+
+		/**
+		 * Filter number of comments per page.
+		 *
+		 * @hook sensei_comments_per_page
+		 *
+		 * @param {int} $per_page Comments per page.
+		 * @param {string} $comments_type Type of comments.
+		 * @return {int} Filtered comments per page.
+		 */
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
 
 		$paged  = $this->get_pagenum();
@@ -187,6 +227,14 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				break;
 		}
 
+		/**
+		 * Filter activity statuses arguments for Grading.
+		 *
+		 * @hook sensei_grading_filter_statuses
+		 *
+		 * @param {array} $activity_args Student activity arguments.
+		 * @return {array} Filtered activity arguments.
+		 */
 		$activity_args = apply_filters( 'sensei_grading_filter_statuses', $activity_args );
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice
@@ -305,6 +353,16 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			)
 		) . '">' . esc_html( get_the_title( $item->comment_post_ID ) ) . '</a>';
 
+		/**
+		 * Filter columns data for the Grading list table.
+		 *
+		 * @hook sensei_grading_main_column_data
+		 *
+		 * @param {array}  $column_data Column data for a row.
+		 * @param {object} $item Activity comment object.
+		 * @param {int}    $course_id The course ID.
+		 * @return {array} Filtered column data.
+		 */
 		$column_data = apply_filters(
 			'sensei_grading_main_column_data',
 			array(
@@ -415,6 +473,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
+		/* Filter documented in includes/class-sensei-list-table.php */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 
@@ -472,7 +531,29 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				break;
 		endswitch;
 
-		$counts = Sensei()->grading->count_statuses( apply_filters( 'sensei_grading_count_statues', $count_args ) );
+		/**
+		 * Filter count statuses arguments in Grading.
+		 *
+		 * @hook sensei_grading_count_statues
+		 *
+		 * @deprecated $$next-version$$ Contains typo. Use sensei_grading_count_statuses.
+		 *
+		 * @param {array} $count_args Count statuses arguments.
+		 * @return {array} Filtered count arguments.
+		 */
+		$count_args = apply_filters( 'sensei_grading_count_statues', $count_args );
+
+		/**
+		 * Filter count statuses arguments in Grading.
+		 *
+		 * @hook sensei_grading_count_statuses
+		 *
+		 * @param {array} $count_args Count statuses arguments.
+		 * @return {array} Filtered count arguments.
+		 */
+		$count_args = apply_filters( 'sensei_grading_count_statuses', $count_args );
+
+		$counts = Sensei()->grading->count_statuses( $count_args );
 
 		$inprogress_lessons_count = $counts['in-progress'];
 		$ungraded_lessons_count   = $counts['ungraded'];
@@ -517,6 +598,14 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			number_format( (int) $inprogress_lessons_count )
 		);
 
+		/**
+		 * Filter sub-menu for Grading.
+		 *
+		 * @hook sensei_grading_sub_menu
+		 *
+		 * @param {array} $sub_munu Sub-menu.
+		 * @return {array} Filtered sub-menu.
+		 */
 		return apply_filters( 'sensei_grading_sub_menu', $menu );
 	}
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -541,7 +541,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		 * @param {array} $count_args Count statuses arguments.
 		 * @return {array} Filtered count arguments.
 		 */
-		$count_args = apply_filters( 'sensei_grading_count_statues', $count_args );
+		$count_args = apply_filters_deprecated( 'sensei_grading_count_statues', $count_args, '4.18.0', 'sensei_grading_count_statuses' );
 
 		/**
 		 * Filter count statuses arguments in Grading.

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -549,7 +549,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		 * @param {array} $count_args Count statuses arguments.
 		 * @return {array} Filtered count arguments.
 		 */
-		$count_args = apply_filters_deprecated( 'sensei_grading_count_statues', $count_args, '4.18.0', 'sensei_grading_count_statuses' );
+		$count_args = apply_filters_deprecated( 'sensei_grading_count_statues', array( $count_args ), '$$next-version$$', 'sensei_grading_count_statuses' );
 
 		/**
 		 * Filter count statuses arguments in Grading.

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -473,7 +473,15 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
-		/* Filter documented in includes/class-sensei-list-table.php */
+
+		/**
+		 * Filter the search button text for the list table.
+		 *
+		 * @hook sensei_list_table_search_button_text
+		 *
+		 * @param {string} $text The search button text.
+		 * @return {string} The filtered search button text.
+		 */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -599,12 +599,12 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		);
 
 		/**
-		 * Filter sub-menu for Grading.
+		 * Filter submenu for Grading.
 		 *
 		 * @hook sensei_grading_sub_menu
 		 *
-		 * @param {array} $sub_munu Sub-menu.
-		 * @return {array} Filtered sub-menu.
+		 * @param {array} $submunu Submenu.
+		 * @return {array} Filtered submenu.
 		 */
 		return apply_filters( 'sensei_grading_sub_menu', $menu );
 	}

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -328,7 +328,17 @@ class Sensei_Grading_User_Quiz {
 								$_user_answer = htmlspecialchars_decode( $_user_answer );
 							}
 
-							$html = wp_kses_post( apply_filters( 'sensei_answer_text', $_user_answer ) );
+							/**
+							 * Filter user answer text.
+							 *
+							 * @hook sensei_answer_text
+							 *
+							 * @param {string} Answer text.
+							 * @return {string} Filtered answer text.
+							 */
+							$_user_answer = apply_filters( 'sensei_answer_text', $_user_answer );
+
+							$html = wp_kses_post( $_user_answer );
 							$html = '<html><head><title></title></head><body>' . $html . '</body></html>';
 							?>
 							<iframe class="user-answer" srcdoc="<?php echo esc_attr( $html ); ?>" sandbox="allow-same-origin" height="auto"></iframe>
@@ -346,6 +356,7 @@ class Sensei_Grading_User_Quiz {
 									$_right_answer = htmlspecialchars_decode( nl2br( $_right_answer ) );
 								}
 
+								/* This filter is documented in includes/class-sensei-grading-user-quiz.php (above)*/
 								echo wp_kses_post( apply_filters( 'sensei_answer_text', $_right_answer ) ) . '<br>';
 
 							}

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -241,7 +241,6 @@ class Sensei_Grading_User_Quiz {
 				 * }
 				 * @param {string} $type
 				 * @param {int}    $question_id
-				 *
 				 * @return {array|null}
 				 */
 				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id, $right_answer, $user_answer_content );
@@ -311,7 +310,17 @@ class Sensei_Grading_User_Quiz {
 						</div>
 					</div>
 					<div class="sensei-grading-answer">
-						<h4><?php echo wp_kses_post( apply_filters( 'sensei_question_title', $question->post_title ) ); ?></h4>
+						<h4><?php
+							/**
+							 * Filters the question title.
+							 *
+							 * @hook sensei_question_title
+							 *
+							 * @param {string} $question_title The question title.
+							 * @return {string} Filtered question title.
+							 */
+							echo wp_kses_post( apply_filters( 'sensei_question_title', $question->post_title ) );
+						?></h4>
 						<?php
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped before core filter applied.
 						echo Sensei_Question::get_the_question_description( $question_id );

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -310,7 +310,8 @@ class Sensei_Grading_User_Quiz {
 						</div>
 					</div>
 					<div class="sensei-grading-answer">
-						<h4><?php
+						<h4>
+						<?php
 							/**
 							 * Filters the question title.
 							 *
@@ -320,7 +321,8 @@ class Sensei_Grading_User_Quiz {
 							 * @return {string} Filtered question title.
 							 */
 							echo wp_kses_post( apply_filters( 'sensei_question_title', $question->post_title ) );
-						?></h4>
+						?>
+						</h4>
 						<?php
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped before core filter applied.
 						echo Sensei_Question::get_the_question_description( $question_id );

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -367,7 +367,14 @@ class Sensei_Grading_User_Quiz {
 									$_right_answer = htmlspecialchars_decode( nl2br( $_right_answer ) );
 								}
 
-								/* This filter is documented in includes/class-sensei-grading-user-quiz.php (above)*/
+								/**
+								 * Filter user answer text.
+								 *
+								 * @hook sensei_answer_text
+								 *
+								 * @param {string} Answer text.
+								 * @return {string} Filtered answer text.
+								 */
 								echo wp_kses_post( apply_filters( 'sensei_answer_text', $_right_answer ) ) . '<br>';
 
 							}

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -335,7 +335,17 @@ class Sensei_Grading {
 
 		}
 		?>
-			<h1><?php echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) ); ?></h1>
+			<h1><?php
+			/**
+			 * Filter the title of the Grading page.
+			 *
+			 * @hook sensei_grading_nav_title
+			 *
+			 * @param {string} $title
+			 * @return {string} Filtered title.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) );
+			?></h1>
 		<?php
 	}
 
@@ -377,6 +387,7 @@ class Sensei_Grading {
 
 		}
 		?>
+			<?php /** Filter is documented earlier in this file. */ ?>
 			<h2><?php echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) ); ?></h2>
 		<?php
 	}
@@ -426,11 +437,14 @@ class Sensei_Grading {
 		/**
 		 * Filter fires inside Sensei_Grading::count_statuses
 		 *
-		 * Alter the post_in array to determine which posts the
-		 * comment query should be limited to.
+		 * Alter the post_in array to determine which posts the comment query should be limited to.
 		 *
 		 * @since 1.8.0
-		 * @param array $args
+		 *
+		 * @hook sensei_count_statuses_args
+		 *
+		 * @param {array} $args Array of arguments for the query.
+		 * @return {array} Filtered arguments.
 		 */
 		$args = apply_filters( 'sensei_count_statuses_args', $args );
 
@@ -498,6 +512,15 @@ class Sensei_Grading {
 			$counts['complete'] = 0;
 		}
 
+		/**
+		 * Filter the counts of statuses for a given type.
+		 *
+		 * @hook sensei_count_statuses
+		 *
+		 * @param {array} $counts Array of counts for each status.
+		 * @param {string} $type Type of status to count: sensei_course_status or sensei_lesson_status.
+		 * @return {array} Filtered counts.
+		 */
 		return apply_filters( 'sensei_count_statuses', $counts, $type );
 	}
 
@@ -520,6 +543,14 @@ class Sensei_Grading {
 			'suppress_filters' => 0,
 			'fields'           => 'ids',
 		);
+		/**
+		 * Filter the arguments used to query for courses in the grading dropdown.
+		 *
+		 * @hook sensei_grading_filter_courses
+		 *
+		 * @param {array} $course_args Array of arguments for the query.
+		 * @return {array} Filtered arguments.
+		 */
 		$courses     = get_posts( apply_filters( 'sensei_grading_filter_courses', $course_args ) );
 
 		$html .= '<option value="">' . __( 'Select a course', 'sensei-lms' ) . '</option>';
@@ -611,6 +642,14 @@ class Sensei_Grading {
 				'suppress_filters' => 0,
 				'fields'           => 'ids',
 			);
+			/**
+			 * Filter the arguments used to query for lessons in the grading dropdown.
+			 *
+			 * @hook sensei_grading_filter_lessons
+			 *
+			 * @param {array} $lesson_args Array of arguments for the query.
+			 * @return {array} Filtered arguments.
+			 */
 			$lessons     = get_posts( apply_filters( 'sensei_grading_filter_lessons', $lesson_args ) );
 
 			$html .= '<option value="">' . esc_html__( 'Select a lesson', 'sensei-lms' ) . '</option>';
@@ -903,15 +942,14 @@ class Sensei_Grading {
 		$quiz_autogradable = true;
 
 		/**
-		 * Filter the types of question types that can be automatically graded.
+		 * Filter question types that can be automatically graded.
 		 *
 		 * This filter fires inside the auto grade quiz function and provides you with the default list.
 		 *
-		 * @param array {
-		 *      'multiple-choice',
-		 *      'boolean',
-		 *      'gap-fill'.
-		 * }
+		 * @hook sensei_autogradable_question_types
+		 *
+		 * @param {array} Types of questions, default: array( 'multiple-choice', 'boolean', 'gap-fill' ).
+		 * @return {array} Filtered array of question types.
 		 */
 		$autogradable_question_types = apply_filters( 'sensei_autogradable_question_types', array( 'multiple-choice', 'boolean', 'gap-fill' ) );
 
@@ -996,10 +1034,13 @@ class Sensei_Grading {
 		 * in the sensei_grade_question_auto function. It fires irrespective of the question type. If you return a value
 		 * other than false the auto grade functionality will be ignored and your supplied grade will be user for this question.
 		 *
-		 * @param int $question_grade default false
-		 * @param int $question_id
-		 * @param string $question_type one of the Sensei question type.
-		 * @param string $answer user supplied question answer
+		 * @hook sensei_pre_grade_question_auto
+		 *
+		 * @param {int|false} $question_grade Question grade, default false.
+		 * @param {int}       $question_id    ID of the question being graded.
+		 * @param {string}    $question_type  One of the Sensei question type.
+		 * @param {string}    $answer         User supplied question answer.
+		 * @return {int|false} Filtered question grade.
 		 */
 		$question_grade = apply_filters( 'sensei_pre_grade_question_auto', false, $question_id, $question_type, $answer );
 
@@ -1041,10 +1082,13 @@ class Sensei_Grading {
 			 * This filter is applied the context of ta single question within the sensei_grade_question_auto function.
 			 * It fires for all other questions types. It does not apply to 'multiple-choice'  , 'boolean' and gap-fill.
 			 *
-			 * @param int $question_grade default zero
-			 * @param int $question_id
-			 * @param string $question_type one of the Sensei question type.
-			 * @param string $answer user supplied question answer
+			 * @hook sensei_grade_question_auto
+			 *
+			 * @param {int}    $question_grade Question grade.
+			 * @param {int}    $question_id    ID of the question being graded.
+			 * @param {string} $question_type  One of the Sensei question type.
+			 * @param {string} $answer         User supplied question answer
+			 * @return {int} Filtered question grade.
 			 */
 			$question_grade = (int) apply_filters( 'sensei_grade_question_auto', $question_grade, $question_id, $question_type, $answer );
 
@@ -1075,9 +1119,12 @@ class Sensei_Grading {
 		 * alter the value simply use this code in your plugin or the themes functions.php
 		 * add_filter( 'sensei_gap_fill_case_sensitive_grading','__return_true' );
 		 *
-		 * @param bool $do_case_sensitive_comparison default false.
-		 *
 		 * @since 1.9.0
+		 *
+		 * @hook sensei_gap_fill_case_sensitive_grading
+		 *
+		 * @param {bool} $do_case_sensitive_comparison Whether to do case sensitive comparison or not, default false.
+		 * @return {bool} Filtered value.
 		 */
 		$do_case_sensitive_comparison = apply_filters( 'sensei_gap_fill_case_sensitive_grading', false );
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -389,7 +389,8 @@ class Sensei_Grading {
 
 		}
 		?>
-			<h2><?php
+			<h2>
+			<?php
 			/**
 			 * Filter the title of the Grading page.
 			 *
@@ -399,7 +400,8 @@ class Sensei_Grading {
 			 * @return {string} Filtered title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) );
-			?></h2>
+			?>
+			</h2>
 		<?php
 	}
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -335,7 +335,8 @@ class Sensei_Grading {
 
 		}
 		?>
-			<h1><?php
+			<h1>
+			<?php
 			/**
 			 * Filter the title of the Grading page.
 			 *
@@ -345,7 +346,8 @@ class Sensei_Grading {
 			 * @return {string} Filtered title.
 			 */
 			echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) );
-			?></h1>
+			?>
+			</h1>
 		<?php
 	}
 
@@ -551,7 +553,7 @@ class Sensei_Grading {
 		 * @param {array} $course_args Array of arguments for the query.
 		 * @return {array} Filtered arguments.
 		 */
-		$courses     = get_posts( apply_filters( 'sensei_grading_filter_courses', $course_args ) );
+		$courses = get_posts( apply_filters( 'sensei_grading_filter_courses', $course_args ) );
 
 		$html .= '<option value="">' . __( 'Select a course', 'sensei-lms' ) . '</option>';
 		if ( $courses ) {
@@ -650,7 +652,7 @@ class Sensei_Grading {
 			 * @param {array} $lesson_args Array of arguments for the query.
 			 * @return {array} Filtered arguments.
 			 */
-			$lessons     = get_posts( apply_filters( 'sensei_grading_filter_lessons', $lesson_args ) );
+			$lessons = get_posts( apply_filters( 'sensei_grading_filter_lessons', $lesson_args ) );
 
 			$html .= '<option value="">' . esc_html__( 'Select a lesson', 'sensei-lms' ) . '</option>';
 			if ( $lessons ) {

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -389,8 +389,17 @@ class Sensei_Grading {
 
 		}
 		?>
-			<?php /** Filter is documented earlier in this file. */ ?>
-			<h2><?php echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) ); ?></h2>
+			<h2><?php
+			/**
+			 * Filter the title of the Grading page.
+			 *
+			 * @hook sensei_grading_nav_title
+			 *
+			 * @param {string} $title
+			 * @return {string} Filtered title.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) );
+			?></h2>
 		<?php
 	}
 

--- a/includes/class-sensei-guest-user.php
+++ b/includes/class-sensei-guest-user.php
@@ -429,11 +429,11 @@ class Sensei_Guest_User {
 		/**
 		 * Filters the list of supported actions for Guest Users.
 		 *
-		 * @hook  sensei_guest_user_supported_actions
 		 * @since 4.11
 		 *
-		 * @param {array} List of supported actions for guest users.
+		 * @hook sensei_guest_user_supported_actions
 		 *
+		 * @param {array} List of supported actions for guest users.
 		 * @return {array} List of supported actions for guest users.
 		 */
 		$supported_actions = apply_filters( 'sensei_guest_user_supported_actions', $this->supported_actions );

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -174,9 +174,20 @@ class Sensei_Learner_Profiles {
 		 */
 		$name = apply_filters( 'sensei_learner_profile_courses_heading_name', $name );
 
-		/** This filter is documented earlier in this file. */
-		// translators: Placeholder is the name of the student.
-		echo '<h2>' . wp_kses_post( apply_filters( 'sensei_learner_profile_courses_heading', sprintf( __( 'Courses %s is taking', 'sensei-lms' ), $name ) ) ) . '</h2>';
+		/**
+		 * Filter the title for the learner profile page.
+		 *
+		 * @hook sensei_learner_profile_courses_heading
+		 *
+		 * @param {string} $title The title.
+		 * @return {string} The filtered title.
+		 */
+		$title = apply_filters(
+			'sensei_learner_profile_courses_heading',
+			// translators: Placeholder is the name of the student.
+			sprintf( __( 'Courses %s is taking', 'sensei-lms' ), $name )
+		);
+		echo '<h2>' . wp_kses_post( $title ) . '</h2>';
 	}
 
 	/**

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -92,8 +92,19 @@ class Sensei_Learner_Profiles {
 
 			$name = Sensei_Learner::get_full_name( $learner_user->ID );
 
-			// translators: Placeholder is the name of the student.
-			$title = apply_filters( 'sensei_learner_profile_courses_heading', sprintf( __( 'Courses %s is taking', 'sensei-lms' ), $name ) ) . ' ' . $sep . ' ';
+			/**
+			 * Filter the title for the learner profile page.
+			 *
+			 * @hook sensei_learner_profile_courses_heading
+			 *
+			 * @param {string} $title The title.
+			 * @return {string} The filtered title.
+			 */
+			$title = apply_filters(
+				'sensei_learner_profile_courses_heading',
+				// translators: Placeholder is the name of the student.
+				sprintf( __( 'Courses %s is taking', 'sensei-lms' ), $name )
+			) . ' ' . $sep . ' ';
 		}
 		return $title;
 	}
@@ -129,6 +140,12 @@ class Sensei_Learner_Profiles {
 		 * This allows filtering of the Learner Profile permalinks.
 		 *
 		 * @since 1.9.13
+		 *
+		 * @hook sensei_learner_profile_permalink
+		 *
+		 * @param {string} $permalink The profile permalink.
+		 * @param {object} $user      The user object.
+		 * @return {string} The filtered permalink.
 		 */
 		return apply_filters( 'sensei_learner_profile_permalink', $permalink, $user );
 	}
@@ -146,7 +163,18 @@ class Sensei_Learner_Profiles {
 		} else {
 			$name = $user->display_name;
 		}
+
+		/**
+		 * Filter the name for the heading in the courses section of the learner profile.
+		 *
+		 * @hook sensei_learner_profile_courses_heading_name
+		 *
+		 * @param {string} $name The name.
+		 * @return {string} The filtered name.
+		 */
 		$name = apply_filters( 'sensei_learner_profile_courses_heading_name', $name );
+
+		/** This filter is documented earlier in this file. */
 		// translators: Placeholder is the name of the student.
 		echo '<h2>' . wp_kses_post( apply_filters( 'sensei_learner_profile_courses_heading', sprintf( __( 'Courses %s is taking', 'sensei-lms' ), $name ) ) ) . '</h2>';
 	}
@@ -174,7 +202,11 @@ class Sensei_Learner_Profiles {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param false|string `<img>` $user_avatar
+		 * @hook sensei_learner_profile_info_avatar
+		 *
+		 * @param {false|string} $user_avatar The user avatar.
+		 * @param {int}          $user_id     The user ID.
+		 * @return {false|string} The filtered avatar.
 		 */
 		$learner_avatar = apply_filters( 'sensei_learner_profile_info_avatar', get_avatar( $user->ID, 120 ), $user->ID );
 
@@ -184,8 +216,11 @@ class Sensei_Learner_Profiles {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $user_display_name
-		 * @param string $user_id
+		 * @hook sensei_learner_profile_info_name
+		 *
+		 * @param {string} $user_display_name The user display name.
+		 * @param {string} $user_id           The user ID.
+		 * @return {string} The filtered display name.
 		 */
 		$learner_name = apply_filters( 'sensei_learner_profile_info_name', $user->display_name, $user->ID );
 
@@ -196,8 +231,11 @@ class Sensei_Learner_Profiles {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $user_description
-		 * @param string $user_id
+		 * @hook sensei_learner_profile_info_bio
+		 *
+		 * @param {string} $user_description The user description.
+		 * @param {string} $user_id          The user ID.
+		 * @return {string} The filtered description.
 		 */
 		$learner_bio = apply_filters( 'sensei_learner_profile_info_bio', $user->description, $user->ID );
 		?>

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -440,11 +440,11 @@ class Sensei_Learner {
 		 * Filters the arguments of the query which fetches a learner's enrolled courses.
 		 *
 		 * @since 3.3.0
+		 *
 		 * @hook sensei_learner_enrolled_courses_args
 		 *
 		 * @param {array} $query_args  The query args.
 		 * @param {int}   $user_id     The user id.
-		 *
 		 * @return {array} Query arguments.
 		 */
 		return apply_filters( 'sensei_learner_enrolled_courses_args', $query_args, $user_id );
@@ -585,8 +585,12 @@ class Sensei_Learner {
 		 * Filter the user full name from the get_learner_full_name function.
 		 *
 		 * @since 1.8.0
-		 * @param $full_name
-		 * @param $user_id
+		 *
+		 * @hook sensei_learner_full_name
+		 *
+		 * @param {string} $full_name The full name of the user.
+		 * @param {int}]   $user_id   The user ID.
+		 * @return {string} The full name of the user.
 		 */
 		return apply_filters( 'sensei_learner_full_name', $full_name, $user_id );
 
@@ -670,7 +674,14 @@ class Sensei_Learner {
 				'search' => '*' . $args['search'] . '*',
 				'fields' => 'ID',
 			);
-			// Filter for extending.
+			/**
+			 * Filter the user arguments used to search for learners.
+			 *
+			 * @hook sensei_learners_search_users
+			 *
+			 * @param {array} $user_args The user arguments.
+			 * @return {array} The filtered user arguments.
+			 */
 			$user_args = apply_filters( 'sensei_learners_search_users', $user_args );
 			if ( ! empty( $user_args ) ) {
 				$learners_search          = new WP_User_Query( $user_args );
@@ -678,6 +689,14 @@ class Sensei_Learner {
 			}
 		}
 
+		/**
+		 * Filter the arguments used to search for learners activity.
+		 *
+		 * @hook sensei_learners_filter_users
+		 *
+		 * @param {array} $activity_args The activity arguments.
+		 * @return {array} The filtered activity arguments.
+		 */
 		$activity_args = apply_filters( 'sensei_learners_filter_users', $activity_args );
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4912,7 +4912,15 @@ class Sensei_Lesson {
 			&& Sensei_Utils::is_preview_lesson( $post->ID )
 			&& ! Sensei_Course::is_user_enrolled( $course_id, $current_user->ID );
 
-		/** This filter is documented in includes/class-sensei-messages.php */
+		/**
+		 * Filter Sensei single title
+		 *
+		 * @hook sensei_single_title
+		 *
+		 * @param {string} $title     The title.
+		 * @param {string} $post_type The post type.
+		 * @return {string} Filtered title.
+		 */
 		$title = apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type );
 
 		if ( ! $title ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -296,8 +296,9 @@ class Sensei_Lesson {
 		/**
 		 * Filters the Content Drip promo metabox toggle.
 		 *
-		 * @hook  sensei_lesson_content_drip_hide
 		 * @since 4.1.0
+		 *
+		 * @hook  sensei_lesson_content_drip_hide
 		 *
 		 * @param  {bool} $hide_content_drip Whether to hide the Content Drip promo metabox.
 		 * @return {bool} Whether to hide the Content Drip promo metabox.
@@ -1870,6 +1871,7 @@ class Sensei_Lesson {
 		 * Filter the quiz panel add html.
 		 *
 		 * @since 1.9.7
+		 *
 		 * @hook sensei_quiz_panel_add
 		 *
 		 * @param {string} $html    HTML for adding a question.
@@ -1957,6 +1959,7 @@ class Sensei_Lesson {
 		 * Filter existing questions query
 		 *
 		 * @since 1.8.0
+		 *
 		 * @hook sensei_existing_questions_query_results
 		 *
 		 * @param {object} $qry Query object containing an array of existing questions.
@@ -2663,10 +2666,10 @@ class Sensei_Lesson {
 		 * Enqueue scripts for the quiz question AI upsell if the the feature is not available.
 		 *
 		 * @since 4.14.0
+		 *
 		 * @hook sensei_quiz_question_ai_upsell_scripts
 		 *
 		 * @param {bool} $enqueue_scripts Whether to enqueue the scripts. Default false.
-		 *
 		 * @return {bool} Whether to enqueue the scripts.
 		 */
 		if ( ! apply_filters( 'sensei_ai_quiz_generation_available', false ) ) {
@@ -3758,10 +3761,10 @@ class Sensei_Lesson {
 						 * this filter.
 						 *
 						 * @since 3.10.0
+						 *
 						 * @hook sensei_filter_category_questions_by_author
 						 *
 						 * @param {array}  $quiz_id The quiz id.
-						 *
 						 * @return {array} Whether questions should be filtered by author.
 						 */
 						$should_filter = apply_filters( 'sensei_filter_category_questions_by_author', true, $quiz_id );
@@ -3832,6 +3835,7 @@ class Sensei_Lesson {
 		 * Filter the questions returned by Sensei_Lesson::lessons_quiz_questions.
 		 *
 		 * @since 1.8.0
+		 *
 		 * @hook sensei_lesson_quiz_questions
 		 *
 		 * @param {array}  $questions Questions.
@@ -4473,6 +4477,7 @@ class Sensei_Lesson {
 		 * Filter whether to show lesson numbers next to the lesson.
 		 *
 		 * @since 1.0
+		 *
 		 * @hook sensei_show_lesson_numbers
 		 *
 		 * @param {bool} $show_lesson_numbers Whether to show lesson numbers. Default false.
@@ -4612,6 +4617,7 @@ class Sensei_Lesson {
 		 * Filter the lesson prerequisite.
 		 *
 		 * @since 1.0
+		 *
 		 * @hook sensei_lesson_prerequisite
 		 *
 		 * @param {string|bool} $prerequisite_lesson_id Prerequisite lesson ID. False if prerequisite lesson ID is
@@ -4754,6 +4760,7 @@ class Sensei_Lesson {
 		 * Filter whether to show the course sign up notice on the lesson page.
 		 *
 		 * @since 2.0.0
+		 *
 		 * @hook sensei_lesson_show_course_signup_notice
 		 *
 		 * @param {bool}   $show_course_signup_notice True if we should show the signup notice to the user.
@@ -4772,6 +4779,7 @@ class Sensei_Lesson {
 			 * Filter the course sign up notice message on the lesson page.
 			 *
 			 * @since 2.0.0
+			 *
 			 * @hook sensei_lesson_course_signup_notice_message
 			 *
 			 * @param {string} $message_default Message to show user.
@@ -4785,6 +4793,7 @@ class Sensei_Lesson {
 			 * Filter the course sign up notice message alert level on the lesson page.
 			 *
 			 * @since 2.0.0
+			 *
 			 * @hook sensei_lesson_course_signup_notice_level
 			 *
 			 * @param {string} $notice_level Level to use for the sign up notice (alert, tick, download, info).

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -124,7 +124,18 @@ class Sensei_List_Table extends WP_List_Table {
 		?><form method="get">
 			<?php
 			Sensei_Utils::output_query_params_as_inputs( [ 's' ] );
-			$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
+
+			/**
+			 * Filter search button text in Sensei list table.
+			 *
+			 * @hook sensei_list_table_search_button_text
+			 *
+			 * @param {string} $button_text Search button text.
+			 * @return {string} Filtered search button text.
+			 */
+			$search_button_text = apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) );
+
+			$this->search_box( $search_button_text, 'search_id' );
 			?>
 		</form>
 		<?php

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -360,7 +360,6 @@ class Sensei_List_Table extends WP_List_Table {
 			 * @hook sensei_list_bulk_actions
 			 *
 			 * @param {string} $bulk_action_html Output of bulk action function.
-			 *
 			 * @return {string} Filtered output of bulk action function.
 			 */
 			apply_filters( 'sensei_list_bulk_actions', $bulk_action_html ),

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -19,6 +19,13 @@ class Sensei_Messages {
 	public $meta_fields;
 
 	/**
+	 * The message notice.
+	 *
+	 * @var string
+	 */
+	public $message_notice;
+
+	/**
 	 * The nonce name when submitting a new message.
 	 *
 	 * @var string
@@ -39,6 +46,7 @@ class Sensei_Messages {
 		$this->token       = 'messages';
 		$this->post_type   = 'sensei_message';
 		$this->meta_fields = array( 'sender', 'receiver' );
+		$this->message_notice = '';
 
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ), 10, 2 );
 		add_action( 'admin_menu', array( $this, 'remove_meta_box' ) );
@@ -289,12 +297,13 @@ class Sensei_Messages {
 		 *
 		 * @since 1.9.18
 		 *
-		 * @param string    $html
-		 * @param array     $this->message_notice
-		 * @param int       $post_id
-		 * @param int       $user_id
+		 * @hook sensei_messages_send_message_link
 		 *
-		 * @return string
+		 * @param {string} $html           The HTML for the send message link.
+		 * @param {array}  $message_notice The message notice.
+		 * @param {int}    $post_id        The post ID.
+		 * @param {int}    $user_id        The user ID.
+		 * @return {string} Filtered HTML.
 		 */
 		echo wp_kses(
 			apply_filters( 'sensei_messages_send_message_link', $html, isset( $this->message_notice ) ? $this->message_notice : '', $post_id, $user_id ),
@@ -906,9 +915,13 @@ class Sensei_Messages {
 				 * Filter Sensei single title
 				 *
 				 * @since 1.8.0
-				 * @param string $title
-				 * @param string $template
-				 * @param string $post_type
+				 *
+				 * @hook sensei_single_title
+				 *
+				 * @param {string} $title     The title.
+				 * @param {string} $template  The template.
+				 * @param {string} $post_type The post type.
+				 * @return {string} Filtered title.
 				 */
 				echo wp_kses_post( apply_filters( 'sensei_single_title', $title, $post->post_type ) );
 				?>
@@ -940,6 +953,11 @@ class Sensei_Messages {
 		 * Filter the sensei messages archive title.
 		 *
 		 * @since 1.0.0
+		 *
+		 * @hook sensei_message_archive_title
+		 *
+		 * @param {string} $html The HTML for the archive title.
+		 * @return {string} Filtered HTML.
 		 */
 		echo wp_kses_post( apply_filters( 'sensei_message_archive_title', $html ) );
 

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -911,7 +911,6 @@ class Sensei_Messages {
 				 * @hook sensei_single_title
 				 *
 				 * @param {string} $title     The title.
-				 * @param {string} $template  The template.
 				 * @param {string} $post_type The post type.
 				 * @return {string} Filtered title.
 				 */

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -19,13 +19,6 @@ class Sensei_Messages {
 	public $meta_fields;
 
 	/**
-	 * The message notice.
-	 *
-	 * @var string
-	 */
-	public $message_notice;
-
-	/**
 	 * The nonce name when submitting a new message.
 	 *
 	 * @var string
@@ -46,7 +39,6 @@ class Sensei_Messages {
 		$this->token       = 'messages';
 		$this->post_type   = 'sensei_message';
 		$this->meta_fields = array( 'sender', 'receiver' );
-		$this->message_notice = '';
 
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ), 10, 2 );
 		add_action( 'admin_menu', array( $this, 'remove_meta_box' ) );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -819,9 +819,12 @@ class Sensei_Core_Modules {
 		 *
 		 * @since 1.10.0
 		 *
-		 * @param bool    $do_link_to_module  True if module should be linked to.
-		 * @param WP_Term $module             Module to check if it should be linked to.
-		 * @param bool    $link_to_current    Allow for linking to the currently displayed module.
+		 * @hook sensei_do_link_to_module
+		 *
+		 * @param {bool}    $do_link_to_module  True if module should be linked to.
+		 * @param {WP_Term} $module             Module to check if it should be linked to.
+		 * @param {bool}    $link_to_current    Allow for linking to the currently displayed module.
+		 * @return {bool} Filtered value of $do_link_to_module.
 		 */
 		return apply_filters( 'sensei_do_link_to_module', $do_link_to_module, $module, $link_to_current );
 	}
@@ -919,6 +922,14 @@ class Sensei_Core_Modules {
 	 */
 	public function module_archive_title( $title ) {
 		if ( is_tax( $this->taxonomy ) ) {
+			/**
+			 * Filter the module archive title.
+			 *
+			 * @hook sensei_module_archive_title
+			 *
+			 * @param {string} $title Archive title.
+			 * @return {string} Filtered title.
+			 */
 			$title = apply_filters( 'sensei_module_archive_title', get_queried_object()->name );
 		}
 		return $title;
@@ -958,6 +969,15 @@ class Sensei_Core_Modules {
 			}
 
 			if ( $this->can_view_module_content( $module, $course_id, $user_id ) ) {
+				/**
+				 * Filter the module archive description.
+				 *
+				 * @hook sensei_module_archive_description
+				 *
+				 * @param {string} $description Archive description.
+				 * @param {int}    $module_id   Module term ID.
+				 * @return {string} Filtered description.
+				 */
 				echo '<p class="archive-description module-description">' . wp_kses_post( apply_filters( 'sensei_module_archive_description', nl2br( $module->description ), $module->term_id ) ) . '</p>';
 			}
 		}
@@ -999,10 +1019,13 @@ class Sensei_Core_Modules {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool $can_view_module_content True if they can view module content.
-		 * @param int  $module_term_id          Module term ID.
-		 * @param int  $course_id               Course post ID.
-		 * @param int  $user_id                 User ID.
+		 * @hook sensei_can_user_view_module
+		 *
+		 * @param {bool} $can_view_module_content True if they can view module content.
+		 * @param {int}  $module_term_id          Module term ID.
+		 * @param {int}  $course_id               Course post ID.
+		 * @param {int}  $user_id                 User ID.
+		 * @return {bool} Filtered value of $can_view_module_content.
 		 */
 		return apply_filters( 'sensei_can_user_view_module', $can_view_module_content, $module->term_id, $course_id, $user_id );
 	}
@@ -1027,8 +1050,11 @@ class Sensei_Core_Modules {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool $show_course_signup_notice True if we should show the signup notice to the user.
-		 * @param int  $course_id                 Post ID for the course.
+		 * @hook sensei_module_show_course_signup_notice
+		 *
+		 * @param {bool} $show_course_signup_notice True if we should show the signup notice to the user.
+		 * @param {int}  $course_id                 Post ID for the course.
+		 * @return {bool} Filtered value of $show_course_signup_notice.
 		 */
 		if ( ! apply_filters( 'sensei_module_show_course_signup_notice', $show_course_signup_notice, $course_id ) ) {
 			return;
@@ -1046,9 +1072,12 @@ class Sensei_Core_Modules {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param string $message     Message to show user.
-		 * @param int    $course_id   Post ID for the course.
-		 * @param string $course_link Generated HTML link to the course.
+		 * @hook sensei_module_course_signup_notice_message
+		 *
+		 * @param {string} $message     Message to show user.
+		 * @param {int}    $course_id   Post ID for the course.
+		 * @param {string} $course_link Generated HTML link to the course.
+		 * @return {string} Filtered message.
 		 */
 		$message = apply_filters( 'sensei_module_course_signup_notice_message', $message_default, $course_id, $course_link );
 
@@ -1057,8 +1086,11 @@ class Sensei_Core_Modules {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param string $notice_level Notice level to use for the shown alert (alert, tick, download, info).
-		 * @param int    $course_id    Post ID for the course.
+		 * @hook sensei_module_course_signup_notice_level
+		 *
+		 * @param {string} $notice_level Notice level to use for the shown alert (alert, tick, download, info).
+		 * @param {int}    $course_id    Post ID for the course.
+		 * @return {string} Filtered notice level.
 		 */
 		$notice_level = apply_filters( 'sensei_module_course_signup_notice_level', 'info', $course_id );
 		Sensei()->notices->add_notice( $message, $notice_level );
@@ -1426,10 +1458,11 @@ class Sensei_Core_Modules {
 		 * Filter to change the number of links in the course modules column.
 		 *
 		 * @since 4.0.0
-		 * @hook  sensei_module_course_column_max_links_count
 		 *
-		 * @param  {int} $max_links_count The number of links.
-		 * @return {int}
+		 * @hook sensei_module_course_column_max_links_count
+		 *
+		 * @param {int} $max_links_count The number of links.
+		 * @return {int} The filtered number of links.
 		 */
 		$max_links_count = apply_filters( 'sensei_module_course_column_max_links_count', 3 );
 		$links_count     = count( $modules );
@@ -1861,7 +1894,14 @@ class Sensei_Core_Modules {
 			$disable_styles = Sensei()->settings->settings['styles_disable'];
 		}
 
-		// Add filter for theme overrides
+		/**
+		 * Filter to disable Sensei styles.
+		 *
+		 * @hook sensei_disable_styles
+		 *
+		 * @param {bool} $disable_styles Whether to disable Sensei styles.
+		 * @return {bool} Whether to disable Sensei styles.
+		 */
 		$disable_styles = apply_filters( 'sensei_disable_styles', $disable_styles );
 
 		if ( ! $disable_styles ) {
@@ -1954,8 +1994,11 @@ class Sensei_Core_Modules {
 		 *
 		 * @since 2.2.0
 		 *
-		 * @param string $html   The HTML to be displayed.
-		 * @param int $course_id Course ID.
+		 * @hook sensei_modules_title
+		 *
+		 * @param {string} $html      The HTML to be displayed.
+		 * @param {int}    $course_id Course ID.
+		 * @return {string} The filtered HTML.
 		 */
 		echo wp_kses_post( apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . __( 'Modules', 'sensei-lms' ) . '</h2></header>', $post->ID ) );
 	}
@@ -2129,7 +2172,11 @@ class Sensei_Core_Modules {
 		 * Filter to alter the Sensei Modules rewrite slug
 		 *
 		 * @since 1.8.0
-		 * @param string default 'modules'
+		 *
+		 * @hook sensei_module_slug
+		 *
+		 * @param {string} $modules_rewrite_slug The rewrite slug for the modules taxonomy.
+		 * @return {string} The filtered rewrite slug for the modules taxonomy.
 		 */
 		$modules_rewrite_slug = apply_filters( 'sensei_module_slug', 'modules' );
 
@@ -2603,12 +2650,13 @@ class Sensei_Core_Modules {
 		/**
 		 * Filters the module terms when ownership is being checked for them.
 		 *
-		 * @hook   sensei_filter_module_terms_by_owner
 		 * @since  4.9.0
 		 *
-		 * @param  {WP_Term[]} $user_terms The terms after applying the filter by owner.
-		 * @param  {WP_Term[]|int[]} $terms The original terms before the filtering was applied.
-		 * @param  {int} $user_id The user ID to check for ownership.
+		 * @hook   sensei_filter_module_terms_by_owner
+		 *
+		 * @param {WP_Term[]}       $user_terms The terms after applying the filter by owner.
+		 * @param {WP_Term[]|int[]} $terms      The original terms before the filtering was applied.
+		 * @param {int}             $user_id    The user ID to check for ownership.
 		 * @return {WP_Term[]} The final list of terms that must be considered as owner by the given user ID.
 		 */
 		return apply_filters( 'sensei_filter_module_terms_by_owner', $users_terms, $terms, $user_id );

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -91,10 +91,10 @@ class Sensei_Notices {
 		 * Allows to modify a sensei notice that will be shown to the user.
 		 *
 		 * @since 4.7.0
+		 *
 		 * @hook sensei_notice
 		 *
 		 * @param {array} $notice The notice data.
-		 *
 		 * @return {array|null} The notice data. Or return null if you want to prevent the notice showing up.
 		 */
 		$notice = apply_filters( 'sensei_notice', $notice );

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -241,6 +241,14 @@ class Sensei_PostTypes {
 			'show_in_admin_bar'     => true,
 			'query_var'             => true,
 			'rewrite'               => array(
+				/**
+				 * Filter the rewrite slug for the course post type.
+				 *
+				 * @hook sensei_course_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
 				'slug'       => esc_attr( apply_filters( 'sensei_course_slug', _x( 'course', 'post type single url base', 'sensei-lms' ) ) ),
 				'with_front' => $with_front,
 				'feeds'      => true,
@@ -261,12 +269,15 @@ class Sensei_PostTypes {
 		 * Filter the arguments passed in when registering the Sensei Course post type.
 		 *
 		 * @since 1.9.0
-		 * @param array $args
+		 *
+		 * @hook sensei_register_post_type_course
+		 *
+		 * @param {array} $args The arguments passed in when registering the Sensei Course post type.
+		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'course', apply_filters( 'sensei_register_post_type_course', $args ) );
 
 	}
-
 
 	/**
 	 * Redirect to the correct course archive link when using plain permalinks.
@@ -347,7 +358,6 @@ class Sensei_PostTypes {
 
 	}
 
-
 	/**
 	 * Setup the "lesson" post type, it's admin menu item and the appropriate labels and permissions.
 	 *
@@ -378,6 +388,14 @@ class Sensei_PostTypes {
 			'show_in_admin_bar'     => true,
 			'query_var'             => true,
 			'rewrite'               => array(
+				/**
+				 * Filter the rewrite slug for the lesson post type.
+				 *
+				 * @hook sensei_lesson_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
 				'slug'       => esc_attr( apply_filters( 'sensei_lesson_slug', _x( 'lesson', 'post type single slug', 'sensei-lms' ) ) ),
 				'with_front' => $with_front,
 				'feeds'      => true,
@@ -398,7 +416,11 @@ class Sensei_PostTypes {
 		 * Filter the arguments passed in when registering the Sensei Lesson post type.
 		 *
 		 * @since 1.9.0
-		 * @param array $args
+		 *
+		 * @hook sensei_register_post_type_lesson
+		 *
+		 * @param {array} $args The arguments passed in when registering the Sensei Lesson post type.
+		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'lesson', apply_filters( 'sensei_register_post_type_lesson', $args ) );
 
@@ -430,6 +452,14 @@ class Sensei_PostTypes {
 			'query_var'           => true,
 			'exclude_from_search' => true,
 			'rewrite'             => array(
+				/**
+				 * Filter the rewrite slug for the quiz post type.
+				 *
+				 * @hook sensei_quiz_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
 				'slug'       => esc_attr( apply_filters( 'sensei_quiz_slug', _x( 'quiz', 'post type single slug', 'sensei-lms' ) ) ),
 				'with_front' => $with_front,
 				'feeds'      => true,
@@ -450,12 +480,15 @@ class Sensei_PostTypes {
 		 * Filter the arguments passed in when registering the Sensei Quiz post type.
 		 *
 		 * @since 1.9.0
-		 * @param array $args
+		 *
+		 * @hook sensei_register_post_type_quiz
+		 *
+		 * @param {array} $args The arguments passed in when registering the Sensei Quiz post type.
+		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'quiz', apply_filters( 'sensei_register_post_type_quiz', $args ) );
 
 	}
-
 
 	/**
 	 * Setup the "question" post type, it's admin menu item and the appropriate labels and permissions.
@@ -493,7 +526,11 @@ class Sensei_PostTypes {
 		 * Filter the arguments passed in when registering the Sensei Question post type.
 		 *
 		 * @since 1.9.0
-		 * @param array $args
+		 *
+		 * @hook sensei_register_post_type_question
+		 *
+		 * @param {array} $args The arguments passed in when registering the Sensei Question post type.
+		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'question', apply_filters( 'sensei_register_post_type_question', $args ) );
 
@@ -517,6 +554,14 @@ class Sensei_PostTypes {
 			'query_var'           => false,
 			'exclude_from_search' => true,
 			'rewrite'             => array(
+				/**
+				 * Filter the rewrite slug for the multiple_question post type.
+				 *
+				 * @hook sensei_multiple_question_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
 				'slug'       => esc_attr( apply_filters( 'sensei_multiple_question_slug', _x( 'multiple_question', 'post type single slug', 'sensei-lms' ) ) ),
 				'with_front' => false,
 				'feeds'      => false,
@@ -553,6 +598,14 @@ class Sensei_PostTypes {
 				'query_var'             => true,
 				'exclude_from_search'   => true,
 				'rewrite'               => array(
+					/**
+					 * Filter the rewrite slug for the Sensei Message post type.
+					 *
+					 * @hook sensei_messages_slug
+					 *
+					 * @param {string} $slug The rewrite slug.
+					 * @return {string} The filtered rewrite slug.
+					 */
 					'slug'       => esc_attr( apply_filters( 'sensei_messages_slug', _x( 'messages', 'post type single slug', 'sensei-lms' ) ) ),
 					'with_front' => false,
 					'feeds'      => false,
@@ -574,7 +627,11 @@ class Sensei_PostTypes {
 			 * Filter the arguments passed in when registering the Sensei sensei_message post type.
 			 *
 			 * @since 1.9.0
-			 * @param array $args
+			 *
+			 * @hook sensei_register_post_type_sensei_message
+			 *
+			 * @param {array} $args The arguments passed in when registering the Sensei sensei_message post type.
+			 * @return {array} The filtered arguments.
 			 */
 			register_post_type( 'sensei_message', apply_filters( 'sensei_register_post_type_sensei_message', $args ) );
 		}
@@ -635,7 +692,17 @@ class Sensei_PostTypes {
 				'delete_terms' => 'manage_categories',
 				'assign_terms' => 'edit_courses',
 			),
-			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_course_category_slug', _x( 'course-category', 'taxonomy archive slug', 'sensei-lms' ) ) ) ),
+			'rewrite'           => array(
+				/**
+				 * Filter the rewrite slug for the course category taxonomy.
+				 *
+				 * @hook sensei_course_category_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
+				'slug' => esc_attr( apply_filters( 'sensei_course_category_slug', _x( 'course-category', 'taxonomy archive slug', 'sensei-lms' ) ) )
+			),
 		);
 
 		register_taxonomy( 'course-category', array( 'course' ), $args );
@@ -673,7 +740,17 @@ class Sensei_PostTypes {
 			'query_var'         => true,
 			'show_in_nav_menus' => false,
 			'public'            => false,
-			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_quiz_type_slug', _x( 'quiz-type', 'taxonomy archive slug', 'sensei-lms' ) ) ) ),
+			'rewrite'           => array(
+				/**
+				 * Filter the rewrite slug for the quiz type taxonomy.
+				 *
+				 * @hook sensei_quiz_type_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
+				'slug' => esc_attr( apply_filters( 'sensei_quiz_type_slug', _x( 'quiz-type', 'taxonomy archive slug', 'sensei-lms' ) ) )
+			),
 		);
 
 		register_taxonomy( 'quiz-type', array( 'quiz' ), $args );
@@ -712,7 +789,17 @@ class Sensei_PostTypes {
 			'show_in_nav_menus' => false,
 			'show_admin_column' => true,
 			'show_in_rest'      => true,
-			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_question_type_slug', _x( 'question-type', 'taxonomy archive slug', 'sensei-lms' ) ) ) ),
+			'rewrite'           => array(
+				/**
+				 * Filter the rewrite slug for the question type taxonomy.
+				 *
+				 * @hook sensei_question_type_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
+				'slug' => esc_attr( apply_filters( 'sensei_question_type_slug', _x( 'question-type', 'taxonomy archive slug', 'sensei-lms' ) ) )
+			),
 		);
 
 		register_taxonomy( 'question-type', array( 'question' ), $args );
@@ -757,7 +844,17 @@ class Sensei_PostTypes {
 				'delete_terms' => 'manage_categories',
 				'assign_terms' => 'edit_questions',
 			),
-			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_question_category_slug', _x( 'question-category', 'taxonomy archive slug', 'sensei-lms' ) ) ) ),
+			'rewrite'           => array(
+				/**
+				 * Filter the rewrite slug for the question category taxonomy.
+				 *
+				 * @hook sensei_question_category_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
+				'slug' => esc_attr( apply_filters( 'sensei_question_category_slug', _x( 'question-category', 'taxonomy archive slug', 'sensei-lms' ) ) )
+			),
 		);
 
 		register_taxonomy( 'question-category', array( 'question' ), $args );
@@ -800,7 +897,17 @@ class Sensei_PostTypes {
 				'delete_terms' => 'manage_categories',
 				'assign_terms' => 'edit_lessons',
 			),
-			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_lesson_tag_slug', _x( 'lesson-tag', 'taxonomy archive slug', 'sensei-lms' ) ) ) ),
+			'rewrite'           => array(
+				/**
+				 * Filter the rewrite slug for the lesson tag taxonomy.
+				 *
+				 * @hook sensei_lesson_tag_slug
+				 *
+				 * @param {string} $slug The rewrite slug.
+				 * @return {string} The filtered rewrite slug.
+				 */
+				'slug' => esc_attr( apply_filters( 'sensei_lesson_tag_slug', _x( 'lesson-tag', 'taxonomy archive slug', 'sensei-lms' ) ) )
+			),
 		);
 
 		register_taxonomy( 'lesson-tag', array( 'lesson' ), $args );
@@ -1124,10 +1231,11 @@ class Sensei_PostTypes {
 		/**
 		 * Filters the Student groups promo landing page.
 		 *
-		 * @hook  sensei_student_groups_hide
 		 * @since 4.5.2
 		 *
-		 * @param  {bool} $sensei_student_groups_hide Whether to hide the Student Groups promo landing page.
+		 * @hook sensei_student_groups_hide
+		 *
+		 * @param {bool} $sensei_student_groups_hide Whether to hide the Student Groups promo landing page.
 		 * @return {bool} Whether to hide the Student groups landing page.
 		 */
 		if ( ! apply_filters( 'sensei_student_groups_hide', false ) ) {

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -701,7 +701,7 @@ class Sensei_PostTypes {
 				 * @param {string} $slug The rewrite slug.
 				 * @return {string} The filtered rewrite slug.
 				 */
-				'slug' => esc_attr( apply_filters( 'sensei_course_category_slug', _x( 'course-category', 'taxonomy archive slug', 'sensei-lms' ) ) )
+				'slug' => esc_attr( apply_filters( 'sensei_course_category_slug', _x( 'course-category', 'taxonomy archive slug', 'sensei-lms' ) ) ),
 			),
 		);
 
@@ -749,7 +749,7 @@ class Sensei_PostTypes {
 				 * @param {string} $slug The rewrite slug.
 				 * @return {string} The filtered rewrite slug.
 				 */
-				'slug' => esc_attr( apply_filters( 'sensei_quiz_type_slug', _x( 'quiz-type', 'taxonomy archive slug', 'sensei-lms' ) ) )
+				'slug' => esc_attr( apply_filters( 'sensei_quiz_type_slug', _x( 'quiz-type', 'taxonomy archive slug', 'sensei-lms' ) ) ),
 			),
 		);
 
@@ -798,7 +798,7 @@ class Sensei_PostTypes {
 				 * @param {string} $slug The rewrite slug.
 				 * @return {string} The filtered rewrite slug.
 				 */
-				'slug' => esc_attr( apply_filters( 'sensei_question_type_slug', _x( 'question-type', 'taxonomy archive slug', 'sensei-lms' ) ) )
+				'slug' => esc_attr( apply_filters( 'sensei_question_type_slug', _x( 'question-type', 'taxonomy archive slug', 'sensei-lms' ) ) ),
 			),
 		);
 
@@ -853,7 +853,7 @@ class Sensei_PostTypes {
 				 * @param {string} $slug The rewrite slug.
 				 * @return {string} The filtered rewrite slug.
 				 */
-				'slug' => esc_attr( apply_filters( 'sensei_question_category_slug', _x( 'question-category', 'taxonomy archive slug', 'sensei-lms' ) ) )
+				'slug' => esc_attr( apply_filters( 'sensei_question_category_slug', _x( 'question-category', 'taxonomy archive slug', 'sensei-lms' ) ) ),
 			),
 		);
 
@@ -906,7 +906,7 @@ class Sensei_PostTypes {
 				 * @param {string} $slug The rewrite slug.
 				 * @return {string} The filtered rewrite slug.
 				 */
-				'slug' => esc_attr( apply_filters( 'sensei_lesson_tag_slug', _x( 'lesson-tag', 'taxonomy archive slug', 'sensei-lms' ) ) )
+				'slug' => esc_attr( apply_filters( 'sensei_lesson_tag_slug', _x( 'lesson-tag', 'taxonomy archive slug', 'sensei-lms' ) ) ),
 			),
 		);
 

--- a/includes/class-sensei-preview-user.php
+++ b/includes/class-sensei-preview-user.php
@@ -74,11 +74,11 @@ class Sensei_Preview_User {
 		/**
 		 * Enable or disable 'preview as student' feature.
 		 *
-		 * @hook sensei_feature_preview_students
 		 * @since 4.11.0
 		 *
-		 * @param {bool} $enable Enable feature. Default true.
+		 * @hook sensei_feature_preview_students
 		 *
+		 * @param {bool} $enable Enable feature. Default true.
 		 * @return {bool} Wether to enable feature.
 		 */
 		if ( ! apply_filters( 'sensei_feature_preview_students', true ) ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -599,6 +599,7 @@ class Sensei_Question {
 		 * Filter the grade for the given question.
 		 *
 		 * @since 1.9.6
+		 *
 		 * @hook sensei_get_question_grade
 		 *
 		 * @param {int} $question_grade Question grade.
@@ -655,6 +656,7 @@ class Sensei_Question {
 		 * Filter the question title.
 		 *
 		 * @since 1.3.0
+		 *
 		 * @hook sensei_question_title
 		 *
 		 * @param {string} $title Question title.
@@ -929,15 +931,15 @@ class Sensei_Question {
 		/**
 		 * Allow dynamic overriding of whether to show question answers or not
 		 *
-		 * @hook  sensei_question_show_answers
 		 * @since 1.9.7
+		 *
+		 * @hook  sensei_question_show_answers
 		 *
 		 * @param {bool} $show_answers Whether to show the answer to the question.
 		 * @param {int}  $question_id  Question ID.
 		 * @param {int}  $quiz_id      Quiz ID.
 		 * @param {int}  $lesson_id    Lesson ID.
 		 * @param {int}  $user_id      User ID.
-		 *
 		 * @return {bool} Whether to show the answer to the question.
 		 */
 		$show_correct_answers = apply_filters( 'sensei_question_show_answers', $show_correct_answers, $question_id, $quiz_id, $lesson_id, get_current_user_id() );
@@ -960,15 +962,15 @@ class Sensei_Question {
 		/**
 		 * Filter the answer message CSS classes.
 		 *
-		 * @hook  sensei_question_answer_message_css_class
 		 * @since  1.9.0
+		 *
+		 * @hook  sensei_question_answer_message_css_class
 		 *
 		 * @param {string} $answer_notes_classname Space-separated CSS classes to apply to answer message.
 		 * @param {int}    $lesson_id              Lesson ID.
 		 * @param {int}    $question_id            Question ID.
 		 * @param {int}    $user_id                User ID.
 		 * @param {bool}   $answer_correct         Whether this is the correct answer.
-		 *
 		 * @return {string} Space-separated CSS classes to apply to answer message.
 		 */
 		$answer_notes_classnames = apply_filters( 'sensei_question_answer_message_css_class', $answer_notes_classnames, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
@@ -978,12 +980,12 @@ class Sensei_Question {
 		 * Filter the answer feedback.
 		 *
 		 * @since  1.9.0
+		 *
 		 * @hook   sensei_question_answer_notes
 		 *
 		 * @param  {bool|string} $answer_notes Answer notes.
 		 * @param  {int}         $question_id  Question ID.
 		 * @param  {int}         $lesson_id    Lesson ID.
-		 *
 		 * @return {string} Answer notes.
 		 */
 		$answer_notes = apply_filters( 'sensei_question_answer_notes', $answer_notes, $question_id, $lesson_id );
@@ -997,15 +999,15 @@ class Sensei_Question {
 		/**
 		 * Filter the learner grade displayed.
 		 *
-		 * @hook  sensei_question_answer_message_grade
 		 * @since 3.14.0
+		 *
+		 * @hook  sensei_question_answer_message_grade
 		 *
 		 * @param {string} $grade          Formatted grade (eg "0/3 points")
 		 * @param {int}    $lesson_id      Lesson ID.
 		 * @param {int}    $question_id    Question ID.
 		 * @param {int}    $user_id        User ID.
 		 * @param {bool}   $answer_correct Whether this is the correct answer.
-		 *
 		 * @return {string} Answer message.
 		 */
 		$grade = apply_filters( 'sensei_question_answer_message_grade', $grade, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
@@ -1013,15 +1015,15 @@ class Sensei_Question {
 		/**
 		 * Filter the correct answer.
 		 *
-		 * @hook  sensei_question_answer_message_correct_answer
 		 * @since 1.9.0
+		 *
+		 * @hook  sensei_question_answer_message_correct_answer
 		 *
 		 * @param {string} $answer_message Answer message.
 		 * @param {int}    $lesson_id      Lesson ID.
 		 * @param {int}    $question_id    Question ID.
 		 * @param {int}    $user_id        User ID.
 		 * @param {bool}   $answer_correct Whether this is the correct answer.
-		 *
 		 * @return {string} Answer message.
 		 */
 		$correct_answer   = apply_filters( 'sensei_question_answer_message_correct_answer', $correct_answer, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
@@ -1174,8 +1176,9 @@ class Sensei_Question {
 		/**
 		 * Filter the answer message.
 		 *
-		 * @hook sensei_question_answer_message_text
 		 * @deprecated
+		*
+		 * @hook sensei_question_answer_message_text
 		 *
 		 * @param {string} $answer_message Answer message.
 		 * @param {int}    $lesson_id      Lesson ID.
@@ -1238,6 +1241,7 @@ class Sensei_Question {
 		 * the get_template_data function.
 		 *
 		 * @since 1.9.0
+		 *
 		 * @hook sensei_get_question_template_data
 		 *
 		 * @param {array} $data        Question data.
@@ -1555,6 +1559,7 @@ class Sensei_Question {
 		 * Can be used for text filters.
 		 *
 		 * @since 1.9.7
+		 *
 		 * @hook sensei_questions_get_correct_answer
 		 *
 		 * @param {string} $right_answer Correct answer.

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -664,7 +664,15 @@ class Sensei_Question {
 		 */
 		$title = apply_filters( 'sensei_question_title', get_the_title( $question_id ) );
 
-		/** This filter is documented in includes/class-sensei-messages.php */
+		/**
+		 * Filter Sensei single title
+		 *
+		 * @hook sensei_single_title
+		 *
+		 * @param {string} $title     The title.
+		 * @param {string} $post_type The post type.
+		 * @return {string} Filtered title.
+		 */
 		$title = apply_filters( 'sensei_single_title', $title, 'question' );
 
 		$question_grade = Sensei()->question->get_question_grade( $question_id );
@@ -1119,7 +1127,18 @@ class Sensei_Question {
 			$show_answers = false;
 		}
 
-		/** This filter is documented in self::the_answer_feedback */
+		/**
+		 * Allow dynamic overriding of whether to show question answers or not
+		 *
+		 * @hook  sensei_question_show_answers
+		 *
+		 * @param {bool} $show_answers Whether to show the answer to the question.
+		 * @param {int}  $question_id  Question ID.
+		 * @param {int}  $quiz_id      Quiz ID.
+		 * @param {int}  $lesson_id    Lesson ID.
+		 * @param {int}  $user_id      User ID.
+		 * @return {bool} Whether to show the answer to the question.
+		 */
 		$show_answers = apply_filters( 'sensei_question_show_answers', $show_answers, $question_item->ID, $quiz_id, $lesson_id, get_current_user_id() );
 
 		if ( $show_answers ) {
@@ -1170,7 +1189,18 @@ class Sensei_Question {
 			$answer_message_class .= ' has_notes';
 		}
 
-		/** This filter is documented in self::the_answer_feedback */
+		/**
+		 * Filter the answer message CSS classes.
+		 *
+		 * @hook  sensei_question_answer_message_css_class
+		 *
+		 * @param {string} $answer_notes_classname Space-separated CSS classes to apply to answer message.
+		 * @param {int}    $lesson_id              Lesson ID.
+		 * @param {int}    $question_id            Question ID.
+		 * @param {int}    $user_id                User ID.
+		 * @param {bool}   $answer_correct         Whether this is the correct answer.
+		 * @return {string} Space-separated CSS classes to apply to answer message.
+		 */
 		$final_css_classes = apply_filters( 'sensei_question_answer_message_css_class', $answer_message_class, $lesson_id, $question_id, get_current_user_id(), $user_correct );
 
 		/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1626,7 +1626,13 @@ class Sensei_Quiz {
 			$title = sprintf( __( '%s Quiz', 'sensei-lms' ), $title_with_no_quizzes );
 
 			/**
-			 * hook document in class-woothemes-sensei-message.php
+			 * Filter Sensei single title
+			 *
+			 * @hook sensei_single_title
+			 *
+			 * @param {string} $title     The title.
+			 * @param {string} $post_type The post type.
+			 * @return {string} Filtered title.
 			 */
 			$title = apply_filters( 'sensei_single_title', $title, get_post_type() );
 		}
@@ -1740,7 +1746,13 @@ class Sensei_Quiz {
 
 				<?php
 				/**
-				 * Filter documented in class-sensei-messages.php the_title
+				 * Filter Sensei single title
+				 *
+				 * @hook sensei_single_title
+				 *
+				 * @param {string} $title     The title.
+				 * @param {string} $post_type The post type.
+				 * @return {string} Filtered title.
 				 */
 				echo wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( get_post() ), get_post_type( get_the_ID() ) ) );
 				?>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -129,11 +129,11 @@ class Sensei_Quiz {
 		 * editor if necessary.
 		 *
 		 * @since 3.9.0
+		 *
 		 * @hook sensei_quiz_enable_block_based_editor
 		 *
 		 * @param {bool} $is_block_based_editor_enabled True if block based editor is enabled.
-		 *
-		 * @return {bool}
+		 * @return {bool} Filtered value.
 		 */
 		return apply_filters( 'sensei_quiz_enable_block_based_editor', $is_block_editor );
 	}
@@ -732,11 +732,11 @@ class Sensei_Quiz {
 		 * Filters allowed which mimetypes are allowed.
 		 *
 		 * @since 3.7.0
+		 *
 		 * @hook sensei_quiz_answer_file_upload_types
 		 *
 		 * @param {false|array} $allowed_mime_types Array of allowed mimetypes. Returns `false` to allow all file types.
 		 * @param {int}         $question_id        Question post ID.
-		 *
 		 * @return {false|array} Allowed mime types or false to allow all types.
 		 */
 		$allowed_mime_types = apply_filters( 'sensei_quiz_answer_file_upload_types', false, $question_id );
@@ -1401,10 +1401,14 @@ class Sensei_Quiz {
 		 * Filter the user question feedback.
 		 *
 		 * @since 1.9.12
-		 * @param string $feedback
-		 * @param int    $lesson_id
-		 * @param int    $question_id
-		 * @param int    $user_id
+		 *
+		 * @hook sensei_user_question_feedback
+		 *
+		 * @param {string} $feedback    The feedback.
+		 * @param {int}    $lesson_id   The lesson ID.
+		 * @param {int}    $question_id The question ID.
+		 * @param {int}    $user_id     The user ID.
+		 * @return {string} The filtered feedback.
 		 */
 		return apply_filters( 'sensei_user_question_feedback', $feedback, $lesson_id, $question_id, $user_id );
 

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -493,9 +493,10 @@ class Sensei_Settings_API {
 		 *
 		 * @since 4.1.0
 		 *
-		 * @hook  sensei_settings_woocommerce_hide  Hook used to hide woocommerce promo banner and section.
+		 * @hook sensei_settings_woocommerce_hide  Hook used to hide woocommerce promo banner and section.
 		 *
-		 * @return {boolean}                        Returns a boolean value that defines if the woocommerce promo banner should be hidden.
+		 * @param {bool} $hide_woocommerce_settings Defines if the woocommerce promo banner should be hidden.
+		 * @return {bool} Returns a boolean value that defines if the woocommerce promo banner should be hidden.
 		 */
 		$hide_woocommerce_settings = apply_filters( 'sensei_settings_woocommerce_hide', false );
 		if ( 'woocommerce-settings' === $section_id && ! $hide_woocommerce_settings ) {
@@ -509,7 +510,8 @@ class Sensei_Settings_API {
 		 *
 		 * @hook  sensei_settings_content_drip_hide  Hook used to hide content drip promo banner and section.
 		 *
-		 * @return {boolean}                        Returns a boolean value that defines if the content drip promo banner should be hidden.
+		 * @param {bool} $hide_content_drip_settings Defines if the content drip promo banner should be hidden.
+		 * @return {bool} Returns a boolean value that defines if the content drip promo banner should be hidden.
 		 */
 		$hide_content_drip_settings = apply_filters( 'sensei_settings_content_drip_hide', false );
 		if ( 'sensei-content-drip-settings' === $section_id && ! $hide_content_drip_settings ) {

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -118,11 +118,11 @@ class Sensei_Settings extends Sensei_Settings_API {
 		/**
 		 * Filters content for the settings page.
 		 *
-		 * @hook  sensei_settings_content
 		 * @since 4.12.0
 		 *
-		 * @param {string} $tab_name The tab slug.
+		 * @hook  sensei_settings_content
 		 *
+		 * @param {string} $tab_name The tab slug.
 		 * @return {string} Filtered tab content.
 		 */
 		$content = apply_filters( 'sensei_settings_content', $tab_name );
@@ -233,11 +233,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 		/**
 		 * Filters the woocommerce promo settings section.
 		 *
+		 * Hook used to hide woocommerce promo banner and section.
+
 		 * @since 4.1.0
 		 *
-		 * @hook  sensei_settings_woocommerce_hide  Hook used to hide woocommerce promo banner and section.
+		 * @hook sensei_settings_woocommerce_hide
 		 *
-		 * @return {boolean}                        Returns a boolean value that defines if the woocommerce promo banner should be hidden.
+		 * @param {bool} $hide_woocommerce_settings  Boolean value that defines if the woocommerce promo banner should be hidden.
+		 * @return {bool} Filtered boolean value that defines if the woocommerce promo banner should be hidden.
 		 */
 		$hide_woocommerce_settings = apply_filters( 'sensei_settings_woocommerce_hide', false );
 		if ( ! $hide_woocommerce_settings ) {
@@ -250,11 +253,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 		/**
 		 * Filters the content drip promo settings section.
 		 *
+		 * Hook used to hide content drip promo banner and section.
+		 *
 		 * @since 4.1.0
 		 *
-		 * @hook  sensei_settings_content_drip_hide  Hook used to hide content drip promo banner and section.
+		 * @hook sensei_settings_content_drip_hide
 		 *
-		 * @return {boolean}                        Returns a boolean value that defines if the content drip promo banner should be hidden.
+		 * @param {bool} $hide_content_drip_settings  Boolean value that defines if the content drip promo banner should be hidden.
+		 * @return {bool} Filtered boolean value that defines if the content drip promo banner should be hidden.
 		 */
 		$hide_content_drip_settings = apply_filters( 'sensei_settings_content_drip_hide', false );
 		if ( ! $hide_content_drip_settings ) {
@@ -264,6 +270,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 			);
 		}
 
+		/**
+		 * Filters settings tabs.
+		 *
+		 * @hook sensei_settings_tabs
+		 *
+		 * @param {array} $sections  Array of settings sections.
+		 * @return {array} Filtered array of settings sections.
+		 */
 		$this->sections = apply_filters( 'sensei_settings_tabs', $sections );
 	}
 
@@ -631,6 +645,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		// Learner Profile settings
+		/**
+		 * Filters the learner profile URL base.
+		 *
+		 * @hook sensei_learner_profiles_url_base
+		 *
+		 * @param {string} $profile_url_base  The profile URL base, default is 'learner'.
+		 * @return {string} Filtered profile URL base.
+		 */
 		$profile_url_base    = apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'sensei-lms' ) );
 		$profile_url_example = trailingslashit( get_home_url() ) . $profile_url_base . '/%username%';
 
@@ -813,6 +835,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'required'    => 1,
 		);
 
+		/**
+		 * Filters settings fields.
+		 *
+		 * @hook sensei_settings_fields
+		 *
+		 * @param {array} $fields The array of fields.
+		 * @return {array} Filtered array of fields.
+		 */
 		$this->fields = apply_filters( 'sensei_settings_fields', $fields );
 
 	}

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -796,13 +796,15 @@ class Sensei_Teacher {
 			case 'question':
 			case 'lesson_page_module-order':
 				/**
-				 * sensei_filter_queries_set_author
-				 * Filter the author Sensei set for queries
+				 * Filter the author Sensei set for queries.
 				 *
 				 * @since 1.8.0
 				 *
-				 * @param int $user_id
-				 * @param string $screen_id
+				 * @hook sensei_filter_queries_set_author
+				 *
+				 * @param {int}    $user_id   The user ID to set as author.
+				 * @param {string} $screen_id The current screen ID.
+				 * @return {int} Filtered author ID.
 				 */
 				$query->set( 'author', apply_filters( 'sensei_filter_queries_set_author', $current_user->ID, $screen->id ) );
 				break;
@@ -841,11 +843,13 @@ class Sensei_Teacher {
 			/**
 			 * Allows to change the list of teacher IDs with grading access allowed for a given course ID.
 			 *
-			 * @hook   sensei_grading_allowed_user_ids
-			 * @since  4.9.0
+			 * @since 4.9.0
 			 *
-			 * @param {int[]} $user_ids The list of user IDs with access granted. By default the course author.
-			 * @param {int} $course_id The course ID.
+			 * @hook sensei_grading_allowed_user_ids
+			 *
+			 * @param {int[]} $user_ids  The list of user IDs with access granted. By default the course author.
+			 * @param {int}   $course_id The course ID.
+			 * @return {int[]} Filtered list of user IDs with access granted.
 			 */
 			$allowed_user_ids = apply_filters( 'sensei_grading_allowed_user_ids', [ intval( $course->post_author ) ], $course_id );
 			if ( ! isset( $course->post_author ) || ! in_array( intval( get_current_user_id() ), $allowed_user_ids, true ) ) {
@@ -952,7 +956,11 @@ class Sensei_Teacher {
 		 * Change the query on the teacher author archive template
 		 *
 		 * @since 1.8.4
-		 * @param WP_Query $query
+		 *
+		 * @hook sensei_teacher_archive_query
+		 *
+		 * @param {WP_Query} $query The query object.
+		 * @return {WP_Query} The filtered query object.
 		 */
 		return apply_filters( 'sensei_teacher_archive_query', $query );
 
@@ -963,8 +971,8 @@ class Sensei_Teacher {
 	 *
 	 * @since 1.8.0
 	 *
-	 * @param $teacher_id
-	 * @param $course_id
+	 * @param int $teacher_id The ID of the teacher.
+	 * @param int $course_id  The ID of the course.
 	 * @return bool
 	 */
 	public function teacher_course_assigned_notification( $teacher_id, $course_id ) {
@@ -1006,12 +1014,14 @@ class Sensei_Teacher {
 		}
 
 		/**
-		 * Filter the option to send admin notification emails when teachers creation
-		 * course.
+		 * Filter the option to send admin notification emails when teachers creation course.
 		 *
 		 * @since 1.8.0
 		 *
-		 * @param bool $on default true
+		 * @hook sensei_notify_admin_new_course_creation
+		 *
+		 * @param {bool} $on The option of whether admin notification emails should be sent, default true.
+		 * @return {bool} Filtered option.
 		 */
 		if ( ! apply_filters( 'sensei_notify_admin_new_course_creation', true ) ) {
 			return false;
@@ -1032,20 +1042,28 @@ class Sensei_Teacher {
 		do_action( 'sensei_before_mail', $recipient );
 
 		/**
-		 * Filter the email Header for the admin-teacher-new-course-created template
+		 * Filter the email header for the admin-teacher-new-course-created template
 		 *
 		 * @since 1.8.0
-		 * @param string $template
+		 *
+		 * @hook sensei_email_heading
+		 *
+		 * @param {string} $heading  Email heading, default: New course created.
+		 * @param {string} $template Template name.
+		 * @return {string} Filtered heading.
 		 */
 		$heading = apply_filters( 'sensei_email_heading', __( 'New course created.', 'sensei-lms' ), $template );
 
 		/**
-		 * Filter the email subject for the the
-		 * admin-teacher-new-course-created template
+		 * Filter the email subject for the the admin-teacher-new-course-created template.
 		 *
 		 * @since 1.8.0
-		 * @param string $subject default New course assigned to you
-		 * @param string $template
+		 *
+		 * @hook sensei_email_subject
+		 *
+		 * @param {string} $subject The email subject, default: New course created by {teacher name}.
+		 * @param {string} $template Template name.
+		 * @return {string} Filtered subject.
 		 */
 		$subject = apply_filters(
 			'sensei_email_subject',
@@ -1070,8 +1088,12 @@ class Sensei_Teacher {
 		 * Filter the sensei email data for the admin-teacher-new-course-created template
 		 *
 		 * @since 1.8.0
-		 * @param array $email_data
-		 * @param string $template
+		 *
+		 * @hook sensei_email_data
+		 *
+		 * @param {array}  $email_data The email data array.
+		 * @param {string} $template   Template name.
+		 * @return {array} Filtered email data array.
 		 */
 		$sensei_email_data = apply_filters( 'sensei_email_data', $email_data, $template );
 
@@ -1658,9 +1680,11 @@ class Sensei_Teacher {
 		 *
 		 * @since 1.8.7
 		 *
-		 * @param bool $restrict default true
+		 * @hook sensei_restrict_posts_menu_page
+		 *
+		 * @param {bool} $restrict Whether to hide the posts menu page, default true.
+		 * @return {bool} Filtered option.
 		 */
-
 		$restrict = apply_filters( 'sensei_restrict_posts_menu_page', true );
 
 		if ( in_array( 'teacher', (array) $user->roles ) && ! current_user_can( 'delete_posts' ) && $restrict ) {

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -163,12 +163,14 @@ class Sensei_Templates {
 		/**
 		 * Filters if Sensei templates and content wrappers should be used. For development purposes.
 		 *
-		 * @hook   sensei_use_sensei_template
-		 *
-		 * @param  {bool} $use_templates Whether to use Sensei templates for the request.
+		 * @access private
 		 *
 		 * @since  3.6.0
-		 * @access private
+		 *
+		 * @hook sensei_use_sensei_template
+		 *
+		 * @param {bool} $use_templates Whether to use Sensei templates for the request.
+		 * @return {bool} Whether to use Sensei templates for the request.
 		 */
 		if ( ! apply_filters( 'sensei_use_sensei_template', true ) && ! isset( $email_template ) ) {
 			return $template;
@@ -386,7 +388,10 @@ class Sensei_Templates {
 		 *
 		 * @since 1.9.0
 		 *
-		 * @param $title_html_tag default is 'h3'
+		 * @hook sensei_the_title_html_tag
+		 *
+		 * @param {string} $title_html_tag HTML tag for title, default is 'h3'.
+		 * @return {string} Filtered HTML tag for title.
 		 */
 		$title_html_tag = apply_filters( 'sensei_the_title_html_tag', 'h3' );
 
@@ -394,7 +399,11 @@ class Sensei_Templates {
 		 * Filter the title classes
 		 *
 		 * @since 1.9.0
-		 * @param string $title_classes defaults to $post_type-title
+		 *
+		 * @hook sensei_the_title_classes
+		 *
+		 * @param {string} $title_classes Title classes, defaults to `{$post_type}-title`.
+		 * @return {string} Filtered title classes.
 		 */
 		$title_classes = apply_filters( 'sensei_the_title_classes', $post->post_type . '-title' );
 
@@ -406,7 +415,10 @@ class Sensei_Templates {
 		 *
 		 * @since 1.9.16
 		 *
-		 * @param string $course_title The Course Title.
+		 * @hook sensei_course_the_title
+		 *
+		 * @param {string} $course_title The Course Title.
+		 * @return {string} Filtered course title.
 		 */
 		$course_title = (string) apply_filters( 'sensei_course_the_title', $post->post_title );
 		$html        .= $course_title;

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -127,8 +127,20 @@ class Sensei_Templates {
 			$template = '';
 		}
 
+		/**
+		 * Filter located template.
+		 *
+		 * @hook sensei_locate_template
+		 *
+		 * @param {string} $template The located template.
+		 * @param {string} $template_name The template name.
+		 * @param {string} $template_path The template path.
+		 * @return {string} Filetered located template.
+		 */
+		$template = apply_filters( 'sensei_locate_template', $template, $template_name, $template_path );
+
 		// Return what we found
-		return apply_filters( 'sensei_locate_template', $template, $template_name, $template_path );
+		return $template;
 
 	}
 

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -122,12 +122,14 @@ class Sensei_Unsupported_Themes {
 		/**
 		 * Filters if Sensei templates and content wrappers should be used. For development purposes.
 		 *
-		 * @hook   sensei_use_sensei_template
-		 *
-		 * @param  {bool} $use_templates Whether to use Sensei templates for the request.
-		 *
-		 * @since  3.6.0
 		 * @access private
+		 *
+		 * @since 3.6.0
+		 *
+		 * @hook sensei_use_sensei_template
+		 *
+		 * @param {bool} $use_templates Whether to use Sensei templates for the request.
+		 * @return {bool} Filtered value.
 		 */
 		if ( ! apply_filters( 'sensei_use_sensei_template', true ) ) {
 			return;

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -154,12 +154,12 @@ class Sensei_Updates {
 		/**
 		 * Filter to disable attempts at adding the comment indexes.
 		 *
-		 * @hook sensei_add_comment_indexes
 		 * @since 3.7.0
 		 *
-		 * @param {bool} $do_add_indexes True if indexes should be added to comment table.
+		 * @hook sensei_add_comment_indexes
 		 *
-		 * @return {bool}
+		 * @param {bool} $do_add_indexes True if indexes should be added to comment table.
+		 * @return {bool} Filtered value.
 		 */
 		if ( ! apply_filters( 'sensei_add_comment_indexes', true ) ) {
 			return;

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -69,10 +69,10 @@ class Sensei_Usage_Tracking_Data {
 		 * Filter the usage tracking data.
 		 *
 		 * @since 4.10.0
+		 *
 		 * @hook sensei_usage_tracking_data
 		 *
 		 * @param {array} $usage_data The usage tracking data.
-		 *
 		 * @return {array} Returns filtered usage tracking data.
 		 */
 		return apply_filters( 'sensei_usage_tracking_data', $usage_data );
@@ -119,7 +119,10 @@ class Sensei_Usage_Tracking_Data {
 		/**
 		 * Filter the fields that should be sent with every event that is logged.
 		 *
-		 * @param array $base_fields The default base fields.
+		 * @hook sensei_event_logging_base_fields
+		 *
+		 * @param {array} $base_fields The default base fields.
+		 * @return {array} Returns filtered base fields.
 		 */
 		return apply_filters( 'sensei_event_logging_base_fields', $base_fields );
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -997,7 +997,7 @@ class Sensei_Utils {
 		 * @param {int} $total_grade  User's total grade
 		 * @param {int} $course_id    ID of course
 		 * @param {int} $user_id      ID of user
-		 * @return {int} Fitlered user total grade.
+		 * @return {int} Filtered user total grade.
 		 */
 		return apply_filters( 'sensei_course_user_grade', self::round( $total_grade ), $course_id, $user_id );
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2229,7 +2229,7 @@ class Sensei_Utils {
 	 *
 	 * @since 1.8.5
 	 *
-	 * @param float $val        Value to round.
+	 * @param float  $val        Value to round.
 	 * @param int    $precision Precision.
 	 * @param int    $mode      Round mode.
 	 * @param string $context   Context.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -341,11 +341,8 @@ class Sensei_Utils {
 		 *
 		 * @hook sensei_file_upload_args
 		 *
-		 * @param {array} $file_upload_args {
-		 *      array of current values
-		 *
-		 *     @type {string} test_form set to false by default
-		 * }
+		 * @param {array} $file_upload_args Array of current values
+		 * @property {string} test_form set to false by default
 		 * @return {array} Filtered data array.
 		 */
 		$file_upload_args = apply_filters( 'sensei_file_upload_args', array( 'test_form' => false ) );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -28,6 +28,14 @@ class Sensei_Utils {
 	 */
 	public static function get_placeholder_image() {
 
+		/**
+		 * Filter the placeholder thumbnail image.
+		 *
+		 * @hook sensei_placeholder_thumbnail
+		 *
+		 * @param {string} $placeholder_image_url The URL to the placeholder thumbnail image.
+		 * @return {string} The URL to the placeholder thumbnail image.
+		 */
 		return esc_url( apply_filters( 'sensei_placeholder_thumbnail', Sensei()->plugin_url . 'assets/images/placeholder.png' ) );
 	}
 
@@ -132,8 +140,11 @@ class Sensei_Utils {
 		 *
 		 * It runs while getting the comments for the given request.
 		 *
-		 * @param int|array $comments
-		 * @param array $args Search arguments.
+		 * @hook sensei_check_for_activity
+		 *
+		 * @param {int|array} $comments Activity to filter.
+		 * @param {array}     $args     Search arguments.
+		 * @return {int|array} Filtered activity.
 		 */
 		$comments = apply_filters( 'sensei_check_for_activity', get_comments( $args ), $args );
 
@@ -328,10 +339,10 @@ class Sensei_Utils {
 		 *
 		 * @since 1.7.4
 		 *
-		 * @param array  $file_upload_args {
+		 * @param {array} $file_upload_args {
 		 *      array of current values
 		 *
-		 *     @type string test_form set to false by default
+		 *     @type {string} test_form set to false by default
 		 * }
 		 */
 		$file_upload_args = apply_filters( 'sensei_file_upload_args', array( 'test_form' => false ) );
@@ -340,11 +351,11 @@ class Sensei_Utils {
 		 * Customize the prefix prepended onto files uploaded in Sensei.
 		 *
 		 * @since 3.9.0
+		 *
 		 * @hook sensei_file_upload_file_prefix
 		 *
 		 * @param {string} $prefix Prefix to prepend to uploaded files.
 		 * @param {array}  $file   Arguments with uploaded file information.
-		 *
 		 * @return {string}
 		 */
 		$file_prefix = apply_filters( 'sensei_file_upload_file_prefix', substr( md5( uniqid() ), 0, 7 ) . '_', $file );
@@ -921,8 +932,11 @@ class Sensei_Utils {
 		 *
 		 * @since 1.9.7
 		 *
-		 * @param integer $course_passmark  Pass mark for course
-		 * @param integer $course_id        ID of course
+		 * @hook sensei_course_pass_grade
+		 *
+		 * @param {int} $course_passmark  Pass mark for course.
+		 * @param {int} $course_id        ID of course.
+		 * @return {int} Filtered course pass mark.
 		 */
 		return apply_filters( 'sensei_course_pass_grade', self::round( $course_passmark ), $course_id );
 	}
@@ -930,9 +944,9 @@ class Sensei_Utils {
 	/**
 	 * Get user total grade for course
 	 *
-	 * @param  integer $course_id ID of course
-	 * @param  integer $user_id   ID of user
-	 * @return integer            User's total grade
+	 * @param  int $course_id ID of course
+	 * @param  int $user_id   ID of user
+	 * @return int            User's total grade
 	 */
 	public static function sensei_course_user_grade( $course_id = 0, $user_id = 0 ) {
 
@@ -978,9 +992,12 @@ class Sensei_Utils {
 		 *
 		 * @since 1.9.7
 		 *
-		 * @param integer $total_grade  User's total grade
-		 * @param integer $course_id    ID of course
-		 * @param integer $user_id      ID of user
+		 * @hook sensei_course_user_grade
+		 *
+		 * @param {int} $total_grade  User's total grade
+		 * @param {int} $course_id    ID of course
+		 * @param {int} $user_id      ID of user
+		 * @return {int} Fitlered user total grade.
 		 */
 		return apply_filters( 'sensei_course_user_grade', self::round( $total_grade ), $course_id, $user_id );
 	}
@@ -988,9 +1005,9 @@ class Sensei_Utils {
 	/**
 	 * Check if user has passed a course
 	 *
-	 * @param  integer $course_id ID of course
-	 * @param  integer $user_id   ID of user
-	 * @return boolean
+	 * @param  int $course_id ID of course
+	 * @param  int $user_id   ID of user
+	 * @return bool
 	 */
 	public static function sensei_user_passed_course( $course_id = 0, $user_id = 0 ) {
 		if ( intval( $user_id ) == 0 ) {
@@ -1055,6 +1072,16 @@ class Sensei_Utils {
 			}
 		}
 
+		/**
+		 * Filter a message for user course status.
+		 *
+		 * Possible statuses: not_started, passed, failed.
+		 *
+		 * @hook sensei_user_course_status_{status}
+		 *
+		 * @param {string} $message Status message.
+		 * @return {string} Filtered status message.
+		 */
 		$message = apply_filters( 'sensei_user_course_status_' . $status, $message );
 		Sensei()->notices->add_notice( $message, $box_class );
 	}
@@ -1240,9 +1267,12 @@ class Sensei_Utils {
 			 *
 			 * @since 2.0.0
 			 *
-			 * @param string $message     Message to show user.
-			 * @param int    $course_id   Post ID for the course.
-			 * @param string $course_link Generated HTML link to the course.
+			 * @hook sensei_quiz_course_signup_notice_message
+			 *
+			 * @param {string} $message     Message to show user.
+			 * @param {int}    $course_id   Post ID for the course.
+			 * @param {string} $course_link Generated HTML link to the course.
+			 * @return {string} Filtered message.
 			 */
 			$message = apply_filters( 'sensei_quiz_course_signup_notice_message', $message_default, $course_id, $course_link );
 		}
@@ -1255,7 +1285,17 @@ class Sensei_Utils {
 			$extra   = '<p><a class="button" href="' . esc_url( get_permalink( $quiz_id ) ) . '" title="' . __( 'View the lesson quiz', 'sensei-lms' ) . '">' . __( 'View the lesson quiz', 'sensei-lms' ) . '</a></p>';
 		}
 
-		// Filter of all messages
+		/**
+		 * Filter user quiz status.
+		 *
+		 * @hook sensei_user_quiz_status
+		 *
+		 * @param {array} $status_data Array containing the status, message and additions information.
+		 * @param {int}   $lesson_id   Lesson ID.
+		 * @param {int}   $user_id     User ID.
+		 * @param {bool}  $is_leeson   A flag is $lesson_id is a lesson.
+		 * @return {array} Filtered quiz status.
+		 */
 		return apply_filters(
 			'sensei_user_quiz_status',
 			array(
@@ -2170,30 +2210,50 @@ class Sensei_Utils {
 	 *
 	 * @since 1.8.5
 	 *
-	 * @param double $val
-	 * @param int    $precision
-	 * @param $mode
-	 * @param string $context
+	 * @param float $val        Value to round.
+	 * @param int    $precision Precision.
+	 * @param int    $mode      Round mode.
+	 * @param string $context   Context.
 	 *
 	 * @return double $val
 	 */
 	public static function round( $val, $precision = 0, $mode = PHP_ROUND_HALF_UP, $context = '' ) {
 
 		/**
+		 * Filter the round precision.
+		 *
 		 * Change the precision for the Sensei_Utils::round function.
 		 * the precision given will be passed into the php round function
 		 *
 		 * @since 1.8.5
+		 *
+		 * @hook sensei_round_precision
+		 *
+		 * @param {int}    $precision Precision.
+		 * @param {float}  $value     Value to round.
+		 * @param {string} $context   Context.
+		 * @param {int}    $mode      Round mode.
+		 * @return {int} Filtered precision.
 		 */
 		$precision = apply_filters( 'sensei_round_precision', $precision, $val, $context, $mode );
 
 		/**
+		 * Filter round mode.
+		 *
 		 * Change the mode for the Sensei_Utils::round function.
 		 * the mode given will be passed into the php round function
 		 *
 		 * This applies only to PHP version 5.3.0 and greater
 		 *
 		 * @since 1.8.5
+		 *
+		 * @hook sensei_round_mode
+		 *
+		 * @param {int}    $mode      Round mode.
+		 * @param {float}  $value     Value to round.
+		 * @param {string} $context   Context.
+		 * @param {int}    $precision Precision.
+		 * @return {int} Filtered round mode.
 		 */
 		$mode = apply_filters( 'sensei_round_mode', $mode, $val, $context, $precision );
 
@@ -2571,8 +2631,11 @@ class Sensei_Utils {
 		 *
 		 * @since 2.2.0
 		 *
-		 * @param bool $show_lessons   Whether the lessons should be shown. Default true.
-		 * @param int|false $course_id Course ID.
+		 * @hook sensei_course_show_lessons
+		 *
+		 * @param {bool} $show_lessons   Whether the lessons should be shown. Default true.
+		 * @param {int|false} $course_id Course ID.
+		 * @return {bool} Filtered visibility of lessons.
 		 */
 		return apply_filters( 'sensei_course_show_lessons', true, $course_id );
 	}
@@ -2768,12 +2831,12 @@ class Sensei_Utils {
 		/**
 		 * Filter to allow adding products slugs to check if it has an active WPCOM subscription.
 		 *
-		 * @hook sensei_wpcom_product_slugs
 		 * @since 4.11.0
 		 *
-		 * @param {Array} $products Array of products slugs to check if it has an active WPCOM subscription.
+		 * @hook sensei_wpcom_product_slugs
 		 *
-		 * @return {array}
+		 * @param {array} $products Array of products slugs to check if it has an active WPCOM subscription.
+		 * @return {array} Filtered array of products slugs.
 		 */
 		$product_slugs = apply_filters( 'sensei_wpcom_product_slugs', [] );
 		foreach ( $product_slugs as $product_slug ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -339,11 +339,14 @@ class Sensei_Utils {
 		 *
 		 * @since 1.7.4
 		 *
+		 * @hook sensei_file_upload_args
+		 *
 		 * @param {array} $file_upload_args {
 		 *      array of current values
 		 *
 		 *     @type {string} test_form set to false by default
 		 * }
+		 * @return {array} Filtered data array.
 		 */
 		$file_upload_args = apply_filters( 'sensei_file_upload_args', array( 'test_form' => false ) );
 
@@ -356,7 +359,7 @@ class Sensei_Utils {
 		 *
 		 * @param {string} $prefix Prefix to prepend to uploaded files.
 		 * @param {array}  $file   Arguments with uploaded file information.
-		 * @return {string}
+		 * @return {string} Filtered prefix.
 		 */
 		$file_prefix = apply_filters( 'sensei_file_upload_file_prefix', substr( md5( uniqid() ), 0, 7 ) . '_', $file );
 
@@ -1277,7 +1280,16 @@ class Sensei_Utils {
 			$message = apply_filters( 'sensei_quiz_course_signup_notice_message', $message_default, $course_id, $course_link );
 		}
 
-		// Legacy filter
+		/**
+		 * Filter a message for user quiz status. Legacy filter.
+		 *
+		 * Possible statuses: not_started, passed, failed.
+		 *
+		 * @hook sensei_user_quiz_status_{status}
+		 *
+		 * @param {string} $message Status message.
+		 * @return {string} Filtered status message.
+		 */
 		$message = apply_filters( 'sensei_user_quiz_status_' . $status, $message );
 
 		if ( $is_lesson && ! in_array( $status, array( 'login_required', 'not_started_course' ) ) ) {
@@ -1401,8 +1413,12 @@ class Sensei_Utils {
 		 *
 		 * @since 1.9.3
 		 *
-		 * @param bool|int $user_started_course
-		 * @param integer $course_id
+		 * @hook sensei_user_started_course
+		 *
+		 * @param {bool|int} $user_started_course False if the user has not started the course, otherwise the comment ID of the course progress.
+		 * @param {int}      $course_id           The course ID.
+		 * @param {int}      $user_id             The user ID.
+		 * @return {bool|int} Filtered user started course ID.
 		 */
 		return apply_filters( 'sensei_user_started_course', $user_started_course, $course_id, $user_id );
 
@@ -1658,9 +1674,12 @@ class Sensei_Utils {
 			 *
 			 * @since 1.9.7
 			 *
-			 * @param string    $user_lesson_status User lesson status
-			 * @param int       $lesson_id          ID of lesson
-			 * @param int       $user_id            ID of user
+			 * @hook sensei_user_completed_lesson
+			 *
+			 * @param {string} $user_lesson_status User lesson status.
+			 * @param {int}    $lesson_id          ID of lesson.
+			 * @param {int}    $user_id            ID of user.
+			 * @return {string} Filtered user lesson status.
 			 */
 			$user_lesson_status = apply_filters( 'sensei_user_completed_lesson', $user_lesson_status, $lesson_id, $user_id );
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -341,8 +341,8 @@ class Sensei_Utils {
 		 *
 		 * @hook sensei_file_upload_args
 		 *
-		 * @param {array} $file_upload_args Array of current values
-		 * @property {string} test_form set to false by default
+		 * @param    {array}   $file_upload_args               Array of current values.
+		 * @property {string} `$file_upload_args['test_form']` Set to false by default.
 		 * @return {array} Filtered data array.
 		 */
 		$file_upload_args = apply_filters( 'sensei_file_upload_args', array( 'test_form' => false ) );

--- a/includes/class-sensei-view-helper.php
+++ b/includes/class-sensei-view-helper.php
@@ -47,8 +47,11 @@ class Sensei_View_Helper {
 		 *
 		 * @since 1.9.13
 		 *
-		 * @param string|int $points the quiz question points
-		 * @param string $formatted_points the formatted point output
+		 * @hook sensei_quiz_question_points_format
+		 *
+		 * @param {string|int} $points           The quiz question points.
+		 * @param {string}     $formatted_points The formatted point output.
+		 * @return {string} The formatted point output.
 		 */
 		$filtered_formatted_points = apply_filters( 'sensei_quiz_question_points_format', $formatted_points, $points );
 

--- a/includes/class-sensei-wp-kses.php
+++ b/includes/class-sensei-wp-kses.php
@@ -23,7 +23,14 @@ class Sensei_Wp_Kses {
 		$string = wp_kses_no_null( $string, array( 'slash_zero' => 'keep' ) );
 		$string = wp_kses_normalize_entities( $string );
 		/**
-		 * Filter content similar to pre_kses
+		 * Filter content before passing it to kses, similar to pre_kses.
+		 *
+		 * @hook sensei_pre_kses
+		 *
+		 * @param {string} $string            Content to run through kses.
+		 * @param {array}  $allowed_html      Allowed HTML elements.
+		 * @param {array}  $allowed_protocols Allowed protocol in links.
+		 * @return {string} Filtered content.
 		 */
 		$string = apply_filters( 'sensei_pre_kses', $string, $allowed_html, $allowed_protocols );
 		return wp_kses_split( $string, $allowed_html, $allowed_protocols );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -347,6 +347,14 @@ class Sensei_Main {
 		$this->main_plugin_file_name = $main_plugin_file_name;
 		$this->plugin_url            = trailingslashit( plugins_url( '', $this->main_plugin_file_name ) );
 		$this->plugin_path           = trailingslashit( dirname( $this->main_plugin_file_name ) );
+		/**
+		 * Filter the template url.
+		 *
+		 * @hook sensei_template_url
+		 *
+		 * @param {string} $template_url The template url.
+		 * @return {string} Filtered template url.
+		 */
 		$this->template_url          = apply_filters( 'sensei_template_url', 'sensei/' );
 		$this->version               = isset( $args['version'] ) ? $args['version'] : null;
 
@@ -1032,6 +1040,17 @@ class Sensei_Main {
 	 * @return int
 	 */
 	public function get_page_id( $page ) {
+
+		/**
+		 * Filter the page ID.
+		 *
+		 * {page} is the page name.
+		 *
+		 * @hook sensei_get_{page}_page_id
+		 *
+		 * @param {int} $page The page ID.
+		 * @return {int} Filtered page ID.
+		 */
 		$page = apply_filters( 'sensei_get_' . esc_attr( $page ) . '_page_id', get_option( 'sensei_' . esc_attr( $page ) . '_page_id' ) );
 		return ( $page ) ? $page : -1;
 	}
@@ -1282,6 +1301,16 @@ class Sensei_Main {
 
 		// Only return sizes we define in settings.
 		if ( ! in_array( $image_size, array( 'course_archive_image', 'course_single_image', 'lesson_archive_image', 'lesson_single_image' ), true ) ) {
+			/**
+			 * Filter the image size.
+			 *
+			 * {image_size} is one of: course_archive_image, course_single_image, lesson_archive_image, lesson_single_image.
+			 *
+			 * @hook sensei_get_image_size_{image_size}
+			 *
+			 * @param {string} $image_size Image Size.
+			 * @return {string} Filtered image size.
+			 */
 			return apply_filters( 'sensei_get_image_size_' . $image_size, '' );
 		}
 
@@ -1307,6 +1336,7 @@ class Sensei_Main {
 		$size['height'] = isset( $size['height'] ) ? $size['height'] : '100';
 		$size['crop']   = isset( $size['crop'] ) ? $size['crop'] : 0;
 
+		/** This filter is documented in includes/class-sensei.php (above). */
 		return apply_filters( 'sensei_get_image_size_' . $image_size, $size );
 	}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -355,8 +355,8 @@ class Sensei_Main {
 		 * @param {string} $template_url The template url.
 		 * @return {string} Filtered template url.
 		 */
-		$this->template_url          = apply_filters( 'sensei_template_url', 'sensei/' );
-		$this->version               = isset( $args['version'] ) ? $args['version'] : null;
+		$this->template_url = apply_filters( 'sensei_template_url', 'sensei/' );
+		$this->version      = isset( $args['version'] ) ? $args['version'] : null;
 
 		// Only set the install version if it is included in alloptions. This prevents a query on every page load.
 		$alloptions            = wp_load_alloptions();

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1307,7 +1307,7 @@ class Sensei_Main {
 			/**
 			 * Filter the image size.
 			 *
-			 * {image_size} is one of: course_archive_image, course_single_image, lesson_archive_image, lesson_single_image.
+			 * {image_size} is NOT one of: course_archive_image, course_single_image, lesson_archive_image, lesson_single_image.
 			 *
 			 * @hook sensei_get_image_size_{image_size}
 			 *
@@ -1339,7 +1339,16 @@ class Sensei_Main {
 		$size['height'] = isset( $size['height'] ) ? $size['height'] : '100';
 		$size['crop']   = isset( $size['crop'] ) ? $size['crop'] : 0;
 
-		/** This filter is documented in includes/class-sensei.php (above). */
+		/**
+		 * Filter the image size.
+		 *
+		 * {image_size} is one of: course_archive_image, course_single_image, lesson_archive_image, lesson_single_image.
+		 *
+		 * @hook sensei_get_image_size_{image_size}
+		 *
+		 * @param {string} $image_size Image Size.
+		 * @return {string} Filtered image size.
+		*/
 		return apply_filters( 'sensei_get_image_size_' . $image_size, $size );
 	}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -666,11 +666,11 @@ class Sensei_Main {
 		/**
 		 * Integrate MailPoet by adding lists for courses and groups.
 		 *
-		 * @hook  sensei_email_mailpoet_feature
 		 * @since 4.13.0
 		 *
-		 * @param {bool} $enable Enable feature. Default true.
+		 * @hook  sensei_email_mailpoet_feature
 		 *
+		 * @param {bool} $enable Enable feature. Default true.
 		 * @return {bool} Whether to enable feature.
 		 */
 		if ( apply_filters( 'sensei_email_mailpoet_feature', true ) ) {
@@ -1160,8 +1160,11 @@ class Sensei_Main {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool $includes_sensei_comments Whether the count already includes Sensei's comments.
-		 * @param int  $post_id                  Post ID.
+		 * @hook sensei_comment_counts_include_sensei_comments
+		 *
+		 * @param {bool} $includes_sensei_comments Whether the count already includes Sensei's comments.
+		 * @param {int}  $post_id                  Post ID.
+		 * @return {bool} Whether the count already includes Sensei's comments.
 		 */
 		return apply_filters( 'sensei_comment_counts_include_sensei_comments', $includes_sensei_comments, $post_id );
 	}

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -145,12 +145,13 @@ class Sensei_Course_Theme_Option {
 		/**
 		 * Filters if the theme should be overriden for learning mode.
 		 *
-		 * @since 4.0.2
-		 * @hook  sensei_course_learning_mode_theme_override_enabled
 		 * @deprecated 4.7.0
 		 *
-		 * @param {bool} $enabled True if the learning mode theme override is enabled.
+		 * @since 4.0.2
 		 *
+		 * @hook  sensei_course_learning_mode_theme_override_enabled
+		 *
+		 * @param {bool} $enabled True if the learning mode theme override is enabled.
 		 * @return {bool} The modified learning mode theme override setting.
 		 */
 		return (bool) apply_filters( 'sensei_course_learning_mode_theme_override_enabled', false );
@@ -188,11 +189,11 @@ class Sensei_Course_Theme_Option {
 		 * Filters if a course has learning mode enabled.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @hook  sensei_course_learning_mode_enabled
 		 *
 		 * @param {bool} $enabled    True if the learning mode is enabled for the course or globally.
 		 * @param {int}  $course_id  The id of the course.
-		 *
 		 * @return {bool} The modified learning mode setting.
 		 */
 		return (bool) apply_filters( 'sensei_course_learning_mode_enabled', $enabled, $course_id );

--- a/includes/course-theme/class-sensei-course-theme-template-selection.php
+++ b/includes/course-theme/class-sensei-course-theme-template-selection.php
@@ -159,13 +159,13 @@ class Sensei_Course_Theme_Template_Selection {
 		 * Filters the Learning Mode block templates list. Allows to add additional ones too.
 		 *
 		 * @since 4.7.0
+		 *
 		 * @hook  sensei_learning_mode_block_templates
 		 *
-		 * @param Sensei_Course_Theme_Template[] $templates {
-		 *     The list of Learning Mode block templates. If adding a new template then it's key
-		 *     should be the template name.
-		 *
-		 * @return Sensei_Course_Theme_Template[] The list of extra learning mode block templates.
+		 * @param {Sensei_Course_Theme_Template[]} $templates The list of Learning Mode block templates.
+		 *                                                    If adding a new template then it's key
+		 *                                                    should be the template name.
+		 * @return {Sensei_Course_Theme_Template[]} The list of extra learning mode block templates.
 		 */
 		return apply_filters( 'sensei_learning_mode_block_templates', $templates );
 	}

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -140,9 +140,12 @@ class Sensei_Data_Port_Utilities {
 		 * Increase this value in case big attachments are imported and the request to get them
 		 * times out.
 		 *
-		 * @param float $timeout Time in seconds until a request times out. Default 10.
-		 *
 		 * @since 3.3.0
+		 *
+		 * @hook sensei_import_attachment_request_timeout
+		 *
+		 * @param {float} $timeout Time in seconds until a request times out. Default 10.
+		 * @return {float} Filtered timeout value.
 		 */
 		$timeout  = apply_filters( 'sensei_import_attachment_request_timeout', 10 );
 		$response = wp_safe_remote_get( $external_url, [ 'timeout' => $timeout ] );

--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -91,10 +91,10 @@ class Sensei_Import_CSV_Reader {
 		 *
 		 * @since 3.2.0
 		 * @since 3.3.0 Updated the default to `false`, so it'll get through the delimiter detection.
+		 *
 		 * @hook sensei_import_csv_delimiter
 		 *
 		 * @param {string} $delimiter The CSV file delimiter.
-		 *
 		 * @return {false|string} CSV file delimiter or false to skip.
 		 */
 		$forced_delimiter = apply_filters( 'sensei_import_csv_delimiter', false );
@@ -108,10 +108,10 @@ class Sensei_Import_CSV_Reader {
 		 * Filters the CSV delimiter options.
 		 *
 		 * @since 3.3.0
+		 *
 		 * @hook sensei_import_csv_delimiter_options
 		 *
 		 * @param {string[]} $delimiters The CSV file delimiter options.
-		 *
 		 * @return {array} CSV delimiter options.
 		 */
 		$delimiters         = apply_filters( 'sensei_import_csv_delimiter_options', [ ',', ';', "\t", '|' ] );

--- a/includes/emails/class-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-sensei-email-teacher-started-course.php
@@ -55,8 +55,31 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course', false ) ) :
 
 			do_action( 'sensei_before_mail', $this->recipient );
 
-			// translators: Placeholder is the blog name.
-			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a course', 'sensei-lms' ), get_bloginfo( 'name' ) ), $this->template );
+			/**
+			 * Filter the email subject.
+			 *
+			 * @hook sensei_email_subject
+			 *
+			 * @param {string} $subject The email subject.
+			 * @param {string} $template The email template.
+			 * @return {string} The filtered email subject.
+			 */
+			$this->subject = apply_filters(
+				'sensei_email_subject',
+				// translators: Placeholder is the blog name.
+				sprintf( __( '[%1$s] Your student has started a course', 'sensei-lms' ), get_bloginfo( 'name' ) ),
+				$this->template
+			);
+
+			/**
+			 * Filter the email heading.
+			 *
+			 * @hook sensei_email_heading
+			 *
+			 * @param {string} $heading The email heading.
+			 * @param {string} $template The email template.
+			 * @return {string} The filtered email heading.
+			 */
 			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has started a course', 'sensei-lms' ), $this->template );
 
 			// Construct data array

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -108,9 +108,12 @@ class Sensei_Course_Enrolment_Manager {
 		/**
 		 * Fetch all registered course enrolment providers.
 		 *
-		 * @param Sensei_Course_Enrolment_Provider_Interface[] $providers List of enrolment providers instances.
-		 *
 		 * @since 3.0.0
+		 *
+		 * @hook sensei_course_enrolment_providers
+		 *
+		 * @param {Sensei_Course_Enrolment_Provider_Interface[]} $providers List of enrolment providers instances.
+		 * @return {Sensei_Course_Enrolment_Provider_Interface[]} Filtered list of enrolment providers instances.
 		 */
 		$providers = apply_filters( 'sensei_course_enrolment_providers', $providers );
 		foreach ( $providers as $provider ) {
@@ -231,7 +234,10 @@ class Sensei_Course_Enrolment_Manager {
 		 *
 		 * @since 4.5.2
 		 *
-		 * @param Sensei_Course_Enrolment_Provider_Interface[] $providers List of enrolment providers instances.
+		 * @hook sensei_course_enrolment_providers_prevent_manual_enrol
+		 *
+		 * @param {Sensei_Course_Enrolment_Provider_Interface[]} $providers List of enrolment providers instances.
+		 * @return {Sensei_Course_Enrolment_Provider_Interface[]} Filtered list of enrolment providers instances.
 		 */
 		$all_providers = apply_filters( 'sensei_course_enrolment_providers_prevent_manual_enrol', $all_providers );
 
@@ -390,7 +396,10 @@ class Sensei_Course_Enrolment_Manager {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool $should_defer_enrolment_check True if enrolment checks should be deferred to the end of the request.
+		 * @hook sensei_should_defer_enrolment_check
+		 *
+		 * @param {bool} $should_defer_enrolment_check True if enrolment checks should be deferred to the end of the request.
+		 * @return {bool} Filtered value.
 		 */
 		return apply_filters( 'sensei_should_defer_enrolment_check', $should_defer_enrolment_check );
 	}

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -114,10 +114,13 @@ class Sensei_Course_Enrolment {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool|null $is_enrolled If a boolean, that value will be used. Null values will keep default behavior.
-		 * @param int       $user_id     User ID.
-		 * @param int       $course_id   Course post ID.
-		 * @param bool      $check_cache Advise hooked method if cached values should be trusted.
+		 * @hook sensei_is_enrolled
+		 *
+		 * @param {bool|null} $is_enrolled If a boolean, that value will be used. Null values will keep default behavior.
+		 * @param {int}       $user_id     User ID.
+		 * @param {int}       $course_id   Course post ID.
+		 * @param {bool}      $check_cache Advise hooked method if cached values should be trusted.
+		 * @return {bool|null} Filtered value.
 		 */
 		$is_enrolled = apply_filters( 'sensei_is_enrolled', null, $user_id, $this->course_id, $check_cache );
 		if ( null !== $is_enrolled ) {
@@ -338,11 +341,14 @@ class Sensei_Course_Enrolment {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool                                     $store_results      Whether to store the results.
-		 * @param int                                      $user_id            User ID.
-		 * @param int                                      $course_id          Course post ID.
-		 * @param bool                                     $had_existing_value True if a stale enrolment result is already stored.
-		 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results  Enrolment results object.
+		 * @hook sensei_course_enrolment_store_results
+		 *
+		 * @param {bool}                                     $store_results      Whether to store the results.
+		 * @param {int}                                      $user_id            User ID.
+		 * @param {int}                                      $course_id          Course post ID.
+		 * @param {bool}                                     $had_existing_value True if a stale enrolment result is already stored.
+		 * @param {Sensei_Course_Enrolment_Provider_Results} $enrolment_results  Enrolment results object.
+		 * @return {bool} Filtered value.
 		 */
 		$store_results = apply_filters( 'sensei_course_enrolment_store_results', true, $user_id, $this->course_id, $had_existing_value, $enrolment_results );
 

--- a/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
@@ -177,10 +177,13 @@ class Sensei_Course_Manual_Enrolment_Provider
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool      $is_legacy_enrolled          If the user was actually enrolled before 3.0.0 migration.
-		 * @param int       $user_id                     User ID.
-		 * @param int       $course_id                   Course post ID.
-		 * @param int|false $course_progress_comment_id  Comment ID for the course progress record (if it exists).
+		 * @hook sensei_is_legacy_enrolled
+		 *
+		 * @param {bool}      $is_legacy_enrolled          If the user was actually enrolled before 3.0.0 migration.
+		 * @param {int}       $user_id                     User ID.
+		 * @param {int}       $course_id                   Course post ID.
+		 * @param {int|false} $course_progress_comment_id  Comment ID for the course progress record (if it exists).
+		 * @return {bool} Filtered value.
 		 */
 		$is_legacy_enrolled = apply_filters( 'sensei_is_legacy_enrolled', true, $user_id, $course_id, $course_progress_comment_id );
 		$this->set_migrated_legacy_enrolment_status( $user_id, $course_id, $is_legacy_enrolled );

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -62,8 +62,11 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param int  $batch_size       Batch size to filter.
-		 * @param int  $course_id        Course ID we're running.
+		 * @hook sensei_enrolment_course_calculation_job_batch_size
+		 *
+		 * @param {int} $batch_size Batch size to filter.
+		 * @param {int} $course_id  Course ID we're running.
+		 * @return {int} Filtered batch size.
 		 */
 		$this->batch_size = apply_filters( 'sensei_enrolment_course_calculation_job_batch_size', self::DEFAULT_BATCH_SIZE, $this->course_id );
 	}

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -67,8 +67,11 @@ class Sensei_Enrolment_Job_Scheduler {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param bool   $is_job_enabled     True if the job is enabled.
-		 * @param string $enrolment_job_name Name of the job.
+		 * @hook sensei_is_enrolment_background_job_enabled
+		 *
+		 * @param {bool}   $is_job_enabled     True if the job is enabled.
+		 * @param {string} $enrolment_job_name Name of the job.
+		 * @return {bool} Filtered value.
 		 */
 		return apply_filters( 'sensei_is_enrolment_background_job_enabled', true, $enrolment_job_name );
 	}

--- a/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
@@ -42,7 +42,10 @@ class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param int $batch_size Batch size to filter.
+		 * @hook sensei_enrolment_learner_calculation_job_batch_size
+		 *
+		 * @param {int} $batch_size Batch size to filter.
+		 * @return {int} Filtered batch size.
 		 */
 		$this->batch_size = apply_filters( 'sensei_enrolment_learner_calculation_job_batch_size', self::DEFAULT_BATCH_SIZE );
 	}

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -122,7 +122,10 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool $enable_journal True to enable.
+		 * @hook sensei_enable_enrolment_provider_journal
+		 *
+		 * @param {bool} $enable_journal True to enable.
+		 * @return {bool} Filtered value.
 		 */
 		if ( ! apply_filters( 'sensei_enable_enrolment_provider_journal', false ) ) {
 			return false;

--- a/includes/enrolment/class-sensei-enrolment-provider-journal.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal.php
@@ -185,7 +185,10 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param int  $message_log_size Default message log size.
+		 * @hook sensei_enrolment_message_log_size
+		 *
+		 * @param {int} $message_log_size Default message log size.
+		 * @return {int} Filtered message log size.
 		 */
 		$message_log_size = apply_filters( 'sensei_enrolment_message_log_size', self::DEFAULT_MESSAGE_LOG_SIZE );
 
@@ -290,7 +293,10 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param int  $history_size Default history size.
+		 * @hook sensei_enrolment_history_size
+		 *
+		 * @param {int} $history_size Default history size.
+		 * @return {int} Filtered history size.
 		 */
 		$history_size = apply_filters( 'sensei_enrolment_history_size', self::DEFAULT_HISTORY_SIZE );
 

--- a/includes/internal/emails/class-email-generator.php
+++ b/includes/internal/emails/class-email-generator.php
@@ -100,10 +100,10 @@ class Email_Generator {
 		 * Filter the individual email generators.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_email_generators
 		 *
 		 * @param {Email_Generators_Abstract[]} $email_generators The email generators.
-		 *
 		 * @return {Email_Generators_Abstract[]} The email generators.
 		 */
 		$email_generators = apply_filters( 'sensei_email_generators', $this->email_generators );

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -64,11 +64,11 @@ class Email_List_Table extends Sensei_List_Table {
 		 * Filter the columns that are displayed on the email list.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_email_list_columns
 		 *
 		 * @param {array}  $columns    The table columns.
 		 * @param {object} $list_table Email_List_Table instance.
-		 *
 		 * @return {array} The modified table columns.
 		 */
 		return apply_filters( 'sensei_email_list_columns', $columns, $this );
@@ -159,13 +159,13 @@ class Email_List_Table extends Sensei_List_Table {
 		 * Filter the row data displayed on the email list.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_email_list_row_data
 		 *
 		 * @param {array}  $row_data The row data.
 		 * @param {object} $post The post.
 		 * @param {object} $list_table Email_List_Table instance.
-		 *
-		 * @return {array}
+		 * @return {array} The modified row data.
 		 */
 		return apply_filters( 'sensei_email_list_row_data', $row_data, $post, $this );
 	}
@@ -246,13 +246,13 @@ class Email_List_Table extends Sensei_List_Table {
 		 * Filter the row actions displayed on the email list.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_email_list_row_actions
 		 *
 		 * @param {array}  $actions The row actions.
 		 * @param {object} $post The post.
 		 * @param {object} $list_table Email_List_Table instance.
-		 *
-		 * @return {array}
+		 * @return {array} The modified row actions.
 		 */
 		return apply_filters( 'sensei_email_list_row_actions', $actions, $post, $this );
 	}
@@ -298,13 +298,13 @@ class Email_List_Table extends Sensei_List_Table {
 		 * Filter if the email is available.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_email_is_available
 		 *
 		 * @param {boolean} $available True if the email is available, false otherwise.
 		 * @param {object}  $post The post.
 		 * @param {object}  $list_table Email_List_Table instance.
-		 *
-		 * @return {boolean}
+		 * @return {boolean} Filtered value.
 		 */
 		return apply_filters( 'sensei_email_is_available', $available, $post, $this );
 	}

--- a/includes/internal/emails/class-email-seeder.php
+++ b/includes/internal/emails/class-email-seeder.php
@@ -67,10 +67,10 @@ class Email_Seeder {
 		 * Filter the email data.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_email_seeder_data
 		 *
 		 * @param {array} $emails Email data.
-		 *
 		 * @return {array} Filtered array of email data.
 		 */
 		$this->emails = apply_filters( 'sensei_email_seeder_data', $this->email_data->get_email_data() );

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -104,13 +104,13 @@ class Email_Sender {
 		 * Filter the email replacements.
 		 *
 		 * @since 4.12.0
+		 *
 		 * @hook sensei_email_replacements
 		 *
-		 * @param {Array}        $replacements The email replacements.
+		 * @param {array}        $replacements The email replacements.
 		 * @param {string}       $email_name   The email name.
 		 * @param {WP_Post}      $email_post   The email post.
 		 * @param {Email_Sender} $email_sender The email sender class instance.
-		 *
 		 * @return {Array} The email replacements.
 		 */
 		$replacements = apply_filters( 'sensei_email_replacements', $replacements, $email_name, $email_post, $this );

--- a/includes/internal/emails/generators/class-course-teachers-trait.php
+++ b/includes/internal/emails/generators/class-course-teachers-trait.php
@@ -37,9 +37,11 @@ trait Course_Teachers_Trait {
 		 *
 		 * @since 4.15.1
 		 *
-		 * @param array $teacher_ids The teacher IDs.
-		 * @param int   $course_id   The course ID.
-		 * @return array The teacher IDs.
+		 * @hook sensei_email_course_teachers
+		 *
+		 * @param {array} $teacher_ids The teacher IDs.
+		 * @param {int}   $course_id   The course ID.
+		 * @return {array} The teacher IDs.
 		 */
 		return apply_filters( 'sensei_email_course_teachers', array( $teacher_id ), $course_id );
 	}

--- a/includes/internal/installer/class-schema.php
+++ b/includes/internal/installer/class-schema.php
@@ -166,7 +166,10 @@ CREATE TABLE {$wpdb->prefix}sensei_lms_quiz_grades (
 		 *
 		 * @since 4.16.1
 		 *
-		 * @param array $tables An array of Sensei specific database table names.
+		 * @hook sensei_lms_schema_get_tables
+		 *
+		 * @param {array} $tables An array of Sensei specific database table names.
+		 * @return {array} Filtered array of Sensei specific database table names.
 		 */
 		$tables = apply_filters( 'sensei_lms_schema_get_tables', $tables );
 

--- a/includes/reports/class-sensei-no-users-table-relationship.php
+++ b/includes/reports/class-sensei-no-users-table-relationship.php
@@ -64,12 +64,12 @@ class Sensei_No_Users_Table_Relationship {
 		 * Filters if site environment is able to make queries including a relationship between users
 		 * table and others.
 		 *
-		 * @hook  sensei_can_use_users_relationship
 		 * @since 4.6.4
+		 *
+		 * @hook sensei_can_use_users_relationship
 		 *
 		 * @param {null} $can_use_users_relationship Default value is `null`. With this value the
 		 *                                           filter is ignored.
-		 *
 		 * @return {boolean|null} Whether the site environment is able to make queries including a
 		 *                        relationship between users table and others..
 		 */

--- a/includes/reports/class-sensei-no-users-table-relationship.php
+++ b/includes/reports/class-sensei-no-users-table-relationship.php
@@ -70,8 +70,8 @@ class Sensei_No_Users_Table_Relationship {
 		 *
 		 * @param {null} $can_use_users_relationship Default value is `null`. With this value the
 		 *                                           filter is ignored.
-		 * @return {boolean|null} Whether the site environment is able to make queries including a
-		 *                        relationship between users table and others..
+		 * @return {bool|null} Whether the site environment is able to make queries including a
+		 *                     relationship between users table and others..
 		 */
 		$filtered_can_use_users_relationship = apply_filters( 'sensei_can_use_users_relationship', null );
 

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
@@ -69,6 +69,15 @@ class Sensei_Reports_Overview_Data_Provider_Courses implements Sensei_Reports_Ov
 		if ( 'count_of_completions' === $course_args['orderby'] ) {
 			add_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 );
 		}
+
+		/**
+		 * Filter the courses query arguments.
+		 *
+		 * @hook sensei_analysis_overview_filter_courses
+		 *
+		 * @param {array} $course_args Array of arguments for the courses query.
+		 * @return {array} Filtered array of arguments for the courses query.
+		 */
 		$course_args   = apply_filters( 'sensei_analysis_overview_filter_courses', $course_args );
 		$courses_query = new WP_Query( $course_args );
 

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -70,7 +70,9 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 		}
 		add_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );
 		add_filter( 'posts_clauses', [ $this, 'add_last_activity_to_lessons_query' ] );
+
 		// Using WP_Query as get_posts() doesn't support 'found_posts'.
+
 		/*
 		 * Filter the arguments for the query used to fetch the lessons for the overview report.
 		 *

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -71,6 +71,14 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 		add_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );
 		add_filter( 'posts_clauses', [ $this, 'add_last_activity_to_lessons_query' ] );
 		// Using WP_Query as get_posts() doesn't support 'found_posts'.
+		/*
+		 * Filter the arguments for the query used to fetch the lessons for the overview report.
+		 *
+		 * @hook sensei_analysis_overview_filter_lessons
+		 *
+		 * @param {array} $lessons_args Arguments for the query.
+		 * @return {array} Filtered arguments for the query.
+		 */
 		$lessons_query = new WP_Query( apply_filters( 'sensei_analysis_overview_filter_lessons', $lessons_args ) );
 		remove_filter( 'posts_clauses', [ $this, 'add_last_activity_to_lessons_query' ] );
 		remove_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
@@ -67,7 +67,11 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 		 * Filter the WP_User_Query arguments
 		 *
 		 * @since 1.6.0
-		 * @param $query_args
+		 *
+		 * @hook sensei_analysis_overview_filter_users
+		 *
+		 * @param {array} $query_args The WP_User_Query arguments.
+		 * @return {array} Filtered arguments.
 		 */
 		$query_args = apply_filters( 'sensei_analysis_overview_filter_users', $query_args );
 
@@ -107,12 +111,12 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 		 * Filters if the last activity filter by date and the last activity sorting are enabled in
 		 * the students report.
 		 *
-		 * @hook  sensei_students_report_last_activity_filter_enabled
 		 * @since 4.6.4
 		 *
-		 * @param {boolean} $enabled Whether the students last activity filter is enabled.
+		 * @hook sensei_students_report_last_activity_filter_enabled
 		 *
-		 * @return {boolean} Whether the students last activity filter is enabled.
+		 * @param {bool} $enabled Whether the students last activity filter is enabled.
+		 * @return {bool} Whether the students last activity filter is enabled.
 		 */
 		return apply_filters( 'sensei_students_report_last_activity_filter_enabled', true );
 	}

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -420,11 +420,11 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 		/**
 		 * Customize the export button URL on the reports overview screen.
 		 *
-		 * @hook  sensei_reports_overview_export_button_url
 		 * @since 4.6.0
 		 *
-		 * @param {string} $url The export button URL.
+		 * @hook sensei_reports_overview_export_button_url
 		 *
+		 * @param {string} $url The export button URL.
 		 * @return {string} The export button URL.
 		 */
 		$url = apply_filters( 'sensei_reports_overview_export_button_url', $url );

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -262,6 +262,15 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
+
+		/**
+		 * Filter the search button text for the list table.
+		 *
+		 * @hook sensei_list_table_search_button_text
+		 *
+		 * @param {string} $text The search button text.
+		 * @return {string} The filtered search button text.
+		 */
 		$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 	}
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -120,7 +120,26 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		);
 
 		// Backwards compatible filter name, moving forward should have single filter name.
+		/**
+		 * Filter the columns for the courses overview report.
+		 *
+		 * @hook sensei_analysis_overview_courses_columns
+		 *
+		 * @param {array} $columns The columns for the courses overview report.
+		 * @param {Sensei_Reports_Overview_List_Table_Courses} $this The current instance of the class.
+		 * @return {array} The filtered columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_courses_columns', $columns, $this );
+
+		/**
+		 * Filter the columns for the courses overview report.
+		 *
+		 * @hook sensei_analysis_overview_columns
+		 *
+		 * @param {array} $columns The columns for the courses overview report.
+		 * @param {Sensei_Reports_Overview_List_Table_Courses} $this The current instance of the class.
+		 * @return {array} The filtered columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns', $columns, $this );
 
 		$this->columns = $columns;
@@ -140,7 +159,26 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		);
 
 		// Backwards compatible filter name, moving forward should have single filter name.
+		/**
+		 * Filter the sortable columns for the courses overview report.
+		 *
+		 * @hook sensei_analysis_overview_courses_columns_sortable
+		 *
+		 * @param {array} $columns The sortable columns for the courses overview report.
+		 * @param {Sensei_Reports_Overview_List_Table_Courses} $this The current instance of the class.
+		 * @return {array} The filtered sortable columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_courses_columns_sortable', $columns, $this );
+
+		/**
+		 * Filter the sortable columns for the courses overview report.
+		 *
+		 * @hook sensei_analysis_overview_columns_sortable
+		 *
+		 * @param {array} $columns The sortable columns for the courses overview report.
+		 * @param {Sensei_Reports_Overview_List_Table_Courses} $this The current instance of the class.
+		 * @return {array} The filtered sortable columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns_sortable', $columns, $this );
 
 		return $columns;
@@ -164,6 +202,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			'type'    => 'sensei_course_status',
 			'status'  => 'complete',
 		);
+		/** This filter is documented in sensei-analysis-overview-list-table.php */
 		$course_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_completions', $course_args, $item ) );
 
 		// Average Grade will be N/A if the course has no lessons or quizzes, if none of the lessons
@@ -179,6 +218,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 				'meta_key' => 'grade', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			);
 
+			/** This filter is documented in sensei-analysis-overview-list-table.php */
 			$percent_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_percentage', $grade_args, $item ), false );
 			$percent_total = $this->grading::get_course_users_grades_sum( $item->ID );
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -197,7 +197,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		$lessons = $this->course->course_lessons( $item->ID, 'any', 'ids' );
 
 		// Get Course Completions.
-		$course_args        = array(
+		$course_args = array(
 			'post_id' => $item->ID,
 			'type'    => 'sensei_course_status',
 			'status'  => 'complete',

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -202,7 +202,15 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			'type'    => 'sensei_course_status',
 			'status'  => 'complete',
 		);
-		/** This filter is documented in sensei-analysis-overview-list-table.php */
+		/**
+		 * Filter the course completions query arguments.
+		 *
+		 * @hook sensei_analysis_course_completions
+		 *
+		 * @param {array} $course_args Array of query arguments for course completions.
+		 * @param {WP_Post} $item Current course post object.
+		 * @return {array} Filtered array of query arguments for course completions.
+		 */
 		$course_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_completions', $course_args, $item ) );
 
 		// Average Grade will be N/A if the course has no lessons or quizzes, if none of the lessons
@@ -218,7 +226,15 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 				'meta_key' => 'grade', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			);
 
-			/** This filter is documented in sensei-analysis-overview-list-table.php */
+			/**
+			 * Filter the course completion percentage query arguments.
+			 *
+			 * @hook sensei_analysis_course_percentage
+			 *
+			 * @param {array} $grade_args Array of query arguments for course percentage.
+			 * @param {WP_Post} $item Current course post object.
+			 * @return {array} Filtered array of query arguments for course percentage.
+			 */
 			$percent_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_percentage', $grade_args, $item ), false );
 			$percent_total = $this->grading::get_course_users_grades_sum( $item->ID );
 
@@ -233,7 +249,6 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		$average_completion_days = $item->count_of_completions > 0 ? ceil( $item->days_to_completion / $item->count_of_completions ) : __( 'N/A', 'sensei-lms' );
 
 		// Output course data.
-		/** This filter is documented in wp-includes/post-template.php */
 		$course_title   = apply_filters( 'the_title', $item->post_title, $item->ID ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 		$total_enrolled = $this->reports_overview_service_courses->get_total_enrollments( [ $item->ID ] );
 
@@ -251,6 +266,16 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 
 		$average_course_progress = $this->get_average_progress_for_courses_table( $item->ID );
 
+		/**
+		 * Filter the row data for the Analysis Overview list table.
+		 *
+		 * @hook sensei_analysis_overview_column_data
+		 *
+		 * @param {array} $column_data Array of column data for the report table.
+		 * @param {object|WP_Post|WP_User} $item Current row object.
+		 * @param {Sensei_Reports_Overview_List_Table_Courses} $this Current instance of the list table.
+		 * @return {array} Filtered array of column data for the report table.
+		 */
 		$column_data = apply_filters(
 			'sensei_analysis_overview_column_data',
 			array(

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -167,7 +167,15 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			'type'    => 'sensei_lesson_status',
 			'status'  => 'any',
 		);
-		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
+		/**
+		 * Filter the lesson learners activity arguments for the Course Analysis list table.
+		 *
+		 * @hook sensei_analysis_lesson_learners
+		 *
+		 * @param {array}  $lesson_args The lesson learners activity arguments.
+		 * @param {object} $item The current item.
+		 * @return {array} The lesson learners activity arguments.
+		 */
 		$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
 
 		// Get Course Completions.
@@ -177,7 +185,16 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			'status'  => array( 'complete', 'graded', 'passed', 'failed', 'ungraded' ),
 			'count'   => true,
 		);
-		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
+
+		/**
+		 * Filter the lesson completions activity arguments.
+		 *
+		 * @hook sensei_analysis_lesson_completions
+		 *
+		 * @param {array}  $lesson_args The lesson completions activity arguments.
+		 * @param {object} $item The current item.
+		 * @return {array} The lesson completions activity arguments.
+		 */
 		$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
 		// Taking the ceiling value for the average.
 		$average_completion_days = $lesson_completions > 0 ? ceil( $item->days_to_complete / $lesson_completions ) : __( 'N/A', 'sensei-lms' );
@@ -198,6 +215,16 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			$lesson_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 		}
 
+		/**
+		 * Filter the row data for the Analysis Overview list table.
+		 *
+		 * @hook sensei_analysis_overview_column_data
+		 *
+		 * @param {array} $column_data Array of column data for the report table.
+		 * @param {object|WP_Post|WP_User} $item Current row object.
+		 * @param {Sensei_Reports_Overview_List_Table_Lessons} $this Current instance of the list table.
+		 * @return {array} Filtered array of column data for the report table.
+		 */
 		$column_data = apply_filters(
 			'sensei_analysis_overview_column_data',
 			array(

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -162,7 +162,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 	 */
 	protected function get_row_data( $item ) {
 		// Get Learners (i.e. those who have started).
-		$lesson_args     = array(
+		$lesson_args = array(
 			'post_id' => $item->ID,
 			'type'    => 'sensei_lesson_status',
 			'status'  => 'any',
@@ -171,7 +171,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 		$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
 
 		// Get Course Completions.
-		$lesson_args        = array(
+		$lesson_args = array(
 			'post_id' => $item->ID,
 			'type'    => 'sensei_lesson_status',
 			'status'  => array( 'complete', 'graded', 'passed', 'failed', 'ungraded' ),

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -55,7 +55,26 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 		);
 
 		// Backwards compatible filter name, moving forward should have single filter name.
+		/**
+		 * Filter the columns for the lesson report.
+		 *
+		 * @hook sensei_analysis_overview_lessons_columns
+		 *
+		 * @param {array} $columns The array of columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Lessons} $this The current instance of the class.
+		 * @return {array} The array of columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_lessons_columns', $columns, $this );
+
+		/**
+		 * Filter the columns for the lesson report.
+		 *
+		 * @hook sensei_analysis_overview_columns
+		 *
+		 * @param {array} $columns The array of columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Lessons} $this The current instance of the class.
+		 * @return {array} The array of columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns', $columns, $this );
 
 		$this->columns = $columns;
@@ -108,7 +127,26 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 		);
 
 		// Backwards compatible filter name, moving forward should have single filter name.
+		/**
+		 * Filter the sortable columns for the lesson report.
+		 *
+		 * @hook sensei_analysis_overview_lessons_columns_sortable
+		 *
+		 * @param {array} $columns The array of sortable columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Lessons} $this The current instance of the class.
+		 * @return {array} The array of sortable columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_lessons_columns_sortable', $columns, $this );
+
+		/**
+		 * Filter the sortable columns for the lesson report.
+		 *
+		 * @hook sensei_analysis_overview_columns_sortable
+		 *
+		 * @param {array} $columns The array of sortable columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Lessons} $this The current instance of the class.
+		 * @return {array} The array of sortable columns to use with the table.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns_sortable', $columns, $this );
 
 		return $columns;
@@ -129,6 +167,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			'type'    => 'sensei_lesson_status',
 			'status'  => 'any',
 		);
+		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
 		$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
 
 		// Get Course Completions.
@@ -138,6 +177,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			'status'  => array( 'complete', 'graded', 'passed', 'failed', 'ungraded' ),
 			'count'   => true,
 		);
+		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
 		$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
 		// Taking the ceiling value for the average.
 		$average_completion_days = $lesson_completions > 0 ? ceil( $item->days_to_complete / $lesson_completions ) : __( 'N/A', 'sensei-lms' );

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -166,7 +166,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	 */
 	protected function get_row_data( $item ) {
 		// Get Started Courses.
-		$course_args          = array(
+		$course_args = array(
 			'user_id' => $item->ID,
 			'type'    => 'sensei_course_status',
 			'status'  => 'any',
@@ -175,7 +175,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		$user_courses_started = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item ) );
 
 		// Get Completed Courses.
-		$course_args        = array(
+		$course_args = array(
 			'user_id' => $item->ID,
 			'type'    => 'sensei_course_status',
 			'status'  => 'complete',

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -181,7 +181,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		 * @param {WP_User} $item Current user object.
 		 * @return {array} Filtered array of query arguments for started user courses.
 		*/
-		$course_args = apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item );
+		$course_args          = apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item );
 		$user_courses_started = Sensei_Utils::sensei_check_for_activity( $course_args );
 
 		// Get Completed Courses.

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -90,7 +90,26 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		);
 
 		// Backwards compatible filter name, moving forward should have single filter name.
+		/**
+		 * Filter the columns that are going to be used in the table.
+		 *
+		 * @hook sensei_analysis_overview_users_columns
+		 *
+		 * @param {array} $columns The array of columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Students} $this The current instance of the class.
+		 * @return {array} Filtered columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_users_columns', $columns, $this );
+
+		/**
+		 * Filter the columns that are going to be used in the table.
+		 *
+		 * @hook sensei_analysis_overview_columns
+		 *
+		 * @param {array} $columns The array of columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Students} $this The current instance of the class.
+		 * @return {array} Filtered columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns', $columns, $this );
 
 		$this->columns = $columns;
@@ -112,7 +131,26 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		];
 
 		// Backwards compatible filter name, moving forward should have single filter name.
+		/**
+		 * Filter the sortable columns that are going to be used in the table.
+		 *
+		 * @hook sensei_analysis_overview_users_columns_sortable
+		 *
+		 * @param {array} $columns The array of columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Students} $this The current instance of the class.
+		 * @return {array} Filtered columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_users_columns_sortable', $columns, $this );
+
+		/**
+		 * Filter the sortable columns that are going to be used in the table.
+		 *
+		 * @hook sensei_analysis_overview_columns_sortable
+		 *
+		 * @param {array} $columns The array of columns to use with the table.
+		 * @param {Sensei_Reports_Overview_List_Table_Students} $this The current instance of the class.
+		 * @return {array} Filtered columns.
+		 */
 		$columns = apply_filters( 'sensei_analysis_overview_columns_sortable', $columns, $this );
 
 		return $columns;
@@ -133,6 +171,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			'type'    => 'sensei_course_status',
 			'status'  => 'any',
 		);
+		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
 		$user_courses_started = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item ) );
 
 		// Get Completed Courses.
@@ -141,6 +180,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			'type'    => 'sensei_course_status',
 			'status'  => 'complete',
 		);
+		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
 		$user_courses_ended = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_ended', $course_args, $item ) );
 
 		// Get Quiz Grades.
@@ -151,6 +191,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			'meta_key' => 'grade', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Filtering graded only.
 		);
 
+		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
 		$grade_count        = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item ), false );
 		$grade_total        = Sensei_Grading::get_user_graded_lessons_sum( $item->ID );
 		$user_average_grade = 0;

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -171,8 +171,18 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			'type'    => 'sensei_course_status',
 			'status'  => 'any',
 		);
-		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
-		$user_courses_started = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item ) );
+
+		/**
+		 * Filter user progress query arguments for courses: find started courses.
+		 *
+		 * @hook sensei_analysis_user_courses_started
+		 *
+		 * @param {array} $course_args Array of query arguments for started user courses.
+		 * @param {WP_User} $item Current user object.
+		 * @return {array} Filtered array of query arguments for started user courses.
+		*/
+		$course_args = apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item );
+		$user_courses_started = Sensei_Utils::sensei_check_for_activity( $course_args );
 
 		// Get Completed Courses.
 		$course_args = array(
@@ -180,7 +190,16 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			'type'    => 'sensei_course_status',
 			'status'  => 'complete',
 		);
-		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
+
+		/**
+		 * Filter user progress query arguments for courses: find completed courses.
+		 *
+		 * @hook sensei_analysis_user_courses_ended
+		 *
+		 * @param {array} $course_args Array of query arguments for ended user courses.
+		 * @param {WP_User} $item Current user object.
+		 * @return {array} Filtered array of query arguments for ended user courses.
+		 */
 		$user_courses_ended = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_ended', $course_args, $item ) );
 
 		// Get Quiz Grades.
@@ -191,7 +210,15 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			'meta_key' => 'grade', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Filtering graded only.
 		);
 
-		/** Filter is documented in class-sensei-analysis-overview-list-table.php */
+		/**
+		 * Filter user progress query arguments for lessons: find graded lessons.
+		 *
+		 * @hook sensei_analysis_user_lesson_grades
+		 *
+		 * @param {array} $grade_args Array of query arguments for graded user lessons.
+		 * @param {WP_User} $item Current user object.
+		 * @return {array} Filtered array of query arguments for graded user lessons.
+		 */
 		$grade_count        = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item ), false );
 		$grade_total        = Sensei_Grading::get_user_graded_lessons_sum( $item->ID );
 		$user_average_grade = 0;
@@ -213,6 +240,16 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			$last_activity_date = $this->csv_output ? $item->last_activity_date : Sensei_Utils::format_last_activity_date( $item->last_activity_date );
 		}
 
+		/**
+		 * Filter the row data for the Analysis Overview list table.
+		 *
+		 * @hook sensei_analysis_overview_column_data
+		 *
+		 * @param {array} $column_data Array of column data for the report table.
+		 * @param {object|WP_Post|WP_User} $item Current row object.
+		 * @param {Sensei_Reports_Overview_List_Table_Students} $this Current instance of the list table.
+		 * @return {array} Filtered array of column data for the report table.
+		 */
 		$column_data = apply_filters(
 			'sensei_analysis_overview_column_data',
 			array(

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -403,7 +403,6 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		 *
 		 * @param {array}   $quiz_data The response data.
 		 * @param {WP_Post} $quiz      The quiz post.default interval.
-		 *
 		 * @return {array} $quiz_data The modified response data.
 		 */
 		return apply_filters( 'sensei_rest_api_lesson_quiz_response', $quiz_data, $quiz );

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -504,7 +504,15 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 
 			if ( ! empty( $mimetype_array[0] ) ) {
 				if ( 'image' === $mimetype_array[0] ) {
-					// This filter is documented in class-sensei-question.php.
+					/**
+					 * Filter the size of the question image.
+					 *
+					 * @hook sensei_question_image_size
+					 *
+					 * @param {string} $size        Image size.
+					 * @param {int}    $question_id Question ID.
+					 * @return {string} Image size.
+					 */
 					$image_size            = apply_filters( 'sensei_question_image_size', 'medium', $question_id );
 					$attachment_src        = wp_get_attachment_image_src( $question_media_id, $image_size );
 					$question_media['url'] = esc_url( $attachment_src[0] );

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -53,13 +53,13 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		/**
 		 * Modify or add REST API schema for a question type.
 		 *
-		 * @since  3.9.0
-		 * @hook   sensei_rest_api_schema_question_type
+		 * @since 3.9.0
 		 *
-		 * @param  {Array}  $schema Schema for a single question.
-		 * @param  {string} $type   Question type.
+		 * @hook sensei_rest_api_schema_question_type
 		 *
-		 * @return {array}
+		 * @param {Array}  $schema Schema for a single question.
+		 * @param {string} $type   Question type.
+		 * @return {array} Filtered schema.
 		 */
 		return apply_filters( 'sensei_rest_api_schema_question_type', $schema, $type );
 	}
@@ -570,14 +570,14 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		/**
 		 * Allows modification of type specific question properties.
 		 *
-		 * @since  3.9.0
-		 * @hook   sensei_question_type_specific_properties
+		 * @since 3.9.0
 		 *
-		 * @param  {array}   $type_specific_properties The properties of the question.
-		 * @param  {string}  $question_type            The question type.
-		 * @param  {WP_Post} $question                 The question post.
+		 * @hook sensei_question_type_specific_properties
 		 *
-		 * @return {array}
+		 * @param {array}   $type_specific_properties The properties of the question.
+		 * @param {string}  $question_type            The question type.
+		 * @param {WP_Post} $question                 The question post.
+		 * @return {array} Filtered properties.
 		 */
 		return apply_filters( 'sensei_question_type_specific_properties', $type_specific_properties, $question_type, $question );
 	}
@@ -695,11 +695,11 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 * Add additional question types to the REST API schema.
 		 *
 		 * @since 3.9.0
+		 *
 		 * @hook sensei_rest_api_schema_single_question
 		 *
 		 * @param {Array} $schema Schema for a single question.
-		 *
-		 * @return {array}
+		 * @return {array} Filtered schema.
 		 */
 		return apply_filters( 'sensei_rest_api_schema_single_question', $single_question_schema );
 	}

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -101,8 +101,11 @@ function sensei_all_access( $user_id = null ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param bool $access  True if user has all access.
-	 * @param int  $user_id User ID to check.
+	 * @hooks sensei_user_all_access
+	 *
+	 * @param {bool} $access  True if user has all access.
+	 * @param {int}  $user_id User ID to check.
+	 * @return {bool} Filtered access.
 	 */
 	return apply_filters( 'sensei_user_all_access', $access, $user_id );
 }
@@ -163,9 +166,12 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param bool $can_user_view_lesson True if they can view lesson/quiz content.
-	 * @param int  $lesson_id            Lesson post ID.
-	 * @param int  $user_id              User ID.
+	 * @hook sensei_can_user_view_lesson
+	 *
+	 * @param {bool} $can_user_view_lesson True if they can view lesson/quiz content.
+	 * @param {int}  $lesson_id            Lesson post ID.
+	 * @param {int}  $user_id              User ID.
+	 * @return {bool} Filtered access.
 	 */
 	return apply_filters( 'sensei_can_user_view_lesson', $can_user_view_lesson, $lesson_id, $user_id );
 }
@@ -338,12 +344,14 @@ function sensei_is_a_course( $post ) {
  */
 function sensei_user_registration_url( bool $return_wp_registration_url = true, string $redirect = '' ) {
 	/**
-	 * Filter to force Sensei to output the default WordPress user
-	 * registration link.
-	 *
-	 * @param bool $wp_register_link default false
+	 * Filter to force Sensei to output the default WordPress user registration link.
 	 *
 	 * @since 1.9.0
+	 *
+	 * @hook sensei_use_wp_register_link
+	 *
+	 * @param {bool} $wp_register_link Whether to use the default WordPress registration link, default: false.
+	 * @return {bool} Filtered value.
 	 */
 	$wp_register_link = apply_filters( 'sensei_use_wp_register_link', false );
 	$registration_url = '';
@@ -367,11 +375,11 @@ function sensei_user_registration_url( bool $return_wp_registration_url = true, 
 	 * Filter the registration URL.
 	 *
 	 * @since 4.4.1
+	 *
 	 * @hook sensei_registration_url
 	 *
 	 * @param {string} $registration_url Registration URL.
 	 * @param {string} $redirect         Redirect url after registration.
-	 *
 	 * @return {string} Returns filtered registration URL.
 	 */
 	return apply_filters( 'sensei_registration_url', $registration_url, $redirect );
@@ -411,11 +419,11 @@ function sensei_user_login_url( string $redirect = '' ) {
 	 * Filter the login URL.
 	 *
 	 * @since 4.4.1
+	 *
 	 * @hook sensei_login_url
 	 *
 	 * @param {string} $login_url Login URL.
 	 * @param {string} $redirect  Redirect url after login.
-	 *
 	 * @return {string} Returns filtered login URL.
 	 */
 	return apply_filters( 'sensei_login_url', $login_url, $redirect );
@@ -437,8 +445,7 @@ function sensei_is_login_required() {
 	$login_required = isset( Sensei()->settings->settings['access_permission'] ) && ( true == Sensei()->settings->settings['access_permission'] );
 
 	/**
-	 * Filters the access_permission that says if the user must be logged
-	 * to view the lesson content.
+	 * Filters the access_permission that says if the user must be logged to view the lesson content.
 	 *
 	 * @since 3.5.2
 	 *
@@ -446,7 +453,6 @@ function sensei_is_login_required() {
 	 *
 	 * @param {bool}     $must_be_logged_to_view_lesson True if user need to be logged to see the lesson.
 	 * @param {int|null} $course_id                     Course post ID.
-	 *
 	 * @return {bool} Whether the user needs to be logged in to view content.
 	 */
 	return apply_filters( 'sensei_is_login_required', $login_required, $course_id );
@@ -484,9 +490,12 @@ function sensei_log_event( $event_name, $properties = [] ) {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param bool   $log_event    Whether we should log the event.
-	 * @param string $event_name   The name of the event, without the `sensei_` prefix.
-	 * @param array  $properties   The event properties to be sent.
+	 * @hook sensei_log_event
+	 *
+	 * @param {bool}   $log_event    Whether we should log the event.
+	 * @param {string} $event_name   The name of the event, without the `sensei_` prefix.
+	 * @param {array}  $properties   The event properties to be sent.
+	 * @return {bool} Whether we should log the event.
 	 */
 	if ( false === apply_filters( 'sensei_log_event', true, $event_name, $properties ) ) {
 		return;

--- a/includes/shortcodes/class-sensei-shortcode-teachers.php
+++ b/includes/shortcodes/class-sensei-shortcode-teachers.php
@@ -117,8 +117,11 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
 			 *
 			 * @since 1.9.0
 			 *
-			 * @param string $teacher_li the html for the teacher li
-			 * @param WP_User $user
+			 * @hook sensei_teachers_shortcode_list_item
+			 *
+			 * @param {string}  $teacher_li the html for the teacher li.
+			 * @param {WP_User} $user The user object.
+			 * @return {string} Filtered html for the teacher li.
 			 */
 			$users_output .= apply_filters( 'sensei_teachers_shortcode_list_item', '<li class="teacher"><a href="' . get_author_posts_url( $user->ID ) . '">' . $user_display_name . '<a/></li>', $user );
 

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -214,13 +214,13 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		 * Filters the query which fetches the user courses.
 		 *
 		 * @since 3.13.3
+		 *
 		 * @hook sensei_user_courses_query
 		 *
 		 * @param {null}   $query
 		 * @param {int}    $user_id         The user id.
 		 * @param {string} $status          Status of query to run.
 		 * @param {array}  $base_query_args Base query args.
-		 *
 		 * @return {WP_Query} The query.
 		 */
 		$filtered_query = apply_filters( 'sensei_user_courses_query', null, $user_id, $this->status, $base_query_args );
@@ -529,11 +529,12 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		/**
 		 * Determine if we should display course toggles on User Courses Shortcode.
 		 *
-		 * @param bool $should_display_course_toggles Should we Display the course toggles.
-		 *
 		 * @since 1.9.18
 		 *
-		 * @return bool
+		 * @hook sensei_shortcode_user_courses_display_course_toggle_actions
+		 *
+		 * @param {bool} $should_display_course_toggles Should we display the course toggles.
+		 * @return {bool} Filtered value.
 		 */
 		$should_display_course_toggles = (bool) apply_filters( 'sensei_shortcode_user_courses_display_course_toggle_actions', true );
 		if ( false === $should_display_course_toggles ) {
@@ -574,10 +575,10 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		 * Filters the the user courses filter options.
 		 *
 		 * @since 3.13.3
+		 *
 		 * @hook sensei_user_courses_filter_options
 		 *
 		 * @param {array} $filter_options The filter options.
-		 *
 		 * @return {array} The filter options.
 		 */
 		return apply_filters( 'sensei_user_courses_filter_options', $filter_options );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -488,9 +488,12 @@ function sensei_the_module_permalink() {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param string $module_url
-	 * @param int $module_term_id
-	 * @param string $course_id
+	 * @hook sensei_the_module_permalink
+	 *
+	 * @param {string} $module_url     The module permalink url.
+	 * @param {int}    $module_term_id The module term id.
+	 * @param {string} $course_id      The course id.
+	 * @return {string} The module permalink url.
 	 */
 	 echo esc_url_raw( apply_filters( 'sensei_the_module_permalink', $module_url, $module_term_id, $course_id ) );
 
@@ -519,9 +522,12 @@ function sensei_get_the_module_title() {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param $module_title
-	 * @param $module_term_id
-	 * @param $course_id
+	 * @hook sensei_the_module_title
+	 *
+	 * @param {string} $module_title   The module title.
+	 * @param {int}    $module_term_id The module term id.
+	 * @param {int}    $course_id      The course id.
+	 * @return {string} The module title.
 	 */
 	return apply_filters( 'sensei_the_module_title', $module_title, $module_term_id, $course_id );
 
@@ -590,9 +596,12 @@ function sensei_get_the_module_status() {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param $module_status_html
-	 * @param $module_term_id
-	 * @param $course_id
+	 * @hook sensei_the_module_status_html
+	 *
+	 * @param {string} $module_status_html The module status html.
+	 * @param {int}    $module_term_id     The module term id.
+	 * @param {int}    $course_id          The course id.
+	 * @return {string} The module status html.
 	 */
 	return apply_filters( 'sensei_the_module_status_html', $module_status_html, $module_term_id, $course_id );
 
@@ -629,7 +638,10 @@ function sensei_get_the_module_id() {
 	 *
 	 * @since 1.9.7
 	 *
-	 * @param int $module_term_id Module ID.
+	 * @hook sensei_the_module_id
+	 *
+	 * @param {int} $module_term_id Module ID.
+	 * @return {int} Module ID.
 	 */
 	return apply_filters( 'sensei_the_module_id', $module_term_id );
 }
@@ -771,10 +783,14 @@ function sensei_the_question_class() {
 	$question_type = Sensei()->question->get_question_type( $sensei_question_loop['current_question']->ID );
 
 	/**
-	 * filter the sensei question class within
-	 * the quiz question loop.
+	 * filter the sensei question class within the quiz question loop.
 	 *
 	 * @since 1.9.0
+	 *
+	 * @hook sensei_question_classes
+	 *
+	 * @param {array} $classes The classes to be applied to the question.
+	 * @return {array} The classes to be applied to the question.
 	 */
 	 $classes = apply_filters( 'sensei_question_classes', array( $question_type ) );
 
@@ -876,6 +892,17 @@ function sensei_the_single_lesson_meta() {
 		?>
 		<section class="lesson-meta">
 			<?php
+			/**
+			 * Filters the position of the video in the lesson meta.
+			 *
+			 * Fires before the lesson meta is displayed.
+			 *
+			 * @hook sensei_video_position
+			 *
+			 * @param {string} $position  The position of the video in the lesson meta, default: top.
+			 * @param {int}    $lesson_id The lesson ID.
+			 * @return {string} The position of the video in the lesson meta.
+			 */
 			if ( apply_filters( 'sensei_video_position', 'top', get_the_ID() ) == 'bottom' ) {
 
 				do_action( 'sensei_lesson_video', get_the_ID() );
@@ -908,10 +935,14 @@ function sensei_the_single_lesson_meta() {
 function get_sensei_header() {
 
 	/**
-	 * Allow user to stop the output of
-	 * get_sensei_header which also includes a call to get_header.
+	 * Allow user to stop the output of get_sensei_header which also includes a call to get_header.
 	 *
-	 * @since 1.9.5 introduced
+	 * @since 1.9.5
+	 *
+	 * @hook sensei_show_main_header
+	 *
+	 * @param {bool} $show_main_header Whether to show the main header.
+	 * @return {bool} Whether to show the main header.
 	 */
 	if ( ! apply_filters( 'sensei_show_main_header', true ) ) {
 		return;
@@ -945,10 +976,14 @@ function get_sensei_header() {
 function get_sensei_footer() {
 
 	/**
-	 * Allow user to stop the output of
-	 * get_sensei_footer which also includes a call to get_header.
+	 * Allow user to stop the output of get_sensei_footer which also includes a call to get_header.
 	 *
-	 * @since 1.9.5 introduced
+	 * @since 1.9.5
+	 *
+	 * @hook sensei_show_main_footer
+	 *
+	 * @param {bool} $show_main_footer Whether to show the main footer.
+	 * @return {bool} Whether to show the main footer.
 	 */
 	if ( ! apply_filters( 'sensei_show_main_footer', true ) ) {
 		return;
@@ -988,11 +1023,14 @@ function get_sensei_footer() {
 function the_no_permissions_title() {
 
 	/**
-	 * Filter the no permissions title just before it is echo'd on the
-	 * no-permissions.php file.
+	 * Filter the no permissions title just before it is echo'd on the no-permissions.php file.
 	 *
 	 * @since 1.9.0
-	 * @param $no_permissions_title
+	 *
+	 * @hook sensei_the_no_permissions_title
+	 *
+	 * @param {string} $no_permissions_title The no permissions title.
+	 * @return {string} Filtered no permissions title.
 	 */
 	echo wp_kses_post( apply_filters( 'sensei_the_no_permissions_title', Sensei()->permissions_message['title'] ) );
 
@@ -1006,11 +1044,15 @@ function the_no_permissions_title() {
 function the_no_permissions_message( $post_id ) {
 
 	/**
-	 * Filter the no permissions message just before it is echo'd on the
-	 * no-permissions.php file.
+	 * Filter the no permissions message just before it is echo'd on the no-permissions.php file.
 	 *
 	 * @since 1.9.0
-	 * @param $no_permissions_message
+	 *
+	 * @hook sensei_the_no_permissions_message
+	 *
+	 * @param {string} $no_permissions_message The no permissions message.
+	 * @param {int}    $post_id                The post ID.
+	 * @return {string} Filtered no permissions message.
 	 */
 	echo wp_kses_post( apply_filters( 'sensei_the_no_permissions_message', Sensei()->permissions_message['message'], $post_id ) );
 }
@@ -1208,7 +1250,10 @@ function sensei_get_the_module_description() {
 	 *
 	 * This fires within the sensei_get_the_module_description function.
 	 *
-	 * @param $module_description Module Description.
+	 * @hook sensei_the_module_description
+	 *
+	 * @param {string} $module_description Module Description.
+	 * @return {string} Filtered module description.
 	 */
 	return apply_filters( 'sensei_the_module_description', $module_description );
 }

--- a/includes/theme-integrations/theme-integration-loader.php
+++ b/includes/theme-integrations/theme-integration-loader.php
@@ -88,9 +88,12 @@ class Sensei_Theme_Integration_Loader {
 		 * Allow developer to stop the loading of the default supported theme wrappers.
 		 * After removing this you can follow the documentation on how to add theme support.
 		 *
-		 * @since 1.9.4 introduced filter
+		 * @since 1.9.4
 		 *
-		 * @param boolean $load_default_supported_theme_wrappers
+		 * @hook sensei_load_default_supported_theme_wrappers
+		 *
+		 * @param {bool} $load_default_supported_theme_wrappers Whether to load the default supported theme wrappers.
+		 * @return {bool} Filtered value.
 		 */
 		$load_default_supported_theme_wrappers = apply_filters( 'sensei_load_default_supported_theme_wrappers', true );
 

--- a/templates/single-lesson.php
+++ b/templates/single-lesson.php
@@ -39,8 +39,26 @@ do_action( 'sensei_single_lesson_content_inside_before', get_the_ID() );
 
 if ( sensei_can_user_view_lesson() ) {
 
-	if ( 'top' === apply_filters( 'sensei_video_position', 'top', $post->ID ) ) {
+	/**
+	 * Filter video position.
+	 *
+	 * @hook sensei_video_position
+	 *
+	 * @param {string} $position The video position.
+	 * @param {int}    $post_id  The post ID.
+	 * @return {string} Filtered video position.
+	 */
+	$sensei_video_position = apply_filters( 'sensei_video_position', 'top', $post->ID );
 
+	if ( 'top' === $sensei_video_position ) {
+
+		/**
+		 * Fire action when a lesson video expected.
+		 *
+		 * @hook sensei_lesson_video
+		 *
+		 * @param {int} $post_id The post ID.
+		 */
 		do_action( 'sensei_lesson_video', $post->ID );
 
 	}

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -26,6 +26,7 @@ $sensei_is_quiz_view_only_mode = $question_data['quiz_is_completed'] || ! Sensei
 
 <p class="gapfill-answer">
 	<span class="gapfill-answer-pre">
+		<?php /* This filter is documented in includes/class-sensei-grading-user-quiz.php */ ?>
 		<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_pre'] ) ) ); ?>
 		<?php if ( $sensei_is_quiz_view_only_mode ) { ?>
 			<span class="wp-block-sensei-lms-question-answers__answer">
@@ -40,6 +41,7 @@ $sensei_is_quiz_view_only_mode = $question_data['quiz_is_completed'] || ! Sensei
 			/>
 		<?php } ?>
 		<span class="gapfill-answer-post">
+			<?php /* This filter is documented in includes/class-sensei-grading-user-quiz.php */ ?>
 			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_post'] ) ) ); ?>
 		</span>
 	</span>

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -26,8 +26,17 @@ $sensei_is_quiz_view_only_mode = $question_data['quiz_is_completed'] || ! Sensei
 
 <p class="gapfill-answer">
 	<span class="gapfill-answer-pre">
-		<?php /* This filter is documented in includes/class-sensei-grading-user-quiz.php */ ?>
-		<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_pre'] ) ) ); ?>
+		<?php
+		/**
+		 * Filter user answer text.
+		 *
+		 * @hook sensei_answer_text
+		 *
+		 * @param {string} Answer text.
+		 * @return {string} Filtered answer text.
+		 */
+		echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_pre'] ) ) );
+		?>
 		<?php if ( $sensei_is_quiz_view_only_mode ) { ?>
 			<span class="wp-block-sensei-lms-question-answers__answer">
 				<?php echo wp_kses_post( $question_data['user_answer_entry'] ); ?>
@@ -41,8 +50,17 @@ $sensei_is_quiz_view_only_mode = $question_data['quiz_is_completed'] || ! Sensei
 			/>
 		<?php } ?>
 		<span class="gapfill-answer-post">
-			<?php /* This filter is documented in includes/class-sensei-grading-user-quiz.php */ ?>
-			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_post'] ) ) ); ?>
+			<?php
+			/**
+			 * Filter user answer text.
+			 *
+			 * @hook sensei_answer_text
+			 *
+			 * @param {string} Answer text.
+			 * @return {string} Filtered answer text.
+			 */
+			echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_post'] ) ) );
+			?>
 		</span>
 	</span>
 </p>

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -35,6 +35,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 			<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
 				<?php
 				echo wp_kses(
+					/* This filter is documented in includes/class-sensei-grading-user-quiz.php */
 					apply_filters( 'sensei_answer_text', $option['answer'] ),
 					Sensei_Wp_Kses::get_allowed_html_formatting_tags(),
 					array()

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -35,7 +35,14 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 			<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
 				<?php
 				echo wp_kses(
-					/* This filter is documented in includes/class-sensei-grading-user-quiz.php */
+					/**
+					 * Filter user answer text.
+					 *
+					 * @hook sensei_answer_text
+					 *
+					 * @param {string} Answer text.
+					 * @return {string} Filtered answer text.
+					 */
 					apply_filters( 'sensei_answer_text', $option['answer'] ),
 					Sensei_Wp_Kses::get_allowed_html_formatting_tags(),
 					array()

--- a/tests/unit-tests/test-class-sensei-analysis.php
+++ b/tests/unit-tests/test-class-sensei-analysis.php
@@ -93,7 +93,8 @@ class Sensei_Analysis_Test extends WP_UnitTestCase {
 		$actual = trim( ob_get_clean() );
 
 		/* Assert */
-		$expected = '<h1><a href="http://example.org/wp-admin/admin.php?page=sensei_reports">Reports</a>&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="http://example.org/wp-admin/admin.php?page=sensei_reports&#038;user_id=1">admin</a></span></h1>';
+		$expected = '<h1>
+			<a href="http://example.org/wp-admin/admin.php?page=sensei_reports">Reports</a>&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="http://example.org/wp-admin/admin.php?page=sensei_reports&#038;user_id=1">admin</a></span>			</h1>';
 		$this->assertEquals( $expected, $actual );
 	}
 

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -154,7 +154,16 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 				'name'             => $this->get_field_name( 'course_category' ),
 				'class'            => 'widefat',
 			);
-			wp_dropdown_categories( apply_filters( 'widget_course_categories_dropdown_args', $cat_args ) );
+			/**
+			* Filter course categories dropdown arguments.
+			*
+			* @hook widget_course_categories_dropdown_args
+			*
+			* @param {array} $cat_args Course categories dropdown arguments.
+			* @return {array} Fitlered course categories dropdown arguments.
+			*/
+			$cat_args = apply_filters( 'widget_course_categories_dropdown_args', $cat_args );
+			wp_dropdown_categories( $cat_args );
 			?>
 		</p>
 		<!-- Widget Limit: Text Input -->

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -160,7 +160,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 			* @hook widget_course_categories_dropdown_args
 			*
 			* @param {array} $cat_args Course categories dropdown arguments.
-			* @return {array} Fitlered course categories dropdown arguments.
+			* @return {array} Filtered course categories dropdown arguments.
 			*/
 			$cat_args = apply_filters( 'widget_course_categories_dropdown_args', $cat_args );
 			wp_dropdown_categories( $cat_args );

--- a/widgets/class-sensei-course-categories-widget.php
+++ b/widgets/class-sensei-course-categories-widget.php
@@ -181,7 +181,16 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 			$cat_args['number'] = $limit;
 		}
 		echo '<ul>';
-			wp_list_categories( apply_filters( 'widget_course_categories_args', $cat_args ) );
+		/**
+		 * Filter course categories arguments.
+		 *
+		 * @hook widget_course_categories_args
+		 *
+		 * @param {array} $cat_args Course categories arguments.
+		 * @return {array} Filtereed course categories arguments.
+		 */
+		$cat_args = apply_filters( 'widget_course_categories_args', $cat_args );
+		wp_list_categories( $cat_args );
 		echo '</ul>';
 	}
 }


### PR DESCRIPTION
This PR is part of my "weekend mini-project" to improve our developer documentation.

The main goal is to have all filters in documentation, which means the doc blocks must follow the specific format.

## Proposed Changes
* Add or update filters' documentation comments.

## New/Updated Hooks

* sensei_analysis_overview_{type}_columns - deprecated.
* sensei_analysis_overview_{type}_columns_sortable - deprecated.
* sensei_grading_count_statues - deprecated, contains typo.
* sensei_grading_count_statuses - introduced a new hook (fixed typo)


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues

# Screenshots
Before:
![Before](https://github.com/Automattic/sensei/assets/329356/94ca296a-b372-4d21-b1aa-46e5f227a183)

After:
![After](https://github.com/Automattic/sensei/assets/329356/a7fef864-e6c1-4133-bd66-b9a4d115a942)

