### PR TITLE
Fix Take Quiz button not appearing in site editor when latest Gutenberg is enabled

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -48,8 +48,9 @@ const LessonActionsEdit = ( props ) => {
 		IN_PROGRESS_PREVIEW
 	);
 	const { isSiteEditor } = useSelect( ( select ) => {
+		const currentPostId = select( editorStore ).getCurrentPostId();
 		return {
-			isSiteEditor: ! select( editorStore ).getCurrentPostId(),
+			isSiteEditor: ! Number.isInteger( currentPostId ),
 		};
 	} );
 

--- a/changelog/fix-take-quiz-button-not-visible-gutenberg
+++ b/changelog/fix-take-quiz-button-not-visible-gutenberg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Resolved the issue of the 'Take Quiz' button not displaying in the site editor when Gutenberg is enabled


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7323

## Proposed Changes
* Gutenberg recently changed the behavior of the `getCurrentPostId` function in the editor. Previously it returned the postId in the post specific editors like the lesson editor and returned undefined when it was called from site editor. Now it returns the name of the template. So the falsy based check we had there did not work any longer. We've updated the code here to explicitly check if the returned value is an integer or not.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install and activate the latest Gutenberg
2. Enable Learning Mode
3. Open the Lesson (Learning Mode - Default) template in the site editor
4. Make sure you can see the Take Quiz button at the bottom and can also change its background color
5. Now disable Learning Mode
6. Now create a lesson without a quiz
7. Add the Lesson Actions block there
8. Make sure you don't see the Take Quiz button in the editor (it should be in the tree)
9. Now add a quiz block without any question
10. You should still not see the Take Quiz block
11. Now add a question in the Quiz block, make sure the question has a Title
12. You should now see the Take Quiz button appearing
13. Try changing the background color of the button, you should be able to
14. Now try all that with Gutenberg disabled to make sure it still works.

<img width="1332" alt="image" src="https://github.com/Automattic/sensei/assets/6820724/367904e1-87e6-4323-aa87-eab2d31dfc51">

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
