### PR TITLE
Properly determine a submitted quiz

### DIFF
--- a/changelog/fix-quiz-complete-status
+++ b/changelog/fix-quiz-complete-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix how we determine whether a quiz has been submitted.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3649,7 +3649,7 @@ class Sensei_Lesson {
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
 
-		return ! empty( $quiz_progress ) && in_array( $quiz_progress->get_status(), [ 'ungraded', 'passed', 'failed', 'graded' ], true );
+		return ! empty( $quiz_progress ) && $quiz_progress->is_quiz_submitted();
 	}
 
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1724,8 +1724,8 @@ class Sensei_Quiz {
 		}
 
 		// Don't use pagination if quiz has been completed.
-		$quiz_progress  = Sensei()->quiz_progress_repository->get( $quiz_id, get_current_user_id() );
-		$quiz_completed = $quiz_progress && 'in-progress' !== $quiz_progress->get_status();
+		$quiz_progress   = Sensei()->quiz_progress_repository->get( $quiz_id, get_current_user_id() );
+		$quiz_completed  = $quiz_progress && $quiz_progress->is_quiz_submitted();
 
 		$sensei_question_loop['questions'] = $quiz_completed ? $all_questions : $loop_questions;
 		$sensei_question_loop['quiz_id']   = $quiz_id;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1724,8 +1724,8 @@ class Sensei_Quiz {
 		}
 
 		// Don't use pagination if quiz has been completed.
-		$quiz_progress   = Sensei()->quiz_progress_repository->get( $quiz_id, get_current_user_id() );
-		$quiz_completed  = $quiz_progress && $quiz_progress->is_quiz_submitted();
+		$quiz_progress  = Sensei()->quiz_progress_repository->get( $quiz_id, get_current_user_id() );
+		$quiz_completed = $quiz_progress && $quiz_progress->is_quiz_submitted();
 
 		$sensei_question_loop['questions'] = $quiz_completed ? $all_questions : $loop_questions;
 		$sensei_question_loop['quiz_id']   = $quiz_id;

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -137,7 +137,7 @@ class Sensei_Course_Theme_Quiz {
 		}
 
 		// "Continue to next lesson" button.
-		if ( in_array( $quiz_progress->get_status(), [ 'complete', 'graded', 'passed' ], true ) ) {
+		if ( in_array( $quiz_progress->get_status(), array( 'graded', 'passed' ), true ) ) {
 			$prev_next_urls  = sensei_get_prev_next_lessons( $lesson_id );
 			$next_lesson_url = $prev_next_urls['next']['url'] ?? null;
 			$actions[]       = Sensei_Quiz::get_primary_button_html( __( 'Continue to next lesson', 'sensei-lms' ), $next_lesson_url );

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -163,7 +163,7 @@ class Sensei_Course_Theme_Templates {
 
 		$progress = Sensei()->quiz_progress_repository->get( $post->ID, get_current_user_id() );
 
-		$has_submitted_quiz = $progress && in_array( $progress->get_status(), [ 'ungraded', 'graded', 'passed', 'failed' ], true );
+		$has_submitted_quiz = $progress && $progress->is_quiz_submitted();
 
 		if ( 'quiz' !== $post->post_type || $has_submitted_quiz ) {
 			return false;

--- a/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-abstract.php
+++ b/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-abstract.php
@@ -204,6 +204,23 @@ class Quiz_Progress_Abstract implements Quiz_Progress_Interface {
 	}
 
 	/**
+	 * Returns whether the quiz is submitted.
+	 *
+	 * @internal
+	 *
+	 * @return bool
+	 */
+	public function is_quiz_submitted(): bool {
+		$submitted_statuses = array(
+			Quiz_Progress_Interface::STATUS_UNGRADED,
+			Quiz_Progress_Interface::STATUS_GRADED,
+			Quiz_Progress_Interface::STATUS_PASSED,
+			Quiz_Progress_Interface::STATUS_FAILED,
+		);
+		return in_array( $this->status, $submitted_statuses, true );
+	}
+
+	/**
 	 * Get the quiz start date.
 	 *
 	 * @internal

--- a/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-interface.php
+++ b/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-interface.php
@@ -134,6 +134,15 @@ interface Quiz_Progress_Interface {
 	public function get_status(): ?string;
 
 	/**
+	 * Returns whether the quiz is submitted.
+	 *
+	 * @internal
+	 *
+	 * @return bool
+	 */
+	public function is_quiz_submitted(): bool;
+
+	/**
 	 * Get the quiz start date.
 	 *
 	 * @internal

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-quiz.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-quiz.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SenseiTest;
+
+use Sensei_Factory;
+
+class Sensei_Course_Theme_Quiz_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Sensei factory.
+	 *
+	 * @var Sensei_Facotry
+	 */
+	protected $factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function testInit_QuizPassed_AddsNotice(): void {
+		/* Arrange. */
+		global $post;
+
+		$notices   = \Sensei_Context_Notices::instance( 'course_theme_quiz_grade' );
+		$lesson_id = $this->factory->lesson->create();
+		$quiz      = $this->factory->quiz->create_and_get( array( 'post_parent' => $lesson_id ) );
+		$user      = $this->factory->user->create_and_get();
+		$post      = $quiz;
+		wp_set_current_user( $user->ID );
+		$notices->remove_notice( 'course-theme-quiz-grade' );
+
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user->ID );
+		$quiz_progress = Sensei()->quiz_progress_repository->create( $quiz->ID, $user->ID );
+		$quiz_progress->pass();
+		Sensei()->quiz_progress_repository->save( $quiz_progress );
+
+		$course_theme_quiz = \Sensei_Course_Theme_Quiz::instance();
+
+		/* Act. */
+		$course_theme_quiz->init();
+
+		/* Assert. */
+		$notices_html = $notices->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
+		$this->assertStringContainsString( 'Continue to next lesson', $notices_html );
+	}
+
+	public function testInit_QuizInProgress_DoesntAddNotice(): void {
+		/* Arrange. */
+		global $post;
+
+		$notices   = \Sensei_Context_Notices::instance( 'course_theme_quiz_grade' );
+		$lesson_id = $this->factory->lesson->create();
+		$quiz      = $this->factory->quiz->create_and_get( array( 'post_parent' => $lesson_id ) );
+		$user      = $this->factory->user->create_and_get();
+		$post      = $quiz;
+		wp_set_current_user( $user->ID );
+		$notices->remove_notice( 'course-theme-quiz-grade' );
+
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user->ID );
+		$quiz_progress = Sensei()->quiz_progress_repository->create( $quiz->ID, $user->ID );
+		$quiz_progress->start();
+		Sensei()->quiz_progress_repository->save( $quiz_progress );
+
+		$course_theme_quiz = \Sensei_Course_Theme_Quiz::instance();
+
+		/* Act. */
+		$course_theme_quiz->init();
+
+		/* Assert. */
+		$notices_html = $notices->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
+		$this->assertStringNotContainsString( 'Continue to next lesson', $notices_html );
+	}
+}

--- a/tests/unit-tests/internal/student-progress/quiz-progress/models/test-class-comments-based-quiz-progress.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/models/test-class-comments-based-quiz-progress.php
@@ -13,10 +13,10 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_id();
+		$actual = $quiz_progress->get_id();
 
 		/* Assert. */
 		self::assertSame( 1, $actual );
@@ -24,10 +24,10 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetQuizId_ConstructedWithQuizId_ReturnsSameQuizId(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_quiz_id();
+		$actual = $quiz_progress->get_quiz_id();
 
 		/* Assert. */
 		self::assertSame( 2, $actual );
@@ -35,10 +35,10 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetUserId_ConstructedWithUserId_ReturnsSameUserId(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_user_id();
+		$actual = $quiz_progress->get_user_id();
 
 		/* Assert. */
 		self::assertSame( 3, $actual );
@@ -46,21 +46,48 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_ConstructedWithStatus_ReturnsSameStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'in-progress', $actual );
 	}
 
-	public function testGetStartedAt_ConstructedWithStartedAt_ReturnsSameStartedAt(): void {
+	/**
+	 * Test that the quiz is considered submitted based on the quiz progress status.
+	 *
+	 * @dataProvider providerIsQuizSubmitted_ConstructedWithStatus_ReturnsMatchingValue
+	 */
+	public function testIsQuizSubmitted_ConstructedWithStatus_ReturnsMatchingValue( string $status, bool $expected ): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress( $status );
 
 		/* Act. */
-		$actual = $course_progress->get_started_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->is_quiz_submitted();
+
+		/* Assert. */
+		self::assertSame( $expected, $actual );
+	}
+
+	public function providerIsQuizSubmitted_ConstructedWithStatus_ReturnsMatchingValue(): array {
+		return array(
+			'quiz in progress'                => array( 'in-progress', false ),
+			'quiz graded'                     => array( 'graded', true ),
+			'quiz failed'                     => array( 'failed', true ),
+			'quiz passed'                     => array( 'passed', true ),
+			'quiz ungraded'                   => array( 'ungraded', true ),
+			'lesson complete (legacy status)' => array( 'complete', false ),
+		);
+	}
+
+	public function testGetStartedAt_ConstructedWithStartedAt_ReturnsSameStartedAt(): void {
+		/* Arrange. */
+		$quiz_progress = $this->create_progress();
+
+		/* Act. */
+		$actual = $quiz_progress->get_started_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:00', $actual );
@@ -68,10 +95,10 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetCompletedAt_ConstructedWithCompletedAt_ReturnsSameCompletedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_completed_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_completed_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:01', $actual );
@@ -79,10 +106,10 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_created_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_created_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:02', $actual );
@@ -90,10 +117,10 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:03', $actual );
@@ -101,11 +128,11 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetUpdatedAt_WhenUpdatedAtSet_ReturnsSameUpdatedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->set_updated_at( new \DateTime( '2020-01-01 00:00:04' ) );
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->set_updated_at( new \DateTime( '2020-01-01 00:00:04' ) );
 
 		/* Act. */
-		$actual = $course_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:04', $actual );
@@ -113,11 +140,11 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenGradeCalled_ReturnsGradedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->grade();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->grade();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'graded', $actual );
@@ -125,11 +152,11 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenFailCalled_ReturnsFailedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->fail();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->fail();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'failed', $actual );
@@ -137,11 +164,11 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenPassCalled_ReturnsPassedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->pass();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->pass();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'passed', $actual );
@@ -149,11 +176,11 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenUngradeCalled_ReturnsUngradedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->ungrade();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->ungrade();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'ungraded', $actual );

