### PR TITLE
Enable erase tables tool when the feature is enabled, but tables not in use

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -629,16 +629,16 @@ class Sensei_Main {
 		$tables_feature_enabled = isset( $this->settings->settings['experimental_progress_storage'] )
 			&& ( true === $this->settings->settings['experimental_progress_storage'] );
 
+		if ( $tables_feature_enabled ) {
+			// Enable tables based progress feature flag.
+			add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
+		}
+
 		$tables_sync_enabled = $tables_feature_enabled
 			&& ( true === $this->settings->settings['experimental_progress_storage_synchronization'] );
 
 		$read_from_tables_setting = isset( $this->settings->settings['experimental_progress_storage_repository'] )
 			&& ( 'custom_tables' === $this->settings->settings['experimental_progress_storage_repository'] );
-
-		if ( $tables_sync_enabled ) {
-			// Enable tables based progress feature flag.
-			add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
-		}
 
 		/**
 		 * Filter whether to read student progress from tables.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -662,7 +662,7 @@ class Sensei_Main {
 		$this->quiz_grade_repository      = ( new Grade_Repository_Factory( $tables_enabled, $read_from_tables ) )->create();
 
 		// Progress tables eraser.
-		if ( ! $tables_enabled ) {
+		if ( $tables_enabled ) {
 			( new Progress_Tables_Eraser() )->init();
 		}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -626,14 +626,16 @@ class Sensei_Main {
 		$this->rest_api_internal = new Sensei_REST_API_Internal();
 
 		// Student progress repositories.
-		$tables_enabled = isset( $this->settings->settings['experimental_progress_storage'] )
-			&& ( true === $this->settings->settings['experimental_progress_storage'] )
+		$tables_feature_enabled = isset( $this->settings->settings['experimental_progress_storage'] )
+			&& ( true === $this->settings->settings['experimental_progress_storage'] );
+
+		$tables_sync_enabled = $tables_feature_enabled
 			&& ( true === $this->settings->settings['experimental_progress_storage_synchronization'] );
 
 		$read_from_tables_setting = isset( $this->settings->settings['experimental_progress_storage_repository'] )
 			&& ( 'custom_tables' === $this->settings->settings['experimental_progress_storage_repository'] );
 
-		if ( $tables_enabled ) {
+		if ( $tables_sync_enabled ) {
 			// Enable tables based progress feature flag.
 			add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
 		}
@@ -649,20 +651,20 @@ class Sensei_Main {
 		 * @return {bool} Whether to read student progress from tables.
 		 */
 		$read_from_tables                         = apply_filters( 'sensei_student_progress_read_from_tables', $read_from_tables_setting );
-		$this->course_progress_repository_factory = new Course_Progress_Repository_Factory( $tables_enabled, $read_from_tables );
+		$this->course_progress_repository_factory = new Course_Progress_Repository_Factory( $tables_sync_enabled, $read_from_tables );
 		$this->course_progress_repository         = $this->course_progress_repository_factory->create();
-		$this->lesson_progress_repository_factory = new Lesson_Progress_Repository_Factory( $tables_enabled, $read_from_tables );
+		$this->lesson_progress_repository_factory = new Lesson_Progress_Repository_Factory( $tables_sync_enabled, $read_from_tables );
 		$this->lesson_progress_repository         = $this->lesson_progress_repository_factory->create();
-		$this->quiz_progress_repository_factory   = new Quiz_Progress_Repository_Factory( $tables_enabled, $read_from_tables );
+		$this->quiz_progress_repository_factory   = new Quiz_Progress_Repository_Factory( $tables_sync_enabled, $read_from_tables );
 		$this->quiz_progress_repository           = $this->quiz_progress_repository_factory->create();
 
 		// Quiz submission repositories.
-		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $tables_enabled, $read_from_tables ) )->create();
-		$this->quiz_answer_repository     = ( new Answer_Repository_Factory( $tables_enabled, $read_from_tables ) )->create();
-		$this->quiz_grade_repository      = ( new Grade_Repository_Factory( $tables_enabled, $read_from_tables ) )->create();
+		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
+		$this->quiz_answer_repository     = ( new Answer_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
+		$this->quiz_grade_repository      = ( new Grade_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
 
 		// Progress tables eraser.
-		if ( $tables_enabled ) {
+		if ( $tables_feature_enabled ) {
 			( new Progress_Tables_Eraser() )->init();
 		}
 
@@ -671,7 +673,7 @@ class Sensei_Main {
 		}
 
 		// Student progress migration.
-		if ( $tables_enabled && $this->action_scheduler ) {
+		if ( $tables_sync_enabled && $this->action_scheduler ) {
 			$this->init_migration_scheduler();
 			if ( ! is_null( $this->migration_scheduler ) ) {
 				( new Migration_Tool( \Sensei_Tools::instance(), $this->migration_scheduler ) )->init();

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -88,7 +88,7 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	 * @return string
 	 */
 	public function get_description() {
-		return __( 'Delete student progress and quiz submission tables. This will delete those tables, but won\'t affect comment-based data.', 'sensei-lms' );
+		return __( 'Delete student progress and quiz submission tables. This will delete those tables, but won\'t affect comment-based data. The tables can be deleted only if progress sync is disabled (Settings -> Experimental Features).', 'sensei-lms' );
 	}
 
 	/**

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -136,6 +136,14 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	 * @return bool True if tool is available.
 	 */
 	public function is_available() {
+		$sync       = (bool) ( Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false );
+		$repository = Sensei()->settings->settings['experimental_progress_storage_repository'] ?? 'comments';
+
+		// Disable the tool if tables are in use.
+		if ( $sync || 'comments' !== $repository ) {
+			return false;
+		}
+
 		global $wpdb;
 
 		foreach ( $this->eraser->get_tables() as $table ) {

--- a/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
+++ b/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
@@ -104,11 +104,48 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 		self::assertTrue( $table_exists );
 	}
 
-	public function testIsAvailable_Always_ReturnsTrue(): void {
+	public function testIsAvailable_HppsSyncEnabled_ReturnsFalse(): void {
+		/* Arrange. */
+		$settings                    = Sensei()->settings->settings;
+		Sensei()->settings->settings = array( 'experimental_progress_storage_synchronization' => true );
+
 		/* Act. */
 		$result = $this->eraser->is_available();
 
 		/* Assert. */
+		Sensei()->settings->settings = $settings;
+		self::assertFalse( $result );
+	}
+
+	public function testIsAvailable_HppsRepositoryWasTables_ReturnsFalse(): void {
+		/* Arrange. */
+		$settings                    = Sensei()->settings->settings;
+		Sensei()->settings->settings = array(
+			'experimental_progress_storage_synchronization' => false,
+			'experimental_progress_storage_repository' => 'custom_tables',
+		);
+
+		/* Act. */
+		$result = $this->eraser->is_available();
+
+		/* Assert. */
+		Sensei()->settings->settings = $settings;
+		self::assertFalse( $result );
+	}
+
+	public function testIsAvailable_HppsSyncDisabledAndRepositoryWasComments_ReturnsTrue(): void {
+		/* Arrange. */
+		$settings                    = Sensei()->settings->settings;
+		Sensei()->settings->settings = array(
+			'experimental_progress_storage_synchronization' => false,
+			'experimental_progress_storage_repository' => 'comments',
+		);
+
+		/* Act. */
+		$result = $this->eraser->is_available();
+
+		/* Assert. */
+		Sensei()->settings->settings = $settings;
 		self::assertTrue( $result );
 	}
 

--- a/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
+++ b/tests/unit-tests/internal/tools/test-class-progress-tables-eraser.php
@@ -63,7 +63,7 @@ class Progress_Tables_Eraser_Test extends \WP_UnitTestCase {
 		$description = $this->eraser->get_description();
 
 		/* Assert. */
-		self::assertSame( 'Delete student progress and quiz submission tables. This will delete those tables, but won\'t affect comment-based data.', $description );
+		self::assertSame( 'Delete student progress and quiz submission tables. This will delete those tables, but won\'t affect comment-based data. The tables can be deleted only if progress sync is disabled (Settings -> Experimental Features).', $description );
 	}
 
 	public function testProcess_ConfirmationProvided_DeletesTables(): void {


### PR DESCRIPTION
Resolves #7240

## Proposed Changes
* Show the Erase Tables tool when the HPPS feature is enabled.
* Show it as unavailable if sync is enabled or non-comments storage is in use (i.e. we make sure tables are not in use).

## Testing Instructions

1. Go to Sensei LMS > Settings > Experimental Feature, make sure HPPS is disabled.
2. Go to Sensei LMS > Tools, make sure there is no "Delete student progress tables" tool.
3. Go to Sensei LMS > Settings > Experimental Feature, enable HPPS.
4. Go to Sensei LMS > Tools, make sure you see the "Delete student progress tables" tool and it is enabled.
5. Go to Sensei LMS > Settings > Experimental Feature, enable synchronization.
6. Go to Sensei LMS > Tools, make sure you see the "Delete student progress tables" tool and it is not available.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
