### PR TITLE
Add a repository selection settings UI

### DIFF
--- a/assets/js/admin/settings/experimental-features.js
+++ b/assets/js/admin/settings/experimental-features.js
@@ -1,0 +1,8 @@
+jQuery( document ).ready( function ( $ ) {
+	const progressStorage = $(
+		'#sensei_experimental_progress_storage_feature'
+	);
+	progressStorage.on( 'change', function () {
+		$( '.sensei-settings_progress-storage-settings' ).toggle();
+	} );
+} );

--- a/assets/js/admin/settings/experimental-features.js
+++ b/assets/js/admin/settings/experimental-features.js
@@ -1,8 +1,10 @@
 jQuery( document ).ready( function ( $ ) {
-	const progressStorage = $(
-		'#sensei_experimental_progress_storage_feature'
-	);
+	const progressStorage = $( '#experimental_progress_storage' );
 	progressStorage.on( 'change', function () {
-		$( '.sensei-settings_progress-storage-settings' ).toggle();
+		if ( $( this ).is( ':checked' ) ) {
+			$( '.sensei-settings_progress-storage-settings' ).show();
+		} else {
+			$( '.sensei-settings_progress-storage-settings' ).hide();
+		}
 	} );
 } );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -857,7 +857,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				'section'     => 'sensei-experimental-features',
 			);
 			$fields['experimental_progress_storage_repository']      = array(
-				'name'        => '',//,
+				'name'        => '', // ,
 				'description' => __( 'Choose a repository to store the progress and quiz submissions of your students.', 'sensei-lms' ),
 				'form'        => 'render_progress_storage_repositories',
 				'type'        => 'radio',
@@ -1087,12 +1087,12 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$settings      = $this->get_settings();
 		$key           = $args['key'];
 		$value         = $settings[ $key ];
-		$visible       = $settings[ 'experimental_progress_storage' ] ?? false;
+		$visible       = $settings['experimental_progress_storage'] ?? false;
 		$block_display = $visible ? 'block' : 'none';
 		$disabled      = false; // Disable when storages are not in sync.
 		?>
-		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ) ?>">
-			<h4><?php echo __( 'Progress storage repository', 'sensei-lms' ) ?></h4>
+		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
+			<h4><?php echo __( 'Progress storage repository', 'sensei-lms' ); ?></h4>
 			<p><?php echo esc_html( $args['data']['description'] ); ?></p>
 			<ul>
 				<?php foreach ( $args['data']['options'] as $option_value => $option_name ) : ?>
@@ -1100,12 +1100,12 @@ class Sensei_Settings extends Sensei_Settings_API {
 					<label>
 						<input
 							type="radio"
-							name="<?php echo esc_attr( "{$this->token}[{$key}]" ) ?>"
-							value="<?php echo esc_attr( $option_value ) ?>"
+							name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>"
+							value="<?php echo esc_attr( $option_value ); ?>"
 							<?php disabled( true, $disabled, true ); ?>
 							<?php checked( $option_value, $value, true ); ?>
 						/>
-						<?php echo esc_html( $option_name ) ?>
+						<?php echo esc_html( $option_name ); ?>
 					</label>
 				</li>
 				<?php endforeach; ?>
@@ -1125,21 +1125,21 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$settings      = $this->get_settings();
 		$key           = $args['key'];
 		$value         = $settings[ $key ];
-		$visible       = $settings[ 'experimental_progress_storage' ] ?? false;
+		$visible       = $settings['experimental_progress_storage'] ?? false;
 		$block_display = $visible ? 'block' : 'none';
 		$disabled      = false; // Disable when migrtion is in progress.
 		?>
-		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ) ?>">
-			<h4><?php echo __( 'Progress storage synchronization', 'sensei-lms' ) ?></h4>
+		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
+			<h4><?php echo __( 'Progress storage synchronization', 'sensei-lms' ); ?></h4>
 			<label>
 				<input
 					type="checkbox"
-					name="<?php echo esc_attr( "{$this->token}[{$key}]" ) ?>"
-					value="<?php echo esc_attr( $value ) ?>"
+					name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>"
+					value="<?php echo esc_attr( $value ); ?>"
 					<?php disabled( true, $disabled, true ); ?>
 					<?php checked( $value, true, true ); ?>
 				/>
-				<?php echo esc_html( $args['data']['description'] ) ?>
+				<?php echo esc_html( $args['data']['description'] ); ?>
 			</label>
 		</div>
 		<?php

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -861,10 +861,10 @@ class Sensei_Settings extends Sensei_Settings_API {
 				'description' => __( 'Choose a repository to store the progress and quiz submissions of your students.', 'sensei-lms' ),
 				'form'        => 'render_progress_storage_repositories',
 				'type'        => 'radio',
-				'default'     => 'legacy',
+				'default'     => 'comments',
 				'section'     => 'sensei-experimental-features',
 				'options'     => array(
-					'comments'      => __( 'WordPress comments based storage (legacy)', 'sensei-lms' ),
+					'comments'      => __( 'WordPress comments based storage', 'sensei-lms' ),
 					'custom_tables' => __( 'High-Performance progress storage (experimental)', 'sensei-lms' ),
 				),
 			);

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1092,7 +1092,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$disabled      = false; // Disable when storages are not in sync.
 		?>
 		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
-			<h4><?php echo __( 'Progress storage repository', 'sensei-lms' ); ?></h4>
+			<h4><?php echo esc_html( __( 'Progress storage repository', 'sensei-lms' ) ); ?></h4>
 			<p><?php echo esc_html( $args['data']['description'] ); ?></p>
 			<ul>
 				<?php foreach ( $args['data']['options'] as $option_value => $option_name ) : ?>
@@ -1130,7 +1130,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$disabled      = false; // Disable when migrtion is in progress.
 		?>
 		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
-			<h4><?php echo __( 'Progress storage synchronization', 'sensei-lms' ); ?></h4>
+			<h4><?php echo esc_html( __( 'Progress storage synchronization', 'sensei-lms' ) ); ?></h4>
 			<label>
 				<input
 					type="checkbox"

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -852,7 +852,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 			$fields['experimental_progress_storage']                 = array(
 				'name'        => __( 'High-Performance Progress Storage', 'sensei-lms' ),
 				'description' => __( 'Store the progress of your students in separate tables. This feature is currently in development and should be used with caution.', 'sensei-lms' ),
-				'form'        => 'render_progress_storage_feature',
 				'type'        => 'checkbox',
 				'default'     => false,
 				'section'     => 'sensei-experimental-features',
@@ -1079,31 +1078,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 	}
 
 	/**
-	 * Renders the High-Performance Progress Storage feature setting.
-	 *
-	 * @param array $args The field arguments.
-	 */
-	public function render_progress_storage_feature( $args ) {
-
-		$settings = $this->get_settings();
-		$key      = $args['key'];
-		$value    = $settings[ $key ];
-		?>
-			<label>
-				<input
-					type="checkbox"
-					id="sensei_experimental_progress_storage_feature"
-					name="<?php echo esc_attr( "{$this->token}[{$key}]" ) ?>"
-					value="<?php echo esc_attr( $value ) ?>"
-					<?php checked( $value, $value, true ); ?>
-				/>
-				<?php echo esc_html( $args['data']['description'] ) ?>
-			</label>
-		<?php
-		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
-	}
-
-	/**
 	 * Renders the High-Performance Progress Storage repository setting.
 	 *
 	 * @param array $args The field arguments.
@@ -1138,6 +1112,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			</ul>
 		</div>
 		<?php
+		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
 	}
 
 	/**
@@ -1162,12 +1137,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 					name="<?php echo esc_attr( "{$this->token}[{$key}]" ) ?>"
 					value="<?php echo esc_attr( $value ) ?>"
 					<?php disabled( true, $disabled, true ); ?>
-					<?php checked( $value, $value, true ); ?>
+					<?php checked( $value, true, true ); ?>
 				/>
 				<?php echo esc_html( $args['data']['description'] ) ?>
 			</label>
 		</div>
 		<?php
+		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ const files = [
 	'js/modules-admin.js',
 	'js/ranges.js',
 	'js/settings.js',
+	'js/admin/settings/experimental-features.js',
 	'js/user-dashboard.js',
 	'js/stop-double-submission.js',
 	'js/question-answer-tinymce-editor.js',


### PR DESCRIPTION
Resolves #7234

## Proposed Changes
* Add two new settings in the Experimental Features tab.
* Manage the visibility of new settings depending on the status of HPPS setting.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei LMS Settings > Experimental Features
2. It is expected to see Repositories and Synchronization settings when the HPPS is enabled.
3. Try do disable/enable HPPS. Try to save the new value and play with disabling/enabling again.

## Video
https://github.com/Automattic/sensei/assets/329356/fa09ff39-7b53-44fa-ad92-bb4e61b96191


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
