### PR TITLE
Fix Take Quiz button being visible when quiz added after lesson is completed

### DIFF
--- a/includes/blocks/class-sensei-view-quiz-block.php
+++ b/includes/blocks/class-sensei-view-quiz-block.php
@@ -44,13 +44,17 @@ class Sensei_View_Quiz_Block {
 			return '';
 		}
 
-		$user_id           = get_current_user_id();
-		$quiz_permalink    = Sensei()->lesson->get_quiz_permalink( $lesson_id );
-		$is_quiz_submitted = Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id );
-		$course_id         = Sensei()->lesson->get_course_id( $lesson_id );
-		$is_learning_mode  = \Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
+		$user_id             = get_current_user_id();
+		$quiz_permalink      = Sensei()->lesson->get_quiz_permalink( $lesson_id );
+		$is_quiz_submitted   = Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id );
+		$course_id           = Sensei()->lesson->get_course_id( $lesson_id );
+		$is_learning_mode    = \Sensei_Course_Theme_Option::has_learning_mode_enabled( intval( $course_id ) );
+		$is_lesson_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 
-		if ( ! $quiz_permalink || ( $is_learning_mode && $is_quiz_submitted ) ) {
+		// In and Outside learning mode - If the quiz is not available
+		// Inside learning mode - the user has already submitted the quiz
+		// or the user has already completed the lesson.
+		if ( ! $quiz_permalink || ( $is_learning_mode && ( $is_quiz_submitted || $is_lesson_completed ) ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
Fixes an edge case of the Take Quiz button being visible when quiz added after lesson is completed.

## Proposed Changes
* Added a check to not render the Take Quiz button when the lesson is already completed in learning mode to match the behavior of the legacy Lesson Actions of Learning mode

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with two or more lessons
2. Complete the first lesson as a student
3. Now go back to the editor and add a quiz to the first lesson
4. Now visit the first lesson as a student
5. Make sure you see only the Completed and Next Lesson buttons

#### Before

![image](https://github.com/Automattic/sensei/assets/6820724/de50d601-c5b3-469e-8c3b-a6cbdf0358b6)

#### After

![image](https://github.com/Automattic/sensei/assets/6820724/71eaa7b2-0b41-4dbd-8c58-f942c0ec41f2)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
