### PR TITLE
Fix broken Learning Mode templates on Gutenberg 17.1.0

### DIFF
--- a/assets/course-theme/blocks/register-template-blocks.js
+++ b/assets/course-theme/blocks/register-template-blocks.js
@@ -28,8 +28,6 @@ export function registerTemplateBlocks( blocks ) {
 	toggleBlockRegistration( true );
 
 	// TODO Only subscribe when in the post editor.
-	// Commented this out as it breaks the editor. Need to find a proper way to unregister blocks
-	// for templates other than lesson or quiz.
 	subscribe( () => {
 		const postType = select( 'core/editor' )?.getCurrentPostType();
 		const editPost = select( 'core/edit-post' );

--- a/assets/course-theme/blocks/register-template-blocks.js
+++ b/assets/course-theme/blocks/register-template-blocks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
-// import { select, subscribe } from '@wordpress/data';
+import { select, subscribe } from '@wordpress/data';
 
 /**
  * Makes sure the template blocks are only registered when in the site or widget editor, or editing the template from
@@ -30,16 +30,16 @@ export function registerTemplateBlocks( blocks ) {
 	// TODO Only subscribe when in the post editor.
 	// Commented this out as it breaks the editor. Need to find a proper way to unregister blocks
 	// for templates other than lesson or quiz.
-	// subscribe( () => {
-	// 	const postType = select( 'core/editor' )?.getCurrentPostType();
-	// 	const editPost = select( 'core/edit-post' );
+	subscribe( () => {
+		const postType = select( 'core/editor' )?.getCurrentPostType();
+		const editPost = select( 'core/edit-post' );
 
-	// 	if ( ! postType || ! editPost ) {
-	// 		return;
-	// 	}
+		if ( ! postType || ! editPost || 'wp_template' === postType ) {
+			return;
+		}
 
-	// 	const isTemplate =
-	// 		'lesson' === postType && editPost.isEditingTemplate();
-	// 	toggleBlockRegistration( isTemplate );
-	// } );
+		const isTemplate =
+			'lesson' === postType && editPost.isEditingTemplate();
+		toggleBlockRegistration( isTemplate );
+	} );
 }

--- a/assets/course-theme/blocks/register-template-blocks.js
+++ b/assets/course-theme/blocks/register-template-blocks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
-import { select, subscribe } from '@wordpress/data';
+// import { select, subscribe } from '@wordpress/data';
 
 /**
  * Makes sure the template blocks are only registered when in the site or widget editor, or editing the template from
@@ -28,16 +28,18 @@ export function registerTemplateBlocks( blocks ) {
 	toggleBlockRegistration( true );
 
 	// TODO Only subscribe when in the post editor.
-	subscribe( () => {
-		const postType = select( 'core/editor' )?.getCurrentPostType();
-		const editPost = select( 'core/edit-post' );
+	// Commented this out as it breaks the editor. Need to find a proper way to unregister blocks
+	// for templates other than lesson or quiz.
+	// subscribe( () => {
+	// 	const postType = select( 'core/editor' )?.getCurrentPostType();
+	// 	const editPost = select( 'core/edit-post' );
 
-		if ( ! postType || ! editPost ) {
-			return;
-		}
+	// 	if ( ! postType || ! editPost ) {
+	// 		return;
+	// 	}
 
-		const isTemplate =
-			'lesson' === postType && editPost.isEditingTemplate();
-		toggleBlockRegistration( isTemplate );
-	} );
+	// 	const isTemplate =
+	// 		'lesson' === postType && editPost.isEditingTemplate();
+	// 	toggleBlockRegistration( isTemplate );
+	// } );
 }

--- a/changelog/fix-gutenberg-compat-fix
+++ b/changelog/fix-gutenberg-compat-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix broken Learning Mode templates on Gutenberg 17.1.0


### PR DESCRIPTION
## Proposed Changes
~Comments out code that was erroneously unregistering Sensei's blocks for the Learning Mode templates (see screenshot below).~ UPDATE: Return early if the post type is `wp_template` (prior to Gutenberg 17.1.0 the call to `getCurrentPostType` would return `null`).

The original intention of this code appears to have been to only make Sensei's blocks available for the Learning Mode templates. However, this code wasn't working regardless because the call to [`getCurrentPostType`](https://github.com/Automattic/sensei/blob/trunk/assets/course-theme/blocks/register-template-blocks.js#L32) always returned `null`, which meant the call to [unregister the blocks](https://github.com/Automattic/sensei/blob/trunk/assets/course-theme/blocks/register-template-blocks.js#L21) never actually fired because it [returned early](https://github.com/Automattic/sensei/blob/trunk/assets/course-theme/blocks/register-template-blocks.js#L36).

This is a quick fix to get things back to working how they were before, but we will need to create a separate issue to properly unregister Sensei blocks for non-Learning Mode templates (which likely hasn't worked for quite some time, if ever).

### Before
![Screenshot 2023-11-22 at 10 35 39 AM (4)](https://github.com/Automattic/sensei/assets/1190420/ff5fb709-b172-432f-b322-bc4f32613d96)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate Gutenberg 17.1.0.
2. In the site editor, check that the Lesson and Quiz Learning Mode templates load.
3. Check that the same Sensei blocks are still loaded for courses, lessons, posts and pages as they did before.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
