### PR TITLE
Delete HPPS settings when HPPS feature disabled

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1157,31 +1157,4 @@ $promo_highlight: #43af99;
 		margin-left: 10px;
 		position: absolute;
 	}
-
-	&__notice {
-		position: relative;
-		background: #fff;
-		border: 1px solid #c3c4c7;
-		border-left-width: 4px;
-		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-		margin: 5px 0px;
-		padding: 1px 12px;
-
-
-		&--info {
-			border-left-color: #72aee6;
-		}
-
-		&--success {
-			border-left-color: #00a32a;
-		}
-
-		&--error {
-			border-left-color: #d63638;
-		}
-
-		&--warning {
-			border-left-color: #dba617;
-		}
-	}
 }

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1157,4 +1157,31 @@ $promo_highlight: #43af99;
 		margin-left: 10px;
 		position: absolute;
 	}
+
+	&__notice {
+		position: relative;
+		background: #fff;
+		border: 1px solid #c3c4c7;
+		border-left-width: 4px;
+		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+		margin: 5px 0px;
+		padding: 1px 12px;
+
+
+		&--info {
+			border-left-color: #72aee6;
+		}
+
+		&--success {
+			border-left-color: #00a32a;
+		}
+
+		&--error {
+			border-left-color: #d63638;
+		}
+
+		&--warning {
+			border-left-color: #dba617;
+		}
+	}
 }

