### PR TITLE
Fix lesson status in the course navigation: use lesson progress when quiz progress didn't exist

### DIFF
--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -320,17 +320,21 @@ class Course_Navigation {
 			$status = 'completed';
 		} else {
 			// If the lesson has a quiz, use the quiz progress.
-			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+			$quiz_id       = Sensei()->lesson->lesson_quizzes( $lesson_id );
+			$quiz_progress = null;
 			if ( $quiz_id ) {
-				$user_progress = \Sensei()->quiz_progress_repository->get( $quiz_id, $this->user_id );
-			} else {
-				$user_progress = \Sensei()->lesson_progress_repository->get( $lesson_id, $this->user_id );
+				$quiz_progress = \Sensei()->quiz_progress_repository->get( $quiz_id, $this->user_id );
 			}
-			if ( $user_progress ) {
-				$status = $user_progress->get_status();
 
+			if ( $quiz_progress ) {
+				$status = $quiz_progress->get_status();
 				if ( in_array( $status, $in_progress_statuses, true ) ) {
 					$status = 'in-progress';
+				}
+			} else {
+				$lesson_progress = \Sensei()->lesson_progress_repository->get( $lesson_id, $this->user_id );
+				if ( $lesson_progress ) {
+					$status = $lesson_progress->get_status();
 				}
 			}
 		}


### PR DESCRIPTION
Resolves #7352 

## Proposed Changes
* Use lesson progress when quiz progress didn't exist.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

0. Go to Sensei LMS > Settings > Experimental Features.
1. Turn on HPPS, turn on synchronization, switch to "High-Performance progress storage (experimental)".
2. Create a course with some lessons .
3. As a student, access the course and navigate through the lessons.
4. Make sure each visited lesson is marked as "in progress" (half-filled circle).

![CleanShot 2023-12-03 at 18 47 15@2x](https://github.com/Automattic/sensei/assets/329356/743cbd61-0c38-4fb8-a04c-8dcfcdbff7a8)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
