### PR TITLE
Fix contact teacher full width in learning mode

### DIFF
--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -321,3 +321,7 @@ $breakpoint: 782px;
 		line-height: normal;
 	}
 }
+
+.sensei-contact-teacher-wrapper {
+	display: flex;
+}

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -322,6 +322,8 @@ $breakpoint: 782px;
 	}
 }
 
-.sensei-contact-teacher-wrapper {
-	display: flex;
+.wp-block-post-content {
+	.sensei-contact-teacher-wrapper {
+		display: flex;
+	}
 }

--- a/changelog/fix-contact-teacher-full-width-in-learning-mode
+++ b/changelog/fix-contact-teacher-full-width-in-learning-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix contact teacher button becoming full width in learning mode


### PR DESCRIPTION
Resolves the issue of the Contact teacher button becoming full width in learning mode in Divi and Astra

## Proposed Changes
* Fixed contact teacher button becoming full width in learning mode. It was probably a side effect of [this change](https://github.com/Automattic/sensei/commit/d813122c15410a7169ce9e616331fe25d84e16e7).

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a course with a lesson
2. Add a contact teacher button in the lesson
3. Make sure learning mode is on
4. Enable Astra theme
5. Access the lesson as student from frontend
6. Make sure contact teacher button isn't full width.

#### Before
![Screenshot 2023-11-14 at 2 36 19 PM](https://github.com/Automattic/sensei/assets/6820724/ad9c0016-4baa-4b66-8d46-ccda5902d951)

##### After
![Screenshot 2023-11-14 at 2 36 33 PM](https://github.com/Automattic/sensei/assets/6820724/48666ccc-f9e9-409f-9893-dcc50f28f7b9)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
