### PR TITLE
Migrate legacy quiz data

### DIFF
--- a/changelog/update-migrate-quiz-answers
+++ b/changelog/update-migrate-quiz-answers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate legacy quiz data

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -17,10 +17,6 @@
       <code>$screen-&gt;id</code>
       <code>$screen-&gt;post_type</code>
     </PossiblyNullPropertyFetch>
-    <UndefinedFunction occurrences="2">
-      <code>'sensei_admin_load_learning_mode_style_for_course_theme'</code>
-      <code>'sensei_load_learning_mode_style_for_course_theme'</code>
-    </UndefinedFunction>
   </file>
   <file src="includes/admin/class-sensei-admin-notices.php">
     <DocblockTypeContradiction occurrences="2">
@@ -30,6 +26,10 @@
     <MissingFile occurrences="1">
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
+    <MissingPropertyType occurrences="2">
+      <code>Sensei()-&gt;version</code>
+      <code>Sensei()-&gt;version</code>
+    </MissingPropertyType>
     <PossiblyFalseArgument occurrences="3">
       <code>$plugin_version</code>
       <code>$plugin_version</code>
@@ -132,6 +132,9 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/admin/class-sensei-learners-admin-bulk-actions-controller.php">
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;version</code>
+    </MissingPropertyType>
     <PossiblyNullArgument occurrences="1">
       <code>$edit_course_cap</code>
     </PossiblyNullArgument>
@@ -163,12 +166,10 @@
       <code>$learner-&gt;user_id</code>
       <code>$learner-&gt;user_login</code>
     </InvalidPropertyFetch>
-    <InvalidScalarArgument occurrences="6">
-      <code>$course-&gt;ID</code>
+    <InvalidScalarArgument occurrences="4">
       <code>$full_name</code>
       <code>$full_name</code>
       <code>$this-&gt;total_items</code>
-      <code>$user_id</code>
       <code>Sensei_Learner::get_full_name( $learner-&gt;user_id )</code>
     </InvalidScalarArgument>
     <PossiblyInvalidPropertyFetch occurrences="3">
@@ -200,14 +201,7 @@
     <InvalidArgument occurrences="1">
       <code>'course-category'</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="9">
-      <code>$form_course_id</code>
-      <code>$form_lesson_id</code>
-      <code>$post_id</code>
-      <code>$post_id</code>
-      <code>$post_id</code>
-      <code>$post_id</code>
-      <code>$post_id</code>
+    <InvalidScalarArgument occurrences="2">
       <code>$title</code>
       <code>$title</code>
     </InvalidScalarArgument>
@@ -347,6 +341,9 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;plugin_path</code>
+    </MissingPropertyType>
     <PossiblyFalseArgument occurrences="1">
       <code>$installed_time</code>
     </PossiblyFalseArgument>
@@ -553,10 +550,6 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="includes/admin/tools/views/html-enrolment-debug-form.php">
-    <InvalidScalarArgument occurrences="2">
-      <code>$course_value</code>
-      <code>$user_value</code>
-    </InvalidScalarArgument>
     <RawObjectIteration occurrences="2">
       <code>$courses</code>
       <code>$users</code>
@@ -569,11 +562,6 @@
     <PossiblyFalseArgument occurrences="1">
       <code>$view_course_url</code>
     </PossiblyFalseArgument>
-  </file>
-  <file src="includes/admin/tools/views/html-recalculate-course-enrolment-form.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$course_value</code>
-    </InvalidScalarArgument>
   </file>
   <file src="includes/admin/views/html-admin-page-tools-header.php">
     <RedundantConditionGivenDocblockType occurrences="2">
@@ -640,6 +628,9 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>true</code>
+    </InvalidArgument>
     <MissingClosureParamType occurrences="1">
       <code>$attributes</code>
     </MissingClosureParamType>
@@ -665,9 +656,9 @@
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-block-contact-teacher.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>absint( $post-&gt;ID )</code>
-    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
   </file>
   <file src="includes/blocks/class-sensei-block-helpers.php">
     <DocblockTypeContradiction occurrences="1">
@@ -675,7 +666,12 @@
     </DocblockTypeContradiction>
   </file>
   <file src="includes/blocks/class-sensei-block-quiz-progress.php">
-    <PossiblyFalseArgument occurrences="1">
+    <InvalidScalarArgument occurrences="1">
+      <code>$lesson_id</code>
+    </InvalidScalarArgument>
+    <PossiblyFalseArgument occurrences="3">
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
       <code>$quiz_id</code>
     </PossiblyFalseArgument>
   </file>
@@ -719,6 +715,10 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$block_content</code>
     </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="2">
+      <code>true</code>
+      <code>true</code>
+    </InvalidArgument>
     <PossiblyInvalidCast occurrences="1">
       <code>$post</code>
     </PossiblyInvalidCast>
@@ -727,6 +727,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/blocks/class-sensei-complete-lesson-block.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink()</code>
     </PossiblyFalseArgument>
@@ -735,18 +738,21 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/blocks/class-sensei-conditional-content-block.php">
+    <InvalidScalarArgument occurrences="3">
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <PossiblyFalseArgument occurrences="1">
-      <code>$course_id</code>
+      <code>get_the_ID()</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="1">
-      <code>$course_id</code>
-    </PossiblyNullArgument>
   </file>
   <file src="includes/blocks/class-sensei-continue-course-block.php">
     <DocblockTypeContradiction occurrences="1">
       <code>$course_id</code>
     </DocblockTypeContradiction>
-    <PossiblyFalseArgument occurrences="3">
+    <PossiblyFalseArgument occurrences="4">
+      <code>$course_id</code>
       <code>$course_id</code>
       <code>$course_id</code>
       <code>get_permalink( absint( $target_post_id ?? $course_id ) )</code>
@@ -756,6 +762,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/blocks/class-sensei-course-blocks.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>get_post()</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullPropertyAssignment occurrences="1">
       <code>$post_type_object</code>
     </PossiblyNullPropertyAssignment>
@@ -790,12 +799,15 @@
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-outline-module-block.php">
+    <InvalidArgument occurrences="1">
+      <code>$module_id</code>
+    </InvalidArgument>
     <MissingClosureParamType occurrences="1">
       <code>$block</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
-      <code>function( $block ) use ( $course_id ) {</code>
-    </MissingClosureReturnType>
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;modules-&gt;taxonomy</code>
+    </MissingPropertyType>
   </file>
   <file src="includes/blocks/class-sensei-course-overview-block.php">
     <PossiblyFalseArgument occurrences="1">
@@ -803,7 +815,9 @@
     </PossiblyFalseArgument>
   </file>
   <file src="includes/blocks/class-sensei-course-progress-block.php">
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument occurrences="3">
+      <code>$course_id</code>
+      <code>$course_id</code>
       <code>$course_id</code>
     </PossiblyFalseArgument>
   </file>
@@ -829,6 +843,10 @@
     </PossiblyNullArgument>
   </file>
   <file src="includes/blocks/class-sensei-learner-messages-button-block.php">
+    <MissingPropertyType occurrences="2">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_post_type_archive_link( 'sensei_message' )</code>
     </PossiblyFalseArgument>
@@ -870,12 +888,20 @@
     </PossiblyNullPropertyAssignment>
   </file>
   <file src="includes/blocks/class-sensei-reset-lesson-block.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink()</code>
     </PossiblyFalseArgument>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$lesson-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
+  </file>
+  <file src="includes/blocks/class-sensei-view-quiz-block.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
   </file>
   <file src="includes/blocks/course-list/class-sensei-course-list-block.php">
     <RedundantConditionGivenDocblockType occurrences="2">
@@ -886,9 +912,6 @@
     <InvalidArgument occurrences="1">
       <code>'course-category'</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="1">
-      <code>$default_option</code>
-    </InvalidScalarArgument>
     <MissingClosureParamType occurrences="1">
       <code>$category</code>
     </MissingClosureParamType>
@@ -897,11 +920,20 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="includes/blocks/course-theme/class-course-navigation.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>string</code>
+    </InvalidNullableReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$status</code>
+    </NullableReturnStatement>
     <PossiblyFalseArgument occurrences="3">
       <code>get_permalink( $lesson_id )</code>
       <code>get_permalink( $lesson_id )</code>
       <code>get_permalink( $quiz_id )</code>
     </PossiblyFalseArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$quiz_id</code>
+    </PossiblyNullArgument>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>\Sensei_Utils::get_current_course()</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -920,12 +952,23 @@
     </PossiblyNullArgument>
   </file>
   <file src="includes/blocks/course-theme/class-lesson-actions.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>$course_id</code>
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $lesson_id )</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="2">
       <code>$lesson_id</code>
+      <code>$quiz_permalink</code>
     </PossiblyNullArgument>
+  </file>
+  <file src="includes/blocks/course-theme/class-lesson-module.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>! $module_term</code>
+      <code>$module_term</code>
+    </DocblockTypeContradiction>
   </file>
   <file src="includes/blocks/course-theme/class-lesson-video.php">
     <MissingClosureParamType occurrences="1">
@@ -940,6 +983,14 @@
       <code>$aria_label</code>
     </RedundantConditionGivenDocblockType>
   </file>
+  <file src="includes/blocks/course-theme/class-quiz-back-to-lesson.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$lesson_id</code>
+    </InvalidScalarArgument>
+    <PossiblyFalseArgument occurrences="1">
+      <code>get_the_ID()</code>
+    </PossiblyFalseArgument>
+  </file>
   <file src="includes/class-sensei-admin.php">
     <ArgumentTypeCoercion occurrences="3">
       <code>$args</code>
@@ -948,8 +999,13 @@
     <FalsableReturnStatement occurrences="1">
       <code>false</code>
     </FalsableReturnStatement>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument occurrences="6">
       <code>$args</code>
+      <code>'screen'</code>
+      <code>true</code>
+      <code>true</code>
+      <code>true</code>
+      <code>true</code>
     </InvalidArgument>
     <InvalidNullableReturnType occurrences="1">
       <code>array</code>
@@ -960,13 +1016,10 @@
     <InvalidReturnType occurrences="1">
       <code>object</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="6">
-      <code>$course-&gt;ID</code>
-      <code>$course-&gt;ID</code>
+    <InvalidScalarArgument occurrences="3">
       <code>$course_id</code>
-      <code>$course_id</code>
+      <code>$old_quiz_id</code>
       <code>'50'</code>
-      <code>intval( $course-&gt;ID )</code>
     </InvalidScalarArgument>
     <MissingDocblockType occurrences="2">
       <code>private $course_order_page_slug;</code>
@@ -985,9 +1038,10 @@
       <code>$post_id</code>
       <code>$settings</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="2">
+    <MissingPropertyType occurrences="3">
       <code>$course_order_page_slug</code>
       <code>$lesson_order_page_slug</code>
+      <code>Sensei()-&gt;plugin_url</code>
     </MissingPropertyType>
     <NullableReturnStatement occurrences="2">
       <code>$new_post</code>
@@ -1043,6 +1097,10 @@
     <TooManyArguments occurrences="1">
       <code>esc_html( sprintf( __( 'Please supply a %1$s ID.', 'sensei-lms' ) ), $post_type )</code>
     </TooManyArguments>
+    <UndefinedDocblockClass occurrences="2">
+      <code>Sensei()-&gt;setup_wizard-&gt;pages</code>
+      <code>Sensei()-&gt;setup_wizard-&gt;pages</code>
+    </UndefinedDocblockClass>
   </file>
   <file src="includes/class-sensei-analysis-course-list-table.php">
     <ArgumentTypeCoercion occurrences="1"/>
@@ -1157,9 +1215,21 @@
     <DeprecatedClass occurrences="1">
       <code>Sensei_Analysis_Overview_List_Table</code>
     </DeprecatedClass>
+    <DeprecatedMethod occurrences="1">
+      <code>get_average_days_to_completion</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="2">
+      <code>0</code>
+      <code>array( $lessons )</code>
+    </DocblockTypeContradiction>
     <FalsableReturnStatement occurrences="1">
       <code>wp_date( get_option( 'date_format' ), $date-&gt;getTimestamp(), $timezone )</code>
     </FalsableReturnStatement>
+    <InvalidArgument occurrences="3">
+      <code>$lessons</code>
+      <code>array( 'publish', 'private' )</code>
+      <code>array( 'publish', 'private' )</code>
+    </InvalidArgument>
     <InvalidFalsableReturnType occurrences="1">
       <code>string</code>
     </InvalidFalsableReturnType>
@@ -1173,9 +1243,10 @@
     <InvalidReturnType occurrences="1">
       <code>data</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="4">
+    <InvalidScalarArgument occurrences="5">
       <code>$this-&gt;total_items</code>
       <code>$this-&gt;total_items</code>
+      <code>$total_average_grade</code>
       <code>$value</code>
       <code>ceil( Sensei()-&gt;grading-&gt;get_courses_average_grade() )</code>
     </InvalidScalarArgument>
@@ -1199,6 +1270,10 @@
       <code>WooThemes_Sensei_Analysis_Overview_List_Table</code>
       <code>WooThemes_Sensei_Analysis_Overview_List_Table</code>
     </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>is_array( $lessons )</code>
+      <code>is_countable( $lessons )</code>
+    </RedundantConditionGivenDocblockType>
     <TooManyArguments occurrences="1">
       <code>remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_non_user_query' ), 10, 2 )</code>
     </TooManyArguments>
@@ -1299,17 +1374,13 @@
       <code>null === self::$instance</code>
     </DocblockTypeContradiction>
   </file>
-  <file src="includes/class-sensei-cli.php">
-    <UndefinedClass occurrences="1">
-      <code>WP_CLI</code>
-    </UndefinedClass>
-  </file>
   <file src="includes/class-sensei-core-lesson-modules.php">
     <MissingParamType occurrences="1">
       <code>$lesson_id</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="1">
+    <MissingPropertyType occurrences="2">
       <code>$lesson_id</code>
+      <code>Sensei()-&gt;modules-&gt;taxonomy</code>
     </MissingPropertyType>
     <ParadoxicalCondition occurrences="2">
       <code>! $module_id || empty( $module_id ) || ! $module_exists_in_course</code>
@@ -1347,7 +1418,8 @@
       <code>$post_args</code>
       <code>$post_args</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_wp_error( $modules )</code>
       <code>is_wp_error( $update_result )</code>
     </DocblockTypeContradiction>
     <FalsableReturnStatement occurrences="1">
@@ -1425,6 +1497,9 @@
       <code>get_post( $this-&gt;course_id )-&gt;post_author</code>
       <code>get_post( $this-&gt;course_id )-&gt;post_author</code>
     </PossiblyNullPropertyFetch>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$lessons_query instanceof WP_Query</code>
+    </RedundantConditionGivenDocblockType>
     <UndefinedMethod occurrences="3">
       <code>$create_result</code>
       <code>$lesson</code>
@@ -1457,11 +1532,19 @@
       <code>$course_quizzes</code>
       <code>$url</code>
     </FalsableReturnStatement>
-    <InvalidArgument occurrences="5">
+    <InvalidArgument occurrences="7">
       <code>$lesson_args</code>
       <code>$lesson_args</code>
       <code>$lesson_args</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
     </InvalidArgument>
