### PR TITLE
Update message about no published lessons to be more clear

### DIFF
--- a/changelog/change-no-published-lessons-message
+++ b/changelog/change-no-published-lessons-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update frontend message when there's no published lessons on the course for a more clear message

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -55,7 +55,7 @@ class Sensei_Course_Outline_Course_Block {
 		$post_id    = $outline['post_id'];
 
 		if ( empty( $blocks ) ) {
-			Sensei()->notices->add_notice( __( 'There is no published content in this course yet.', 'sensei-lms' ), 'info', 'sensei-course-outline-no-content' );
+			Sensei()->notices->add_notice( __( 'There is no published lessons in this course yet.', 'sensei-lms' ), 'info', 'sensei-course-outline-no-content' );
 			return '';
 		}
 

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -55,7 +55,7 @@ class Sensei_Course_Outline_Course_Block {
 		$post_id    = $outline['post_id'];
 
 		if ( empty( $blocks ) ) {
-			Sensei()->notices->add_notice( __( 'There is no published lessons in this course yet.', 'sensei-lms' ), 'info', 'sensei-course-outline-no-content' );
+			Sensei()->notices->add_notice( __( 'There are no published lessons in this course yet.', 'sensei-lms' ), 'info', 'sensei-course-outline-no-content' );
 			return '';
 		}
 

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -38,7 +38,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		Sensei()->notices->maybe_print_notices();
 		$result = ob_get_clean();
 
-		$this->assertStringContainsString( 'There is no published lessons in this course yet.', $result );
+		$this->assertStringContainsString( 'There are no published lessons in this course yet.', $result );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -38,7 +38,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		Sensei()->notices->maybe_print_notices();
 		$result = ob_get_clean();
 
-		$this->assertStringContainsString( 'There is no published content in this course yet.', $result );
+		$this->assertStringContainsString( 'There is no published lessons in this course yet.', $result );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

* Improve frontend message when there's no published lessons yet.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course.
2. Publish it without publishing the lessons.
3. Visit the course on the frontend and make sure the message was changed.

## Screenshot

<img width="809" alt="Screenshot 2023-11-17 at 19 24 10" src="https://github.com/Automattic/sensei/assets/876340/53568fbc-a63e-4cb9-ba1f-273f5d6ceda9">

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
