### PR TITLE
Fix pending teacher grade button becoming wide

### DIFF
--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -182,7 +182,6 @@ $breakpoint: 782px;
 		justify-content: center;
 		padding: 0.83em 1.11em;
 		text-decoration: none;
-		width: 100%; // Fix the animation issue.
 
 		@media screen and (max-width: $breakpoint) {
 			padding: 0.83em 0.556em;

--- a/changelog/fix-pending-teacher-button-full-width
+++ b/changelog/fix-pending-teacher-button-full-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Pending grade button becoming wide in some themes


### PR DESCRIPTION
Resolves issue of pending teacher grade becoming wide in Divi and Astra

## Proposed Changes
* Removed an unnecessary width property from compat style of button

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable Astra theme
2. Create a lesson with a quiz, make sure auto grade is off
3. Take the quiz as a student
4. Make sure the pending grade button at the bottom isn't too wide
5. Check other lessons and quizzes to make sure other buttons are not broken

#### Before
![Screenshot 2023-11-14 at 12 59 46 PM](https://github.com/Automattic/sensei/assets/6820724/983b6632-85b2-4f81-8535-98c3399d94ef)

#### After
![Screenshot 2023-11-14 at 1 00 10 PM](https://github.com/Automattic/sensei/assets/6820724/853ad04d-a51f-4273-be97-2fc9f151ce47)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
