### PR TITLE
Add comment to use component only on the editor side

### DIFF
--- a/assets/shared/blocks/single-line-input/single-line-input.js
+++ b/assets/shared/blocks/single-line-input/single-line-input.js
@@ -11,7 +11,7 @@ import { forwardRef } from '@wordpress/element';
 import { ENTER, BACKSPACE } from '@wordpress/keycodes';
 
 /**
- * Single line input component.
+ * Single line input component, used for the editor only.
  *
  * @param {Object}   props           Component props.
  * @param {Function} props.onChange  Change callback.


### PR DESCRIPTION
## Proposed Changes

* It just adds a comment in a component to make sure it will be used on the editor only. The reason is that it imports a component from `@wordpress/block-editor`, which causes issues on the frontend. For context: p1699459538151769-slack-C02P7FHLVR9

In the future, we could make something more explicit, separating components for the editor side only in a specific folder.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No tests are needed since it just changes a comment in the code.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues