### PR TITLE
Use the quiz repository classes in the front-end

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1,5 +1,6 @@
 <?php
 
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -2403,9 +2404,14 @@ class Sensei_Quiz {
 			return false;
 		}
 
-		$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
+		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		if ( ! $quiz_id ) {
+			return false;
+		}
 
-		return $lesson_status && 'ungraded' === $lesson_status->comment_approved;
+		$progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
+
+		return $progress && Quiz_Progress_Interface::STATUS_UNGRADED === $progress->get_status();
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2438,21 +2438,7 @@ class Sensei_Quiz {
 
 		$quiz_id       = (int) Sensei()->lesson->lesson_quizzes( $lesson_id );
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
-		if ( ! $quiz_progress ) {
-			return null;
-		}
-
-		$is_quiz_complete = in_array(
-			$quiz_progress->get_status(),
-			[
-				Quiz_Progress_Interface::STATUS_GRADED,
-				Quiz_Progress_Interface::STATUS_PASSED,
-				Quiz_Progress_Interface::STATUS_FAILED,
-			],
-			true
-		);
-
-		if ( ! $is_quiz_complete ) {
+		if ( ! $quiz_progress || ! $quiz_progress->is_quiz_completed() ) {
 			return null;
 		}
 

--- a/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-abstract.php
+++ b/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-abstract.php
@@ -221,6 +221,22 @@ class Quiz_Progress_Abstract implements Quiz_Progress_Interface {
 	}
 
 	/**
+	 * Returns whether the quiz is completed.
+	 *
+	 * @internal
+	 *
+	 * @return bool
+	 */
+	public function is_quiz_completed(): bool {
+		$completed_statuses = array(
+			Quiz_Progress_Interface::STATUS_GRADED,
+			Quiz_Progress_Interface::STATUS_PASSED,
+			Quiz_Progress_Interface::STATUS_FAILED,
+		);
+		return in_array( $this->status, $completed_statuses, true );
+	}
+
+	/**
 	 * Get the quiz start date.
 	 *
 	 * @internal

--- a/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-interface.php
+++ b/includes/internal/student-progress/quiz-progress/models/class-quiz-progress-interface.php
@@ -143,6 +143,15 @@ interface Quiz_Progress_Interface {
 	public function is_quiz_submitted(): bool;
 
 	/**
+	 * Returns whether the quiz is completed.
+	 *
+	 * @internal
+	 *
+	 * @return bool
+	 */
+	public function is_quiz_completed(): bool;
+
+	/**
 	 * Get the quiz start date.
 	 *
 	 * @internal

--- a/tests/unit-tests/internal/student-progress/quiz-progress/models/test-class-comments-based-quiz-progress.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/models/test-class-comments-based-quiz-progress.php
@@ -82,6 +82,33 @@ class Comments_Based_Quiz_Progress_Test extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Test that the quiz is considered completed based on the quiz progress status.
+	 *
+	 * @dataProvider providerIsQuizCompleted_ConstructedWithStatus_ReturnsMatchingValue
+	 */
+	public function testIsQuizCompleted_ConstructedWithStatus_ReturnsMatchingValue( string $status, bool $expected ): void {
+		/* Arrange. */
+		$quiz_progress = $this->create_progress( $status );
+
+		/* Act. */
+		$actual = $quiz_progress->is_quiz_completed();
+
+		/* Assert. */
+		self::assertSame( $expected, $actual );
+	}
+
+	public function providerIsQuizCompleted_ConstructedWithStatus_ReturnsMatchingValue(): array {
+		return array(
+			'quiz in progress'                => array( 'in-progress', false ),
+			'quiz graded'                     => array( 'graded', true ),
+			'quiz failed'                     => array( 'failed', true ),
+			'quiz passed'                     => array( 'passed', true ),
+			'quiz ungraded'                   => array( 'ungraded', false ),
+			'lesson complete (legacy status)' => array( 'complete', false ),
+		);
+	}
+
 	public function testGetStartedAt_ConstructedWithStartedAt_ReturnsSameStartedAt(): void {
 		/* Arrange. */
 		$quiz_progress = $this->create_progress();

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2447,7 +2447,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 				],
 			]
 		);
-		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
 
 		$progress = $this->createMock( Quiz_Progress_Interface::class );
 		$progress->method( 'get_status' )
@@ -2479,7 +2479,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 				],
 			]
 		);
-		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
 
 		$progress = $this->createMock( Quiz_Progress_Interface::class );
 		$progress->method( 'get_status' )

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -2,6 +2,8 @@
 
 use Sensei\Internal\Student_Progress\Course_Progress\Models\Course_Progress_Interface;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Tables_Based_Quiz_Progress_Repository;
 
 class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
@@ -2432,5 +2434,69 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		foreach ( $classes as $class ) {
 			$this->assertStringContainsString( $class, $html );
 		}
+	}
+
+	public function testIsQuizAwaitingGradeForUser_IsUngraded_ReturnsTrue() {
+		/* Arrange */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'post_parent' => $course_id,
+				'meta_input'  => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+
+		$progress = $this->createMock( Quiz_Progress_Interface::class );
+		$progress->method( 'get_status' )
+			->willReturn( Quiz_Progress_Interface::STATUS_UNGRADED );
+
+		$quiz_progress_repository          = Sensei()->quiz_progress_repository;
+		Sensei()->quiz_progress_repository = $this->createMock( Quiz_Progress_Repository_Interface::class );
+		Sensei()->quiz_progress_repository->method( 'get' )
+			->willReturn( $progress );
+
+		/* Act */
+		$result = Sensei_Quiz::is_quiz_awaiting_grade_for_user( $lesson_id, 1 );
+
+		/* Assert */
+		$this->assertTrue( $result );
+
+		/* Reset */
+		Sensei()->quiz_progress_repository = $quiz_progress_repository;
+	}
+
+	public function testIsQuizAwaitingGradeForUser_IsNotUngraded_ReturnsFalse() {
+		/* Arrange */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'post_parent' => $course_id,
+				'meta_input'  => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+		$quiz_id = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+
+		$progress = $this->createMock( Quiz_Progress_Interface::class );
+		$progress->method( 'get_status' )
+			->willReturn( Quiz_Progress_Interface::STATUS_GRADED );
+
+		$quiz_progress_repository          = Sensei()->quiz_progress_repository;
+		Sensei()->quiz_progress_repository = $this->createMock( Quiz_Progress_Repository_Interface::class );
+		Sensei()->quiz_progress_repository->method( 'get' )
+			->willReturn( $progress );
+
+		/* Act */
+		$result = Sensei_Quiz::is_quiz_awaiting_grade_for_user( $lesson_id, 1 );
+
+		/* Assert */
+		$this->assertFalse( $result );
+
+		/* Reset */
+		Sensei()->quiz_progress_repository = $quiz_progress_repository;
 	}
 }


### PR DESCRIPTION
Resolves #7223

## Proposed Changes
* Refactor quiz methods that were making direct calls to the comments table. They are now using the new quiz repository classes.
* Added unit tests for the methods that were not covered.

## Testing Instructions

1. Install the Query Monitor plugin.
1. Create a lesson with a quiz.
1. Go to the quiz front-end and check the Query Monitor queries. There should be no calls to the comments tables related to the quiz.
2. Submit the quiz and check again.
3. Grade the quiz and check again.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
