### PR TITLE
Add a course setting to not allow self-enrollment

### DIFF
--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -176,7 +176,7 @@ const CourseGeneralSidebar = () => {
 
 			<h3>{ __( 'Enrollment', 'sensei-lms' ) }</h3>
 			<CheckboxControl
-				label={ __( "Don't allow self enrollment", 'sensei-lms' ) }
+				label={ __( "Don't allow self-enrollment", 'sensei-lms' ) }
 				checked={ selfEnrollmentNotAllowed }
 				onChange={ ( checked ) =>
 					setMeta( {

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -51,6 +51,7 @@ const CourseGeneralSidebar = () => {
 	const featured = meta._course_featured;
 	const prerequisite = meta._course_prerequisite;
 	const notification = meta.disable_notification;
+	const senfEnrollmentNotAllowed = meta._self_enrollment_not_allowed;
 	const openAccess = meta._open_access;
 
 	useEffect( () =>
@@ -170,6 +171,24 @@ const CourseGeneralSidebar = () => {
 					}
 				/>
 			) : null }
+
+			<HorizontalRule />
+
+			<h3>{ __( 'Enrollment', 'sensei-lms' ) }</h3>
+			<CheckboxControl
+				label={ __( "Don't allow self enrollment", 'sensei-lms' ) }
+				checked={ senfEnrollmentNotAllowed }
+				onChange={ ( checked ) =>
+					setMeta( {
+						...meta,
+						_self_enrollment_not_allowed: checked,
+					} )
+				}
+				help={ __(
+					"Students can't take this course by themselves. They can be enrolled only by teachers, administrators, or invitation.",
+					'sensei-lms'
+				) }
+			/>
 
 			{ window.sensei.courseSettingsSidebar.features?.open_access && (
 				<>

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -51,7 +51,7 @@ const CourseGeneralSidebar = () => {
 	const featured = meta._course_featured;
 	const prerequisite = meta._course_prerequisite;
 	const notification = meta.disable_notification;
-	const senfEnrollmentNotAllowed = meta._self_enrollment_not_allowed;
+	const selfEnrollmentNotAllowed = meta._self_enrollment_not_allowed;
 	const openAccess = meta._open_access;
 
 	useEffect( () =>
@@ -177,7 +177,7 @@ const CourseGeneralSidebar = () => {
 			<h3>{ __( 'Enrollment', 'sensei-lms' ) }</h3>
 			<CheckboxControl
 				label={ __( "Don't allow self enrollment", 'sensei-lms' ) }
-				checked={ senfEnrollmentNotAllowed }
+				checked={ selfEnrollmentNotAllowed }
 				onChange={ ( checked ) =>
 					setMeta( {
 						...meta,

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -185,7 +185,7 @@ const CourseGeneralSidebar = () => {
 					} )
 				}
 				help={ __(
-					"Students can't take this course by themselves. They can be enrolled only by teachers, administrators, or invitation.",
+					'Students need to be manually enrolled by teachers or administrators.',
 					'sensei-lms'
 				) }
 			/>

--- a/assets/js/admin/course-general-sidebar.js
+++ b/assets/js/admin/course-general-sidebar.js
@@ -51,7 +51,7 @@ const CourseGeneralSidebar = () => {
 	const featured = meta._course_featured;
 	const prerequisite = meta._course_prerequisite;
 	const notification = meta.disable_notification;
-	const selfEnrollmentNotAllowed = meta._self_enrollment_not_allowed;
+	const selfEnrollmentNotAllowed = meta._sensei_self_enrollment_not_allowed;
 	const openAccess = meta._open_access;
 
 	useEffect( () =>
@@ -181,7 +181,7 @@ const CourseGeneralSidebar = () => {
 				onChange={ ( checked ) =>
 					setMeta( {
 						...meta,
-						_self_enrollment_not_allowed: checked,
+						_sensei_self_enrollment_not_allowed: checked,
 					} )
 				}
 				help={ __(

--- a/changelog/add-setting-not-allowing-self-enrollment
+++ b/changelog/add-setting-not-allowing-self-enrollment
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add a setting to not allow self enrollment on courses
+Add a setting to not allow self-enrollment on courses

--- a/changelog/add-setting-not-allowing-self-enrollment
+++ b/changelog/add-setting-not-allowing-self-enrollment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a setting to not allow self enrollment on courses

--- a/changelog/fix-take-course-notices
+++ b/changelog/fix-take-course-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix course notices that are intended to be displayed only on the course page but were currently appearing on the courses archive page

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -71,6 +71,12 @@ class Sensei_Block_Take_Course {
 				}
 				$html = $this->render_with_start_course_form( $course_id, $content );
 			}
+		} elseif ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) && ! Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() ) ) {
+			Sensei()->notices->add_notice(
+				__( 'Please contact the course administrator to sign up for this course.', 'sensei-lms' ),
+				'info'
+			);
+			$html = $this->render_disabled( $content );
 		} elseif ( ! is_user_logged_in() ) {
 			$html = $this->render_with_login( $content );
 		}

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -54,9 +54,13 @@ class Sensei_Block_Take_Course {
 			return '';
 		}
 
+		$is_course_page = is_single();
+
 		if ( Sensei_Course::can_current_user_manually_enrol( $course_id ) ) {
 			if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
-				Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info', 'sensei-take-course-prerequisite' );
+				if ( $is_course_page ) {
+					Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info', 'sensei-take-course-prerequisite' );
+				}
 				$html = $this->render_disabled( $content );
 			} else {
 				// Replace button label in case it's coming from a sign in with redirect to take course.
@@ -72,10 +76,12 @@ class Sensei_Block_Take_Course {
 				$html = $this->render_with_start_course_form( $course_id, $content );
 			}
 		} elseif ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) && ! Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() ) ) {
-			Sensei()->notices->add_notice(
-				__( 'Please contact the course administrator to sign up for this course.', 'sensei-lms' ),
-				'info'
-			);
+			if ( $is_course_page ) {
+				Sensei()->notices->add_notice(
+					__( 'Please contact the course administrator to sign up for this course.', 'sensei-lms' ),
+					'info'
+				);
+			}
 			$html = $this->render_disabled( $content );
 		} elseif ( ! is_user_logged_in() ) {
 			$html = $this->render_with_login( $content );

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3731,7 +3731,7 @@ class Sensei_Course {
 	/**
 	 * Check if a user can manually enrol themselves.
 	 *
-	 * @since $$next-version$$ Add a check whether self enrollment is not allowed.
+	 * @since $$next-version$$ Add a check whether self-enrollment is not allowed.
 	 *
 	 * @param int $course_id Course post ID.
 	 *
@@ -3742,7 +3742,7 @@ class Sensei_Course {
 		// Check if the user is already enrolled through any provider.
 		$is_user_enrolled = self::is_user_enrolled( $course_id, get_current_user_id() );
 
-		// Check if self enrollment is not allowed for this course.
+		// Check if self-enrollment is not allowed for this course.
 		$is_self_enrollment_not_allowed = self::is_self_enrollment_not_allowed( $course_id );
 
 		$default_can_user_manually_enrol = is_user_logged_in() && ! $is_user_enrolled && ! $is_self_enrollment_not_allowed;
@@ -3769,25 +3769,25 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Check if self enrollment is not allowed for the given course.
+	 * Check if self-enrollment is not allowed for the given course.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @param int $course_id Course post ID.
 	 *
-	 * @return boolean Whether self enrollment is not allowed.
+	 * @return boolean Whether self-enrollment is not allowed.
 	 */
 	public static function is_self_enrollment_not_allowed( $course_id ) {
 		$self_enrollment_not_allowed = (bool) get_post_meta( $course_id, '_self_enrollment_not_allowed', true );
 
 		/**
-		 * Check if self enrollment is not allowed.
+		 * Check if self-enrollment is not allowed.
 		 *
 		 * @since $$next-version$$
 		 *
 		 * @hook sensei_self_enrollment_not_allowed
 		 *
-		 * @param {bool} $self_enrollment_not_allowed True if self enrollment is not allowed, false otherwise.
+		 * @param {bool} $self_enrollment_not_allowed True if self-enrollment is not allowed, false otherwise.
 		 * @param {int}  $course_id                   Course post ID.
 		 * @return {bool} Filtered value.
 		 */
@@ -4379,7 +4379,7 @@ class Sensei_Course {
 		// Course prerequisite completion message.
 		add_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'prerequisite_complete_message' ], 20 );
 
-		// Self enrollment not allowed message.
+		// Self-enrollment not allowed message.
 		add_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'self_enrollment_not_allowed_message' ], 20 );
 	}
 
@@ -4404,7 +4404,7 @@ class Sensei_Course {
 		// Course prerequisite completion message.
 		remove_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'prerequisite_complete_message' ], 20 );
 
-		// Self enrollment not allowed message.
+		// Self-enrollment not allowed message.
 		remove_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'self_enrollment_not_allowed_message' ], 20 );
 
 		// Add message links to courses.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4132,6 +4132,8 @@ class Sensei_Course {
 	 * Show a message telling the user that they are not allowed to self enroll if the setting is enabled.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @internal
 	 */
 	public static function self_enrollment_not_allowed_message() {
 		$course_id = get_the_ID();

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4127,6 +4127,23 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Show a message telling the user that they are not allowed to self enroll if the setting is enabled.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function self_enrollment_not_allowed_message() {
+		$course_id = get_the_ID();
+		$user_id   = get_current_user_id();
+
+		if ( self::is_self_enrollment_not_allowed( get_the_ID() ) && ! self::is_user_enrolled( $course_id, $user_id ) ) {
+			Sensei()->notices->add_notice(
+				__( 'Please contact the course administrator to sign up for this course.', 'sensei-lms' ),
+				'info'
+			);
+		}
+	}
+
+	/**
 	 * Generate the HTML of the course prerequisite notice.
 	 *
 	 * @param int $course_id The course id.
@@ -4341,6 +4358,8 @@ class Sensei_Course {
 		// Course prerequisite completion message.
 		add_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'prerequisite_complete_message' ], 20 );
 
+		// Self enrollment not allowed message.
+		add_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'self_enrollment_not_allowed_message' ], 20 );
 	}
 
 	/**
@@ -4363,6 +4382,9 @@ class Sensei_Course {
 
 		// Course prerequisite completion message.
 		remove_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'prerequisite_complete_message' ], 20 );
+
+		// Self enrollment not allowed message.
+		remove_action( 'sensei_single_course_content_inside_before', [ 'Sensei_Course', 'self_enrollment_not_allowed_message' ], 20 );
 
 		// Add message links to courses.
 		remove_action( 'sensei_single_course_content_inside_before', [ Sensei()->post_types->messages, 'send_message_link' ], 35 );

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -666,7 +666,7 @@ class Sensei_Course {
 		);
 		register_post_meta(
 			'course',
-			'_self_enrollment_not_allowed',
+			'_sensei_self_enrollment_not_allowed',
 			[
 				'show_in_rest'  => true,
 				'single'        => true,
@@ -3783,7 +3783,7 @@ class Sensei_Course {
 	 * @return boolean Whether self-enrollment is not allowed.
 	 */
 	public static function is_self_enrollment_not_allowed( $course_id ) {
-		$self_enrollment_not_allowed = (bool) get_post_meta( $course_id, '_self_enrollment_not_allowed', true );
+		$self_enrollment_not_allowed = (bool) get_post_meta( $course_id, '_sensei_self_enrollment_not_allowed', true );
 
 		/**
 		 * Check if self-enrollment is not allowed.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4139,7 +4139,11 @@ class Sensei_Course {
 		$course_id = get_the_ID();
 		$user_id   = get_current_user_id();
 
-		if ( self::is_self_enrollment_not_allowed( get_the_ID() ) && ! self::is_user_enrolled( $course_id, $user_id ) ) {
+		if ( false === $course_id ) {
+			return;
+		}
+
+		if ( self::is_self_enrollment_not_allowed( $course_id ) && ! self::is_user_enrolled( $course_id, $user_id ) ) {
 			Sensei()->notices->add_notice(
 				__( 'Please contact the course administrator to sign up for this course.', 'sensei-lms' ),
 				'info'

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3771,6 +3771,8 @@ class Sensei_Course {
 	/**
 	 * Check if self enrollment is not allowed for the given course.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param int $course_id Course post ID.
 	 *
 	 * @return boolean Whether self enrollment is not allowed.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -670,6 +670,18 @@ class Sensei_Course {
 		);
 		register_post_meta(
 			'course',
+			'_self_enrollment_not_allowed',
+			[
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'boolean',
+				'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
+					return current_user_can( 'edit_post', $post_id );
+				},
+			]
+		);
+		register_post_meta(
+			'course',
 			'disable_notification',
 			[
 				'show_in_rest'  => true,

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -650,9 +650,7 @@ class Sensei_Course {
 				'show_in_rest'  => true,
 				'single'        => true,
 				'type'          => 'integer',
-				'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
-					return current_user_can( 'edit_post', $post_id );
-				},
+				'auth_callback' => [ $this, 'post_meta_auth_callback' ],
 			]
 		);
 		register_post_meta(
@@ -663,9 +661,7 @@ class Sensei_Course {
 				'single'            => true,
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
-				'auth_callback'     => function ( $allowed, $meta_key, $post_id ) {
-					return current_user_can( 'edit_post', $post_id );
-				},
+				'auth_callback'     => [ $this, 'post_meta_auth_callback' ],
 			]
 		);
 		register_post_meta(
@@ -675,9 +671,7 @@ class Sensei_Course {
 				'show_in_rest'  => true,
 				'single'        => true,
 				'type'          => 'boolean',
-				'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
-					return current_user_can( 'edit_post', $post_id );
-				},
+				'auth_callback' => [ $this, 'post_meta_auth_callback' ],
 			]
 		);
 		register_post_meta(
@@ -687,9 +681,7 @@ class Sensei_Course {
 				'show_in_rest'  => true,
 				'single'        => true,
 				'type'          => 'boolean',
-				'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
-					return current_user_can( 'edit_post', $post_id );
-				},
+				'auth_callback' => [ $this, 'post_meta_auth_callback' ],
 			]
 		);
 		register_post_meta(
@@ -699,9 +691,7 @@ class Sensei_Course {
 				'show_in_rest'  => true,
 				'single'        => true,
 				'type'          => 'boolean',
-				'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
-					return current_user_can( 'edit_post', $post_id );
-				},
+				'auth_callback' => [ $this, 'post_meta_auth_callback' ],
 			]
 		);
 		/**
@@ -715,6 +705,21 @@ class Sensei_Course {
 		 * @return {string[]} Filtered meta field key names.
 		 */
 		$this->meta_fields = apply_filters( 'sensei_course_meta_fields', [ 'course_prerequisite', 'course_featured', 'course_video_embed' ] );
+	}
+
+	/**
+	 * Add the course meta boxes.
+	 *
+	 * @internal
+	 *
+	 * @param bool   $allowed
+	 * @param string $meta_key
+	 * @param int    $post_id  The post ID where the meta key is being edited.
+	 *
+	 * @return boolean Whether the user can edit the meta key.
+	 */
+	public function post_meta_auth_callback( $allowed, $meta_key, $post_id ) {
+		return current_user_can( 'edit_post', $post_id );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3731,6 +3731,8 @@ class Sensei_Course {
 	/**
 	 * Check if a user can manually enrol themselves.
 	 *
+	 * @since $$next-version$$ Add a check whether self enrollment is not allowed.
+	 *
 	 * @param int $course_id Course post ID.
 	 *
 	 * @return bool
@@ -3740,7 +3742,10 @@ class Sensei_Course {
 		// Check if the user is already enrolled through any provider.
 		$is_user_enrolled = self::is_user_enrolled( $course_id, get_current_user_id() );
 
-		$default_can_user_manually_enrol = is_user_logged_in() && ! $is_user_enrolled;
+		// Check if self enrollment is not allowed for this course.
+		$is_self_enrollment_not_allowed = self::is_self_enrollment_not_allowed( $course_id );
+
+		$default_can_user_manually_enrol = is_user_logged_in() && ! $is_user_enrolled && ! $is_self_enrollment_not_allowed;
 
 		$can_user_manually_enrol = apply_filters_deprecated(
 			'sensei_display_start_course_form',
@@ -3761,6 +3766,17 @@ class Sensei_Course {
 		 * @return {bool} Filtered value.
 		 */
 		return (bool) apply_filters( 'sensei_can_user_manually_enrol', $can_user_manually_enrol, $course_id );
+	}
+
+	/**
+	 * Check if self enrollment is not allowed for the given course.
+	 *
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return boolean Whether self enrollment is not allowed.
+	 */
+	public static function is_self_enrollment_not_allowed( $course_id ) {
+		return (bool) get_post_meta( $course_id, '_self_enrollment_not_allowed', true );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -712,8 +712,8 @@ class Sensei_Course {
 	 *
 	 * @internal
 	 *
-	 * @param bool   $allowed
-	 * @param string $meta_key
+	 * @param bool   $allowed  Whether the user can add the meta.
+	 * @param string $meta_key The meta key.
 	 * @param int    $post_id  The post ID where the meta key is being edited.
 	 *
 	 * @return boolean Whether the user can edit the meta key.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3778,7 +3778,20 @@ class Sensei_Course {
 	 * @return boolean Whether self enrollment is not allowed.
 	 */
 	public static function is_self_enrollment_not_allowed( $course_id ) {
-		return (bool) get_post_meta( $course_id, '_self_enrollment_not_allowed', true );
+		$self_enrollment_not_allowed = (bool) get_post_meta( $course_id, '_self_enrollment_not_allowed', true );
+
+		/**
+		 * Check if self enrollment is not allowed.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @hook sensei_self_enrollment_not_allowed
+		 *
+		 * @param {bool} $self_enrollment_not_allowed True if self enrollment is not allowed, false otherwise.
+		 * @param {int}  $course_id                   Course post ID.
+		 * @return {bool} Filtered value.
+		 */
+		return (bool) apply_filters( 'sensei_self_enrollment_not_allowed', $self_enrollment_not_allowed, $course_id );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3823,7 +3823,7 @@ class Sensei_Course {
 
 		if ( self::can_current_user_manually_enrol( $post->ID ) ) {
 				sensei_start_course_form( $post->ID );
-		} else {
+		} elseif ( ! self::is_self_enrollment_not_allowed( $post->ID ) ) {
 			if ( get_option( 'users_can_register' ) ) {
 
 				// set the permissions message

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4782,8 +4782,16 @@ class Sensei_Lesson {
 			$course_link .= esc_html__( 'course', 'sensei-lms' );
 			$course_link .= '</a>';
 
-			// translators: The placeholder %1$s is a link to the Course.
-			$message_default = sprintf( esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'sensei-lms' ), $course_link );
+			$format = '';
+			if ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) ) {
+				// translators: The placeholder %1$s is a link to the Course.
+				$format = esc_html__( 'Please contact the course administrator to sign up for the %1$s before starting the lesson.', 'sensei-lms' );
+			} else {
+				// translators: The placeholder %1$s is a link to the Course.
+				$format = esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'sensei-lms' );
+			}
+
+			$message_default = sprintf( $format, $course_link );
 
 			/**
 			 * Filter the course sign up notice message on the lesson page.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4782,16 +4782,12 @@ class Sensei_Lesson {
 			$course_link .= esc_html__( 'course', 'sensei-lms' );
 			$course_link .= '</a>';
 
-			$format = '';
-			if ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) ) {
-				// translators: The placeholder %1$s is a link to the Course.
-				$format = esc_html__( 'Please contact the course administrator to sign up for the %1$s before starting the lesson.', 'sensei-lms' );
-			} else {
-				// translators: The placeholder %1$s is a link to the Course.
-				$format = esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'sensei-lms' );
-			}
+			// translators: The placeholder %1$s is a link to the Course.
+			$message_default = sprintf( esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'sensei-lms' ), $course_link );
 
-			$message_default = sprintf( $format, $course_link );
+			if ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) ) {
+				$message_default = esc_html__( 'Please contact the course administrator to access the course content.', 'sensei-lms' );
+			}
 
 			/**
 			 * Filter the course sign up notice message on the lesson page.

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -250,8 +250,9 @@ class Sensei_Course_Theme_Lesson {
 	 * @return void
 	 */
 	private function maybe_add_not_enrolled_notice() {
-		$lesson_id = \Sensei_Utils::get_current_lesson();
-		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+		$lesson_id  = \Sensei_Utils::get_current_lesson();
+		$course_id  = Sensei()->lesson->get_course_id( $lesson_id );
+		$is_preview = $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id );
 
 		if ( Sensei_Course::is_user_enrolled( $course_id ) ) {
 			return;
@@ -262,11 +263,16 @@ class Sensei_Course_Theme_Lesson {
 		$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
 		$notice_icon  = 'lock';
 
+		if ( $is_preview ) {
+			$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
+			$notice_icon  = 'eye';
+		}
+
 		// Check if self-enrollment is allowed.
 		if ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) ) {
 			$notices->add_notice(
 				$notice_key,
-				__( 'Please contact the course administrator to access the course content.', 'sensei-lms' ),
+				__( 'Please contact the course administrator to take this lesson.', 'sensei-lms' ),
 				$notice_title,
 				[],
 				$notice_icon
@@ -311,10 +317,8 @@ class Sensei_Course_Theme_Lesson {
 
 			$notice_text = __( 'Please register or sign in to access the course content.', 'sensei-lms' );
 
-			if ( $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
-				$notice_text  = __( 'Register or sign in to take this lesson.', 'sensei-lms' );
-				$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
-				$notice_icon  = 'eye';
+			if ( $is_preview ) {
+				$notice_text = __( 'Register or sign in to take this lesson.', 'sensei-lms' );
 			}
 
 			$notices->add_notice(
@@ -340,10 +344,8 @@ class Sensei_Course_Theme_Lesson {
 
 		$notice_text = __( 'Please register for this course to access the content.', 'sensei-lms' );
 
-		if ( $lesson_id && Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
-			$notice_text  = __( 'Register for this course to take this lesson.', 'sensei-lms' );
-			$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
-			$notice_icon  = 'eye';
+		if ( $is_preview ) {
+			$notice_text = __( 'Register for this course to take this lesson.', 'sensei-lms' );
 		}
 
 		$notices->add_notice(

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -262,6 +262,19 @@ class Sensei_Course_Theme_Lesson {
 		$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
 		$notice_icon  = 'lock';
 
+		// Check if self enrollment is allowed.
+		if ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) ) {
+			$notices->add_notice(
+				$notice_key,
+				__( 'Please contact the course administrator to access the course content.', 'sensei-lms' ),
+				$notice_title,
+				[],
+				$notice_icon
+			);
+
+			return;
+		}
+
 		// Course prerequisite notice.
 		if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
 			$notices->add_notice(

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -262,7 +262,7 @@ class Sensei_Course_Theme_Lesson {
 		$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
 		$notice_icon  = 'lock';
 
-		// Check if self enrollment is allowed.
+		// Check if self-enrollment is allowed.
 		if ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) ) {
 			$notices->add_notice(
 				$notice_key,

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -126,6 +126,8 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	 * When the course has an unmet prerequisite, button is disabled with a message.
 	 */
 	public function testDisabledWhenPrerequisiteUnmet() {
+		$GLOBALS['wp_query']->is_single = true;
+
 		$property = new ReflectionProperty( 'Sensei_Notices', 'has_printed' );
 		$property->setAccessible( true );
 		$property->setValue( Sensei()->notices, false );
@@ -184,6 +186,8 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	 */
 	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowed_AddsNotice() {
 		/* Arrange. */
+		$GLOBALS['wp_query']->is_single = true;
+
 		$this->login_as_student();
 		update_post_meta( $this->course->ID, '_sensei_self_enrollment_not_allowed', true );
 
@@ -198,10 +202,31 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Self-Enrollment Not In Course Page.
+	 */
+	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowedAndNotInSinglePost_DoesNotAddNotice() {
+		/* Arrange. */
+		$GLOBALS['wp_query']->is_single = false;
+
+		$this->login_as_student();
+		update_post_meta( $this->course->ID, '_sensei_self_enrollment_not_allowed', true );
+
+		$notices          = $this->createMock( Sensei_Notices::class );
+		Sensei()->notices = $notices;
+
+		/* Expect & Act */
+		$notices->expects( self::never() )
+			->method( 'add_notice' );
+		do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
+	}
+
+	/**
 	 * Self-Enrollment Not Allowed And User Is Enrolled.
 	 */
 	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowedAndUserIsEnrolled_DoesNotAddNotice() {
 		/* Arrange. */
+		$GLOBALS['wp_query']->is_single = true;
+
 		$student = $this->factory->user->create();
 		$this->manuallyEnrolStudentInCourse( $student, $this->course->ID );
 

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -27,6 +27,13 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	private $course;
 
 	/**
+	 * Keep initial state of Sensei()->notices.
+	 *
+	 * @var Sensei_Notices|null
+	 */
+	private $initial_notices;
+
+	/**
 	 * Set up the test.
 	 */
 	public function setUp(): void {
@@ -40,11 +47,15 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 		$this->course    = $this->factory->course->create_and_get( [ 'post_name' => 'take-block-course' ] );
 		$GLOBALS['post'] = $this->course;
 
+		$this->initial_notices = Sensei()->notices;
+
 	}
 
 	public function tearDown(): void {
 		parent::tearDown();
 		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/button-take-course' );
+
+		Sensei()->notices = $this->initial_notices;
 	}
 
 	public static function tearDownAfterClass(): void {

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -185,7 +185,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowed_AddsNotice() {
 		/* Arrange. */
 		$this->login_as_student();
-		update_post_meta( $this->course->ID, '_self_enrollment_not_allowed', true );
+		update_post_meta( $this->course->ID, '_sensei_self_enrollment_not_allowed', true );
 
 		$notices          = $this->createMock( Sensei_Notices::class );
 		Sensei()->notices = $notices;
@@ -206,7 +206,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 		$this->manuallyEnrolStudentInCourse( $student, $this->course->ID );
 
 		$this->login_as( $student );
-		update_post_meta( $this->course->ID, '_self_enrollment_not_allowed', true );
+		update_post_meta( $this->course->ID, '_sensei_self_enrollment_not_allowed', true );
 
 		$notices          = $this->createMock( Sensei_Notices::class );
 		Sensei()->notices = $notices;

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -180,7 +180,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Self Enrollment Not Allowed.
+	 * Self-Enrollment Not Allowed.
 	 */
 	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowed_AddsNotice() {
 		/* Arrange. */
@@ -198,7 +198,7 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Self Enrollment Not Allowed And User Is Enrolled.
+	 * Self-Enrollment Not Allowed And User Is Enrolled.
 	 */
 	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowedAndUserIsEnrolled_DoesNotAddNotice() {
 		/* Arrange. */

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -245,7 +245,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
 		/* Assert. */
-		$this->assertMatchesRegularExpression( '/Please contact the course administrator to access the course content./', $html, 'Should return not allowed self enrollment notice' );
+		$this->assertStringContainsString( 'Please contact the course administrator to access the course content.', $html, 'Should return not allowed self enrollment notice' );
 	}
 
 	/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -225,7 +225,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		$course_id              = $this->factory->course->create(
 			[
 				'meta_input' => [
-					'_self_enrollment_not_allowed' => true,
+					'_sensei_self_enrollment_not_allowed' => true,
 				],
 			]
 		);

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -245,7 +245,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
 		/* Assert. */
-		$this->assertStringContainsString( 'Please contact the course administrator to access the course content.', $html, 'Should return not allowed self-enrollment notice' );
+		$this->assertStringContainsString( 'Please contact the course administrator to take this lesson.', $html, 'Should return not allowed self-enrollment notice' );
 	}
 
 	/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -217,6 +217,38 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Testing not allowed self enrollment notice.
+	 */
+	public function testCourseNotAllowedSelfEnrollmentNotice() {
+		/* Arrange. */
+		$prerequisite_course_id = $this->factory->course->create();
+		$course_id              = $this->factory->course->create(
+			[
+				'meta_input' => [
+					'_self_enrollment_not_allowed' => true,
+				],
+			]
+		);
+		$lesson                 = $this->factory->lesson->create_and_get(
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+		$GLOBALS['post']        = $lesson;
+
+		$this->login_as_student();
+		\Sensei_Course_Theme_Lesson::instance()->init();
+
+		/* Act. */
+		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
+
+		/* Assert. */
+		$this->assertMatchesRegularExpression( '/Please contact the course administrator to access the course content./', $html, 'Should return not allowed self enrollment notice' );
+	}
+
+	/**
 	 * Testing logged out notice.
 	 */
 	public function testLoggedOutNotice() {

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -217,7 +217,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Testing not allowed self enrollment notice.
+	 * Testing not allowed self-enrollment notice.
 	 */
 	public function testCourseNotAllowedSelfEnrollmentNotice() {
 		/* Arrange. */
@@ -245,7 +245,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
 		/* Assert. */
-		$this->assertStringContainsString( 'Please contact the course administrator to access the course content.', $html, 'Should return not allowed self enrollment notice' );
+		$this->assertStringContainsString( 'Please contact the course administrator to access the course content.', $html, 'Should return not allowed self-enrollment notice' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -749,4 +749,57 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$this->assertTrue( isset( $redirect_status ) );
 		$this->assertStringContainsString( home_url( '/wp-login.php' ), $redirect_location );
 	}
+
+	public function testSelfEnrollmentNotAllowedMessage_WhenCourseDoesntAllowSelfEnrollment_AddsNotice(): void {
+		/* Arrange */
+		global $post;
+
+		$course_id        = $this->factory->course->create();
+		$post             = get_post( $course_id );
+		$notices          = $this->createMock( Sensei_Notices::class );
+		Sensei()->notices = $notices;
+
+		update_post_meta( $course_id, '_self_enrollment_not_allowed', true );
+
+		/* Expect & Act */
+		$notices->expects( self::once() )
+			->method( 'add_notice' )
+			->with( $this->stringContains( 'Please contact the course administrator to sign up for this course.' ) );
+		Sensei_Course::self_enrollment_not_allowed_message();
+	}
+
+	public function testSelfEnrollmentNotAllowedMessage_WhenCourseAllowsSelfEnrollment_DontAddNotice(): void {
+		/* Arrange */
+		global $post;
+
+		$course_id        = $this->factory->course->create();
+		$post             = get_post( $course_id );
+		$notices          = $this->createMock( Sensei_Notices::class );
+		Sensei()->notices = $notices;
+
+		/* Expect & Act */
+		$notices->expects( self::never() )
+			->method( 'add_notice' );
+		Sensei_Course::self_enrollment_not_allowed_message();
+	}
+
+	public function testSelfEnrollmentNotAllowedMessage_WhenCourseDoesntAllowSelfEnrollmentAndUserIsEnrolled_DontAddNotice(): void {
+		/* Arrange */
+		$this->login_as_student();
+		global $post;
+
+		$course_id        = $this->factory->course->create();
+		$post             = get_post( $course_id );
+		$notices          = $this->createMock( Sensei_Notices::class );
+		Sensei()->notices = $notices;
+
+		update_post_meta( $course_id, '_self_enrollment_not_allowed', true );
+
+		$this->manuallyEnrolStudentInCourse( get_current_user_id(), $course_id );
+
+		/* Expect & Act */
+		$notices->expects( self::never() )
+			->method( 'add_notice' );
+		Sensei_Course::self_enrollment_not_allowed_message();
+	}
 }

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -14,6 +14,13 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	protected $factory;
 
 	/**
+	 * Keep initial state of Sensei()->notices.
+	 *
+	 * @var Sensei_Notices|null
+	 */
+	private $initial_notices;
+
+	/**
 	 * Setup function.
 	 *
 	 * This function sets up the lessons, quizes and their questions. This function runs before
@@ -24,11 +31,15 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Test_Events::reset();
+
+		$this->initial_notices = Sensei()->notices;
 	}
 
 	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
+
+		Sensei()->notices = $this->initial_notices;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -770,7 +770,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$notices          = $this->createMock( Sensei_Notices::class );
 		Sensei()->notices = $notices;
 
-		update_post_meta( $course_id, '_self_enrollment_not_allowed', true );
+		update_post_meta( $course_id, '_sensei_self_enrollment_not_allowed', true );
 
 		/* Expect & Act */
 		$notices->expects( self::once() )
@@ -804,7 +804,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$notices          = $this->createMock( Sensei_Notices::class );
 		Sensei()->notices = $notices;
 
-		update_post_meta( $course_id, '_self_enrollment_not_allowed', true );
+		update_post_meta( $course_id, '_sensei_self_enrollment_not_allowed', true );
 
 		$this->manuallyEnrolStudentInCourse( get_current_user_id(), $course_id );
 

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -768,7 +768,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		Sensei_Course::self_enrollment_not_allowed_message();
 	}
 
-	public function testSelfEnrollmentNotAllowedMessage_WhenCourseAllowsSelfEnrollment_DontAddNotice(): void {
+	public function testSelfEnrollmentNotAllowedMessage_WhenCourseAllowsSelfEnrollment_DoesNotAddNotice(): void {
 		/* Arrange */
 		global $post;
 
@@ -783,7 +783,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		Sensei_Course::self_enrollment_not_allowed_message();
 	}
 
-	public function testSelfEnrollmentNotAllowedMessage_WhenCourseDoesntAllowSelfEnrollmentAndUserIsEnrolled_DontAddNotice(): void {
+	public function testSelfEnrollmentNotAllowedMessage_WhenCourseDoesntAllowSelfEnrollmentAndUserIsEnrolled_DoesNotAddNotice(): void {
 		/* Arrange */
 		$this->login_as_student();
 		global $post;

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1192,7 +1192,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		/* Expect & Act */
 		$notices->expects( self::once() )
 			->method( 'add_notice' )
-			->with( $this->stringContains( 'Please contact the course administrator to sign up for' ) );
+			->with( 'Please contact the course administrator to access the course content.' );
 		$result = Sensei_Lesson::course_signup_link();
 	}
 

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1183,7 +1183,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		Sensei()->notices = $notices;
 
 		$course = $this->factory->course->create_and_get();
-		update_post_meta( $course->ID, '_self_enrollment_not_allowed', true );
+		update_post_meta( $course->ID, '_sensei_self_enrollment_not_allowed', true );
 
 		$lesson = $this->createMock( Sensei_Lesson::class );
 		$lesson->method( 'get_course_id' )->willReturn( $course->ID );

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1153,7 +1153,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		self::assertNull( $result );
 	}
 
-	public function testCourseSignupLink_WhenSignupNoticeNeeded_AddsNotice(): void {
+	public function testCourseSignupLink_WhenSignupNoticeNeededAndCourseAllowsSelfEnrollment_AddsNotice(): void {
 		/* Arrange */
 		global $post;
 		$lesson_id        = $this->factory->lesson->create();
@@ -1168,7 +1168,31 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		Sensei()->lesson = $lesson;
 
 		/* Expect & Act */
-		$notices->expects( self::once() )->method( 'add_notice' );
+		$notices->expects( self::once() )
+			->method( 'add_notice' )
+			->with( $this->stringContains( 'Please sign up for' ) );
+		$result = Sensei_Lesson::course_signup_link();
+	}
+
+	public function testCourseSignupLink_WhenSignupNoticeNeededAndCourseDoesntAllowSelfEnrollment_AddsNotice(): void {
+		/* Arrange */
+		global $post;
+		$lesson_id        = $this->factory->lesson->create();
+		$post             = get_post( $lesson_id );
+		$notices          = $this->createMock( Sensei_Notices::class );
+		Sensei()->notices = $notices;
+
+		$course = $this->factory->course->create_and_get();
+		update_post_meta( $course->ID, '_self_enrollment_not_allowed', true );
+
+		$lesson = $this->createMock( Sensei_Lesson::class );
+		$lesson->method( 'get_course_id' )->willReturn( $course->ID );
+		Sensei()->lesson = $lesson;
+
+		/* Expect & Act */
+		$notices->expects( self::once() )
+			->method( 'add_notice' )
+			->with( $this->stringContains( 'Please contact the course administrator to sign up for' ) );
 		$result = Sensei_Lesson::course_signup_link();
 	}
 


### PR DESCRIPTION
Resolves #7182

## Proposed Changes

* Add a course setting to not allow self enrollment.
* Also add notices in the frontend when the setting is enabled.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with blocks and Learning Mode enabled.
2. Enable the setting _"Don't allow self enrollment"_ in the course editor sidebar.
3. Add at least one lesson to the course.
4. As a student, visit the course and the lesson pages.
5. Make sure you see notices and you can't enroll.
6. Enroll the student through the Student Management (WP Admin), and make sure it works properly.
7. Check that you don't see the notices anymore.
8. Repeat the previous steps, but this time with a course without blocks (legacy course), and without Learning Mode.
9. Play around, and make sure there's not take course button for the user when the new setting is enabled.
10. Turn the setting _"Don't allow self enrollment"_ off, and make sure the course works normally (no notices, and it's possible to enroll).

### Known issues

https://github.com/Automattic/sensei/issues/7232

### Screenshots

The setting:
<img width="315" alt="Screenshot 2023-10-18 at 11 40 34" src="https://github.com/Automattic/sensei/assets/876340/cbaed326-1158-4da3-84f4-83655cb01b9a">

Notice on course with blocks:
<img width="1112" alt="Screenshot 2023-10-18 at 14 58 44" src="https://github.com/Automattic/sensei/assets/876340/21c1cfa0-c5f1-44d2-9bc5-a2292d15a3d2">

Notice on lesson with Learning Mode:
<img width="1203" alt="Screenshot 2023-10-18 at 11 41 02" src="https://github.com/Automattic/sensei/assets/876340/acf68e71-aeea-4d84-9998-d03746ca66f9">

Notice on course without blocks (impacted by https://github.com/Automattic/sensei/issues/6173 in some themes):
<img width="1460" alt="Screenshot 2023-10-18 at 12 16 14" src="https://github.com/Automattic/sensei/assets/876340/3fc8fe1e-8a7b-4b9d-83a1-cfecfee1d181">

Notice on lesson without Learning Mode:
<img width="1119" alt="Screenshot 2023-10-17 at 16 42 50" src="https://github.com/Automattic/sensei/assets/876340/19d2e115-afe3-4c74-8499-85012de0c6c0">

Courses list (impacted by https://github.com/Automattic/sensei/issues/7232):
<img width="1192" alt="Screenshot 2023-10-18 at 16 28 17" src="https://github.com/Automattic/sensei/assets/876340/79304ace-f90d-4597-9516-f058f51c00c2">

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* `sensei_self_enrollment_not_allowed` - Filter whether self enrollment is not allowed for a given course.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues