### PR TITLE
Fix no side spacing applied in quiz in learning mode for mobile view

### DIFF
--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -30,12 +30,6 @@ body {
 
 .sensei-course-theme__main-content {
 	padding: 0 var(--content-padding);
-
-	> * {
-		max-width: var(--content-size) !important;
-		margin-left: auto;
-		margin-right: auto;
-	}
 }
 
 /**
@@ -94,6 +88,16 @@ body {
 
 		.post-nav-links {
 			display: none;
+		}
+	}
+
+	&.sensei-default {
+		.sensei-course-theme__main-content {
+			> * {
+				max-width: var(--content-size) !important;
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 	}
 }

--- a/changelog/fix-no-side-spacing-mobile-lm-quiz
+++ b/changelog/fix-no-side-spacing-mobile-lm-quiz
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Lateral spacing not applied in the mobile view of quiz in learning mode

--- a/changelog/fix-no-side-spacing-mobile-lm-quiz
+++ b/changelog/fix-no-side-spacing-mobile-lm-quiz
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Lateral spacing not applied in the mobile view of quiz in learning mode

--- a/themes/sensei-course-theme/templates/quiz.html
+++ b/themes/sensei-course-theme/templates/quiz.html
@@ -1,7 +1,7 @@
 <!-- wp:pattern {"slug":"sensei-course-theme/header"} /-->
 
-<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2", "tagName": "main"} -->
-<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2">
+<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2 sensei-course-theme__main-content", "tagName": "main"} -->
+<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2 sensei-course-theme__main-content">
 	<!-- wp:sensei-lms/quiz-back-to-lesson /-->
 	<!-- wp:post-title {"level": 1} /-->
 	<!-- wp:sensei-lms/course-theme-notices /-->


### PR DESCRIPTION
Resolves issue of no side spacing applied in quiz in learning mode for mobile view.

## Proposed Changes
* The lateral spacing for quiz was removed on mobile due to some recent changes. We've fixed that here.
* Lesson spacing was also not applied except for the default template. We've fixed that both on this PR and the linked Pro PR

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch of Pro https://github.com/Automattic/sensei-pro/pull/2462
2. Check every LM template for both lesson and quiz in mobile and desktop
3. Make sure the spacing on both side is there in all cases

Before:
![Screenshot 2023-10-31 at 3 56 20 PM](https://github.com/Automattic/sensei/assets/6820724/6bd64c75-b662-453e-b615-585de84e8be3)

![Screenshot 2023-10-31 at 4 42 29 PM](https://github.com/Automattic/sensei/assets/6820724/c5a93d25-bed1-43cf-9b50-de73967ad330)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
