### PR TITLE
Output logs for failed migration jobs

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1157,31 +1157,4 @@ $promo_highlight: #43af99;
 		margin-left: 10px;
 		position: absolute;
 	}
-
-	&__notice {
-		position: relative;
-		background: #fff;
-		border: 1px solid #c3c4c7;
-		border-left-width: 4px;
-		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-		margin: 5px 0px;
-		padding: 1px 12px;
-
-
-		&--info {
-			border-left-color: #72aee6;
-		}
-
-		&--success {
-			border-left-color: #00a32a;
-		}
-
-		&--error {
-			border-left-color: #d63638;
-		}
-
-		&--warning {
-			border-left-color: #dba617;
-		}
-	}
 }

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1157,4 +1157,31 @@ $promo_highlight: #43af99;
 		margin-left: 10px;
 		position: absolute;
 	}
+
+	&__notice {
+		position: relative;
+		background: #fff;
+		border: 1px solid #c3c4c7;
+		border-left-width: 4px;
+		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+		margin: 5px 0px;
+		padding: 1px 12px;
+
+
+		&--info {
+			border-left-color: #72aee6;
+		}
+
+		&--success {
+			border-left-color: #00a32a;
+		}
+
+		&--error {
+			border-left-color: #d63638;
+		}
+
+		&--warning {
+			border-left-color: #dba617;
+		}
+	}
 }

--- a/assets/js/admin/settings/experimental-features.js
+++ b/assets/js/admin/settings/experimental-features.js
@@ -5,9 +5,9 @@ jQuery( document ).ready( function ( $ ) {
 	);
 	progressStorageFeature.on( 'change', function () {
 		if ( $( this ).is( ':checked' ) ) {
-			$( '.sensei-settings_progress-storage-settings' ).show();
+			$( '.sensei-settings__progress-storage-settings' ).show();
 		} else {
-			$( '.sensei-settings_progress-storage-settings' ).hide();
+			$( '.sensei-settings__progress-storage-settings' ).hide();
 		}
 	} );
 

--- a/assets/js/admin/settings/experimental-features.js
+++ b/assets/js/admin/settings/experimental-features.js
@@ -17,17 +17,20 @@ jQuery( document ).ready( function ( $ ) {
 		'.sensei-settings_progress-storage-synchronization'
 	);
 	syncProgress.on( 'change', function () {
-		let repository_options = $(
+		const savedState = $( this ).data( 'saved-state' );
+		let repositoryOptions = $(
 			'.sensei-settings_progress-storage-repository'
 		);
 		if ( $( this ).is( ':checked' ) ) {
-			repository_options.prop( 'disabled', false );
+			if ( savedState > 0 ) {
+				repositoryOptions.prop( 'disabled', false );
+			}
 		} else {
 			// ensure comments are selected
-			repository_options
+			repositoryOptions
 				.filter( '[value="comments"]' )
 				.prop( 'checked', true );
-			repository_options.prop( 'disabled', true );
+			repositoryOptions.prop( 'disabled', true );
 		}
 	} );
 } );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1215,7 +1215,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 					<?php if ( ! empty( $failed_jobs_errors ) ) : ?>
 					<p>
-						<?php echo esc_html( __( 'Some migration jobs failed. You can try to disable synchronization and enable it again to restart migration. Log for failed jobs:', 'sensei-lms' ) ) ?>
+						<?php echo esc_html( __( 'Some migration jobs failed. You can try to disable synchronization and enable it again to restart migration. Log for failed jobs:', 'sensei-lms' ) ); ?>
 					</p>
 					<ul>
 						<?php foreach ( $failed_jobs_errors as $error ) : ?>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -863,7 +863,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				'description' => __( 'Choose a repository to store the progress and quiz submissions of your students.', 'sensei-lms' ),
 				'form'        => 'render_progress_storage_repositories',
 				'type'        => 'radio',
-				'default'     => 'comments',
+				'default'     => Progress_Storage_Settings::COMMENTS_STORAGE,
 				'section'     => 'sensei-experimental-features',
 				'options'     => Progress_Storage_Settings::get_storage_repositories(),
 			);
@@ -1196,7 +1196,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$migration_errors      = ! is_null( $migration_scheduler ) ? $migration_scheduler->get_errors() : array();
 
 		// Disables the checkbox if the migration is in progress or HPPS storage is in use.
-		$hpps_repository_in_use = 'custom_tables' === ( $settings['experimental_progress_storage_repository'] ?? null );
+		$hpps_repository_in_use = Progress_Storage_Settings::TABLES_STORAGE === ( $settings['experimental_progress_storage_repository'] ?? null );
 		$disabled               = $migration_in_progress || $hpps_repository_in_use || is_null( Sensei()->action_scheduler );
 		?>
 		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1214,7 +1214,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 					?>
 				</p>
 					<?php if ( ! empty( $failed_jobs_errors ) ) : ?>
-					<p>Some migration jobs failed. You can try to disable synchronization and enable it again to restart migration. Log for failed jobs:</p>
+					<p>
+						<?php echo esc_html( __( 'Some migration jobs failed. You can try to disable synchronization and enable it again to restart migration. Log for failed jobs:', 'sensei-lms' ) ) ?>
+					</p>
 					<ul>
 						<?php foreach ( $failed_jobs_errors as $error ) : ?>
 						<li><?php echo esc_html( $error ); ?></li>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1236,7 +1236,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 			<?php endif; ?>
 		<?php if ( ! $value ) : ?>
-			<div class="sensei-settings__notice sensei-settings__notice--info sensei-settings__progress-storage-settings hidden">
+			<div class="notice notice-info inline sensei-settings__progress-storage-settings hidden">
 				<p>
 					<?php
 					echo esc_html( __( 'Save changes to make synchronization setting available.', 'sensei-lms' ) );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -47,13 +47,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$this->get_settings();
 
 		// Log when settings are updated by the user.
-		add_filter( 'pre_update_option_sensei-settings', [ $this, 'before_experimental_features_saved' ], 100, 2 );
 		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
 
 		// Mark settings section as visited on ajax action received.
 		add_action( 'wp_ajax_sensei_settings_section_visited', [ $this, 'mark_section_as_visited' ] );
 
 		// Do preparation for enabled experimental features.
