### PR TITLE
Fix course notices that are intended to be displayed only on the course page but were currently appearing on the courses archive page

### DIFF
--- a/changelog/fix-take-course-notices
+++ b/changelog/fix-take-course-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix course notices that are intended to be displayed only on the course page but were currently appearing on the courses archive page

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -54,9 +54,13 @@ class Sensei_Block_Take_Course {
 			return '';
 		}
 
+		$is_course_page = is_single();
+
 		if ( Sensei_Course::can_current_user_manually_enrol( $course_id ) ) {
 			if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
-				Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info', 'sensei-take-course-prerequisite' );
+				if ( $is_course_page ) {
+					Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info', 'sensei-take-course-prerequisite' );
+				}
 				$html = $this->render_disabled( $content );
 			} else {
 				// Replace button label in case it's coming from a sign in with redirect to take course.
@@ -72,10 +76,12 @@ class Sensei_Block_Take_Course {
 				$html = $this->render_with_start_course_form( $course_id, $content );
 			}
 		} elseif ( Sensei_Course::is_self_enrollment_not_allowed( $course_id ) && ! Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() ) ) {
-			Sensei()->notices->add_notice(
-				__( 'Please contact the course administrator to sign up for this course.', 'sensei-lms' ),
-				'info'
-			);
+			if ( $is_course_page ) {
+				Sensei()->notices->add_notice(
+					__( 'Please contact the course administrator to sign up for this course.', 'sensei-lms' ),
+					'info'
+				);
+			}
 			$html = $this->render_disabled( $content );
 		} elseif ( ! is_user_logged_in() ) {
 			$html = $this->render_with_login( $content );

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -126,6 +126,8 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	 * When the course has an unmet prerequisite, button is disabled with a message.
 	 */
 	public function testDisabledWhenPrerequisiteUnmet() {
+		$GLOBALS['wp_query']->is_single = true;
+
 		$property = new ReflectionProperty( 'Sensei_Notices', 'has_printed' );
 		$property->setAccessible( true );
 		$property->setValue( Sensei()->notices, false );
@@ -184,6 +186,8 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	 */
 	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowed_AddsNotice() {
 		/* Arrange. */
+		$GLOBALS['wp_query']->is_single = true;
+
 		$this->login_as_student();
 		update_post_meta( $this->course->ID, '_sensei_self_enrollment_not_allowed', true );
 
@@ -198,10 +202,31 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Self-Enrollment Not In Course Page.
+	 */
+	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowedAndNotInSinglePost_DoesNotAddNotice() {
+		/* Arrange. */
+		$GLOBALS['wp_query']->is_single = false;
+
+		$this->login_as_student();
+		update_post_meta( $this->course->ID, '_sensei_self_enrollment_not_allowed', true );
+
+		$notices          = $this->createMock( Sensei_Notices::class );
+		Sensei()->notices = $notices;
+
+		/* Expect & Act */
+		$notices->expects( self::never() )
+			->method( 'add_notice' );
+		do_blocks( '<!-- wp:sensei-lms/button-take-course {"align":"right"} --><button class="sensei-stop-double-submission wp-block-button__link">Take Course</button><!-- /wp:sensei-lms/button-take-course -->' );
+	}
+
+	/**
 	 * Self-Enrollment Not Allowed And User Is Enrolled.
 	 */
 	public function testRenderTakeCourseBlock_WhenSelfEnrollmentIsNotAllowedAndUserIsEnrolled_DoesNotAddNotice() {
 		/* Arrange. */
+		$GLOBALS['wp_query']->is_single = true;
+
 		$student = $this->factory->user->create();
 		$this->manuallyEnrolStudentInCourse( $student, $this->course->ID );
 


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/7231
Resolves https://github.com/Automattic/sensei/issues/7232

## Proposed Changes

* Add a check to display the notices from Take Course button only on course pages.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course.
2. Activate the setting "Don't allow self-enrollment".
3. Navigate to the courses archive.
4. Make sure your course is listed and you don't see the notice "Please contact the course administrator to sign up for this course.".
5. Access the course, and make sure the notice is still displayed there.

## Known Issues

I noticed another issue with the notices on legacy courses, but I couldn't solve it quickly. Since it's only for legacy courses, I just opened the issue to be fixed in the future: https://github.com/Automattic/sensei/issues/7237

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues