### PR TITLE
Add a progress table eraser tool

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -2,7 +2,6 @@
 
 use Sensei\Internal\Action_Scheduler\Action_Scheduler;
 use Sensei\Internal\Emails\Email_Customization;
-use Sensei\Internal\Installer\Schema;
 use Sensei\Internal\Installer\Updates_Factory;
 use Sensei\Internal\Migration\Migration_Tool;
 use Sensei\Internal\Migration\Migration_Job;

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -662,7 +662,7 @@ class Sensei_Main {
 		}
 
 		// Progress tables eraser.
-		if ( $tables_enabled ) {
+		if ( ! $tables_enabled ) {
 			( new Progress_Tables_Eraser( new Schema() ) )->init();
 		}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -2,6 +2,7 @@
 
 use Sensei\Internal\Action_Scheduler\Action_Scheduler;
 use Sensei\Internal\Emails\Email_Customization;
+use Sensei\Internal\Installer\Schema;
 use Sensei\Internal\Installer\Updates_Factory;
 use Sensei\Internal\Migration\Migration_Tool;
 use Sensei\Internal\Migration\Migration_Job;
@@ -24,6 +25,7 @@ use Sensei\Internal\Student_Progress\Services\Course_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\Lesson_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\Quiz_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\User_Deleted_Handler;
+use Sensei\Internal\Tools\Progress_Tables_Eraser;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -657,6 +659,11 @@ class Sensei_Main {
 				new Migration_Job( 'quiz_migration', new Quiz_Migration() )
 			);
 			( new Migration_Tool( \Sensei_Tools::instance(), $this->migration_scheduler ) )->init();
+		}
+
+		// Progress tables eraser.
+		if ( $tables_enabled ) {
+			( new Progress_Tables_Eraser( new Schema() ) )->init();
 		}
 
 		// Quiz submission repositories.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -663,7 +663,7 @@ class Sensei_Main {
 
 		// Progress tables eraser.
 		if ( ! $tables_enabled ) {
-			( new Progress_Tables_Eraser( new Schema() ) )->init();
+			( new Progress_Tables_Eraser() )->init();
 		}
 
 		// Quiz submission repositories.

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * File containing the class Progress_Tables_Eraser.
+ *
+ * @package sensie
+ */
+
+namespace Sensei\Internal\Tools;
+
+use Sensei\Internal\Installer\Schema;
+use Sensei_Tool_Interface;
+use Sensei_Tools;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Progress_Tables_Eraser.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Progress_Tables_Eraser implements Sensei_Tool_Interface {
+
+	/**
+	 * Sensei schema.
+	 *
+	 * @var Schema
+	 */
+	private $schema;
+
+	/**
+	 * Progress_Tables_Eraser constructor.
+	 *
+	 * @param Schema $schema Sensei schema.
+	 */
+	public function __construct( Schema $schema ) {
+		$this->schema = $schema;
+	}
+
+	/**
+	 * Initialize the tool.
+	 */
+	public function init(): void {
+		add_filter( 'sensei_tools', [ $this, 'register_tool' ] );
+	}
+
+	/**
+	 * Register the tool.
+	 *
+	 * @param array $tools List of tools.
+	 *
+	 * @return array
+	 */
+	public function register_tool( $tools ) {
+		$tools[] = $this;
+		return $tools;
+	}
+
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'student-progress-eraser';
+	}
+
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Erase content of student progress tables', 'sensei-lms' );
+	}
+
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return __( 'Erase the content of the student progress and quiz submission tables. This will delete all data in those tables, but won\'t affect comment-based data.', 'sensei-lms' );
+	}
+
+	/**
+	 * Run the tool.
+	 */
+	public function process() {
+		global $wpdb;
+
+		foreach ( $this->schema->get_tables() as $table ) {
+			if ( $wpdb->get_var( "SHOW TABLES LIKE '$table'" ) === $table ) {
+				$wpdb->query( "TRUNCATE TABLE $table" );
+			}
+		}
+	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
+}

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -129,7 +129,9 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 		}
 
 		Sensei_Tools::instance()->add_user_message( $message );
-		wp_safe_redirect( $this->get_tool_url() );
+
+		// Redirect to the tools page to avoid confusion: the tool is no longer available.
+		wp_safe_redirect( Sensei_Tools::instance()->get_tools_url() );
 		exit;
 	}
 

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -93,7 +93,9 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface {
 		global $wpdb;
 
 		foreach ( $this->schema->get_tables() as $table ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( $wpdb->get_var( "SHOW TABLES LIKE '$table'" ) === $table ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$wpdb->query( "TRUNCATE TABLE $table" );
 			}
 		}

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -32,22 +32,6 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	const NONCE_ACTION = 'sensei-tools-progress-tables-eraser';
 
 	/**
-	 * Sensei schema.
-	 *
-	 * @var Schema
-	 */
-	private $schema;
-
-	/**
-	 * Progress_Tables_Eraser constructor.
-	 *
-	 * @param Schema $schema Sensei schema.
-	 */
-	public function __construct( Schema $schema ) {
-		$this->schema = $schema;
-	}
-
-	/**
 	 * Initialize the tool.
 	 */
 	public function init(): void {
@@ -110,13 +94,13 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 		if ( empty( $_POST['confirm'] ) ) {
 			Sensei_Tools::instance()->add_user_message( __( 'You must confirm the action before it can be performed.', 'sensei-lms' ), true );
 			wp_safe_redirect( $this->get_tool_url() );
-			wp_die();
+			exit;
 		}
 
 		global $wpdb;
 
 		$results = array();
-		foreach ( $this->schema->get_tables() as $table ) {
+		foreach ( $this->get_tables() as $table ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.SchemaChange
@@ -146,7 +130,7 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 
 		Sensei_Tools::instance()->add_user_message( $message );
 		wp_safe_redirect( $this->get_tool_url() );
-		wp_die();
+		exit;
 	}
 
 	/**
@@ -157,7 +141,7 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	public function is_available() {
 		global $wpdb;
 
-		foreach ( $this->schema->get_tables() as $table ) {
+		foreach ( $this->get_tables() as $table ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
 				return true;
@@ -183,5 +167,21 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	 */
 	private function get_tool_url(): string {
 		return admin_url( 'admin.php?page=sensei-tools&tool=' . $this->get_id() );
+	}
+
+	/**
+	 * Get the tables to delete.
+	 *
+	 * @return array
+	 */
+	private function get_tables(): array {
+		global $wpdb;
+
+		return array(
+			"{$wpdb->prefix}sensei_lms_progress",
+			"{$wpdb->prefix}sensei_lms_quiz_submissions",
+			"{$wpdb->prefix}sensei_lms_quiz_answers",
+			"{$wpdb->prefix}sensei_lms_quiz_grades",
+		);
 	}
 }

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -81,7 +81,7 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	 * @return string
 	 */
 	public function get_name() {
-		return __( 'Erase content of student progress tables', 'sensei-lms' );
+		return __( 'Delete student progress tables', 'sensei-lms' );
 	}
 
 	/**
@@ -90,7 +90,7 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	 * @return string
 	 */
 	public function get_description() {
-		return __( 'Erase the content of the student progress and quiz submission tables. This will delete all data in those tables, but won\'t affect comment-based data.', 'sensei-lms' );
+		return __( 'Delete student progress and quiz submission tables. This will delete those tables, but won\'t affect comment-based data.', 'sensei-lms' );
 	}
 
 	/**

--- a/includes/internal/tools/views/html-progress-tables-eraser-form.php
+++ b/includes/internal/tools/views/html-progress-tables-eraser-form.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File containing the form for Progress_Tables_Eraser.
+ *
+ * @package sensei
+ *
+ *
+ * @var string $tool_id Tool ID for this tool.
+ */
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+<form method="post" action="">
+	<?php wp_nonce_field( \Sensei\Internal\Tools\Progress_Tables_Eraser::NONCE_ACTION, '_wpnonce', false ); ?>
+	<input type="hidden" name="delete-tables" value="yes">
+	<input type="hidden" name="page" value="sensei-tools">
+	<input type="hidden" name="tool" value="<?php echo esc_attr( $tool_id ); ?>">
+	<div>
+		<?php esc_html_e( 'This tool will delete all progress tables from the database. This action cannot be undone.', 'sensei-lms' ); ?>
+	</div>
+	<p class="confirm">
+		<input
+			type="checkbox"
+			name="confirm"
+			value="yes"
+			id="sensei-tools-progress-tables-eraser-confirm"
+		/>
+		<label for="sensei-tools-progress-tables-eraser-confirm">
+			<?php esc_html_e( 'I understand this action cannot be undone.', 'sensei-lms' ); ?>
+		</label>
+	<p class="submit">
+		<input
+			type="submit"
+			class="button button-primary"
+			name="submit"
+			value="<?php esc_attr_e( 'Delete Progress Tables', 'sensei-lms' ); ?>"
+			confirm="<?php esc_attr_e( 'Are you sure you want to delete all progress tables?', 'sensei-lms' ); ?>"
+		/>
+	</p>
+</form>

--- a/includes/internal/tools/views/html-progress-tables-eraser-form.php
+++ b/includes/internal/tools/views/html-progress-tables-eraser-form.php
@@ -4,7 +4,6 @@
  *
  * @package sensei
  *
- *
  * @var string $tool_id Tool ID for this tool.
  */
 

--- a/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
+++ b/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
@@ -54,7 +54,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 		$name = $this->eraser->get_name();
 
 		/* Assert. */
-		self::assertSame( 'Erase content of student progress tables', $name );
+		self::assertSame( 'Delete student progress tables', $name );
 	}
 
 	public function testGetDescription_Always_ReturnsMatchingString(): void {
@@ -63,7 +63,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 		$description = $this->eraser->get_description();
 
 		/* Assert. */
-		self::assertSame( 'Erase the content of the student progress and quiz submission tables. This will delete all data in those tables, but won\'t affect comment-based data.', $description );
+		self::assertSame( 'Delete student progress and quiz submission tables. This will delete those tables, but won\'t affect comment-based data.', $description );
 	}
 
 	public function testProcess_ConfirmationProvided_DeletesTables(): void {

--- a/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
+++ b/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
@@ -24,7 +24,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->eraser = new Progress_Tables_Eraser( new Schema() );
+		$this->eraser = new Progress_Tables_Eraser();
 		add_filter( 'wp_redirect', [ $this, 'filterWpRedirect' ], 10, 2 );
 	}
 
@@ -68,8 +68,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 
 	public function testProcess_ConfirmationProvided_DeletesTables(): void {
 		/* Arrange. */
-		$schema = new Schema();
-		$schema->create_tables();
+		$this->create_tables();
 
 		$_POST['_wpnonce']      = wp_create_nonce( Progress_Tables_Eraser::NONCE_ACTION );
 		$_POST['confirm']       = 'yes';
@@ -89,8 +88,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 
 	public function testProcess_NoConfirmationProvided_DeletesTables(): void {
 		/* Arrange. */
-		$schema = new Schema();
-		$schema->create_tables();
+		$this->create_tables();
 
 		$_POST['_wpnonce']      = wp_create_nonce( Progress_Tables_Eraser::NONCE_ACTION );
 		$_POST['delete-tables'] = 'yes';
@@ -112,5 +110,10 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertTrue( $result );
+	}
+
+	private function create_tables(): void {
+		$schema = new Schema();
+		$schema->create_tables();
 	}
 }

--- a/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
+++ b/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
@@ -1,0 +1,93 @@
+<?php
+namespace SenseiTest\Internal\Tools;
+
+use Sensei\Internal\Installer\Schema;
+use Sensei\Internal\Tools\Progress_Tables_Eraser;
+
+/**
+ * Class Progress_Tables_Eraser_Test
+ *
+ * @covers \Sensei\Internal\Tools\Progress_Tables_Eraser
+ */
+class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Eraser instance.
+	 *
+	 * @var Progress_Tables_Eraser
+	 */
+	private $eraser;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->eraser = new Progress_Tables_Eraser( new Schema() );
+	}
+
+	public function testRegisterTool_Always_AddsItselfToTools(): void {
+		/* Act. */
+		$tools = $this->eraser->register_tool( array() );
+
+		/* Assert. */
+		self::assertSame( $this->eraser, $tools[0] );
+	}
+
+	public function testGetId_Always_ReturnsMatchingString(): void {
+		/* Act. */
+		$id = $this->eraser->get_id();
+
+		/* Assert. */
+		self::assertSame( 'student-progress-eraser', $id );
+	}
+
+	public function testGetName_Always_ReturnsMatchingString(): void {
+		/* Act. */
+		$name = $this->eraser->get_name();
+
+		/* Assert. */
+		self::assertSame( 'Erase content of student progress tables', $name );
+	}
+
+	public function testGetDescription_Always_ReturnsMatchingString(): void {
+
+		/* Act. */
+		$description = $this->eraser->get_description();
+
+		/* Assert. */
+		self::assertSame( 'Erase the content of the student progress and quiz submission tables. This will delete all data in those tables, but won\'t affect comment-based data.', $description );
+	}
+
+	public function testProcess_Always_DeletesTablesContents(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_progress',
+			array(
+				'post_id'        => 1,
+				'user_id'        => 2,
+				'parent_post_id' => 3,
+				'type'           => 'a',
+				'status'         => 'b',
+				'started_at'     => '2000-01-01 00:00:00',
+				'completed_at'   => '2000-01-01 00:00:00',
+				'created_at'     => '2000-01-01 00:00:00',
+				'updated_at'     => '2000-01-01 00:00:00',
+			)
+		);
+
+		/* Act. */
+		$this->eraser->process();
+
+		/* Assert. */
+		$count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}sensei_lms_progress" );
+		self::assertSame( 0, $count );
+	}
+
+	public function testIsAvailable_Always_ReturnsTrue(): void {
+		/* Act. */
+		$result = $this->eraser->is_available();
+
+		/* Assert. */
+		self::assertTrue( $result );
+	}
+}

--- a/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
+++ b/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
@@ -60,6 +60,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$wpdb->insert(
 			$wpdb->prefix . 'sensei_lms_progress',
 			array(
@@ -79,6 +80,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 		$this->eraser->process();
 
 		/* Assert. */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}sensei_lms_progress" );
 		self::assertSame( 0, $count );
 	}


### PR DESCRIPTION
Resolves #5868 

## Proposed Changes

* Add a tool that deletes progress tables and quiz submission tables.

## Testing Instructions

1. Enable the feature flag. 
3. Make sure you have progress tables in DB. If not remove the `sensei-version` option from `wp_options` table and reload a page (it should run schema update and create tables).
4. Make sure you don't see the tool ("Delete student progress tables").
5. Disable the feature flag.
6. Take a course and submit a quiz to have some rows in tables.
7. Go to Sensei LMS > Tools.
8. Find `Delete student progress tables`, click "Visit Tool".
9. On the next screen, try to click "Delete Progress Tables" without giving your confirmation.
10. Must not delete tables, shows a warning.
11. Now check the confirmation and click "Delete Progress Tables".
12. Make sure tables were deleted.
13. Go to Tools and check the tool is not available. (You can see it, but the "Visit Tool" button is disabled.)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