--- a/tests/unit-tests/internal/student-progress/quiz-progress/models/test-class-tables-based-quiz-progress.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/models/test-class-tables-based-quiz-progress.php
@@ -13,10 +13,10 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetId_ConstructedWithId_ReturnsSameId(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_id();
+		$actual = $quiz_progress->get_id();
 
 		/* Assert. */
 		self::assertSame( 1, $actual );
@@ -24,10 +24,10 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetQuizId_ConstructedWithQuizId_ReturnsSameQuizId(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_quiz_id();
+		$actual = $quiz_progress->get_quiz_id();
 
 		/* Assert. */
 		self::assertSame( 2, $actual );
@@ -35,10 +35,10 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetUserId_ConstructedWithUserId_ReturnsSameUserId(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_user_id();
+		$actual = $quiz_progress->get_user_id();
 
 		/* Assert. */
 		self::assertSame( 3, $actual );
@@ -46,21 +46,48 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_ConstructedWithStatus_ReturnsSameStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'in-progress', $actual );
 	}
 
-	public function testGetStartedAt_ConstructedWithStartedAt_ReturnsSameStartedAt(): void {
+	/**
+	 * Test that the quiz is considered submitted based on the quiz progress status.
+	 *
+	 * @dataProvider providerIsQuizSubmitted_ConstructedWithStatus_ReturnsMatchingValue
+	 */
+	public function testIsQuizSubmitted_ConstructedWithStatus_ReturnsMatchingValue( string $status, bool $expected ): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress( $status );
 
 		/* Act. */
-		$actual = $course_progress->get_started_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->is_quiz_submitted();
+
+		/* Assert. */
+		self::assertSame( $expected, $actual );
+	}
+
+	public function providerIsQuizSubmitted_ConstructedWithStatus_ReturnsMatchingValue(): array {
+		return array(
+			'quiz in progress'                => array( 'in-progress', false ),
+			'quiz graded'                     => array( 'graded', true ),
+			'quiz failed'                     => array( 'failed', true ),
+			'quiz passed'                     => array( 'passed', true ),
+			'quiz ungraded'                   => array( 'ungraded', true ),
+			'lesson complete (legacy status)' => array( 'complete', false ),
+		);
+	}
+
+	public function testGetStartedAt_ConstructedWithStartedAt_ReturnsSameStartedAt(): void {
+		/* Arrange. */
+		$quiz_progress = $this->create_progress();
+
+		/* Act. */
+		$actual = $quiz_progress->get_started_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:00', $actual );
@@ -68,10 +95,10 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetCompletedAt_ConstructedWithCompletedAt_ReturnsSameCompletedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_completed_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_completed_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:01', $actual );
@@ -79,10 +106,10 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetCreatedAt_ConstructedWithCreatedAt_ReturnsSameCreatedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_created_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_created_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:02', $actual );
@@ -90,10 +117,10 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetUpdatedAt_ConstructedWithUpdatedAt_ReturnsSameUpdatedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
+		$quiz_progress = $this->create_progress();
 
 		/* Act. */
-		$actual = $course_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:03', $actual );
@@ -101,11 +128,11 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetUpdatedAt_WhenUpdatedAtSet_ReturnsSameUpdatedAt(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->set_updated_at( new \DateTime( '2020-01-01 00:00:04' ) );
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->set_updated_at( new \DateTime( '2020-01-01 00:00:04' ) );
 
 		/* Act. */
-		$actual = $course_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
+		$actual = $quiz_progress->get_updated_at()->format( 'Y-m-d H:i:s' );
 
 		/* Assert. */
 		self::assertSame( '2020-01-01 00:00:04', $actual );
@@ -113,11 +140,11 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenGradeCalled_ReturnsGradedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->grade();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->grade();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'graded', $actual );
@@ -125,11 +152,11 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenFailCalled_ReturnsFailedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->fail();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->fail();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'failed', $actual );
@@ -137,11 +164,11 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenPassCalled_ReturnsPassedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->pass();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->pass();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'passed', $actual );
@@ -149,11 +176,11 @@ class Tables_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 
 	public function testGetStatus_WhenUngradeCalled_ReturnsUngradedStatus(): void {
 		/* Arrange. */
-		$course_progress = $this->create_progress();
-		$course_progress->ungrade();
+		$quiz_progress = $this->create_progress();
+		$quiz_progress->ungrade();
 
 		/* Act. */
-		$actual = $course_progress->get_status();
+		$actual = $quiz_progress->get_status();
 
 		/* Assert. */
 		self::assertSame( 'ungraded', $actual );


### PR DESCRIPTION
Resolves #7276 

## Proposed Changes
* Add a method to the quiz progress to determine if the quiz has been submitted.
* Fix legacy check of the status.
* Fix pagination not showing in an edge case (when a lesson was completed, but then a quiz was added, we visit the quiz on the frontend —it is not submitted yet— and see all the questions on one page).

## Testing Instructions

1. Publish a lesson.
2. Complete the lesson as a student.
3. Add a quiz with a few questions and pagination to that lesson and update it.
4. As a student, go to the quiz.
5. You should see proper placement of buttons in the footer (quiz template) and paginated output of questions (for example, you see only one question per page if you set it that way, so you don't see all questions on one page).

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [X] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [X] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