+    <InvalidArrayOffset occurrences="4">
+      <code>$dimensions['height']</code>
+      <code>$dimensions['height']</code>
+      <code>$dimensions['width']</code>
+      <code>$dimensions['width']</code>
+    </InvalidArrayOffset>
     <InvalidDocblock occurrences="2">
       <code>public static function course_archive_filters( $query ) {</code>
       <code>public static function course_archive_sorting( $query ) {</code>
@@ -1497,35 +1580,23 @@
       <code>int</code>
       <code>string</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="13">
+    <InvalidScalarArgument occurrences="15">
       <code>$course-&gt;post_author</code>
       <code>$course-&gt;post_author</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
       <code>$i</code>
       <code>$i</code>
       <code>$i</code>
       <code>$i</code>
       <code>$id</code>
-      <code>$progress_percentage</code>
+      <code>$lesson_id</code>
+      <code>100</code>
+      <code>100</code>
       <code>[ $width, $height ]</code>
       <code>[ $width, $height ]</code>
-      <code>absint( $course_item-&gt;ID )</code>
-      <code>absint( $post_item-&gt;ID )</code>
       <code>round( $progress_percentage )</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="12">
-      <code>$allowed</code>
-      <code>$allowed</code>
-      <code>$allowed</code>
-      <code>$allowed</code>
-      <code>$meta_key</code>
-      <code>$meta_key</code>
-      <code>$meta_key</code>
-      <code>$meta_key</code>
-      <code>$post_id</code>
-      <code>$post_id</code>
-      <code>$post_id</code>
-      <code>$post_id</code>
-    </MissingClosureParamType>
     <MissingDocblockType occurrences="1">
       <code>public $token;</code>
     </MissingDocblockType>
@@ -1547,10 +1618,34 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="1">
+    <MissingPropertyType occurrences="24">
       <code>$token</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
     </MissingPropertyType>
-    <NullArgument occurrences="3">
+    <NullArgument occurrences="4">
+      <code>null</code>
       <code>null</code>
       <code>null</code>
       <code>null</code>
@@ -1604,7 +1699,8 @@
       <code>get_post( $course_id )-&gt;post_author</code>
       <code>get_post( get_the_ID() )-&gt;post_excerpt</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="12">
+    <PossiblyNullArgument occurrences="13">
+      <code>$course-&gt;ID</code>
       <code>$course-&gt;ID</code>
       <code>$course-&gt;ID</code>
       <code>$course-&gt;ID</code>
@@ -1637,7 +1733,10 @@
       <code>WooThemes_Sensei_Course</code>
       <code>WooThemes_Sensei_Course</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType occurrences="7">
+      <code>! is_wp_error( $modules )</code>
+      <code>! is_wp_error( $modules ) &amp;&amp; ! empty( $modules ) &amp;&amp; is_array( $modules )</code>
+      <code>is_array( $modules )</code>
       <code>is_array( $this-&gt;meta_fields )</code>
       <code>isset( $query-&gt;query )</code>
       <code>isset( $this-&gt;meta_fields ) &amp;&amp; is_array( $this-&gt;meta_fields )</code>
@@ -1717,6 +1816,30 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </MissingParamType>
+    <MissingPropertyType occurrences="22">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
     <PropertyNotSetInConstructor occurrences="3">
       <code>$_from_address</code>
       <code>$_from_name</code>
@@ -1735,10 +1858,19 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$creds</code>
     </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="4">
+      <code>$lesson_id</code>
+      <code>true</code>
+      <code>true</code>
+      <code>true</code>
+    </InvalidArgument>
     <InvalidArrayAccess occurrences="2">
       <code>$sorted_menu_items[ $k ]</code>
       <code>$sorted_menu_items[ $k ]</code>
     </InvalidArrayAccess>
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <MissingParamType occurrences="5">
       <code>$course_id</code>
       <code>$course_id</code>
@@ -1746,12 +1878,36 @@
       <code>$post_id</code>
       <code>$title</code>
     </MissingParamType>
+    <MissingPropertyType occurrences="20">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;token</code>
+      <code>Sensei()-&gt;token</code>
+    </MissingPropertyType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$tags</code>
     </PossibleRawObjectIteration>
-    <PossiblyFalseArgument occurrences="16">
+    <PossiblyFalseArgument occurrences="18">
       <code>$id</code>
       <code>$id</code>
+      <code>$post_id</code>
+      <code>$post_id</code>
       <code>$post_id</code>
       <code>$post_id</code>
       <code>$post_id</code>
@@ -1805,6 +1961,14 @@
   </file>
   <file src="includes/class-sensei-grading-main.php">
     <ArgumentTypeCoercion occurrences="1"/>
+    <InvalidArrayAccess occurrences="6">
+      <code>$counts['complete']</code>
+      <code>$counts['failed']</code>
+      <code>$counts['graded']</code>
+      <code>$counts['in-progress']</code>
+      <code>$counts['passed']</code>
+      <code>$counts['ungraded']</code>
+    </InvalidArrayAccess>
     <InvalidScalarArgument occurrences="1">
       <code>$title</code>
     </InvalidScalarArgument>
@@ -1834,23 +1998,27 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/class-sensei-grading-user-quiz.php">
-    <InvalidScalarArgument occurrences="12">
-      <code>$count</code>
-      <code>$graded_count</code>
+    <InvalidScalarArgument occurrences="9">
+      <code>$attachment_id</code>
       <code>$lesson_status_id</code>
+      <code>$question_grade_total</code>
       <code>$quiz_grade</code>
       <code>$quiz_grade</code>
       <code>$quiz_grade_total</code>
-      <code>$this-&gt;quiz_id</code>
-      <code>$this-&gt;user_id</code>
-      <code>$user_question_grade</code>
-      <code>$user_quiz_grade_total</code>
+      <code>$quiz_grade_total</code>
       <code>$user_quiz_grade_total</code>
       <code>$user_quiz_grade_total</code>
     </InvalidScalarArgument>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument occurrences="2">
       <code>$answer_media_url</code>
+      <code>$user_answer_content</code>
     </PossiblyFalseArgument>
+    <PossiblyFalseOperand occurrences="1">
+      <code>$user_question_grade</code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument occurrences="1">
+      <code>$user_answer_content</code>
+    </PossiblyNullArgument>
   </file>
   <file src="includes/class-sensei-grading.php">
     <DocblockTypeContradiction occurrences="1">
@@ -1860,6 +2028,10 @@
       <code>false</code>
       <code>false</code>
     </FalsableReturnStatement>
+    <InvalidArrayAccess occurrences="2">
+      <code>$grading_counts['ungraded']</code>
+      <code>$grading_counts['ungraded']</code>
+    </InvalidArrayAccess>
     <InvalidIterator occurrences="1">
       <code>$lesson_metadata</code>
     </InvalidIterator>
@@ -1871,11 +2043,12 @@
       <code>int</code>
       <code>string</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="4">
+    <InvalidScalarArgument occurrences="5">
+      <code>$quiz_lesson_id</code>
+      <code>$quiz_lesson_id</code>
+      <code>$quiz_lesson_id</code>
       <code>$user_name</code>
       <code>$user_name</code>
-      <code>absint( $course_id )</code>
-      <code>absint( $lesson_id )</code>
     </InvalidScalarArgument>
     <MissingParamType occurrences="10">
       <code>$course_id</code>
@@ -1889,10 +2062,11 @@
       <code>$user_id</code>
       <code>$which</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="4">
       <code>$file</code>
       <code>$name</code>
       <code>$page_slug</code>
+      <code>Sensei()-&gt;token</code>
     </MissingPropertyType>
     <PossiblyFalseArgument occurrences="1">
       <code>wp_json_encode( $args )</code>
@@ -1956,6 +2130,11 @@
     <InvalidScalarArgument occurrences="1">
       <code>$name</code>
     </InvalidScalarArgument>
+    <MissingPropertyType occurrences="3">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;token</code>
+    </MissingPropertyType>
   </file>
   <file src="includes/class-sensei-learner.php">
     <DocblockTypeContradiction occurrences="5">
@@ -1981,16 +2160,18 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/class-sensei-lesson.php">
-    <ArgumentTypeCoercion occurrences="4">
+    <ArgumentTypeCoercion occurrences="5">
       <code>$post_type_args</code>
       <code>$post_type_args</code>
+      <code>$questions_array</code>
       <code>'WP_Post'</code>
       <code>'WP_User'</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction occurrences="5">
       <code>! isset( $lesson_id )</code>
       <code>! isset( $question-&gt;ID )</code>
       <code>- 1 !== $new_course</code>
+      <code>-1</code>
       <code>-1 !== $new_complexity</code>
     </DocblockTypeContradiction>
     <FalsableReturnStatement occurrences="2">
@@ -2006,6 +2187,12 @@
       <code>$qargs</code>
       <code>'question-category'</code>
     </InvalidArgument>
+    <InvalidArrayOffset occurrences="4">
+      <code>$dimensions['height']</code>
+      <code>$dimensions['height']</code>
+      <code>$dimensions['width']</code>
+      <code>$dimensions['width']</code>
+    </InvalidArrayOffset>
     <InvalidFalsableReturnType occurrences="1">
       <code>string|null</code>
     </InvalidFalsableReturnType>
@@ -2022,12 +2209,17 @@
     <InvalidReturnType occurrences="1">
       <code>int|null</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="20">
+    <InvalidScalarArgument occurrences="28">
       <code>$course_id</code>
-      <code>$i</code>
-      <code>$i</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
       <code>$id</code>
       <code>$pre_requisite_id</code>
+      <code>$question_id</code>
+      <code>$question_id</code>
       <code>$question_id</code>
       <code>$question_id</code>
       <code>$question_id</code>
@@ -2036,17 +2228,17 @@
       <code>$quiz_id</code>
       <code>$quiz_id</code>
       <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
       <code>$return</code>
       <code>$return</code>
       <code>$this-&gt;get_course_id( $post-&gt;ID )</code>
       <code>$total_right</code>
       <code>$total_wrong</code>
-      <code>absint( $post_item-&gt;ID )</code>
+      <code>$user_id</code>
       <code>array( $width, $height )</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="1">
-      <code>$lesson</code>
-    </MissingClosureParamType>
     <MissingParamType occurrences="39">
       <code>$column_name</code>
       <code>$content</code>
@@ -2088,24 +2280,26 @@
       <code>$user_id</code>
       <code>$widget</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="7">
       <code>$allowed_html</code>
       <code>$meta_fields</code>
       <code>$token</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
     </MissingPropertyType>
     <NullableReturnStatement occurrences="3">
       <code>$this-&gt;get_videopress_thumbnail( $url )</code>
       <code>$this-&gt;get_vimeo_thumbnail( $url )</code>
       <code>$this-&gt;get_youtube_thumbnail( $url )</code>
     </NullableReturnStatement>
-    <PossibleRawObjectIteration occurrences="4">
+    <PossibleRawObjectIteration occurrences="3">
       <code>$question_cats</code>
       <code>$question_cats</code>
       <code>$question_cats</code>
-      <code>$questions_array</code>
     </PossibleRawObjectIteration>
-    <PossiblyFalseArgument occurrences="15">
-      <code>$lesson_id</code>
+    <PossiblyFalseArgument occurrences="17">
       <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
@@ -2135,12 +2329,13 @@
       <code>$question_cats</code>
       <code>$question_cats</code>
     </PossiblyInvalidIterator>
-    <PossiblyInvalidPropertyFetch occurrences="21">
+    <PossiblyInvalidPropertyFetch occurrences="22">
       <code>$attachment-&gt;post_title</code>
       <code>$cat-&gt;count</code>
       <code>$cat-&gt;count</code>
       <code>$cat-&gt;name</code>
       <code>$cat_question-&gt;ID</code>
+      <code>$lesson-&gt;ID</code>
       <code>$lesson-&gt;ID</code>
       <code>$lesson-&gt;post_content</code>
       <code>$lesson-&gt;post_status</code>
@@ -2158,16 +2353,18 @@
       <code>get_post()-&gt;post_author</code>
       <code>get_post()-&gt;post_author</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="16">
+    <PossiblyNullArgument occurrences="18">
       <code>$cat-&gt;name</code>
       <code>$edit_course_url</code>
       <code>$lesson-&gt;post_status</code>
       <code>$lesson-&gt;post_title</code>
+      <code>$lesson_id</code>
       <code>$post-&gt;post_content</code>
       <code>$post_type-&gt;cap-&gt;edit_post</code>
       <code>$question-&gt;post_content</code>
       <code>$question-&gt;post_title</code>
       <code>$question-&gt;post_title</code>
+      <code>$quiz_id</code>
       <code>get_edit_post_link( absint( $lesson_course_id ) )</code>
       <code>get_edit_post_link( absint( $lesson_prerequisite_id ) )</code>
       <code>get_post_type_object( 'course' )-&gt;cap-&gt;edit_post</code>
@@ -2206,18 +2403,22 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$lesson_id_updating</code>
     </PropertyNotSetInConstructor>
-    <RedundantCondition occurrences="2">
+    <RedundantCondition occurrences="3">
       <code>is_array( $question_data )</code>
       <code>is_array( $question_data )</code>
+      <code>is_countable( $questions_array )</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType occurrences="6">
       <code>! is_wp_error( $multiple_id )</code>
+      <code>$module_term</code>
+      <code>$module_term</code>
       <code>- 1 !== $new_course</code>
       <code>-1 !== $new_complexity</code>
       <code>is_array( $data ) &amp;&amp; count( $data ) &gt; 0</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType occurrences="2">
       <code>! isset( $row_counter )</code>
+      <code>0</code>
     </TypeDoesNotContainType>
     <UndefinedPropertyFetch occurrences="2">
       <code>$cat-&gt;name</code>
@@ -2279,7 +2480,7 @@
     <InvalidReturnType occurrences="1">
       <code>string</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="9">
+    <InvalidScalarArgument occurrences="8">
       <code>$comment-&gt;comment_ID</code>
       <code>$comment-&gt;comment_post_ID</code>
       <code>$comment-&gt;comment_post_ID</code>
@@ -2288,7 +2489,6 @@
       <code>$post-&gt;ID</code>
       <code>$post-&gt;post_author</code>
       <code>$post_id</code>
-      <code>absint( $post-&gt;ID )</code>
     </InvalidScalarArgument>
     <MissingParamType occurrences="9">
       <code>$comment_id</code>
@@ -2301,10 +2501,14 @@
       <code>$query</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="7">
       <code>$meta_fields</code>
       <code>$post_type</code>
       <code>$token</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
     </MissingPropertyType>
     <PossiblyFalseArgument occurrences="6">
       <code>get_permalink( $content_post_id )</code>
@@ -2402,18 +2606,15 @@
       <code>WP_Query</code>
       <code>integer</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="11">
+    <InvalidScalarArgument occurrences="8">
       <code>$course-&gt;post_author</code>
-      <code>$course_id</code>
       <code>$course_id</code>
       <code>$course_id</code>
       <code>$possible_user_id</code>
       <code>$post_after-&gt;post_author</code>
       <code>$term</code>
       <code>$term</code>
-      <code>absint( $module-&gt;term_id )</code>
       <code>esc_attr( $_POST['course_id'] )</code>
-      <code>intval( $course-&gt;ID )</code>
     </InvalidScalarArgument>
     <MissingParamType occurrences="21">
       <code>$args</code>
@@ -2438,11 +2639,21 @@
       <code>$title</code>
       <code>$user_id</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="10">
       <code>$file</code>
       <code>$order_page_slug</code>
       <code>$taxonomy</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;version</code>
+      <code>Sensei()-&gt;version</code>
     </MissingPropertyType>
+    <ParadoxicalCondition occurrences="1">
+      <code>! $modules || empty( $modules )</code>
+    </ParadoxicalCondition>
     <PossibleRawObjectIteration occurrences="3">
       <code>$modules</code>
       <code>$modules</code>
@@ -2523,10 +2734,9 @@
       <code>isset( $courses ) &amp;&amp; is_array( $courses )</code>
       <code>isset( $lesson_query-&gt;posts )</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="3">
+    <TypeDoesNotContainType occurrences="2">
       <code>$tax_name === 'category'</code>
       <code>$tax_name === 'category'</code>
-      <code>empty( $modules )</code>
     </TypeDoesNotContainType>
     <UndefinedMagicPropertyFetch occurrences="5">
       <code>$module-&gt;description</code>
@@ -2555,6 +2765,9 @@
     <MissingPropertyType occurrences="1">
       <code>$notices</code>
     </MissingPropertyType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>get_post()</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="includes/class-sensei-posttypes.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -2579,10 +2792,15 @@
     <InvalidStringClass occurrences="1">
       <code>new $class_name()</code>
     </InvalidStringClass>
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="8">
       <code>$role_caps</code>
       <code>$slider_labels</code>
       <code>$token</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
     </MissingPropertyType>
     <PossiblyFalseArgument occurrences="4">
       <code>get_permalink( $post_ID )</code>
@@ -2655,14 +2873,36 @@
       <code>public static function gap_fill_load_question_data( $question_data, $question_id, $quiz_id ) {</code>
       <code>public static function multiple_choice_load_question_data( $question_data, $question_id, $quiz_id ) {</code>
     </InvalidDocblock>
-    <InvalidScalarArgument occurrences="7">
-      <code>$attachment_src[1]</code>
-      <code>$attachment_src[2]</code>
+    <InvalidScalarArgument occurrences="29">
       <code>$id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
       <code>$question_id</code>
       <code>$question_id</code>
       <code>$question_id</code>
       <code>$question_id</code>
+      <code>$question_id</code>
+      <code>$question_id</code>
+      <code>$question_id</code>
+      <code>$question_id</code>
+      <code>$question_id</code>
+      <code>Sensei()-&gt;lesson-&gt;get_course_id( $lesson_id )</code>
     </InvalidScalarArgument>
     <MissingParamType occurrences="18">
       <code>$post</code>
@@ -2689,11 +2929,13 @@
       <code>$cats</code>
       <code>$question_types</code>
     </PossibleRawObjectIteration>
-    <PossiblyFalseArgument occurrences="6">
+    <PossiblyFalseArgument occurrences="8">
       <code>$answer_media_url</code>
       <code>$question_media_url</code>
       <code>$question_media_url</code>
       <code>$question_media_url</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
       <code>$quiz_id</code>
       <code>size_format( $upload_size )</code>
     </PossiblyFalseArgument>
@@ -2723,7 +2965,6 @@
       <code>$quiz-&gt;post_author</code>
       <code>$quiz-&gt;post_type</code>
       <code>$user_lesson_status-&gt;comment_approved</code>
-      <code>$user_lesson_status-&gt;comment_approved</code>
       <code>get_post( $question_id )-&gt;post_content</code>
     </PossiblyInvalidPropertyFetch>
     <PossiblyNullArgument occurrences="4">
@@ -2743,23 +2984,21 @@
     </TypeDoesNotContainType>
   </file>
   <file src="includes/class-sensei-quiz.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$my_post</code>
-    </ArgumentTypeCoercion>
     <DeprecatedProperty occurrences="1">
       <code>$this-&gt;file</code>
     </DeprecatedProperty>
-    <DocblockTypeContradiction occurrences="11">
+    <DocblockTypeContradiction occurrences="7">
       <code>! $encoded_feedback</code>
       <code>! $encoded_feedback</code>
-      <code>! is_array( $all_feedback )</code>
       <code>! is_array( $quiz_answers )</code>
       <code>! is_array( $quiz_answers )</code>
       <code>! is_array( $unprepared_answers )</code>
-      <code>! is_array( $users_answers )</code>
+      <code>0</code>
       <code>empty( $lesson_id ) || empty( $user_id ) || ! is_array( $quiz_answers )</code>
-      <code>is_int( $user_grade )</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>$my_post</code>
+    </InvalidArgument>
     <InvalidDocblock occurrences="1">
       <code>public function reset_button_click_listener() {</code>
     </InvalidDocblock>
@@ -2770,11 +3009,6 @@
       <code>array</code>
       <code>array</code>
     </InvalidNullableReturnType>
-    <InvalidPropertyFetch occurrences="3">
-      <code>$comment-&gt;comment_content</code>
-      <code>$question_activity-&gt;comment_ID</code>
-      <code>$question_activity-&gt;comment_ID</code>
-    </InvalidPropertyFetch>
     <InvalidReturnStatement occurrences="2">
       <code>$posts</code>
       <code>true</code>
@@ -2782,7 +3016,26 @@
     <InvalidReturnType occurrences="1">
       <code>false|int</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="13">
+    <InvalidScalarArgument occurrences="32">
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
@@ -2809,8 +3062,12 @@
       <code>self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-correct' )</code>
       <code>self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-incorrect' )</code>
     </NullableReturnStatement>
-    <ParadoxicalCondition occurrences="2"/>
-    <PossiblyFalseArgument occurrences="10">
+    <PossiblyFalseArgument occurrences="15">
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
       <code>$quiz_id</code>
       <code>$quiz_id</code>
       <code>$quiz_id</code>
@@ -2836,9 +3093,17 @@
       <code>$saved_lesson-&gt;post_name</code>
       <code>$saved_lesson-&gt;post_title</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="10">
       <code>$lesson-&gt;ID</code>
       <code>$question-&gt;post_content</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="6">
       <code>$lesson-&gt;ID</code>
@@ -2848,8 +3113,9 @@
       <code>$saved_lesson-&gt;post_name</code>
       <code>$saved_lesson-&gt;post_title</code>
     </PossiblyNullPropertyFetch>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType occurrences="2">
       <code>! is_wp_error( $grade )</code>
+      <code>is_countable( $all_questions )</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedConstant occurrences="6">
       <code>DAY_IN_SECONDS</code>
@@ -2924,7 +3190,11 @@
       <code>$new_value</code>
       <code>$setting</code>
     </MissingParamType>
-    <PossiblyFalseArgument occurrences="1">
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;version</code>
+    </MissingPropertyType>
+    <PossiblyFalseArgument occurrences="2">
+      <code>\Sensei()-&gt;install_version</code>
       <code>wp_json_encode( $inline_data )</code>
     </PossiblyFalseArgument>
     <PossiblyInvalidArgument occurrences="2">
@@ -2943,19 +3213,23 @@
     </RedundantCondition>
   </file>
   <file src="includes/class-sensei-teacher.php">
-    <ArgumentTypeCoercion occurrences="8">
+    <ArgumentTypeCoercion occurrences="7">
       <code>$args</code>
       <code>$user</code>
       <code>'WP_Role'</code>
       <code>'WP_Role'</code>
       <code>'WP_Role'</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="6">
+    <DocblockTypeContradiction occurrences="10">
+      <code>! $course_id</code>
       <code>! $term_author</code>
       <code>! $term_author</code>
       <code>! is_admin() || ! $this-&gt;is_admin_teacher() || is_numeric( $comments )</code>
       <code>! is_array( $args )</code>
       <code>! is_array( $comments )</code>
+      <code>! is_array( $courses )</code>
+      <code>! is_array( $courses_with_edit_permission )</code>
+      <code>! is_array( $lessons )</code>
       <code>is_numeric( $comments )</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1">
@@ -2971,18 +3245,19 @@
     <InvalidPropertyFetch occurrences="1">
       <code>$activity_comments-&gt;user_id</code>
     </InvalidPropertyFetch>
-    <InvalidScalarArgument occurrences="2">
+    <InvalidScalarArgument occurrences="4">
       <code>$course-&gt;post_author</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
       <code>$module_course-&gt;post_author</code>
     </InvalidScalarArgument>
     <MissingDocblockType occurrences="1">
       <code>public function teacher_filter_query_modify( $query ) {</code>
     </MissingDocblockType>
-    <MissingParamType occurrences="23">
+    <MissingParamType occurrences="21">
       <code>$clauses</code>
       <code>$column</code>
       <code>$columns</code>
-      <code>$course_id</code>
       <code>$course_id</code>
       <code>$course_id</code>
       <code>$data</code>
@@ -2999,7 +3274,6 @@
       <code>$query</code>
       <code>$questions</code>
       <code>$quiz_id</code>
-      <code>$teacher_id</code>
       <code>$wp_query</code>
       <code>$wp_query</code>
     </MissingParamType>
@@ -3007,7 +3281,11 @@
       <code>$teacher_role</code>
       <code>$token</code>
     </MissingPropertyType>
-    <ParadoxicalCondition occurrences="1">
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <ParadoxicalCondition occurrences="2">
+      <code>empty( $course_id ) || ! $course_id</code>
       <code>empty( $lesson_id ) || ! $lesson_id</code>
     </ParadoxicalCondition>
     <PossiblyInvalidPropertyFetch occurrences="16">
@@ -3028,8 +3306,9 @@
       <code>$user-&gt;ID</code>
       <code>$user-&gt;roles</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="3">
       <code>$course-&gt;post_author</code>
+      <code>$lesson-&gt;ID</code>
       <code>$term-&gt;slug</code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="10">
@@ -3044,13 +3323,13 @@
       <code>$screen-&gt;id</code>
       <code>$term-&gt;slug</code>
     </PossiblyNullPropertyFetch>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>! empty( $course_lessons ) &amp;&amp; is_array( $course_lessons )</code>
       <code>! is_wp_error( $search_term )</code>
+      <code>is_array( $course_lessons )</code>
       <code>isset( $screen-&gt;id )</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="4">
-      <code>! $course_id</code>
-      <code>! $course_id</code>
+    <TypeDoesNotContainType occurrences="2">
       <code>! $lesson_id</code>
       <code>empty( $this-&gt;teacher_role )</code>
     </TypeDoesNotContainType>
@@ -3072,6 +3351,29 @@
       <code>$template_name</code>
       <code>$template_name</code>
     </MissingParamType>
+    <MissingPropertyType occurrences="21">
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+    </MissingPropertyType>
     <PossiblyFalseOperand occurrences="1">
       <code>get_permalink( $post-&gt;ID )</code>
     </PossiblyFalseOperand>
@@ -3141,6 +3443,12 @@
     <InvalidReturnType occurrences="1">
       <code>DateTimeImmutable[]</code>
     </InvalidReturnType>
+    <MissingPropertyType occurrences="4">
+      <code>Sensei()-&gt;version</code>
+      <code>Sensei()-&gt;version</code>
+      <code>Sensei()-&gt;version</code>
+      <code>Sensei()-&gt;version</code>
+    </MissingPropertyType>
     <PossiblyNullArgument occurrences="4">
       <code>$this-&gt;current_version</code>
       <code>$this-&gt;current_version</code>
@@ -3164,8 +3472,15 @@
     <DocblockTypeContradiction occurrences="1">
       <code>0</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="4">
+    <InvalidArgument occurrences="11">
       <code>$key</code>
+      <code>$published_quiz_ids</code>
+      <code>$published_quiz_ids</code>
+      <code>$published_quiz_ids</code>
+      <code>$published_quiz_ids</code>
+      <code>$published_quiz_ids</code>
+      <code>$published_quiz_ids</code>
+      <code>$published_quiz_ids</code>
       <code>'module'</code>
       <code>'module'</code>
       <code>'module'</code>
@@ -3199,13 +3514,23 @@
       <code>int</code>
       <code>int</code>
     </InvalidReturnType>
-    <PossiblyInvalidArgument occurrences="2">
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
+    <PossiblyInvalidArgument occurrences="6">
       <code>$learner_terms</code>
       <code>$learner_terms</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$question</code>
+      <code>$question</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$course-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$quiz_id</code>
+    </PossiblyNullArgument>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_array( $courses )</code>
     </RedundantConditionGivenDocblockType>
@@ -3215,6 +3540,10 @@
       <code>$fields</code>
       <code>$fields</code>
     </MissingClosureParamType>
+    <MissingPropertyType occurrences="2">
+      <code>Sensei()-&gt;version</code>
+      <code>Sensei()-&gt;version</code>
+    </MissingPropertyType>
     <TypeDoesNotContainType occurrences="1">
       <code>false</code>
     </TypeDoesNotContainType>
@@ -3238,30 +3567,39 @@
       <code>false</code>
       <code>wp_date( get_option( 'date_format' ), $date-&gt;getTimestamp(), $timezone )</code>
     </FalsableReturnStatement>
+    <InvalidArgument occurrences="2">
+      <code>$id</code>
+      <code>$lesson_id</code>
+    </InvalidArgument>
     <InvalidFalsableReturnType occurrences="1">
       <code>string</code>
     </InvalidFalsableReturnType>
     <InvalidNullableReturnType occurrences="1">
       <code>bool</code>
     </InvalidNullableReturnType>
-    <InvalidReturnStatement occurrences="3">
+    <InvalidReturnStatement occurrences="4">
       <code>$activity_logged</code>
       <code>$activity_logged</code>
-      <code>$success</code>
+      <code>Sensei()-&gt;quiz-&gt;get_lesson_id( $post-&gt;ID )</code>
+      <code>current( $not_completed_lessons )</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="3">
-      <code>bool</code>
       <code>boolean</code>
       <code>boolean</code>
+      <code>int</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="11">
+    <InvalidScalarArgument occurrences="15">
       <code>$comment_id</code>
       <code>$comment_id</code>
+      <code>$course_id</code>
       <code>$data_key</code>
+      <code>$lesson_id</code>
       <code>$post_id</code>
       <code>$user_answer_id</code>
       <code>$user_answer_id</code>
       <code>$user_answer_id</code>
+      <code>$user_id</code>
+      <code>$user_id</code>
       <code>$user_id</code>
       <code>$user_id</code>
       <code>$user_id</code>
@@ -3272,28 +3610,28 @@
       <code>require_once ABSPATH . 'wp-admin/includes/image.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/plugin-install.php'</code>
     </MissingFile>
-    <MissingParamType occurrences="18">
+    <MissingParamType occurrences="15">
       <code>$attributes</code>
       <code>$course_id</code>
       <code>$data_key</code>
       <code>$file</code>
       <code>$from_course</code>
       <code>$key</code>
-      <code>$mode</code>
       <code>$options</code>
       <code>$plugin_class_to_look_for</code>
       <code>$plugin_registered_path</code>
       <code>$post_id</code>
-      <code>$question_id</code>
-      <code>$quiz_id</code>
       <code>$quiz_id</code>
       <code>$quiz_id</code>
       <code>$setting_name</code>
       <code>$trigger_completion_action</code>
       <code>$user_id</code>
-      <code>$user_id</code>
-      <code>$user_id</code>
     </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>Sensei()-&gt;plugin_url</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
     <PossibleRawObjectIteration occurrences="1">
       <code>$attributes</code>
     </PossibleRawObjectIteration>
@@ -3317,6 +3655,20 @@
       <code>get_userdata( $user_id )-&gt;user_login</code>
       <code>get_userdata( $user_id )-&gt;user_login</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyNullArgument occurrences="8">
+      <code>$lesson_quiz_id</code>
+      <code>$quiz_grade</code>
+      <code>$quiz_grade</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>get_id</code>
+      <code>get_id</code>
+    </PossiblyNullReference>
     <RedundantCondition occurrences="2">
       <code>is_array( $comments )</code>
       <code>isset( $_GET )</code>
@@ -3340,6 +3692,10 @@
     <InvalidReturnStatement occurrences="1">
       <code>$default</code>
     </InvalidReturnStatement>
+    <MissingPropertyType occurrences="2">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
     <TypeDoesNotContainNull occurrences="4">
       <code>'brackets' === $format</code>
       <code>'full' === $format</code>
@@ -3389,8 +3745,9 @@
     <InvalidGlobal occurrences="1">
       <code>global $sensei_modules;</code>
     </InvalidGlobal>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument occurrences="2">
       <code>$is_upgrade</code>
+      <code>$lesson_id</code>
     </InvalidScalarArgument>
     <MissingDocblockType occurrences="1">
       <code>private $id;</code>
@@ -3402,7 +3759,7 @@
       <code>$main_plugin_file_name</code>
       <code>$plugin</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="12">
+    <MissingPropertyType occurrences="13">
       <code>$id</code>
       <code>$plugin_path</code>
       <code>$plugin_url</code>
@@ -3415,7 +3772,12 @@
       <code>$this-&gt;version</code>
       <code>$token</code>
       <code>$version</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
     </MissingPropertyType>
+    <PossiblyFalseArgument occurrences="2">
+      <code>get_the_ID()</code>
+      <code>get_the_ID()</code>
+    </PossiblyFalseArgument>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -3499,10 +3861,6 @@
       <code>$user_id</code>
       <code>$user_id</code>
     </PossiblyInvalidCast>
-    <UndefinedClass occurrences="2">
-      <code>WP_CLI</code>
-      <code>WP_CLI</code>
-    </UndefinedClass>
   </file>
   <file src="includes/course-theme/class-sensei-course-theme-compat.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -3526,6 +3884,9 @@
     <InvalidDocblock occurrences="1">
       <code>WP_Post?</code>
     </InvalidDocblock>
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <MissingParamType occurrences="1">
       <code>$post</code>
     </MissingParamType>
@@ -3539,15 +3900,29 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
+    <InvalidScalarArgument occurrences="6">
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <PossiblyFalseArgument occurrences="4">
       <code>$current_link</code>
       <code>$current_link</code>
       <code>get_permalink( $course_id )</code>
       <code>get_permalink( $lesson_prerequisite )</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="4">
       <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$quiz_id</code>
     </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>get_status</code>
+    </PossiblyNullReference>
   </file>
   <file src="includes/course-theme/class-sensei-course-theme-option.php">
     <DocblockTypeContradiction occurrences="3">
@@ -3555,7 +3930,8 @@
       <code>null === get_post_type( 'lesson' )</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument occurrences="2">
+      <code>$course_id</code>
       <code>'lesson'</code>
     </InvalidScalarArgument>
     <MissingClosureParamType occurrences="3">
@@ -3576,15 +3952,17 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <NullArgument occurrences="1">
-      <code>null</code>
-    </NullArgument>
+    <MissingPropertyType occurrences="2">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink()</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="3">
       <code>$lesson_id</code>
       <code>$lesson_id</code>
+      <code>$quiz_id</code>
     </PossiblyNullArgument>
   </file>
   <file src="includes/course-theme/class-sensei-course-theme-styles.php">
@@ -3639,6 +4017,10 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$post-&gt;post_author</code>
     </InvalidPropertyAssignmentValue>
+    <InvalidScalarArgument occurrences="2">
+      <code>$course_id</code>
+      <code>$matches[1]</code>
+    </InvalidScalarArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$query['post_type'] ?? null</code>
     </PossiblyNullArgument>
@@ -3659,9 +4041,13 @@
       <code>self::$instance</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1"/>
-    <PossiblyFalseArgument occurrences="2">
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;plugin_url</code>
+    </MissingPropertyType>
+    <PossiblyFalseArgument occurrences="3">
       <code>get_permalink( $module_lessons[0] )</code>
       <code>get_post_type()</code>
+      <code>get_the_ID()</code>
     </PossiblyFalseArgument>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$lesson-&gt;ID</code>
@@ -3739,6 +4125,9 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>true</code>
+    </InvalidArgument>
     <MissingClosureParamType occurrences="3">
       <code>$allowed</code>
       <code>$meta_key</code>
@@ -3842,9 +4231,6 @@
       <code>get_import_id</code>
       <code>is_complete</code>
     </PossiblyNullReference>
-    <UndefinedClass occurrences="1">
-      <code>WP_CLI</code>
-    </UndefinedClass>
     <UndefinedConstant occurrences="1">
       <code>DAY_IN_SECONDS</code>
     </UndefinedConstant>
@@ -4017,6 +4403,10 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>get_term( $module_term_id )-&gt;name</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyNullArgument occurrences="2">
+      <code>$quiz_id</code>
+      <code>$quiz_id</code>
+    </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>get_term( $module_term_id )-&gt;name</code>
     </PossiblyNullPropertyFetch>
@@ -4043,10 +4433,6 @@
     <InvalidFalsableReturnType occurrences="1">
       <code>string</code>
     </InvalidFalsableReturnType>
-    <MissingClosureParamType occurrences="2">
-      <code>$value</code>
-      <code>$value</code>
-    </MissingClosureParamType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$categories</code>
     </PossiblyInvalidArgument>
@@ -4075,6 +4461,9 @@
     <InvalidReturnType occurrences="1">
       <code>int[]</code>
     </InvalidReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <MissingClosureParamType occurrences="4">
       <code>$code</code>
       <code>$code</code>
@@ -4096,6 +4485,10 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$batch_remaining</code>
     </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$module_term</code>
+      <code>$module_term</code>
+    </RedundantConditionGivenDocblockType>
     <RedundantPropertyInitializationCheck occurrences="3">
       <code>isset( $this-&gt;total_tasks )</code>
       <code>isset( $this-&gt;total_tasks )</code>
@@ -4797,6 +5190,11 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/emails/generators/class-quiz-graded.php">
+    <InvalidScalarArgument occurrences="3">
+      <code>$course_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+    </InvalidScalarArgument>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $quiz_id )</code>
     </PossiblyFalseArgument>
@@ -4806,13 +5204,18 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/emails/generators/class-student-completes-lesson.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>$course_id</code>
+      <code>$course_id</code>
+    </InvalidScalarArgument>
     <RedundantCast occurrences="2">
       <code>(int) $lesson_id</code>
       <code>(int) $student_id</code>
     </RedundantCast>
   </file>
   <file src="includes/internal/emails/generators/class-student-message-reply.php">
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument occurrences="2">
+      <code>$lesson_id</code>
       <code>$teacher_id</code>
     </InvalidScalarArgument>
     <PossiblyInvalidPropertyFetch occurrences="7">
@@ -4856,6 +5259,10 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/emails/generators/class-student-submits-quiz.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>$course_id</code>
+      <code>$lesson_id</code>
+    </InvalidScalarArgument>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$course-&gt;ID</code>
       <code>$lesson-&gt;ID</code>
@@ -4895,6 +5302,11 @@
       <code>$plugin_version</code>
     </PossiblyNullArgument>
   </file>
+  <file src="includes/internal/migration/migrations/class-student-progress-migration.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$quiz_id</code>
+    </PossiblyNullArgument>
+  </file>
   <file src="includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php">
     <PossiblyNullIterator occurrences="1">
       <code>$this-&gt;wpdb-&gt;get_results( $query )</code>
@@ -4906,7 +5318,8 @@
     </PossiblyNullIterator>
   </file>
   <file src="includes/internal/quiz-submission/submission/repositories/class-comments-based-submission-repository.php">
-    <InvalidScalarArgument occurrences="9">
+    <InvalidScalarArgument occurrences="10">
+      <code>$lesson_id</code>
       <code>$status_comment-&gt;comment_ID</code>
       <code>$status_comment-&gt;comment_ID</code>
       <code>$status_comment-&gt;comment_ID</code>
@@ -4963,10 +5376,22 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>$comment-&gt;comment_post_ID</code>
+      <code>$lesson_id</code>
+    </InvalidScalarArgument>
     <PossiblyInvalidIterator occurrences="2">
       <code>$comments</code>
       <code>$comments</code>
     </PossiblyInvalidIterator>
+  </file>
+  <file src="includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php">
+    <InvalidScalarArgument occurrences="4">
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+    </InvalidScalarArgument>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php">
     <PossiblyInvalidPropertyFetch occurrences="8">
@@ -5151,6 +5576,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>array( $lessons )</code>
+    </DocblockTypeContradiction>
     <InvalidScalarArgument occurrences="2">
       <code>ceil( $this-&gt;reports_overview_service_courses-&gt;get_courses_average_grade( $all_course_ids ) )</code>
       <code>count( $all_course_ids )</code>
@@ -5161,6 +5589,9 @@
       <code>Sensei_Reports_Overview_List_Table_Courses</code>
       <code>Sensei_Reports_Overview_List_Table_Courses</code>
     </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_array( $lessons )</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php">
     <InvalidArgument occurrences="1">
@@ -5299,9 +5730,13 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="6">
       <code>$post-&gt;post_type</code>
+      <code>$post_id</code>
+      <code>$post_id</code>
       <code>$post_type-&gt;cap-&gt;edit_post</code>
+      <code>$teacher</code>
+      <code>$teacher</code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="2">
       <code>$post-&gt;post_type</code>
@@ -5423,10 +5858,10 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php">
-    <ArgumentTypeCoercion occurrences="1"/>
     <DocblockTypeContradiction occurrences="1">
       <code>is_wp_error( $quiz_id )</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1"/>
     <InvalidReturnStatement occurrences="2">
       <code>$question_id</code>
       <code>$quiz_id</code>
@@ -5456,7 +5891,9 @@
       <code>$lesson-&gt;post_type</code>
       <code>$lesson-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="5">
+      <code>$lesson-&gt;ID</code>
+      <code>$lesson-&gt;ID</code>
       <code>$lesson-&gt;ID</code>
       <code>get_post_type_object( 'lesson' )-&gt;cap-&gt;edit_post</code>
       <code>get_post_type_object( 'lesson' )-&gt;cap-&gt;edit_post</code>
@@ -5488,6 +5925,9 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$post-&gt;ID</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$post-&gt;ID</code>
+    </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="1">
       <code>$post-&gt;ID</code>
     </PossiblyNullPropertyFetch>
@@ -5605,9 +6045,6 @@
     <MissingClosureParamType occurrences="1">
       <code>$object</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
-      <code>function( $object ) {</code>
-    </MissingClosureReturnType>
     <PossiblyInvalidArgument occurrences="3">
       <code>$post</code>
       <code>$question_id</code>
@@ -5657,6 +6094,12 @@
       <code>boolean</code>
       <code>string</code>
     </InvalidReturnType>
+    <InvalidScalarArgument occurrences="4">
+      <code>$post-&gt;ID</code>
+      <code>$post-&gt;post_author</code>
+      <code>\Sensei()-&gt;lesson-&gt;get_course_id( $post-&gt;ID )</code>
+      <code>\Sensei()-&gt;quiz-&gt;get_lesson_id( $post-&gt;ID )</code>
+    </InvalidScalarArgument>
     <PossiblyInvalidPropertyFetch occurrences="6">
       <code>$post-&gt;ID</code>
       <code>$post-&gt;ID</code>
@@ -5665,6 +6108,11 @@
       <code>$post-&gt;post_author</code>
       <code>$post-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyNullArgument occurrences="3">
+      <code>$message</code>
+      <code>$post-&gt;ID</code>
+      <code>$post-&gt;ID</code>
+    </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="6">
       <code>$post-&gt;ID</code>
       <code>$post-&gt;ID</code>
@@ -5723,13 +6171,26 @@
     <InvalidReturnType occurrences="1">
       <code>string</code>
     </InvalidReturnType>
+    <InvalidScalarArgument occurrences="3">
+      <code>$course_id</code>
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
+    </InvalidScalarArgument>
     <MissingParamType occurrences="4">
       <code>$alternative</code>
       <code>$hook_tag</code>
       <code>$post</code>
       <code>$version</code>
     </MissingParamType>
-    <PossiblyFalseArgument occurrences="1">
+    <MissingPropertyType occurrences="5">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
+    <PossiblyFalseArgument occurrences="2">
+      <code>get_the_ID()</code>
       <code>get_the_ID()</code>
     </PossiblyFalseArgument>
     <PossiblyInvalidPropertyFetch occurrences="2">
@@ -5878,9 +6339,15 @@
       <code>$course_status</code>
       <code>$user_id</code>
     </MissingParamType>
-    <PossiblyInvalidArgument occurrences="2">
+    <MissingPropertyType occurrences="3">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
+    <PossiblyInvalidArgument occurrences="3">
       <code>$category_output</code>
       <code>$course</code>
+      <code>get_post( $course_id )</code>
     </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$query</code>
@@ -5893,6 +6360,10 @@
     <InvalidReturnType occurrences="1">
       <code>mixed</code>
     </InvalidReturnType>
+    <MissingPropertyType occurrences="2">
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+    </MissingPropertyType>
   </file>
   <file src="includes/template-functions.php">
     <DocblockTypeContradiction occurrences="4">
@@ -5917,7 +6388,8 @@
       <code>string</code>
       <code>string</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="3">
+    <InvalidScalarArgument occurrences="4">
+      <code>$course_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>sensei_get_the_module_id()</code>
@@ -5930,6 +6402,16 @@
       <code>$question_type</code>
       <code>$template_name</code>
     </MissingParamType>
+    <MissingPropertyType occurrences="8">
+      <code>Sensei()-&gt;modules-&gt;taxonomy</code>
+      <code>Sensei()-&gt;modules-&gt;taxonomy</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;settings-&gt;settings</code>
+      <code>Sensei()-&gt;template_url</code>
+      <code>Sensei()-&gt;template_url</code>
+    </MissingPropertyType>
     <PossiblyFalseArgument occurrences="1">
       <code>get_permalink( $course_id )</code>
     </PossiblyFalseArgument>
@@ -5937,7 +6419,8 @@
       <code>$item</code>
       <code>get_post( $lesson_id )</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="2">
+      <code>$lesson_id</code>
       <code>Sensei_Course::get_loop_number_of_columns()</code>
     </PossiblyNullArgument>
     <RedundantConditionGivenDocblockType occurrences="1">
@@ -5957,6 +6440,11 @@
       <code>$item-&gt;term_id</code>
       <code>$item-&gt;term_id</code>
     </UndefinedMagicPropertyFetch>
+  </file>
+  <file src="includes/theme-integrations/theme-integration-loader.php">
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;plugin_path</code>
+    </MissingPropertyType>
   </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php">
     <DocblockTypeContradiction occurrences="1">
@@ -6006,7 +6494,18 @@
       <code>$post_to_copy</code>
     </ParamNameMismatch>
   </file>
+  <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php">
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;template_url</code>
+    </MissingPropertyType>
+  </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$course_id</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="1">
+      <code>Sensei()-&gt;modules-&gt;taxonomy</code>
+    </MissingPropertyType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post_to_copy</code>
     </MoreSpecificImplementedParamType>
@@ -6054,6 +6553,9 @@
     </PossiblyFalsePropertyAssignmentValue>
   </file>
   <file src="includes/update-tasks/class-sensei-update-fix-question-author.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$quiz-&gt;post_author</code>
+    </InvalidScalarArgument>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$quiz-&gt;ID</code>
       <code>$quiz-&gt;post_author</code>

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -687,7 +687,6 @@ class Sensei_Grading {
 	 */
 	public function admin_process_grading_submission() {
 
-		// NEEDS REFACTOR/OPTIMISING, such as combining the various meta data stored against the sensei_user_answer entry.
 		if ( ! isset( $_POST['sensei_manual_grade'] )
 			|| ! wp_verify_nonce( $_POST['_wp_sensei_manual_grading_nonce'], 'sensei_manual_grading' )
 			|| ! isset( $_GET['quiz_id'] )

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -417,7 +417,7 @@ class Sensei_Quiz {
 	 * @param int $lesson_id
 	 * @param int $user_id
 	 *
-	 * @return array|false $answers or false
+	 * @return array<int, string>|false $answers or false
 	 */
 	public function get_user_answers( $lesson_id, $user_id ) {
 
@@ -997,10 +997,9 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Get the user question answer
+	 * Get the user question answer.
 	 *
-	 * This function gets the users saved answer on given quiz for the given question parameter
-	 * this function allows for a fallback to users still using the question saved data from before 1.7.4
+	 * This function gets the users saved answer on given quiz for the given question parameter.
 	 *
 	 * @since 1.7.4
 	 *
@@ -1008,7 +1007,7 @@ class Sensei_Quiz {
 	 * @param int $question_id
 	 * @param int $user_id ( optional )
 	 *
-	 * @return bool|null $answers_submitted
+	 * @return string|null|false
 	 */
 	public function get_user_question_answer( $lesson_id, $question_id, $user_id = 0 ) {
 
@@ -1032,28 +1031,7 @@ class Sensei_Quiz {
 
 		$users_answers = $this->get_user_answers( $lesson_id, $user_id );
 
-		if ( ! $users_answers || empty( $users_answers )
-		|| ! is_array( $users_answers ) || ! isset( $users_answers[ $question_id ] ) ) {
-
-			// Fallback for pre 1.7.4 data
-			$comment = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'post_id' => $question_id,
-					'user_id' => $user_id,
-					'type'    => 'sensei_user_answer',
-				),
-				true
-			);
-
-			if ( ! isset( $comment->comment_content ) ) {
-				return null;
-			}
-
-			return maybe_unserialize( base64_decode( $comment->comment_content ) );
-		}
-
-		return $users_answers[ $question_id ];
-
+		return $users_answers[ $question_id ] ?? null;
 	}
 
 	/**
@@ -1192,7 +1170,7 @@ class Sensei_Quiz {
 	 * @param int $question_id
 	 * @param int $user_id ( optional )
 	 *
-	 * @return bool $question_grade
+	 * @return int|false
 	 */
 	public function get_user_question_grade( $lesson_id, $question_id, $user_id = 0 ) {
 
@@ -1206,32 +1184,9 @@ class Sensei_Quiz {
 			return false;
 		}
 
-		$all_user_grades = self::get_user_grades( $lesson_id, $user_id );
+		$all_user_grades = $this->get_user_grades( $lesson_id, $user_id );
 
-		if ( ! $all_user_grades || ! isset( $all_user_grades[ $question_id ] ) ) {
-			$fall_back_grade = false;
-
-			if ( 0 === $user_id ) {
-				return $fall_back_grade;
-			}
-
-			// fallback to data pre 1.7.4
-			$args = array(
-				'post_id' => $question_id,
-				'user_id' => $user_id,
-				'type'    => 'sensei_user_answer',
-			);
-
-			$question_activity = Sensei_Utils::sensei_check_for_activity( $args, true );
-			if ( isset( $question_activity->comment_ID ) ) {
-				$fall_back_grade = get_comment_meta( $question_activity->comment_ID, 'user_grade', true );
-			}
-
-			return $fall_back_grade;
-
-		}
-
-		return $all_user_grades[ $question_id ];
+		return $all_user_grades[ $question_id ] ?? false;
 
 	}
 
@@ -1392,34 +1347,15 @@ class Sensei_Quiz {
 		// get all the feedback for the user on the given lesson
 		$all_feedback = $this->get_user_answers_feedback( $lesson_id, $user_id );
 
-		if ( ! $all_feedback || empty( $all_feedback )
-			|| ! is_array( $all_feedback ) || empty( $all_feedback[ $question_id ] ) ) {
+		if ( ! is_array( $all_feedback ) || empty( $all_feedback[ $question_id ] ) ) {
+			$feedback       = get_post_meta( $question_id, '_answer_feedback', true );
+			$user_grade     = $this->get_user_question_grade( $lesson_id, $question_id, $user_id );
+			$answer_correct = is_int( $user_grade ) && $user_grade > 0;
 
-			// fallback to data pre 1.7.4
-			// setup the sensei data query
-			$args              = array(
-				'post_id' => $question_id,
-				'user_id' => $user_id,
-				'type'    => 'sensei_user_answer',
-			);
-			$question_activity = Sensei_Utils::sensei_check_for_activity( $args, true );
+			$feedback_block = $answer_correct ? self::get_correct_answer_feedback( $question_id ) : self::get_incorrect_answer_feedback( $question_id );
 
-			// set the default to false and return that if no old data is available.
-			if ( isset( $question_activity->comment_ID ) ) {
-				$feedback = base64_decode( get_comment_meta( $question_activity->comment_ID, 'answer_note', true ) );
-			}
-
-			// finally use the default question feedback
-			if ( empty( $feedback ) ) {
-				$feedback       = get_post_meta( $question_id, '_answer_feedback', true );
-				$user_grade     = $this->get_user_question_grade( $lesson_id, $question_id, $user_id );
-				$answer_correct = is_int( $user_grade ) && $user_grade > 0;
-
-				$feedback_block = $answer_correct ? self::get_correct_answer_feedback( $question_id ) : self::get_incorrect_answer_feedback( $question_id );
-
-				if ( $feedback_block ) {
-					$feedback = $feedback_block;
-				}
+			if ( $feedback_block ) {
+				$feedback = $feedback_block;
 			}
 		} else {
 			$feedback = $all_feedback[ $question_id ];

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -87,9 +87,28 @@ class Sensei_Updates {
 		$this->v3_9_remove_abandoned_multiple_question();
 		$this->v4_10_update_install_time();
 		$this->v4_12_create_default_emails();
+		$this->v4_19_2_update_legacy_quiz_data();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
+	}
+
+	/**
+	 * Enqueue job to update the legacy quiz data.
+	 *
+	 * @since $$next-version$$
+	 */
+	private function v4_19_2_update_legacy_quiz_data() {
+		$legacy_answers_count = (int) Sensei_Utils::sensei_check_for_activity(
+			array(
+				'type'   => 'sensei_user_answer',
+				'status' => 'log',
+			)
+		);
+
+		if ( $legacy_answers_count ) {
+			Sensei_Scheduler::instance()->schedule_job( new Sensei_Update_Legacy_Quiz_Data() );
+		}
 	}
 
 	/**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -425,12 +425,16 @@ class Sensei_Utils {
 	/**
 	 * Grade question
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param  integer $question_id ID of question
 	 * @param  integer $grade       Grade received
 	 * @param int     $user_id
 	 * @return boolean
 	 */
 	public static function sensei_grade_question( $question_id = 0, $grade = 0, $user_id = 0 ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Quiz::set_user_grades' );
+
 		if ( intval( $user_id ) == 0 ) {
 			$user_id = get_current_user_id();
 		}
@@ -457,7 +461,19 @@ class Sensei_Utils {
 		return $activity_logged;
 	}
 
+	/**
+	 * Delete the question grade.
+	 *
+	 * @deprecated $$next-version$$
+	 *
+	 * @param int $question_id The question ID.
+	 * @param int $user_id The user ID. Defaults to the current user ID.
+	 *
+	 * @return bool
+	 */
 	public static function sensei_delete_question_grade( $question_id = 0, $user_id = 0 ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Quiz::set_user_grades' );
+
 		if ( intval( $user_id ) == 0 ) {
 			$user_id = get_current_user_id();
 		}
@@ -674,11 +690,15 @@ class Sensei_Utils {
 	/**
 	 * Returns the user_grade for a specific question and user, or sensei_user_answer entry
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param mixed $question
 	 * @param int   $user_id
 	 * @return string
 	 */
 	public static function sensei_get_user_question_grade( $question = 0, $user_id = 0 ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Quiz::get_user_grades' );
+
 		$question_grade = false;
 		if ( $question ) {
 			if ( is_object( $question ) ) {
@@ -777,12 +797,16 @@ class Sensei_Utils {
 	/**
 	 * Add answer notes to question
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param  integer $question_id ID of question
 	 * @param  integer $user_id     ID of user
 	 * @param string  $notes
 	 * @return boolean
 	 */
 	public static function sensei_add_answer_notes( $question_id = 0, $user_id = 0, $notes = '' ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Quiz::save_user_answers_feedback' );
+
 		if ( intval( $user_id ) == 0 ) {
 			$user_id = get_current_user_id();
 		}

--- a/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
+++ b/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
@@ -91,6 +91,6 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 			return $comments;
 		}
 
-		return [ $comments ];
+		return array( $comments );
 	}
 }

--- a/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
+++ b/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * File containing the class Sensei_Update_Legacy_Quiz_Data.
+ *
+ * @since $$next-version$$
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Update the legacy quiz data generated before version 1.7.4.
+ */
+class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
+	/**
+	 * Get the job batch size.
+	 *
+	 * @return int
+	 */
+	protected function get_batch_size() : int {
+		return 20;
+	}
+
+	/**
+	 * Can multiple instances be enqueued at the same time?
+	 *
+	 * @return bool
+	 */
+	protected function allow_multiple_instances() : bool {
+		return false;
+	}
+
+	/**
+	 * Run batch.
+	 *
+	 * @param int $offset Current offset.
+	 *
+	 * @return bool Returns true if there is more to do.
+	 */
+	protected function run_batch( int $offset ) : bool {
+		$answer_comments = $this->get_legacy_answers();
+		$run_again       = count( $answer_comments ) === $this->get_batch_size();
+
+		/**
+		 * Loop through the legacy answers and update the data.
+		 *
+		 * @var WP_Comment $comment
+		 */
+		foreach ( $answer_comments as $comment ) {
+			$answer_value = $comment->comment_content;
+			$question_id  = $comment->comment_post_ID;
+			$user_id      = $comment->user_id;
+			$quiz_id      = (int) get_post_meta( $question_id, '_quiz_id', true );
+			$points       = get_comment_meta( $comment->comment_ID, 'user_grade', true );
+			$submission   = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
+			$answer       = Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer_value );
+
+			if ( is_numeric( $points ) ) {
+				$feedback = get_comment_meta( $comment->comment_ID, 'answer_note', true );
+				$feedback = false === $feedback ? null : $feedback;
+
+				Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, $points, $feedback );
+			}
+
+			wp_delete_comment( $comment ); // Soft delete.
+		}
+
+		return $run_again;
+	}
+
+	/**
+	 * Get the legacy answer comments.
+	 *
+	 * @return array An array of comments holding the legacy answers.
+	 */
+	protected function get_legacy_answers() : array {
+		$comments = Sensei_Utils::sensei_check_for_activity(
+			array(
+				'type'   => 'sensei_user_answer',
+				'number' => $this->get_batch_size(),
+				'status' => 'log',
+				'order'  => 'ASC',
+			),
+			true
+		);
+
+		if ( is_array( $comments ) ) {
+			return $comments;
+		}
+
+		return [ $comments ];
+	}
+}

--- a/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
+++ b/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
@@ -50,18 +50,19 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 		 */
 		foreach ( $answer_comments as $comment ) {
 			$answer_value = $comment->comment_content;
-			$question_id  = $comment->comment_post_ID;
-			$user_id      = $comment->user_id;
+			$comment_id   = (int) $comment->comment_ID;
+			$question_id  = (int) $comment->comment_post_ID;
+			$user_id      = (int) $comment->user_id;
 			$quiz_id      = (int) get_post_meta( $question_id, '_quiz_id', true );
-			$points       = get_comment_meta( $comment->comment_ID, 'user_grade', true );
+			$points       = get_comment_meta( $comment_id, 'user_grade', true );
 			$submission   = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
 			$answer       = Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer_value );
 
 			if ( is_numeric( $points ) ) {
-				$feedback = get_comment_meta( $comment->comment_ID, 'answer_note', true );
+				$feedback = get_comment_meta( $comment_id, 'answer_note', true );
 				$feedback = false === $feedback ? null : $feedback;
 
-				Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, $points, $feedback );
+				Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, (int) $points, $feedback );
 			}
 
 			wp_delete_comment( $comment ); // Soft delete.

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -116,6 +116,8 @@ if ( ! function_exists( 'Sensei' ) ) {
 	 * phpcs:disable WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	 *
 	 * @since 1.8.0
+	 *
+	 * @return Sensei_Main
 	 */
 	function Sensei() {
 		// phpcs:enable

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -824,7 +824,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	 * This tests Woothemes_Sensei()->quiz->get_user_question_answer.
 	 */
 	public function testGetUserQuestionAnswer() {
-
 		// Setup the data needed for the assertions.
 		$test_user_id           = wp_create_user( 'studentGetQuestionAnswer', 'studentGetQuestionAnswer', 'studentGetQuestionAnswer@test.com' );
 		$test_lesson_id         = $this->factory->get_random_lesson_id();
@@ -854,43 +853,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		// Testing if the data is returned.
 		$this->assertEquals( $users_saved_answers[ $random_question_id ], $question_answer, $assertion_message );
-
-		// Setup the data for the next assertion.
-		$assertion_message = 'This function does not fall back to the old data';
-		$question_id       = $random_question_id;
-		$answer            = $users_saved_answers[ $question_id ];
-		$old_data_user_id  = wp_create_user( 'olddata', 'olddata', 'olddata@test.com' );
-		$question_type     = Sensei()->question->get_question_type( $question_id );
-
-		$answer = wp_unslash( $answer );
-
-		switch ( $question_type ) {
-			case 'multi-line':
-				$answer = nl2br( $answer );
-				break;
-			case 'single-line':
-				break;
-			case 'gap-fill':
-				break;
-			default:
-				$answer = maybe_serialize( $answer );
-				break;
-		}
-		$args = array(
-			'post_id' => $question_id,
-			'data'    => base64_encode( $answer ),
-			'type'    => 'sensei_user_answer', /* FIELD SIZE 20 */
-			'user_id' => $old_data_user_id,
-			'action'  => 'update',
-		);
-		Sensei_Utils::sensei_log_activity( $args );
-
-		$old_data_answer = Sensei()->quiz->get_user_question_answer( $test_lesson_id, $random_question_id, $old_data_user_id );
-
-		// Testing for users on the pre 1.7.4 data.
-		$this->assertEquals( maybe_unserialize( $answer ), $old_data_answer, $assertion_message );
-
-		// Make sure that after a reset this function returns false.
 	}
 
 	/**
@@ -1083,25 +1045,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			$retrieved_grade,
 			'The grade retrieved is not equal to the one that was set for this question ID'
 		);
-
-		// Setup the next assertion.
-		$transient_key = 'quiz_grades_' . $test_user_id . '_' . $test_lesson_id;
-		delete_transient( $transient_key );
-		Sensei_Utils::delete_user_data( 'quiz_grades', $test_lesson_id, $test_user_id );
-		$random_question_id   = array_rand( $test_user_grades );
-		$old_data_args        = array(
-			'post_id' => $random_question_id,
-			'user_id' => $test_user_id,
-			'type'    => 'sensei_user_answer',
-			'data'    => 'test answer',
-		);
-		$old_data_activity_id = Sensei_Utils::sensei_log_activity( $old_data_args );
-		update_comment_meta( $old_data_activity_id, 'user_grade', 1950 );
-		$retrieved_grade = Sensei()->quiz->get_user_question_grade( $test_lesson_id, $random_question_id, $test_user_id );
-
-		// Does the fall back to 1.7.3 data work?
-		$this->assertEquals( 1950, $retrieved_grade, 'The get user question grade does not fall back th old data' );
-
 	}
 
 	/**
@@ -1250,7 +1193,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	 * This test Sensei()->quiz->get_user_question_feedback.
 	 */
 	public function testGetUserQuestionFeedback() {
-
 		// Does this function add_user_data exist?
 		$this->assertTrue(
 			method_exists( Sensei()->quiz, 'get_user_question_feedback' ),
@@ -1284,25 +1226,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			$retrieved_grade,
 			'The feedback retrieved is not equal to the one that was set for this question ID'
 		);
-
-		// Setup the next assertion for backwards compatibility.
-		$transient_key = 'sensei_answers_feedback_' . $test_user_id . '_' . $test_lesson_id;
-		delete_transient( $transient_key );
-		Sensei_Utils::delete_user_data( 'quiz_answers_feedback', $test_lesson_id, $test_user_id );
-		$random_question_id   = array_rand( $test_user_answers_feedback );
-		$old_data_args        = array(
-			'post_id' => $random_question_id,
-			'user_id' => $test_user_id,
-			'type'    => 'sensei_user_answer',
-			'data'    => 'test answer feedback',
-		);
-		$old_data_activity_id = Sensei_Utils::sensei_log_activity( $old_data_args );
-		update_comment_meta( $old_data_activity_id, 'answer_note', base64_encode( 'Sensei sample feedback' ) );
-		$retrieved_feedback = Sensei()->quiz->get_user_question_feedback( $test_lesson_id, $random_question_id, $test_user_id );
-
-		// Does the fall back to 1.7.3 data work?
-		$this->assertEquals( 'Sensei sample feedback', $retrieved_feedback, 'The get user feedback does not fall back the old data' );
-
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -389,6 +389,10 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		$submission    = $this->createMock( Submission_Interface::class );
 		$submission->method( 'get_id' )->willReturn( $submission_id );
 
+		$quiz_answer_repository     = Sensei()->quiz_answer_repository;
+		$quiz_grade_repository      = Sensei()->quiz_grade_repository;
+		$quiz_submission_repository = Sensei()->quiz_submission_repository;
+
 		Sensei()->quiz_answer_repository     = $this->createMock( Answer_Repository_Interface::class );
 		Sensei()->quiz_grade_repository      = $this->createMock( Grade_Repository_Interface::class );
 		Sensei()->quiz_submission_repository = $this->createMock( Submission_Repository_Interface::class );
@@ -413,6 +417,11 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 			->with( $submission );
 
 		Sensei_Utils::sensei_delete_quiz_answers( 1, 1 );
+
+		/* Reset. */
+		Sensei()->quiz_answer_repository     = $quiz_answer_repository;
+		Sensei()->quiz_grade_repository      = $quiz_grade_repository;
+		Sensei()->quiz_submission_repository = $quiz_submission_repository;
 	}
 
 	/**

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-legacy-quiz-data.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-legacy-quiz-data.php
@@ -1,0 +1,178 @@
+<?php
+
+use Sensei\Internal\Quiz_Submission\Answer\Models\Answer_Interface;
+use Sensei\Internal\Quiz_Submission\Grade\Models\Grade_Interface;
+
+/**
+ * Tests for Sensei_Update_Legacy_Quiz_Data class.
+ *
+ * @group update-tasks
+ * @group background-jobs
+ */
+class Sensei_Update_Legacy_Quiz_Data_Test extends WP_UnitTestCase {
+	/**
+	 * Sensei Factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up the tests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function testRun_WhenHasMultipleAnswers_MigratesTheAnswers() {
+		/* Arrange */
+		$lesson_id  = $this->factory->lesson->create();
+		$quiz_id    = $this->factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+			)
+		);
+		$question_1 = $this->factory->question->create(
+			array(
+				'quiz_id' => $quiz_id,
+			)
+		);
+		$question_2 = $this->factory->question->create(
+			array(
+				'quiz_id' => $quiz_id,
+			)
+		);
+		$answer_1   = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $question_1,
+				'comment_content'  => 'answer 1',
+				'comment_type'     => 'sensei_user_answer',
+				'comment_approved' => 'log',
+				'user_id'          => 1,
+			)
+		);
+		$answer_2   = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $question_2,
+				'comment_content'  => 'answer 2',
+				'comment_type'     => 'sensei_user_answer',
+				'comment_approved' => 'log',
+				'user_id'          => 1,
+			)
+		);
+
+		Sensei_Utils::sensei_start_lesson( $lesson_id, 1 );
+
+		/* Act */
+		$instance = new Sensei_Update_Legacy_Quiz_Data();
+		$instance->run();
+
+		/* Assert */
+		$submission = Sensei()->quiz_submission_repository->get( $quiz_id, 1 );
+		$answers    = Sensei()->quiz_answer_repository->get_all( $submission->get_id() );
+
+		$this->assertSame(
+			array(
+				array(
+					'question_id' => $question_1,
+					'value'       => 'answer 1',
+				),
+				array(
+					'question_id' => $question_2,
+					'value'       => 'answer 2',
+				),
+			),
+			array(
+				$this->get_answer_data( $answers[0] ),
+				$this->get_answer_data( $answers[1] ),
+			)
+		);
+	}
+
+	public function testRun_WhenHasMultipleGrades_MigratesTheGrades() {
+		/* Arrange */
+		$lesson_id  = $this->factory->lesson->create();
+		$quiz_id    = $this->factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+			)
+		);
+		$question_1 = $this->factory->question->create(
+			array(
+				'quiz_id' => $quiz_id,
+			)
+		);
+		$question_2 = $this->factory->question->create(
+			array(
+				'quiz_id' => $quiz_id,
+			)
+		);
+		$answer_1   = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $question_1,
+				'comment_content'  => 'answer 1',
+				'comment_type'     => 'sensei_user_answer',
+				'comment_approved' => 'log',
+				'user_id'          => 1,
+			)
+		);
+		$answer_2   = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $question_2,
+				'comment_content'  => 'answer 2',
+				'comment_type'     => 'sensei_user_answer',
+				'comment_approved' => 'log',
+				'user_id'          => 1,
+			)
+		);
+
+		update_comment_meta( $answer_1, 'user_grade', 1 );
+		update_comment_meta( $answer_1, 'answer_note', 'note 1' );
+		update_comment_meta( $answer_2, 'user_grade', 0 );
+
+		Sensei_Utils::sensei_start_lesson( $lesson_id, 1 );
+
+		/* Act */
+		$instance = new Sensei_Update_Legacy_Quiz_Data();
+		$instance->run();
+
+		/* Assert */
+		$submission = Sensei()->quiz_submission_repository->get( $quiz_id, 1 );
+		$grades     = Sensei()->quiz_grade_repository->get_all( $submission->get_id() );
+
+		$this->assertSame(
+			array(
+				array(
+					'question_id' => $question_1,
+					'points'      => 1,
+					'feedback'    => 'note 1',
+				),
+				array(
+					'question_id' => $question_2,
+					'points'      => 0,
+					'feedback'    => null,
+				),
+			),
+			array(
+				$this->get_grade_data( $grades[0] ),
+				$this->get_grade_data( $grades[1] ),
+			)
+		);
+	}
+
+	private function get_answer_data( Answer_Interface $answer ) : array {
+		return array(
+			'question_id' => $answer->get_question_id(),
+			'value'       => $answer->get_value(),
+		);
+	}
+
+	private function get_grade_data( Grade_Interface $grade ) : array {
+		return array(
+			'question_id' => $grade->get_question_id(),
+			'points'      => $grade->get_points(),
+			'feedback'    => $grade->get_feedback(),
+		);
+	}
+}


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/7223

This PR cleans up the code related to a very old quiz data structure (pre version 1.7.4). That code was getting in the way of switching to the new quiz repositories. Also, it was triggering extra queries on each request.

## Proposed Changes

* Add a migration for moving the legacy quiz data to the current data structure.
* Clean up the code and deprecate the use of the legacy quiz data.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install [Sensei LMS 1.7.3](https://github.com/Automattic/sensei/archive/refs/tags/version/1.7.3.zip) on a new site. You may have to turn off the `WP_DEBUG`.
2. Go to Lessons -> All Courses -> Add New and create a course.
3. Go to Questions and add a few questions.
4. Go to Lessons -> Add New. Add a title, choose the course from the "Lesson Course" metabox, and assign the existing questions from the "Existing Questions" tab.
5. Enroll in the course and complete the lesson quiz.
6. Grade the quiz and add some feedback.
7. Check the database. In the `wp_comments` table, there should be a few entries with the `sensei_user_answer` comment type.
8. Disable the Sensei LMS 1.7.3 plugin and install the version from this branch.
9. Once you activate it, the legacy quiz data should be migrated in a few seconds.
10. Verify that the submitted quiz answers are migrated.
11. Verify that the quiz grades and feedback are migrated.

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

* `Sensei_Utils::sensei_grade_question`
* `Sensei_Utils::sensei_delete_question_grade`
* `Sensei_Utils::sensei_get_user_question_grade`
* `Sensei_Utils::sensei_add_answer_notes`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues