### PR TITLE
Fix deprecation notice when doing HPPS migration

### DIFF
--- a/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
@@ -66,6 +66,10 @@ class Comments_Based_Course_Progress_Repository implements Course_Progress_Repos
 	 * @return Comments_Based_Course_Progress|null The course progress.
 	 */
 	public function get( int $course_id, int $user_id ): ?Course_Progress_Interface {
+		if ( ! $user_id ) {
+			return null;
+		}
+
 		$activity_args = [
 			'post_id' => $course_id,
 			'user_id' => $user_id,
@@ -147,6 +151,10 @@ class Comments_Based_Course_Progress_Repository implements Course_Progress_Repos
 	 * @return bool Whether the course progress exists.
 	 */
 	public function has( int $course_id, int $user_id ): bool {
+		if ( ! $user_id ) {
+			return false;
+		}
+
 		$activity_args = [
 			'post_id' => $course_id,
 			'user_id' => $user_id,

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
@@ -67,6 +67,10 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 	 * @return Lesson_Progress_Interface|null The lesson progress or null if not found.
 	 */
 	public function get( int $lesson_id, int $user_id ): ?Lesson_Progress_Interface {
+		if ( ! $user_id ) {
+			return null;
+		}
+
 		$activity_args = [
 			'post_id' => $lesson_id,
 			'user_id' => $user_id,
@@ -90,6 +94,10 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 	 * @return bool
 	 */
 	public function has( int $lesson_id, int $user_id ): bool {
+		if ( ! $user_id ) {
+			return false;
+		}
+
 		$activity_args = [
 			'post_id' => $lesson_id,
 			'user_id' => $user_id,
@@ -201,6 +209,10 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 	 * @return int
 	 */
 	public function count( int $course_id, int $user_id ): int {
+		if ( ! $user_id ) {
+			return 0;
+		}
+
 		$lessons = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
 
 		if ( empty( $lessons ) ) {

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -91,6 +91,10 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	 * @return bool
 	 */
 	public function has( int $quiz_id, int $user_id ): bool {
+		if ( ! $user_id ) {
+			return false;
+		}
+
 		$lesson_id     = Sensei()->quiz->get_lesson_id( $quiz_id );
 		$activity_args = [
 			'post_id' => $lesson_id,
@@ -168,6 +172,10 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	 * @param int $user_id User identifier.
 	 */
 	public function delete_for_user( int $user_id ): void {
+		if ( ! $user_id ) {
+			return;
+		}
+
 		$activity_args = [
 			'user_id' => $user_id,
 			'type'    => 'sensei_lesson_status',


### PR DESCRIPTION
Related to https://github.com/Automattic/sensei/pull/7294

While doing the HPPS migration, in some cases, the code calls `sensei_check_for_activity` with a `user_id` of 0. This fills the logs with a deprecation notice `At no point should user_id be equal to 0.`.

## Proposed Changes

Check the `user_id` in the repository classes before calling `sensei_check_for_activity`.

## Testing Instructions

There is no step-by-step way to test this because it happens in specific cases. There are no logic changes, so just make sure the code looks ok.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
