### PR TITLE
Add "[Status] Needs Triage" label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "[Type] Bug"
+labels: "[Status] Needs Triage, [Type] Bug"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: "[Type] Enhancement"
+labels: "[Status] Needs Triage, [Type] Enhancement"
 assignees: ''
 
 ---


### PR DESCRIPTION
As part of introducing a formal triage process, this PR updates the issue templates so that the `[Status] Needs Triage` label is added to all new issues.