### PR TITLE
Fix gap fill question to accept "0" as the right answer

### DIFF
--- a/changelog/fix-gap-fill-question-with-answer-0
+++ b/changelog/fix-gap-fill-question-with-answer-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the gap fill question to accept "0" as the right answer

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -612,7 +612,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		$text_values = explode( '||', $right_answer_meta );
 
 		$result['before'] = isset( $text_values[0] ) ? $text_values[0] : '';
-		$result['gap']    = empty( $text_values[1] ) ? [] : explode( '|', $text_values[1] );
+		$result['gap']    = ( ! isset( $text_values[1] ) || '' === $text_values[1] ) ? [] : explode( '|', $text_values[1] );
 		$result['after']  = isset( $text_values[2] ) ? $text_values[2] : '';
 
 		return $result;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -331,6 +331,50 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	}
 
 	/**
+	 * Tests gap fill question answer with gap "0".
+	 */
+	public function testGetGapFillQuestion_WhenGapIs0_ReturnsGap0() {
+		$this->login_as_teacher();
+
+		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
+		$this->factory->question->create(
+			[
+				'quiz_id'                                => $quiz_id,
+				'question_type'                          => 'gap-fill',
+				'add_question_right_answer_gapfill_pre'  => 'BEFORE',
+				'add_question_right_answer_gapfill_gap'  => '0',
+				'add_question_right_answer_gapfill_post' => 'AFTER',
+			]
+		);
+
+		$response_data = $this->send_get_request( $lesson_id );
+
+		$this->assertEquals( '0', $response_data['questions'][0]['answer']['gap'][0] );
+	}
+
+	/**
+	 * Tests gap fill question answer with empty gap.
+	 */
+	public function testGetGapFillQuestion_WhenGapIsEmptyString_ReturnsEmptyGap() {
+		$this->login_as_teacher();
+
+		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
+		$this->factory->question->create(
+			[
+				'quiz_id'                                => $quiz_id,
+				'question_type'                          => 'gap-fill',
+				'add_question_right_answer_gapfill_pre'  => 'BEFORE',
+				'add_question_right_answer_gapfill_gap'  => '',
+				'add_question_right_answer_gapfill_post' => 'AFTER',
+			]
+		);
+
+		$response_data = $this->send_get_request( $lesson_id );
+
+		$this->assertEquals( [], $response_data['questions'][0]['answer']['gap'] );
+	}
+
+	/**
 	 * Tests single line question properties.
 	 */
 	public function testGetSingleLineQuestion() {


### PR DESCRIPTION
Issue reported in p1699118258790299-slack-CAXUNK9MW

## Proposed Changes

* It fixes an issue with the gap fill question, which wasn't accepting "0" as the right answer.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with a quiz.
2. Add a gap fill question.
3. Add "0" as the right answer.
4. Refresh the editor, and make sure the answer continue there.
5. Answer the quiz as a student and make sure it works properly.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues