### PR TITLE
Fix contact teacher form not working in lm footer button

### DIFF
--- a/changelog/fix-contact-teacher-form-not-working-in-lm-footer-button
+++ b/changelog/fix-contact-teacher-form-not-working-in-lm-footer-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact teacher form not working issue when clicked from quiz footer

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1945,7 +1945,10 @@ class Sensei_Quiz {
 			<?php endif ?>
 
 			<?php if ( $is_learning_mode && $post_grade_action ) : ?>
-				<?php echo wp_kses_post( $post_grade_action ); ?>
+				<?php
+					$allowed_html = self::get_allowed_html_for_modal_form();
+					echo wp_kses( $post_grade_action, $allowed_html );
+				?>
 			<?php endif ?>
 
 			<?php if ( $is_awaiting_grade && $is_learning_mode ) : ?>
@@ -2547,6 +2550,41 @@ class Sensei_Quiz {
 					esc_html( $button_text ) .
 				'</a>
 			</div>'
+		);
+	}
+
+	/**
+	 * Returns allowed HTML elements apart from posts for Kses.
+	 *
+	 * @return array Allowed HTML for modal forms in Kses.
+	 */
+	public static function get_allowed_html_for_modal_form() {
+		return array_merge(
+			wp_kses_allowed_html( 'post' ),
+			array(
+				'form'     => array(
+					'action' => array(),
+					'class'  => array(),
+					'method' => array(),
+					'name'   => array(),
+				),
+				'input'    => array(
+					'class' => array(),
+					'name'  => array(),
+					'type'  => array(),
+					'value' => array(),
+				),
+				'textarea' => array(
+					'name'        => array(),
+					'placeholder' => array(),
+				),
+				'svg'      => array(
+					'class' => array(),
+				),
+				'use'      => array(
+					'href' => array(),
+				),
+			)
 		);
 	}
 }

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2563,20 +2563,24 @@ class Sensei_Quiz {
 			wp_kses_allowed_html( 'post' ),
 			array(
 				'form'     => array(
-					'action' => array(),
-					'class'  => array(),
-					'method' => array(),
-					'name'   => array(),
+					'action'   => array(),
+					'class'    => array(),
+					'method'   => array(),
+					'name'     => array(),
+					'onsubmit' => array(),
 				),
 				'input'    => array(
 					'class' => array(),
 					'name'  => array(),
 					'type'  => array(),
 					'value' => array(),
+					'id'    => array(),
 				),
 				'textarea' => array(
 					'name'        => array(),
 					'placeholder' => array(),
+					'rows'        => array(),
+					'required'    => array(),
 				),
 				'svg'      => array(
 					'class' => array(),

--- a/templates/course-theme/quiz-grade-notice.php
+++ b/templates/course-theme/quiz-grade-notice.php
@@ -32,8 +32,8 @@ if ( ! function_exists( 'sensei_quiz_grade_notices_map' ) ) {
 			<?php if ( isset( $notice['actions'] ) && ! empty( $notice['actions'] ) ) { ?>
 			<div class='sensei-course-theme-quiz-graded-notice__actions'>
 				<?php
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- No user data is being outputted.
-					echo implode( '', $notice['actions'] );
+					$allowed_html = Sensei_Quiz::get_allowed_html_for_modal_form();
+					echo wp_kses( implode( '', $notice['actions'] ), $allowed_html );
 				?>
 			</div>
 			<?php } ?>


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7221

## Proposed Changes
* `wp_kses_post` was removing the form and some other elements, so the modal became broken. Also, the action buttons were not being escaped in the top notice. We've fixed those here. 

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a quiz to a lesson.
2. Enable Auto Grade.
3. Disable Allow Retakes.
4. Enable Pass Required.
5. Set the Passing Grade to 100%.
6. Complete the quiz and fail it.
7. Click the Contact Teacher button.
8. Make sure the modal works as expected
9. Now click on the Contact Teacher button in the top modal
10. Make sure it works as expected

https://github.com/Automattic/sensei/assets/6820724/10422d09-418f-4dd3-a02a-a418b32b6d83

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
