### PR TITLE
Fix icon size on Sensei blocks appender

### DIFF
--- a/assets/shared/components/text-appender/style.scss
+++ b/assets/shared/components/text-appender/style.scss
@@ -20,5 +20,10 @@
 
 	&__menu .components-dropdown-menu__menu-item {
 		min-width: 175px;
+
+		> svg {
+			height: 24px;
+			width: 24px;
+		}
 	}
 }

--- a/changelog/fix-dropdown-menu-icon-size
+++ b/changelog/fix-dropdown-menu-icon-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix dropdown menu icon size


### PR DESCRIPTION
Resolves #7308

## Proposed Changes

* I fixed it originally with a Gutenberg PR: https://github.com/WordPress/gutenberg/pull/56450
* But while it's not merged and to be fixed in the versions where it's broken, I'm sending this PR with a workaround. Basically, it just adds the missing `width` and `height` to the `svg` in the `DropdownMenu` component.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new course.
2. Add a Course Outline block.
3. Click on "+".
4. Check that the icons are displayed correctly.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
