### PR TITLE
Fix module spacing when Learning Mode is not enabled

### DIFF
--- a/assets/blocks/course-outline/module-block/module.scss
+++ b/assets/blocks/course-outline/module-block/module.scss
@@ -39,11 +39,12 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 	}
 
 	#{$block}__title {
+		color: inherit;
+		flex: 1;
 		font-size: 1.1em;
 		font-weight: inherit;
-		flex: 1;
 		margin: 0;
-		color: inherit;
+		padding-top: 0;
 		&::before, &::after {
 			content: none;
 		}

--- a/assets/blocks/course-outline/module-block/module.scss
+++ b/assets/blocks/course-outline/module-block/module.scss
@@ -44,7 +44,7 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 		font-size: 1.1em;
 		font-weight: inherit;
 		margin: 0;
-		padding-top: 0;
+		padding: 0;
 		&::before, &::after {
 			content: none;
 		}

--- a/changelog/fix-module-style
+++ b/changelog/fix-module-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix module spacing when Learning Mode is not enabled


### PR DESCRIPTION
## Proposed Changes

* It fixes module spacing when Learning Mode is not enabled.

It didn't happen with Learning Mode enabled because of this style: https://github.com/Automattic/sensei/blob/96012db38399ac4d3c550ca17be1ac526fde69fb/assets/css/3rd-party/themes/course/learning-mode.scss#L213

I noticed it happening only with Course theme, but I decided to fix it directly in Sensei core because if it happened for other themes, it would also be fixed. Does it make sense?

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with at least a module.
2. Deactivate the Learning Mode for this course.
3. Check that the styles look good in the frontend.

## Screenshots

Before:
<img width="1048" alt="Screenshot 2023-11-07 at 15 25 12" src="https://github.com/Automattic/sensei/assets/876340/3023c346-4fd5-417e-88a3-6f95eb5a1438">

After:
<img width="1079" alt="Screenshot 2023-11-07 at 15 24 46" src="https://github.com/Automattic/sensei/assets/876340/e26f8ef5-a79d-4f83-af3b-d2930c17cea0">


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