--- a/assets/js/admin/settings/experimental-features.js
+++ b/assets/js/admin/settings/experimental-features.js
@@ -5,9 +5,9 @@ jQuery( document ).ready( function ( $ ) {
 	);
 	progressStorageFeature.on( 'change', function () {
 		if ( $( this ).is( ':checked' ) ) {
-			$( '.sensei-settings_progress-storage-settings' ).show();
+			$( '.sensei-settings__progress-storage-settings' ).show();
 		} else {
-			$( '.sensei-settings_progress-storage-settings' ).hide();
+			$( '.sensei-settings__progress-storage-settings' ).hide();
 		}
 	} );
 

--- a/assets/js/admin/settings/experimental-features.js
+++ b/assets/js/admin/settings/experimental-features.js
@@ -17,17 +17,20 @@ jQuery( document ).ready( function ( $ ) {
 		'.sensei-settings_progress-storage-synchronization'
 	);
 	syncProgress.on( 'change', function () {
-		let repository_options = $(
+		const savedState = $( this ).data( 'saved-state' );
+		let repositoryOptions = $(
 			'.sensei-settings_progress-storage-repository'
 		);
 		if ( $( this ).is( ':checked' ) ) {
-			repository_options.prop( 'disabled', false );
+			if ( savedState > 0 ) {
+				repositoryOptions.prop( 'disabled', false );
+			}
 		} else {
 			// ensure comments are selected
-			repository_options
+			repositoryOptions
 				.filter( '[value="comments"]' )
 				.prop( 'checked', true );
-			repository_options.prop( 'disabled', true );
+			repositoryOptions.prop( 'disabled', true );
 		}
 	} );
 } );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1236,7 +1236,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 			<?php endif; ?>
 		<?php if ( ! $value ) : ?>
-			<div class="sensei-settings__notice sensei-settings__notice--info sensei-settings__progress-storage-settings hidden">
+			<div class="notice notice-info inline sensei-settings__progress-storage-settings hidden">
 				<p>
 					<?php
 					echo esc_html( __( 'Save changes to make synchronization setting available.', 'sensei-lms' ) );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -47,13 +47,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$this->get_settings();
 
 		// Log when settings are updated by the user.
-		add_filter( 'pre_update_option_sensei-settings', [ $this, 'before_experimental_features_saved' ], 100, 2 );
 		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
 
 		// Mark settings section as visited on ajax action received.
 		add_action( 'wp_ajax_sensei_settings_section_visited', [ $this, 'mark_section_as_visited' ] );
 
 		// Do preparation for enabled experimental features.
+		add_filter( 'pre_update_option_sensei-settings', [ $this, 'before_experimental_features_saved' ], 10, 2 );
 		add_action( 'update_option_sensei-settings', [ $this, 'experimental_features_saved' ], 10, 2 );
 	}
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1077,8 +1077,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		if ( $new_hpps !== $old_hpps ) {
 			if ( $new_hpps ) {
-				// If the feature is being enabled, set the default values for the repository.
-				// We don't set the default value for the synchronization because it's okay to change it at this moment.
+				// If the feature is being enabled, set the default values for the other settings.
+				$value['experimental_progress_storage_synchronization'] = false;
 				$value['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
 			} else {
 				// If the feature is being disabled, clear the values for the other settings.
@@ -1217,6 +1217,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<label>
 				<input
 					class="sensei-settings_progress-storage-feature"
+					data-saved-state="<?php echo esc_attr( (int) $value ); ?>"
 					type="checkbox"
 					name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>"
 					value="1"
@@ -1235,6 +1236,15 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 			<?php endif; ?>
 		</div>
+		<?php if ( ! $value ) : ?>
+			<div class="notice notice-info sensei-settings_progress-storage-settings hidden">
+				<p>
+					<?php
+					echo esc_html( __( 'Save changes to make synchronization setting available.', 'sensei-lms' ) );
+					?>
+				</p>
+			</div>
+		<?php endif; ?>
 		<?php
 		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
 	}
@@ -1320,7 +1330,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Disables the checkbox if the migration is in progress or HPPS storage is in use.
 		$hpps_repository_in_use = Progress_Storage_Settings::TABLES_STORAGE === ( $settings['experimental_progress_storage_repository'] ?? null );
-		$disabled               = $migration_in_progress || $hpps_repository_in_use || is_null( Sensei()->action_scheduler );
+		$disabled               = ! $visible || $migration_in_progress || $hpps_repository_in_use || is_null( Sensei()->action_scheduler );
 		if ( $migration_errors ) {
 			// Enable the checkbox if there are errors to allow the user to retry.
 			$disabled = false;
@@ -1331,6 +1341,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<label>
 				<input
 					class="sensei-settings_progress-storage-synchronization"
+					data-saved-state="<?php echo esc_attr( (int) ( $value && $migration_complete ) ); ?>"
 					type="checkbox"
 					name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>"
 					value="1"

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1079,7 +1079,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			if ( $new_hpps ) {
 				// If the feature is being enabled, set the default values for the other settings.
 				$value['experimental_progress_storage_synchronization'] = false;
-				$value['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
+				$value['experimental_progress_storage_repository']      = Progress_Storage_Settings::COMMENTS_STORAGE;
 			} else {
 				// If the feature is being disabled, clear the values for the other settings.
 				unset( $value['experimental_progress_storage_repository'] );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1235,9 +1235,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 					<?php endif; ?>
 				</p>
 			<?php endif; ?>
-		</div>
 		<?php if ( ! $value ) : ?>
-			<div class="notice notice-info sensei-settings_progress-storage-settings hidden">
+			<div class="sensei-settings__notice sensei-settings__notice--info sensei-settings__progress-storage-settings hidden">
 				<p>
 					<?php
 					echo esc_html( __( 'Save changes to make synchronization setting available.', 'sensei-lms' ) );
@@ -1245,6 +1244,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 			</div>
 		<?php endif; ?>
+		</div>
 		<?php
 		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
 	}
@@ -1264,7 +1264,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$migration_scheduler  = Sensei()->migration_scheduler;
 		$migration_incomplete = ! $migration_scheduler || ! $migration_scheduler->is_complete();
 		?>
-		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
+		<div class="sensei-settings__progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
 			<h4><?php echo esc_html( __( 'Progress storage repository', 'sensei-lms' ) ); ?></h4>
 			<p><?php echo esc_html( $args['data']['description'] ); ?></p>
 			<ul>
@@ -1336,7 +1336,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			$disabled = false;
 		}
 		?>
-		<div class="sensei-settings_progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
+		<div class="sensei-settings__progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
 			<h4><?php echo esc_html( __( 'Progress storage synchronization', 'sensei-lms' ) ); ?></h4>
 			<label>
 				<input

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -672,7 +672,7 @@ class Sensei_Main {
 		}
 
 		// Student progress migration.
-		if ( $tables_sync_enabled && $this->action_scheduler ) {
+		if ( $tables_feature_enabled && $this->action_scheduler ) {
 			$this->init_migration_scheduler();
 		}
 

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -10,6 +10,7 @@ namespace Sensei\Internal\Migration;
 use Sensei\Internal\Action_Scheduler\Action_Scheduler;
 use Sensei\Internal\Migration\Migrations\Quiz_Migration;
 use Sensei\Internal\Migration\Migrations\Student_Progress_Migration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -281,7 +282,7 @@ class Migration_Job_Scheduler {
 
 		if ( $job->is_complete() ) {
 			$next_job = $this->get_next_job( $job );
-			if ( $next_job ) {
+			if ( $next_job && Progress_Storage_Settings::is_sync_enabled() ) {
 				$this->schedule_job( $next_job );
 			} else {
 				$this->complete( self::STATUS_COMPLETE );

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -218,6 +218,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 
 	public function testRunJob_WhenMultipleJobs_SchedulesNextJob() {
 		/* Arrange. */
+		Sensei()->settings->set( 'experimental_progress_storage_synchronization', true );
 		$action_scheduler = $this->createMock( Action_Scheduler::class );
 		$migration_job_1  = $this->createMock( Migration_Job::class );
 		$migration_job_2  = $this->createMock( Migration_Job::class );

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -155,13 +155,13 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$settings = Sensei()->settings;
 
-		$new = $settings->get_settings();
-		$new['experimental_progress_storage']                 = true;
+		$new                                  = $settings->get_settings();
+		$new['experimental_progress_storage'] = true;
 		$new['experimental_progress_storage_synchronization'] = true;
 		$new['experimental_progress_storage_repository']      = 'comments';
 
-		$old = $settings->get_settings();
-		$old['experimental_progress_storage']                 = true;
+		$old                                  = $settings->get_settings();
+		$old['experimental_progress_storage'] = true;
 		$old['experimental_progress_storage_synchronization'] = true;
 		$old['experimental_progress_storage_repository']      = 'custom_tables';
 
@@ -186,13 +186,13 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$settings = Sensei()->settings;
 
-		$new = $settings->get_settings();
-		$new['experimental_progress_storage']                 = false;
+		$new                                  = $settings->get_settings();
+		$new['experimental_progress_storage'] = false;
 		$new['experimental_progress_storage_synchronization'] = true;
 		$new['experimental_progress_storage_repository']      = 'custom_tables';
 
-		$old = $settings->get_settings();
-		$old['experimental_progress_storage']                 = true;
+		$old                                  = $settings->get_settings();
+		$old['experimental_progress_storage'] = true;
 		$old['experimental_progress_storage_synchronization'] = true;
 		$old['experimental_progress_storage_repository']      = 'custom_tables';
 
@@ -204,11 +204,11 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$expected = array(
 			'experimental_progress_storage_synchronization' => false,
-			'experimental_progress_storage_repository'      => 'comments',
+			'experimental_progress_storage_repository' => 'comments',
 		);
 		$actual   = array(
 			'experimental_progress_storage_synchronization' => $settings->get( 'experimental_progress_storage_synchronization' ),
-			'experimental_progress_storage_repository'      => $settings->get( 'experimental_progress_storage_repository' ),
+			'experimental_progress_storage_repository' => $settings->get( 'experimental_progress_storage_repository' ),
 		);
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -202,13 +202,14 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		$settings->experimental_features_saved( $old, $new );
 
 		/* Assert. */
+		$updated_settings = $settings->get_settings();
 		$expected = array(
 			'experimental_progress_storage_synchronization' => 0,
 			'experimental_progress_storage_repository' => 'comments',
 		);
 		$actual   = array(
-			'experimental_progress_storage_synchronization' => $settings->get( 'experimental_progress_storage_synchronization' ),
-			'experimental_progress_storage_repository' => $settings->get( 'experimental_progress_storage_repository' ),
+			'experimental_progress_storage_synchronization' => $updated_settings['experimental_progress_storage_synchronization'],
+			'experimental_progress_storage_repository' => $updated_settings['experimental_progress_storage_repository'],
 		);
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -182,38 +182,6 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		$this->assertTrue( $has_logged_event );
 	}
 
-	public function testExperimentalFeaturesSaved_HppsWasDisabled_ResetsOtherSettingsToDefaults() {
-		/* Arrange. */
-		$settings = Sensei()->settings;
-
-		$new                                  = $settings->get_settings();
-		$new['experimental_progress_storage'] = false;
-		$new['experimental_progress_storage_synchronization'] = true;
-		$new['experimental_progress_storage_repository']      = 'custom_tables';
-
-		$old                                  = $settings->get_settings();
-		$old['experimental_progress_storage'] = true;
-		$old['experimental_progress_storage_synchronization'] = true;
-		$old['experimental_progress_storage_repository']      = 'custom_tables';
-
-		$this->simulateSettingsRequest();
-
-		/* Act. */
-		$settings->experimental_features_saved( $old, $new );
-
-		/* Assert. */
-		$updated_settings = $settings->get_settings();
-		$expected = array(
-			'experimental_progress_storage_synchronization' => 0,
-			'experimental_progress_storage_repository' => 'comments',
-		);
-		$actual   = array(
-			'experimental_progress_storage_synchronization' => $updated_settings['experimental_progress_storage_synchronization'],
-			'experimental_progress_storage_repository' => $updated_settings['experimental_progress_storage_repository'],
-		);
-		$this->assertSame( $expected, $actual );
-	}
-
 	public function testBeforeExperimentalFeaturesSaved_HppsWasDisabled_DeletesOtherHppsSettings() {
 		/* Arrange. */
 		$settings = Sensei()->settings;

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -203,12 +203,43 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		$expected = array(
-			'experimental_progress_storage_synchronization' => false,
+			'experimental_progress_storage_synchronization' => 0,
 			'experimental_progress_storage_repository' => 'comments',
 		);
 		$actual   = array(
 			'experimental_progress_storage_synchronization' => $settings->get( 'experimental_progress_storage_synchronization' ),
 			'experimental_progress_storage_repository' => $settings->get( 'experimental_progress_storage_repository' ),
+		);
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function testBeforeExperimentalFeaturesSaved_HppsWasDisabled_DeletesOtherHppsSettings() {
+		/* Arrange. */
+		$settings = Sensei()->settings;
+
+		$new                                  = $settings->get_settings();
+		$new['experimental_progress_storage'] = false;
+		$new['experimental_progress_storage_synchronization'] = true;
+		$new['experimental_progress_storage_repository']      = 'custom_tables';
+
+		$old                                  = $settings->get_settings();
+		$old['experimental_progress_storage'] = true;
+		$old['experimental_progress_storage_synchronization'] = true;
+		$old['experimental_progress_storage_repository']      = 'custom_tables';
+
+		$this->simulateSettingsRequest();
+
+		/* Act. */
+		$actual = $settings->before_experimental_features_saved( $new, $old );
+
+		/* Assert. */
+		$expected = array(
+			'experimental_progress_storage_synchronization' => false,
+			'experimental_progress_storage_repository' => false,
+		);
+		$actual   = array(
+			'experimental_progress_storage_synchronization' => array_key_exists( 'experimental_progress_storage_synchronization', $actual ),
+			'experimental_progress_storage_repository' => array_key_exists( 'experimental_progress_storage_repository', $actual ),
 		);
 		$this->assertSame( $expected, $actual );
 	}


### PR DESCRIPTION
Resolves #7348 


## Proposed Changes
* Delete HPPS settings when the feature is disabled. (However, they appear in settings with default values again as it is part of settings loading logic.)
* Don't schedule new migration jobs when sync is disabled.

## Testing Instructions

1. Sensei LMS > Settings > Experimental Features.
2. Enable HPPS and synchronization. Save.
3. Sensei LMS > Settings > Experimental Features.
4. Disable HPPS.
5. Go to database and check `sensei-settings` in `wp_options`. `experimental_progress_storage_synchronization` and `experimental_progress_storage_repository` shouldn't be there.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