+		add_filter( 'pre_update_option_sensei-settings', [ $this, 'before_experimental_features_saved' ], 10, 2 );
 		add_action( 'update_option_sensei-settings', [ $this, 'experimental_features_saved' ], 10, 2 );
 	}
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1077,8 +1077,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		if ( $new_hpps !== $old_hpps ) {
 			if ( $new_hpps ) {
-				// If the feature is being enabled, set the default values for the repository.
-				// We don't set the default value for the synchronization because it's okay to change it at this moment.
+				// If the feature is being enabled, set the default values for the other settings.
+				$value['experimental_progress_storage_synchronization'] = false;
 				$value['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
 			} else {
 				// If the feature is being disabled, clear the values for the other settings.
@@ -1217,6 +1217,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<label>
 				<input
 					class="sensei-settings_progress-storage-feature"
+					data-saved-state="<?php echo esc_attr( (int) $value ); ?>"
 					type="checkbox"
 					name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>"
 					value="1"
@@ -1235,6 +1236,15 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 			<?php endif; ?>
 		</div>
+		<?php if ( ! $value ) : ?>
+			<div class="notice notice-info sensei-settings_progress-storage-settings hidden">
+				<p>
+					<?php
+					echo esc_html( __( 'Save changes to make synchronization setting available.', 'sensei-lms' ) );
+					?>
+				</p>
+			</div>
+		<?php endif; ?>
 		<?php
 		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
 	}
@@ -1320,7 +1330,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Disables the checkbox if the migration is in progress or HPPS storage is in use.
 		$hpps_repository_in_use = Progress_Storage_Settings::TABLES_STORAGE === ( $settings['experimental_progress_storage_repository'] ?? null );
-		$disabled               = $migration_in_progress || $hpps_repository_in_use || is_null( Sensei()->action_scheduler );
+		$disabled               = ! $visible || $migration_in_progress || $hpps_repository_in_use || is_null( Sensei()->action_scheduler );
 		if ( $migration_errors ) {
 			// Enable the checkbox if there are errors to allow the user to retry.
 			$disabled = false;
@@ -1331,6 +1341,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<label>
 				<input
 					class="sensei-settings_progress-storage-synchronization"
+					data-saved-state="<?php echo esc_attr( (int) ( $value && $migration_complete ) ); ?>"
 					type="checkbox"
 					name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>"
 					value="1"

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1079,7 +1079,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			if ( $new_hpps ) {
 				// If the feature is being enabled, set the default values for the other settings.
 				$value['experimental_progress_storage_synchronization'] = false;
-				$value['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
+				$value['experimental_progress_storage_repository']      = Progress_Storage_Settings::COMMENTS_STORAGE;
 			} else {
 				// If the feature is being disabled, clear the values for the other settings.
 				unset( $value['experimental_progress_storage_repository'] );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1174,6 +1174,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$migration_scheduler   = Sensei()->migration_scheduler;
 		$migration_in_progress = $migration_scheduler && $migration_scheduler->is_in_progress();
 		$migration_complete    = $migration_scheduler && $migration_scheduler->is_complete();
+		$migration_failed      = $migration_scheduler && $migration_scheduler->is_failed();
 		$migration_errors      = ! is_null( $migration_scheduler ) ? $migration_scheduler->get_errors() : array();
 
 		// Disables the checkbox if the migration is in progress or HPPS storage is in use.
@@ -1213,6 +1214,18 @@ class Sensei_Settings extends Sensei_Settings_API {
 				<p>
 					<?php
 					echo esc_html( __( 'Migration complete and data synchronization enabled.', 'sensei-lms' ) );
+					?>
+				</p>
+				<?php elseif ( $migration_complete && ! empty( $migration_errors ) ) : ?>
+				<p>
+					<?php
+					echo esc_html( __( 'Migration complete, but errors occurred during data synchronization.', 'sensei-lms' ) );
+					?>
+				</p>
+				<?php elseif ( $migration_failed ) : ?>
+				<p>
+					<?php
+					echo esc_html( __( 'Migration failed. Please retry.', 'sensei-lms' ) );
 					?>
 				</p>
 				<?php elseif ( is_null( $migration_scheduler ) ) : ?>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1179,6 +1179,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Disables the checkbox if the migration is in progress or HPPS storage is in use.
 		$hpps_repository_in_use = 'custom_tables' === ( $settings['experimental_progress_storage_repository'] ?? null );
 		$disabled               = $migration_in_progress || $hpps_repository_in_use || is_null( Sensei()->action_scheduler );
+
+		// Migration job errors.
+		$failed_jobs_errors = array();
+		if ( $migration_scheduler && $migration_scheduler->has_failed_jobs() ) {
+			// If there are failed jobs, the checkbox should enabled to make it possible to restart the migration.
+			$disabled           = false;
+			$failed_jobs_errors = $migration_scheduler->get_failed_jobs_errors();
+		}
 		?>
 		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
 			<h4><?php echo esc_html( __( 'Progress storage synchronization', 'sensei-lms' ) ); ?></h4>
@@ -1205,6 +1213,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 					echo esc_html( __( 'Data migration is in progress. Please wait for it to switch repository.', 'sensei-lms' ) );
 					?>
 				</p>
+					<?php if ( ! empty( $failed_jobs_errors ) ) : ?>
+					<p>Some migration jobs failed. You can try to disable synchronization and enable it again to restart migration. Log for failed jobs:</p>
+					<ul>
+						<?php foreach ( $failed_jobs_errors as $error ) : ?>
+						<li><?php echo esc_html( $error ); ?></li>
+					<?php endforeach; ?>
+					</ul>
+					<?php endif; ?>
 				<?php elseif ( $migration_complete && empty( $migration_errors ) ) : ?>
 				<p>
 					<?php

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -2,6 +2,7 @@
 
 use Sensei\Internal\Installer\Eraser;
 use Sensei\Internal\Installer\Schema;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -864,10 +865,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				'type'        => 'radio',
 				'default'     => 'comments',
 				'section'     => 'sensei-experimental-features',
-				'options'     => array(
-					'comments'      => __( 'WordPress comments based storage', 'sensei-lms' ),
-					'custom_tables' => __( 'High-Performance progress storage (experimental)', 'sensei-lms' ),
-				),
+				'options'     => Progress_Storage_Settings::get_storage_repositories(),
 			);
 			$fields['experimental_progress_storage_synchronization'] = array(
 				'name'        => '',

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1235,9 +1235,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 					<?php endif; ?>
 				</p>
 			<?php endif; ?>
-		</div>
 		<?php if ( ! $value ) : ?>
-			<div class="notice notice-info sensei-settings_progress-storage-settings hidden">
+			<div class="sensei-settings__notice sensei-settings__notice--info sensei-settings__progress-storage-settings hidden">
 				<p>
 					<?php
 					echo esc_html( __( 'Save changes to make synchronization setting available.', 'sensei-lms' ) );
@@ -1245,6 +1244,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 			</div>
 		<?php endif; ?>
+		</div>
 		<?php
 		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
 	}
@@ -1264,7 +1264,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$migration_scheduler  = Sensei()->migration_scheduler;
 		$migration_incomplete = ! $migration_scheduler || ! $migration_scheduler->is_complete();
 		?>
-		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
+		<div class="sensei-settings__progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
 			<h4><?php echo esc_html( __( 'Progress storage repository', 'sensei-lms' ) ); ?></h4>
 			<p><?php echo esc_html( $args['data']['description'] ); ?></p>
 			<ul>
@@ -1336,7 +1336,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			$disabled = false;
 		}
 		?>
-		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
+		<div class="sensei-settings__progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
 			<h4><?php echo esc_html( __( 'Progress storage synchronization', 'sensei-lms' ) ); ?></h4>
 			<label>
 				<input

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1179,13 +1179,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Disables the checkbox if the migration is in progress or HPPS storage is in use.
 		$hpps_repository_in_use = 'custom_tables' === ( $settings['experimental_progress_storage_repository'] ?? null );
 		$disabled               = $migration_in_progress || $hpps_repository_in_use || is_null( Sensei()->action_scheduler );
-
-		// Migration job errors.
-		$failed_jobs_errors = array();
-		if ( $migration_scheduler && $migration_scheduler->has_failed_jobs() ) {
-			// If there are failed jobs, the checkbox should enabled to make it possible to restart the migration.
-			$disabled           = false;
-			$failed_jobs_errors = $migration_scheduler->get_failed_jobs_errors();
+		if ( $migration_errors ) {
+			// Enable the checkbox if there are errors to allow the user to retry.
+			$disabled = false;
 		}
 		?>
 		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
@@ -1213,33 +1209,12 @@ class Sensei_Settings extends Sensei_Settings_API {
 					echo esc_html( __( 'Data migration is in progress. Please wait for it to switch repository.', 'sensei-lms' ) );
 					?>
 				</p>
-					<?php if ( ! empty( $failed_jobs_errors ) ) : ?>
-					<p>
-						<?php echo esc_html( __( 'Some migration jobs failed. You can try to disable synchronization and enable it again to restart migration. Log for failed jobs:', 'sensei-lms' ) ); ?>
-					</p>
-					<ul>
-						<?php foreach ( $failed_jobs_errors as $error ) : ?>
-						<li><?php echo esc_html( $error ); ?></li>
-					<?php endforeach; ?>
-					</ul>
-					<?php endif; ?>
 				<?php elseif ( $migration_complete && empty( $migration_errors ) ) : ?>
 				<p>
 					<?php
 					echo esc_html( __( 'Migration complete and data synchronization enabled.', 'sensei-lms' ) );
 					?>
 				</p>
-				<?php elseif ( ! empty( $migration_errors ) ) : ?>
-				<p>
-					<?php
-					echo esc_html( __( 'Data migration failed.', 'sensei-lms' ) );
-					?>
-				</p>
-				<ul>
-					<?php foreach ( $migration_errors as $error ) : ?>
-					<li><?php echo esc_html( $error ); ?></li>
-					<?php endforeach; ?>
-				</ul>
 				<?php elseif ( is_null( $migration_scheduler ) ) : ?>
 				<p>
 					<?php
@@ -1251,6 +1226,19 @@ class Sensei_Settings extends Sensei_Settings_API {
 					echo esc_html( __( 'Waiting for data migration to start.', 'sensei-lms' ) );
 					?>
 				</p>
+				<?php endif; ?>
+
+				<?php if ( ! empty( $migration_errors ) ) : ?>
+				<p>
+					<?php
+					echo esc_html( __( 'Errors occurred during migration:', 'sensei-lms' ) );
+					?>
+				</p>
+				<ul class="ul-disc">
+					<?php foreach ( $migration_errors as $error ) : ?>
+					<li><?php echo esc_html( $error ); ?></li>
+					<?php endforeach; ?>
+				</ul>
 				<?php endif; ?>
 			<?php endif; ?>
 		</div>

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -13,6 +13,7 @@ use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Factory;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Factory;
@@ -636,7 +637,7 @@ class Sensei_Main {
 			&& ( true === $this->settings->settings['experimental_progress_storage_synchronization'] );
 
 		$read_from_tables_setting = isset( $this->settings->settings['experimental_progress_storage_repository'] )
-			&& ( 'custom_tables' === $this->settings->settings['experimental_progress_storage_repository'] );
+			&& ( Progress_Storage_Settings::TABLES_STORAGE === $this->settings->settings['experimental_progress_storage_repository'] );
 
 		/**
 		 * Filter whether to read student progress from tables.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -717,6 +717,7 @@ class Sensei_Main {
 		}
 
 		$this->migration_scheduler = new Migration_Job_Scheduler( $this->action_scheduler );
+		$this->migration_scheduler->init();
 		$this->migration_scheduler->register_job(
 			new Migration_Job( 'student_progress_migration', new Student_Progress_Migration() )
 		);

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -672,7 +672,7 @@ class Sensei_Main {
 		}
 
 		// Student progress migration.
-		if ( $tables_sync_enabled && $this->action_scheduler ) {
+		if ( $tables_feature_enabled && $this->action_scheduler ) {
 			$this->init_migration_scheduler();
 		}
 

--- a/includes/internal/action-scheduler/class-action-scheduler.php
+++ b/includes/internal/action-scheduler/class-action-scheduler.php
@@ -9,8 +9,6 @@
 
 namespace Sensei\Internal\Action_Scheduler;
 
-use ActionScheduler_Logger;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -105,34 +103,4 @@ class Action_Scheduler {
 	public function has_scheduled_action( string $hook, array $args = null ): bool {
 		return as_has_scheduled_action( $hook, $args, self::GROUP_ID );
 	}
-
-	/**
-	 * Get scheduled actions. This is a wrapper for as_get_scheduled_actions() that sets the group ID.
-	 *
-	 * @internal
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param array $args Arguments to pass to as_get_scheduled_actions().
-	 * @return int[] The scheduled action IDs.
-	 */
-	public function get_scheduled_actions( array $args ): array {
-		$args['group'] = self::GROUP_ID;
-		return as_get_scheduled_actions( $args, 'ids' );
-	}
-
-	/**
-	 * Get logs for an action.
-	 *
-	 * @internal
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param string $action_id The action ID.
-	 * @return array The action logs.
-	 */
-	public function get_action_logs( string $action_id ): array {
-		return ActionScheduler_Logger::instance()->get_logs( $action_id );
-	}
 }
-

--- a/includes/internal/action-scheduler/class-action-scheduler.php
+++ b/includes/internal/action-scheduler/class-action-scheduler.php
@@ -103,4 +103,20 @@ class Action_Scheduler {
 	public function has_scheduled_action( string $hook, array $args = null ): bool {
 		return as_has_scheduled_action( $hook, $args, self::GROUP_ID );
 	}
+
+	/**
+	 * Get the next scheduled action.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array  $args          Args that have been passed to the action scheduler.
+	 * @param string $return_format OBJECT, ARRAY_A, or 'ids'.
+	 * @return array The scheduled actions.
+	 */
+	public function get_scheduled_actions( array $args, $return_format = OBJECT ): array {
+		$args['group'] = self::GROUP_ID;
+		return as_get_scheduled_actions( $args, $return_format );
+	}
 }

--- a/includes/internal/action-scheduler/class-action-scheduler.php
+++ b/includes/internal/action-scheduler/class-action-scheduler.php
@@ -9,6 +9,8 @@
 
 namespace Sensei\Internal\Action_Scheduler;
 
+use ActionScheduler_Logger;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -102,6 +104,36 @@ class Action_Scheduler {
 	 */
 	public function has_scheduled_action( string $hook, array $args = null ): bool {
 		return as_has_scheduled_action( $hook, $args, self::GROUP_ID );
+	}
+
+	/**
+	 * Get scheduled actions. This is a wrapper for as_get_scheduled_actions() that sets the group ID.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Arguments to pass to as_get_scheduled_actions().
+	 * @return int[] The scheduled action IDs.
+	 */
+	public function get_scheduled_actions( array $args ): array {
+		$args['group'] = self::GROUP_ID;
+		return as_get_scheduled_actions( $args, 'ids' );
+	}
+
+	/**
+	 * Get logs for an action.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $action_id The action ID.
+	 * @return array The action logs.
+	 */
+	public function get_action_logs( string $action_id ): array {
+		$args['group'] = self::GROUP_ID;
+		return ActionScheduler_Logger::instance()->get_logs( $action_id );
 	}
 }
 

--- a/includes/internal/action-scheduler/class-action-scheduler.php
+++ b/includes/internal/action-scheduler/class-action-scheduler.php
@@ -132,7 +132,6 @@ class Action_Scheduler {
 	 * @return array The action logs.
 	 */
 	public function get_action_logs( string $action_id ): array {
-		$args['group'] = self::GROUP_ID;
 		return ActionScheduler_Logger::instance()->get_logs( $action_id );
 	}
 }

--- a/includes/internal/action-scheduler/class-action-scheduler.php
+++ b/includes/internal/action-scheduler/class-action-scheduler.php
@@ -117,6 +117,6 @@ class Action_Scheduler {
 	 */
 	public function get_scheduled_actions( array $args, $return_format = null ): array {
 		$args['group'] = self::GROUP_ID;
-		return as_get_scheduled_actions( $args, $return_format );
+		return as_get_scheduled_actions( $args, $return_format ?? 'OBJECT' );
 	}
 }

--- a/includes/internal/action-scheduler/class-action-scheduler.php
+++ b/includes/internal/action-scheduler/class-action-scheduler.php
@@ -115,7 +115,7 @@ class Action_Scheduler {
 	 * @param string $return_format OBJECT, ARRAY_A, or 'ids'.
 	 * @return array The scheduled actions.
 	 */
-	public function get_scheduled_actions( array $args, $return_format = OBJECT ): array {
+	public function get_scheduled_actions( array $args, $return_format = null ): array {
 		$args['group'] = self::GROUP_ID;
 		return as_get_scheduled_actions( $args, $return_format );
 	}

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -74,6 +74,9 @@ class Migration_Job_Scheduler {
 		$this->action_scheduler = $action_scheduler;
 	}
 
+	/**
+	 * Initialize the migration job scheduler.
+	 */
 	public function init(): void {
 		add_action( 'action_scheduler_unexpected_shutdown', [ $this, 'collect_failed_job_errors' ], 10, 2 );
 	}

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -370,7 +370,9 @@ class Migration_Job_Scheduler {
 	}
 
 	/**
-	 * Set completion time.
+	 * Set completion status and time.
+	 *
+	 * @param string $status The migration status.
 	 */
 	private function complete( string $status ): void {
 		update_option( self::STATUS_OPTION_NAME, $status );

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -10,6 +10,7 @@ namespace Sensei\Internal\Migration;
 use Sensei\Internal\Action_Scheduler\Action_Scheduler;
 use Sensei\Internal\Migration\Migrations\Quiz_Migration;
 use Sensei\Internal\Migration\Migrations\Student_Progress_Migration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -281,7 +282,7 @@ class Migration_Job_Scheduler {
 
 		if ( $job->is_complete() ) {
 			$next_job = $this->get_next_job( $job );
-			if ( $next_job ) {
+			if ( $next_job && Progress_Storage_Settings::is_sync_enabled() ) {
 				$this->schedule_job( $next_job );
 			} else {
 				$this->complete( self::STATUS_COMPLETE );

--- a/includes/internal/services/class-progress-storage-settings.php
+++ b/includes/internal/services/class-progress-storage-settings.php
@@ -64,6 +64,24 @@ class Progress_Storage_Settings {
 	}
 
 	/**
+	 * Returns true if the comments repository is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_comments_repository(): bool {
+		return self::COMMENTS_STORAGE === self::get_current_repository();
+	}
+
+	/**
+	 * Returns true if the tables repository is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_tables_repository(): bool {
+		return self::TABLES_STORAGE === self::get_current_repository();
+	}
+
+	/**
 	 * Returns true if the HPPS synchronization is enabled.
 	 *
 	 * @return bool

--- a/includes/internal/services/class-progress-storage-settings.php
+++ b/includes/internal/services/class-progress-storage-settings.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * File containing the Progress_Storage_Settings class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Progress_Storage_Settings.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Progress_Storage_Settings {
+	/**
+	 * Comment-based storage.
+	 *
+	 * @var string
+	 */
+	public const COMMENTS_STORAGE = 'comments';
+
+	/**
+	 * Table-based storage.
+	 *
+	 * @var string
+	 */
+	public const TABLES_STORAGE = 'custom_tables';
+
+	/**
+	 * Get the storage repositories.
+	 *
+	 * @return array Returns an array of repositories where the key is the repository slug and the value is the description.
+	 */
+	public static function get_storage_repositories(): array {
+		return array(
+			self::COMMENTS_STORAGE => __( 'WordPress comments based storage', 'sensei-lms' ),
+			self::TABLES_STORAGE   => __( 'High-Performance progress storage (experimental)', 'sensei-lms' ),
+		);
+	}
+
+	/**
+	 * Returns true if the HPPS feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_hpps_enabled(): bool {
+		return Sensei()->settings->settings['experimental_progress_storage'] ?? false;
+	}
+
+	/**
+	 * Returns current storage repository.
+	 *
+	 * @return string
+	 */
+	public static function get_current_repository(): string {
+		return Sensei()->settings->settings['experimental_progress_storage_repository'] ?? self::COMMENTS_STORAGE;
+	}
+
+	/**
+	 * Returns true if the HPPS synchronization is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_sync_enabled(): bool {
+		return Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
+	}
+}

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -8,6 +8,7 @@
 namespace Sensei\Internal\Tools;
 
 use Sensei\Internal\Installer\Eraser;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei_Tool_Interactive_Interface;
 use Sensei_Tool_Interface;
 use Sensei_Tools;
@@ -136,11 +137,11 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	 * @return bool True if tool is available.
 	 */
 	public function is_available() {
-		$sync       = (bool) ( Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false );
-		$repository = Sensei()->settings->settings['experimental_progress_storage_repository'] ?? 'comments';
+		$sync       = Progress_Storage_Settings::is_sync_enabled();
+		$repository = Progress_Storage_Settings::get_current_repository();
 
 		// Disable the tool if tables are in use.
-		if ( $sync || 'comments' !== $repository ) {
+		if ( $sync || Progress_Storage_Settings::COMMENTS_STORAGE !== $repository ) {
 			return false;
 		}
 

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -137,11 +137,8 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 	 * @return bool True if tool is available.
 	 */
 	public function is_available() {
-		$sync       = Progress_Storage_Settings::is_sync_enabled();
-		$repository = Progress_Storage_Settings::get_current_repository();
-
 		// Disable the tool if tables are in use.
-		if ( $sync || Progress_Storage_Settings::COMMENTS_STORAGE !== $repository ) {
+		if ( Progress_Storage_Settings::is_sync_enabled() || Progress_Storage_Settings::is_tables_repository() ) {
 			return false;
 		}
 

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -6,6 +6,8 @@
  * @package Sensei
  */
 
+use Sensei\Internal\Services\Progress_Storage_Settings;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -377,8 +379,8 @@ abstract class Sensei_Usage_Tracking_Base {
 		 */
 		$theme = wp_get_theme();
 
-		$is_hpps_enabled = Sensei()->settings->settings['experimental_progress_storage'] ?? false;
-		$hpps_repository = Sensei()->settings->settings['experimental_progress_storage_repository'] ?? 'comments';
+		$is_hpps_enabled = Progress_Storage_Settings::is_hpps_enabled();
+		$hpps_repository = Progress_Storage_Settings::get_current_repository();
 
 		$system_data                         = array();
 		$system_data['wp_version']           = $wp_version;

--- a/tests/framework/actionscheduler-mocks.php
+++ b/tests/framework/actionscheduler-mocks.php
@@ -174,7 +174,7 @@ function as_has_scheduled_action( $hook, $args = array(), $group = '' ) {
 	return false;
 }
 
-function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+function as_get_scheduled_actions( $args = array(), $return_format = 'OBJECT' ) {
 	_as_add_call( __FUNCTION__ );
 
 	$matches = [];

--- a/tests/framework/actionscheduler-mocks.php
+++ b/tests/framework/actionscheduler-mocks.php
@@ -130,20 +130,26 @@ function as_next_scheduled_action( $hook, $args = null, $group = '' ) {
 function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
 	_as_add_call( __FUNCTION__ );
 
+	$id = count( $GLOBALS['scheduled_actions'] ?? array() ) + 1;
+
 	$GLOBALS['scheduled_actions'][] = [
+		'id'    => $id,
 		'time'  => $timestamp,
 		'hook'  => $hook,
 		'args'  => $args,
 		'group' => $group,
 	];
 
-	return true;
+	return $id;
 }
 
 function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
 	_as_add_call( __FUNCTION__ );
 
+	$id = count( $GLOBALS['scheduled_actions'] ?? array() ) + 1;
+
 	$GLOBALS['scheduled_actions'][] = [
+		'id'                  => $id,
 		'time'                => $timestamp,
 		'interval_in_seconds' => $interval_in_seconds,
 		'hook'                => $hook,
@@ -151,7 +157,7 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 		'group'               => $group,
 	];
 
-	return true;
+	return $id;
 }
 
 function as_has_scheduled_action( $hook, $args = array(), $group = '' ) {
@@ -166,4 +172,27 @@ function as_has_scheduled_action( $hook, $args = array(), $group = '' ) {
 	}
 
 	return false;
+}
+
+function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+	_as_add_call( __FUNCTION__ );
+
+	$matches = [];
+
+	foreach ( $GLOBALS['scheduled_actions'] as $action ) {
+		if ( _as_match_action( $action, $args ) ) {
+			$matches[] = $action;
+		}
+	}
+
+	if ( 'ids' === $return_format ) {
+		return array_map(
+			function( $action ) {
+				return $action['id'];
+			},
+			$matches
+		);
+	}
+
+	return $matches;
 }

--- a/tests/unit-tests/internal/action-scheduler/test-class-action-scheduler.php
+++ b/tests/unit-tests/internal/action-scheduler/test-class-action-scheduler.php
@@ -21,10 +21,10 @@ class Action_Scheduler_Test extends \WP_UnitTestCase {
 		$scheduler = new Action_Scheduler();
 
 		/* Act. */
-		$scheduler->schedule_recurring_action( 1, 1, 'foo', [ 'bar' ] );
+		$scheduler->schedule_recurring_action( 1, 1, 'foo', array( 'bar' ) );
 
 		/* Assert. */
-		$result = _as_get_schedule_recurring_action( 1, 'foo', [ 'bar' ], Action_Scheduler::GROUP_ID );
+		$result = _as_get_schedule_recurring_action( 1, 'foo', array( 'bar' ), Action_Scheduler::GROUP_ID );
 		$this->assertCount( 1, $result );
 	}
 
@@ -33,23 +33,23 @@ class Action_Scheduler_Test extends \WP_UnitTestCase {
 		$scheduler = new Action_Scheduler();
 
 		/* Act. */
-		$scheduler->schedule_single_action( 'foo', [ 'bar' ] );
+		$scheduler->schedule_single_action( 'foo', array( 'bar' ) );
 
 		/* Assert. */
-		$result = _as_get_scheduled_actions( 'foo', [ 'bar' ], Action_Scheduler::GROUP_ID );
+		$result = _as_get_scheduled_actions( 'foo', array( 'bar' ), Action_Scheduler::GROUP_ID );
 		$this->assertCount( 1, $result );
 	}
 
 	public function testUnscheduleAction_WhenCalled_UnschedulesAction() {
 		/* Arrange. */
 		$scheduler = new Action_Scheduler();
-		$scheduler->schedule_single_action( 'foo', [ 'bar' ] );
+		$scheduler->schedule_single_action( 'foo', array( 'bar' ) );
 
 		/* Act. */
-		$scheduler->unschedule_action( 'foo', [ 'bar' ] );
+		$scheduler->unschedule_action( 'foo', array( 'bar' ) );
 
 		/* Assert. */
-		$result = _as_get_scheduled_actions( 'foo', [ 'bar' ], Action_Scheduler::GROUP_ID );
+		$result = _as_get_scheduled_actions( 'foo', array( 'bar' ), Action_Scheduler::GROUP_ID );
 		$this->assertCount( 0, $result );
 	}
 
@@ -62,17 +62,17 @@ class Action_Scheduler_Test extends \WP_UnitTestCase {
 		$scheduler->unschedule_all_actions();
 
 		/* Assert. */
-		$result = _as_get_scheduled_actions( 'foo', [], Action_Scheduler::GROUP_ID );
+		$result = _as_get_scheduled_actions( 'foo', array(), Action_Scheduler::GROUP_ID );
 		$this->assertCount( 0, $result );
 	}
 
 	public function testHasScheduledAction_WhenHasAction_ReturnsTrue() {
 		/* Arrange. */
 		$scheduler = new Action_Scheduler();
-		$scheduler->schedule_single_action( 'foo', [ 'bar' ] );
+		$scheduler->schedule_single_action( 'foo', array( 'bar' ) );
 
 		/* Act. */
-		$result = $scheduler->has_scheduled_action( 'foo', [ 'bar' ] );
+		$result = $scheduler->has_scheduled_action( 'foo', array( 'bar' ) );
 
 		/* Assert. */
 		$this->assertTrue( $result );
@@ -83,9 +83,35 @@ class Action_Scheduler_Test extends \WP_UnitTestCase {
 		$scheduler = new Action_Scheduler();
 
 		/* Act. */
-		$result = $scheduler->has_scheduled_action( 'foo', [ 'bar' ] );
+		$result = $scheduler->has_scheduled_action( 'foo', array( 'bar' ) );
 
 		/* Assert. */
 		$this->assertFalse( $result );
+	}
+
+
+	public function testGetScheduledActions_WhenHasAction_ReturnsMatchingActions() {
+		/* Arrange. */
+		$scheduler = new Action_Scheduler();
+		$action_id = $scheduler->schedule_single_action( 'foo', array( 'bar' ) );
+
+		/* Act. */
+		$args   = array( 'hook' => 'foo' );
+		$result = $scheduler->get_scheduled_actions( $args, 'ids' );
+
+		/* Assert. */
+		$this->assertSame( array( $action_id ), $result );
+	}
+
+	public function testGetScheduledActions_WhenHasNoAction_ReturnsEmptyArray() {
+		/* Arrange. */
+		$scheduler = new Action_Scheduler();
+
+		/* Act. */
+		$args   = array( 'hook' => 'foo' );
+		$result = $scheduler->get_scheduled_actions( $args, 'ids' );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -352,7 +352,13 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		update_option( Migration_Job_Scheduler::ERRORS_OPTION_NAME, array( 'a' ) );
 
 		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$action_scheduler->method( 'get_scheduled_actions' )->willReturn( array( 'b' ) );
+
+		$job = $this->createMock( Migration_Job::class );
+		$job->method( 'get_name' )->willReturn( 'x' );
+
 		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+		$job_scheduler->register_job( $job );
 
 		/* Act. */
 		$job_scheduler->collect_failed_job_errors( 'b', array( 'message' => 'c' ) );
@@ -363,12 +369,18 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function testIntegration_CollectFailedJobErrors_Always_UpdatesErrorsOptionWithEmptyArray(): void {
+	public function testCollectFailedJobErrors_Always_UpdatesErrorsOptionWithEmptyArray(): void {
 		/* Arrange. */
 		delete_option( Migration_Job_Scheduler::ERRORS_OPTION_NAME );
 
 		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$action_scheduler->method( 'get_scheduled_actions' )->willReturn( array( 'b' ) );
+
+		$job = $this->createMock( Migration_Job::class );
+		$job->method( 'get_name' )->willReturn( 'x' );
+
 		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+		$job_scheduler->register_job( $job );
 
 		/* Act. */
 		$job_scheduler->collect_failed_job_errors( 'b', array( 'message' => 'c' ) );

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -357,7 +357,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$job = $this->createMock( Migration_Job::class );
 		$job->method( 'get_name' )->willReturn( 'x' );
 
-		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+		$job_scheduler = new Migration_Job_Scheduler( $action_scheduler );
 		$job_scheduler->register_job( $job );
 
 		/* Act. */
@@ -379,7 +379,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$job = $this->createMock( Migration_Job::class );
 		$job->method( 'get_name' )->willReturn( 'x' );
 
-		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+		$job_scheduler = new Migration_Job_Scheduler( $action_scheduler );
 		$job_scheduler->register_job( $job );
 
 		/* Act. */

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -218,6 +218,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 
 	public function testRunJob_WhenMultipleJobs_SchedulesNextJob() {
 		/* Arrange. */
+		Sensei()->settings->set( 'experimental_progress_storage_synchronization', true );
 		$action_scheduler = $this->createMock( Action_Scheduler::class );
 		$migration_job_1  = $this->createMock( Migration_Job::class );
 		$migration_job_2  = $this->createMock( Migration_Job::class );

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -332,4 +332,50 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( $expected, $actual );
 	}
+
+	public function testInit_Always_AddsUnexpectedShutdownHook(): void {
+		/* Arrange. */
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+
+		/* Act. */
+		$job_scheduler->init();
+
+		/* Assert. */
+		$actual   = has_action( 'action_scheduler_unexpected_shutdown', [ $job_scheduler, 'collect_failed_job_errors' ] );
+		$expected = 10;
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function testCollectFailedJobErrors_Always_UpdatesErrorsOption(): void {
+		/* Arrange. */
+		update_option( Migration_Job_Scheduler::ERRORS_OPTION_NAME, array( 'a' ) );
+
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+
+		/* Act. */
+		$job_scheduler->collect_failed_job_errors( 'b', array( 'message' => 'c' ) );
+
+		/* Assert. */
+		$actual   = get_option( Migration_Job_Scheduler::ERRORS_OPTION_NAME );
+		$expected = array( 'a', 'c' );
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function testIntegration_CollectFailedJobErrors_Always_UpdatesErrorsOptionWithEmptyArray(): void {
+		/* Arrange. */
+		delete_option( Migration_Job_Scheduler::ERRORS_OPTION_NAME );
+
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+
+		/* Act. */
+		$job_scheduler->collect_failed_job_errors( 'b', array( 'message' => 'c' ) );
+		$actual = get_option( Migration_Job_Scheduler::ERRORS_OPTION_NAME );
+
+		/* Assert. */
+		$expected = array( 'c' );
+		$this->assertSame( $expected, $actual );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-progress-storage-settings.php
+++ b/tests/unit-tests/internal/services/test-class-progress-storage-settings.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SenseiTest\Internal\Services;
+
+use Sensei\Internal\Services\Progress_Storage_Settings;
+
+/**
+ * Class Progress_Storage_Settings_Test.
+ *
+ * @covers \Sensei\Internal\Services\Progress_Storage_Settings
+ */
+class Progress_Storage_Settings_Test extends \WP_UnitTestCase {
+
+	public function testGetStorageRepositories_Always_ReturnsArrayWithMatchingKeys(): void {
+		/* Act.*/
+		$repositories = Progress_Storage_Settings::get_storage_repositories();
+
+		/* Assert. */
+		$expected = array(
+			Progress_Storage_Settings::COMMENTS_STORAGE,
+			Progress_Storage_Settings::TABLES_STORAGE,
+		);
+		$this->assertSame( $expected, array_keys( $repositories ) );
+	}
+
+	public function testIsHppsEnabled_WhenHppsNotSet_ReturnsFalse(): void {
+		/* Arrange. */
+		unset( Sensei()->settings->settings['experimental_progress_storage'] );
+
+		/* Act. */
+		$hpps_enabled = Progress_Storage_Settings::is_hpps_enabled();
+
+		/* Assert. */
+		$this->assertFalse( $hpps_enabled );
+	}
+
+	/**
+	 * Test that the method return the expected value.
+	 *
+	 * @dataProvider providerIsHppsEnabled_WhenHppsSet_ReturnsSameValue
+	 */
+	public function testIsHppsEnabled_WhenHppsSet_ReturnsSameValue( $value ): void {
+		/* Arrange. */
+		Sensei()->settings->settings['experimental_progress_storage'] = $value;
+
+		/* Act. */
+		$hpps_enabled = Progress_Storage_Settings::is_hpps_enabled();
+
+		/* Assert. */
+		$this->assertSame( $value, $hpps_enabled );
+	}
+
+	public function providerIsHppsEnabled_WhenHppsSet_ReturnsSameValue(): array {
+		return array(
+			'hpps enabled'  => array( true ),
+			'hpps disabled' => array( false ),
+		);
+	}
+
+	public function testGetCurrentRepository_WhenRepositoryNotSet_ReturnsDefault(): void {
+		/* Arrange. */
+		unset( Sensei()->settings->settings['experimental_progress_storage_repository'] );
+
+		/* Act. */
+		$repository = Progress_Storage_Settings::get_current_repository();
+
+		/* Assert. */
+		$this->assertSame( Progress_Storage_Settings::COMMENTS_STORAGE, $repository );
+	}
+
+
+	/**
+	 * Test that the method return the expected value.
+	 *
+	 * @dataProvider providerGetCurrentRepository_WhenRepositoryNotSet_ReturnsDefault
+	 */
+	public function testGetCurrentRepository_WhenRepositorySet_ReturnsDefault( $repository ): void {
+		/* Arrange. */
+		Sensei()->settings->settings['experimental_progress_storage_repository'] = $repository;
+
+		/* Act. */
+		$actual = Progress_Storage_Settings::get_current_repository();
+
+		/* Assert. */
+		$this->assertSame( $repository, $actual );
+	}
+
+	public function providerGetCurrentRepository_WhenRepositoryNotSet_ReturnsDefault(): array {
+		return array(
+			'comment-based' => array( 'comments' ),
+			'table-based'   => array( 'custom_tables' ),
+		);
+	}
+
+	public function testIsSyncEnabled_WhenSyncNotSet_ReturnsFalse(): void {
+		/* Arrange. */
+		unset( Sensei()->settings->settings['experimental_progress_storage_synchronization'] );
+
+		/* Act. */
+		$sync_enabled = Progress_Storage_Settings::is_sync_enabled();
+
+		/* Assert. */
+		$this->assertFalse( $sync_enabled );
+	}
+
+	/**
+	 * Test that the method return the expected value.
+	 *
+	 * @dataProvider providerIsSyncEnabled_WhenSyncSet_ReturnsSameValue
+	 */
+	public function testIsSyncEnabled_WhenSyncSet_ReturnsSameValue( $value ): void {
+		/* Arrange. */
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $value;
+
+		/* Act. */
+		$sync_enabled = Progress_Storage_Settings::is_sync_enabled();
+
+		/* Assert. */
+		$this->assertSame( $value, $sync_enabled );
+	}
+
+	public function providerIsSyncEnabled_WhenSyncSet_ReturnsSameValue(): array {
+		return array(
+			'sync enabled'  => array( true ),
+			'sync disabled' => array( false ),
+		);
+	}
+}

--- a/tests/unit-tests/internal/services/test-class-progress-storage-settings.php
+++ b/tests/unit-tests/internal/services/test-class-progress-storage-settings.php
@@ -68,13 +68,12 @@ class Progress_Storage_Settings_Test extends \WP_UnitTestCase {
 		$this->assertSame( Progress_Storage_Settings::COMMENTS_STORAGE, $repository );
 	}
 
-
 	/**
 	 * Test that the method return the expected value.
 	 *
 	 * @dataProvider providerGetCurrentRepository_WhenRepositoryNotSet_ReturnsDefault
 	 */
-	public function testGetCurrentRepository_WhenRepositorySet_ReturnsDefault( $repository ): void {
+	public function testGetCurrentRepository_WhenRepositorySet_ReturnsSameRepository( $repository ): void {
 		/* Arrange. */
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = $repository;
 
@@ -89,6 +88,74 @@ class Progress_Storage_Settings_Test extends \WP_UnitTestCase {
 		return array(
 			'comment-based' => array( 'comments' ),
 			'table-based'   => array( 'custom_tables' ),
+		);
+	}
+
+	public function testIsCommentsRepository_WhenRepositoryNotSet_ReturnsTrue(): void {
+		/* Arrange. */
+		unset( Sensei()->settings->settings['experimental_progress_storage_repository'] );
+
+		/* Act. */
+		$actual = Progress_Storage_Settings::is_comments_repository();
+
+		/* Assert. */
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Test that the method return the expected value.
+	 *
+	 * @dataProvider providerIsCommentsRepository_WhenRepositorySet_ReturnsExpectedValue
+	 */
+	public function testIsCommentsRepository_WhenRepositorySet_ReturnsExpectedValue( $repository, $expected ): void {
+		/* Arrange. */
+		Sensei()->settings->settings['experimental_progress_storage_repository'] = $repository;
+
+		/* Act. */
+		$actual = Progress_Storage_Settings::is_comments_repository();
+
+		/* Assert. */
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function providerIsCommentsRepository_WhenRepositorySet_ReturnsExpectedValue(): array {
+		return array(
+			'comment-based' => array( 'comments', true ),
+			'table-based'   => array( 'custom_tables', false ),
+		);
+	}
+
+	public function testIsTablesRepository_WhenRepositoryNotSet_ReturnsFalse(): void {
+		/* Arrange. */
+		unset( Sensei()->settings->settings['experimental_progress_storage_repository'] );
+
+		/* Act. */
+		$actual = Progress_Storage_Settings::is_tables_repository();
+
+		/* Assert. */
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * Test that the method return the expected value.
+	 *
+	 * @dataProvider providerIsTablesRepository_WhenRepositorySet_ReturnsExpectedValue
+	 */
+	public function testIsTablesRepository_WhenRepositorySet_ReturnsExpectedValue( $repository, $expected ): void {
+		/* Arrange. */
+		Sensei()->settings->settings['experimental_progress_storage_repository'] = $repository;
+
+		/* Act. */
+		$actual = Progress_Storage_Settings::is_tables_repository();
+
+		/* Assert. */
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function providerIsTablesRepository_WhenRepositorySet_ReturnsExpectedValue(): array {
+		return array(
+			'comment-based' => array( 'comments', false ),
+			'table-based'   => array( 'custom_tables', true ),
 		);
 	}
 
@@ -125,4 +192,6 @@ class Progress_Storage_Settings_Test extends \WP_UnitTestCase {
 			'sync disabled' => array( false ),
 		);
 	}
+
+
 }

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -155,13 +155,13 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$settings = Sensei()->settings;
 
-		$new = $settings->get_settings();
-		$new['experimental_progress_storage']                 = true;
+		$new                                  = $settings->get_settings();
+		$new['experimental_progress_storage'] = true;
 		$new['experimental_progress_storage_synchronization'] = true;
 		$new['experimental_progress_storage_repository']      = 'comments';
 
-		$old = $settings->get_settings();
-		$old['experimental_progress_storage']                 = true;
+		$old                                  = $settings->get_settings();
+		$old['experimental_progress_storage'] = true;
 		$old['experimental_progress_storage_synchronization'] = true;
 		$old['experimental_progress_storage_repository']      = 'custom_tables';
 
@@ -186,13 +186,13 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$settings = Sensei()->settings;
 
-		$new = $settings->get_settings();
-		$new['experimental_progress_storage']                 = false;
+		$new                                  = $settings->get_settings();
+		$new['experimental_progress_storage'] = false;
 		$new['experimental_progress_storage_synchronization'] = true;
 		$new['experimental_progress_storage_repository']      = 'custom_tables';
 
-		$old = $settings->get_settings();
-		$old['experimental_progress_storage']                 = true;
+		$old                                  = $settings->get_settings();
+		$old['experimental_progress_storage'] = true;
 		$old['experimental_progress_storage_synchronization'] = true;
 		$old['experimental_progress_storage_repository']      = 'custom_tables';
 
@@ -204,11 +204,11 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$expected = array(
 			'experimental_progress_storage_synchronization' => false,
-			'experimental_progress_storage_repository'      => 'comments',
+			'experimental_progress_storage_repository' => 'comments',
 		);
 		$actual   = array(
 			'experimental_progress_storage_synchronization' => $settings->get( 'experimental_progress_storage_synchronization' ),
-			'experimental_progress_storage_repository'      => $settings->get( 'experimental_progress_storage_repository' ),
+			'experimental_progress_storage_repository' => $settings->get( 'experimental_progress_storage_repository' ),
 		);
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -202,13 +202,14 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		$settings->experimental_features_saved( $old, $new );
 
 		/* Assert. */
+		$updated_settings = $settings->get_settings();
 		$expected = array(
 			'experimental_progress_storage_synchronization' => 0,
 			'experimental_progress_storage_repository' => 'comments',
 		);
 		$actual   = array(
-			'experimental_progress_storage_synchronization' => $settings->get( 'experimental_progress_storage_synchronization' ),
-			'experimental_progress_storage_repository' => $settings->get( 'experimental_progress_storage_repository' ),
+			'experimental_progress_storage_synchronization' => $updated_settings['experimental_progress_storage_synchronization'],
+			'experimental_progress_storage_repository' => $updated_settings['experimental_progress_storage_repository'],
 		);
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -182,38 +182,6 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		$this->assertTrue( $has_logged_event );
 	}
 
-	public function testExperimentalFeaturesSaved_HppsWasDisabled_ResetsOtherSettingsToDefaults() {
-		/* Arrange. */
-		$settings = Sensei()->settings;
-
-		$new                                  = $settings->get_settings();
-		$new['experimental_progress_storage'] = false;
-		$new['experimental_progress_storage_synchronization'] = true;
-		$new['experimental_progress_storage_repository']      = 'custom_tables';
-
-		$old                                  = $settings->get_settings();
-		$old['experimental_progress_storage'] = true;
-		$old['experimental_progress_storage_synchronization'] = true;
-		$old['experimental_progress_storage_repository']      = 'custom_tables';
-
-		$this->simulateSettingsRequest();
-
-		/* Act. */
-		$settings->experimental_features_saved( $old, $new );
-
-		/* Assert. */
-		$updated_settings = $settings->get_settings();
-		$expected = array(
-			'experimental_progress_storage_synchronization' => 0,
-			'experimental_progress_storage_repository' => 'comments',
-		);
-		$actual   = array(
-			'experimental_progress_storage_synchronization' => $updated_settings['experimental_progress_storage_synchronization'],
-			'experimental_progress_storage_repository' => $updated_settings['experimental_progress_storage_repository'],
-		);
-		$this->assertSame( $expected, $actual );
-	}
-
 	public function testBeforeExperimentalFeaturesSaved_HppsWasDisabled_DeletesOtherHppsSettings() {
 		/* Arrange. */
 		$settings = Sensei()->settings;

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -203,12 +203,43 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		$expected = array(
-			'experimental_progress_storage_synchronization' => false,
+			'experimental_progress_storage_synchronization' => 0,
 			'experimental_progress_storage_repository' => 'comments',
 		);
 		$actual   = array(
 			'experimental_progress_storage_synchronization' => $settings->get( 'experimental_progress_storage_synchronization' ),
 			'experimental_progress_storage_repository' => $settings->get( 'experimental_progress_storage_repository' ),
+		);
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function testBeforeExperimentalFeaturesSaved_HppsWasDisabled_DeletesOtherHppsSettings() {
+		/* Arrange. */
+		$settings = Sensei()->settings;
+
+		$new                                  = $settings->get_settings();
+		$new['experimental_progress_storage'] = false;
+		$new['experimental_progress_storage_synchronization'] = true;
+		$new['experimental_progress_storage_repository']      = 'custom_tables';
+
+		$old                                  = $settings->get_settings();
+		$old['experimental_progress_storage'] = true;
+		$old['experimental_progress_storage_synchronization'] = true;
+		$old['experimental_progress_storage_repository']      = 'custom_tables';
+
+		$this->simulateSettingsRequest();
+
+		/* Act. */
+		$actual = $settings->before_experimental_features_saved( $new, $old );
+
+		/* Assert. */
+		$expected = array(
+			'experimental_progress_storage_synchronization' => false,
+			'experimental_progress_storage_repository' => false,
+		);
+		$actual   = array(
+			'experimental_progress_storage_synchronization' => array_key_exists( 'experimental_progress_storage_synchronization', $actual ),
+			'experimental_progress_storage_repository' => array_key_exists( 'experimental_progress_storage_repository', $actual ),
 		);
 		$this->assertSame( $expected, $actual );
 	}


### PR DESCRIPTION
Resolves #7320 

## Proposed Changes
* Output errors for failed migration jobs
* Make the sync checkbox available for changes: make it possible to restart the migration.

## Testing Instructions

1. Enable sync on a large database and wait for a failed job. (Currently, the branch doesn't include changes from https://github.com/Automattic/sensei/pull/7333 is not merged yet.)
2. Make sure you see logs for the failed job.
3. Try to restart the migration.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues

![CleanShot 2023-11-27 at 23 13 35@2x](https://github.com/Automattic/sensei/assets/329356/907f9790-ce03-4f6f-91f7-b089e2f8ad55)

