### PR TITLE
Fix tests failing randomly

### DIFF
--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -104,7 +104,7 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.SchemaChange
-				$wpdb->query( "DROP TABLE $table" );
+				$wpdb->query( "DROP TABLE IF EXISTS $table" );
 				$results[] = $table;
 			}
 		}

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -530,6 +530,8 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 		$quiz_id = $this->maybe_create_quiz_for_lesson( $lesson_id, $quiz_args );
 
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
 		if ( $number > 0 ) {
 			update_post_meta( $lesson_id, '_quiz_has_questions', true );
 		}


### PR DESCRIPTION
This resolves [tests failing randomly](https://github.com/Automattic/sensei/actions/runs/6791384892/job/18462779528) in CI. 

## Proposed Changes
* Fix the progress validation tests to use a migration instead of manually adding the data. This solves issues with datetime being out of sync.
* Fix an "Unknown table" error generated only in CI. I wasn't able to pinpoint the root cause so we may have to revisit it at some point. For now, I've just changed the code to ignore cases where the tables are missing.

## Testing Instructions

Try re-running the PHPUnit tests in CI using the "Re-run all jobs" button. Tests should be passing each time.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
