### PR TITLE
Add border styling ability for sensei buttons

### DIFF
--- a/assets/blocks/button/color-hooks.js
+++ b/assets/blocks/button/color-hooks.js
@@ -80,7 +80,7 @@ const removeColorProps = ( props ) => ( {
 		''
 	),
 	style: omitBy( props?.style, ( value, key ) =>
-		key.match( /(color|background|background-color)/ )
+		key.match( /(color|background|background-color|border)/ )
 	),
 } );
 

--- a/assets/blocks/button/color-props.js
+++ b/assets/blocks/button/color-props.js
@@ -36,6 +36,7 @@ export const getGradientClass = ( gradientSlug ) => {
 export const getColorAndStyleProps = ( { attributes, colors } ) => {
 	const {
 		backgroundColor,
+		borderColor,
 		customBackgroundColor,
 		textColor,
 		customTextColor,
@@ -47,13 +48,15 @@ export const getColorAndStyleProps = ( { attributes, colors } ) => {
 		'background-color',
 		backgroundColor
 	);
+
 	if ( ! style.color ) style.color = {};
 	if ( customBackgroundColor ) style.color.background = customBackgroundColor;
 	if ( customTextColor ) style.color.text = customTextColor;
 
+	const borderColorClass = getColorClassName( 'border-color', borderColor );
 	const gradientClass = getGradientClass( gradient );
 	const textClass = getColorClassName( 'color', textColor );
-	const className = classnames( textClass, gradientClass, {
+	const className = classnames( textClass, gradientClass, borderColorClass, {
 		// Don't apply the background class if there's a custom gradient
 		[ backgroundClass ]: ! style?.color?.gradient && !! backgroundClass,
 		'has-text-color': textColor || style?.color?.text,
@@ -62,6 +65,7 @@ export const getColorAndStyleProps = ( { attributes, colors } ) => {
 			style?.color?.background ||
 			gradient ||
 			style?.color?.gradient,
+		'has-border-color': borderColor,
 	} );
 	const styleProp =
 		style?.color?.background || style?.color?.text || style?.color?.gradient
@@ -75,6 +79,14 @@ export const getColorAndStyleProps = ( { attributes, colors } ) => {
 					color: style?.color?.text ? style.color.text : undefined,
 			  }
 			: {};
+
+	if ( style?.border?.color ) {
+		styleProp.borderColor = style.border.color;
+	}
+
+	if ( style?.border?.width ) {
+		styleProp.borderWidth = style.border.width;
+	}
 
 	// This is needed only for themes that don't load their color stylesheets in the editor
 	// We force an inline style to apply the color.

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -113,6 +113,12 @@ export const createButtonBlockType = ( {
 			},
 			usesContext: [ 'postType' ],
 			supports: {
+				__experimentalBorder: {
+					color: true,
+					width: true,
+					style: true,
+				},
+				border: true,
 				color: {
 					gradients: true,
 					link: true,

--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -100,11 +100,12 @@ export default [
 		},
 	},
 	{
+		// Deprecated since Sensei 4.19.2.
 		...courseThemeLessonActionsMeta,
 		...meta,
 		title: __( 'Lesson Actions (Learning Mode)', 'sensei-lms' ),
 		description: __(
-			'Display buttons for actions the learner can take for the current lesson.',
+			'(Deprecated) Display buttons for actions the learner can take for the current lesson.',
 			'sensei-lms'
 		),
 		attributes: {

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -295,14 +295,25 @@ $breakpoint: 782px;
 	}
 }
 
-.wp-block-sensei-lms-lesson-actions {
-	.wp-block-sensei-button.wp-block-button {
-		&.is-style-outline,
-		&.is-style-default {
-			border: none;
+.sensei-course-theme,
+.editor-styles-wrapper {
+	.wp-block-sensei-lms-lesson-actions {
+		.wp-block-sensei-button.wp-block-button {
+			&.is-style-outline,
+			&.is-style-default {
+				border: none;
+
+				.wp-block-button__link {
+					border: solid 1px var(--sensei-secondary-color);
+				}
+			}
+		}
+
+		.wp-block-sensei-button.wp-block-button.is-style-default {
+			background-color: unset;
 
 			.wp-block-button__link {
-				border: solid 1px var(--sensei-secondary-color);
+				background-color: var(--sensei-secondary-color);
 			}
 		}
 	}

--- a/changelog/add-border-styling-ability-for-action-buttons
+++ b/changelog/add-border-styling-ability-for-action-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added ability to change border color and width of lesson action buttons in learning mode

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -28,6 +28,8 @@ class Lesson_Actions {
 
 	/**
 	 * Lesson_Actions constructor.
+	 *
+	 * @deprecated $$next-version$$ Use the normal Lesson Actions block (Sensei_Lesson_Actions_Block) instead.
 	 */
 	public function __construct() {
 		$block_json_path = Sensei()->assets->src_path( 'course-theme/blocks' ) . self::BLOCK_JSON_FILE;


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7088
Part of the above issue - Handles the border color and width portion only. Stacked on https://github.com/Automattic/sensei/pull/7224

## Proposed Changes
* Many users have requested for this feature. We are adding the ability to change border color from editor for sensei buttons, especially lesson action buttons in learning mode. We are also allowing to change border width.

It'd be easier if the block was using API version 2, but changing to that could potentially break the buttons in different places for current users. So we did it as we used to do for our buttons.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Site editor
2. Open Lesson (Learning Mode - Default) template, clear any previous saved version of this template if there's any
3. Update the border color and border width of the lesson action buttons
4. The styles are getting updated as expected
5. Save the template
6. Go to frontend, open a lesson in a course with learning mode enabled
7. Make sure the style is getting applied there as expected
8. Check in different themes

#### Editor
![Screenshot 2023-11-10 at 6 05 03 PM](https://github.com/Automattic/sensei/assets/6820724/375ea6e8-e2f6-42e1-b079-3d8cccd08965)

#### Frontend
![Screenshot 2023-11-10 at 6 04 37 PM](https://github.com/Automattic/sensei/assets/6820724/db520950-855f-4b02-bf77-9969398745c9)


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
