### PR TITLE
Open the Lesson editor in same tab when Edit Lesson link is clicked in the Course Outline block

### DIFF
--- a/assets/blocks/course-outline/course-outline-editor.scss
+++ b/assets/blocks/course-outline/course-outline-editor.scss
@@ -65,20 +65,15 @@ body .editor-styles-wrapper,
 		margin-top: 0;
 		margin-bottom: 0;
 	}
-
-	.components-toolbar-group, .components-toolbar {
-		.wp-block-sensei-lms-course-outline-lesson__edit {
-			align-self: center;
-			font-size: 15px;
-			padding: 0.9em 0;
-		}
-	}
 }
 
-.wp-block-sensei-lms-course-outline-lesson__edit {
-	align-items: center;
-	display: flex;
-	height: inherit;
+.components-toolbar-group, .components-toolbar {
+	.wp-block-sensei-lms-course-outline-lesson__edit {
+		align-items: center;
+		display: flex;
+		font-size: 15px;
+		padding: 0.9em 0;
+	}
 }
 
 .components-disabled {

--- a/assets/blocks/course-outline/course-outline-editor.scss
+++ b/assets/blocks/course-outline/course-outline-editor.scss
@@ -75,6 +75,12 @@ body .editor-styles-wrapper,
 	}
 }
 
+.wp-block-sensei-lms-course-outline-lesson__edit {
+	align-items: center;
+	display: flex;
+	height: inherit;
+}
+
 .components-disabled {
 	label {
 		color: #828282;

--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	ExternalLink,
-	Spinner,
-	Toolbar,
-	ToolbarItem,
-} from '@wordpress/components';
+import { Button, Spinner, Toolbar, ToolbarItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
@@ -27,13 +21,12 @@ const getLessonURL = ( lessonId ) => `post.php?post=${ lessonId }&action=edit`;
  * @param {number} props.lessonId The lesson ID.
  */
 export const EditLessonLink = ( { lessonId } ) => (
-	<ExternalLink
+	<a
 		href={ getLessonURL( lessonId ) }
-		target="lesson"
 		className="wp-block-sensei-lms-course-outline-lesson__edit"
 	>
 		{ __( 'Edit lesson', 'sensei-lms' ) }
-	</ExternalLink>
+	</a>
 );
 
 /**

--- a/changelog/add-open-lesson-editor-in-same-tab
+++ b/changelog/add-open-lesson-editor-in-same-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Open the Lesson editor in the same tab when link is clicked in the Course Outline block


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7318

## Proposed Changes
* Changed the ExternalLink component to the anchor tag and open it in the same tab upon click
* That also takes care of the icon

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new Course and add a Course Outline block
2. Add one or more Lessons in the block
3. On the Titlebar menu of the lesson, click on the Edit Lesson link as shown in the image below
4. Make sure it opens in the same tab
5. Make sure the new tab icon is not beside the link either
6. Check for an existing course too

<img width="1404" alt="Screenshot 2023-11-29 at 10 32 01 PM" src="https://github.com/Automattic/sensei/assets/6820724/81726890-fbbc-4ec2-9478-727b7b80b495">

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
