### PR TITLE
Fix continue course button not working when using plain permalinks

### DIFF
--- a/changelog/fix-continue-course-block-redirect-using-plain-permalinks
+++ b/changelog/fix-continue-course-block-redirect-using-plain-permalinks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix continue course button not working when using plain permalinks
+Continue course button not working when using plain permalinks

--- a/changelog/fix-continue-course-block-redirect-using-plain-permalinks
+++ b/changelog/fix-continue-course-block-redirect-using-plain-permalinks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix continue course button not working when using plain permalinks

--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -63,8 +63,13 @@ class Sensei_Continue_Course_Block {
 		}
 
 		$target_post_id = Sensei_Utils::get_target_page_post_id_for_continue_url( $course_id, $user_id );
+		$target_url     = get_permalink( absint( $target_post_id ?? $course_id ) );
+		if ( ! $target_url ) {
+			return '';
+		}
 
-		return '<form action="' . esc_url( get_permalink( absint( $target_post_id ?? $course_id ) ) ) . '" method="get" class="sensei-block-wrapper sensei-cta">' .
+		return '<form action="' . esc_url( $target_url ) . '" method="get" class="sensei-block-wrapper sensei-cta">' .
+			Sensei_Utils::output_query_params_as_inputs( [], $target_url, false ) .
 			preg_replace(
 				'/<a(.*)>/',
 				'<button type="submit" $1>',

--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -63,7 +63,7 @@ class Sensei_Continue_Course_Block {
 		}
 
 		$target_post_id = Sensei_Utils::get_target_page_post_id_for_continue_url( $course_id, $user_id );
-		$target_url     = get_permalink( absint( $target_post_id ?? $course_id ) );
+		$target_url     = get_permalink( $target_post_id );
 		if ( ! $target_url ) {
 			return '';
 		}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2792,20 +2792,44 @@ class Sensei_Utils {
 	 *
 	 * @since 4.2.0
 	 *
-	 * @param array $excluded The query params that should be excluded.
+	 * @param array  $excluded The query params that should be excluded.
+	 * @param string $url The URL to parse the query params from. If empty, the current URL will be used.
+	 * @param bool   $echo Whether to echo the output or return it.
+	 *
+	 * @return string|void The HTML output if `$echo` is false, null otherwise.
 	 */
-	public static function output_query_params_as_inputs( array $excluded = [] ) {
+	public static function output_query_params_as_inputs( array $excluded = [], string $url = '', bool $echo = true ) {
 		// phpcs:ignore WordPress.Security.NonceVerification -- The nonce should be checked before calling this method.
-		foreach ( $_GET as $name => $value ) {
+		$query_params = $_GET;
+		if ( $url ) {
+			parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_params );
+		}
+
+		$output = '';
+		foreach ( $query_params as $name => $value ) {
 			if ( in_array( $name, $excluded, true ) ) {
 				continue;
 			}
 
-			?>
-			<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( wp_unslash( $value ) ); ?>">
-			<?php
+			$output .= '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( wp_unslash( $value ) ) . '">';
 		}
+
+		if ( ! $echo ) {
+			return $output;
+		}
+
+		echo wp_kses(
+			$output,
+			[
+				'input' => [
+					'type'  => [],
+					'name'  => [],
+					'value' => [],
+				],
+			]
+		);
 	}
+
 	/**
 	 * Format the last activity date to a more readable form.
 	 *

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -243,12 +243,7 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $array_zipped );
 	}
 
-	/**
-	 * Test that the query params inputs are correct.
-	 *
-	 * @covers Sensei_Utils::output_query_params_as_inputs
-	 */
-	public function testOutputQueryParamsAsInputs() {
+	public function testOutputQueryParamsAsInputs_NoUrlIsProvided_OutputInputsUsingCurrentUrlParams() {
 		/* Arrange. */
 		$_GET = [
 			'param_1' => 'value_1',
@@ -257,12 +252,33 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 
 		/* Act. */
 		ob_start();
-		Sensei_Utils::output_query_params_as_inputs( [ 'param_2' ] );
-		$output = ob_get_clean();
+		Sensei_Utils::output_query_params_as_inputs();
+		$result = ob_get_clean();
 
 		/* Assert. */
-		$this->assertStringContainsString( '<input type="hidden" name="param_1" value="value_1">', $output, 'Output should contain the query param input with the correct value.' );
-		$this->assertStringNotContainsString( 'param_2', $output, 'Output should not contain the excluded query param input.' );
+		$this->assertSame( '<input type="hidden" name="param_1" value="value_1"><input type="hidden" name="param_2" value="value_2">', $result );
+	}
+
+	public function testOutputQueryParamsAsInputs_WhenUrlIsProvidedAndEchoIsFalse_ReturnsCorrectInputs() {
+		/* Arrange. */
+		$url = 'https://example.com?param_1=value_1&param_2=value_2';
+
+		/* Act. */
+		$result = Sensei_Utils::output_query_params_as_inputs( [], $url, false );
+
+		/* Assert. */
+		$this->assertSame( '<input type="hidden" name="param_1" value="value_1"><input type="hidden" name="param_2" value="value_2">', $result );
+	}
+
+	public function testOutputQueryParamsAsInputs_WhenAParamIsExcluded_ReturnsCorrectInputs() {
+		/* Arrange. */
+		$url = 'https://example.com?param_1=value_1&param_2=value_2';
+
+		/* Act. */
+		$result = Sensei_Utils::output_query_params_as_inputs( [ 'param_2' ], $url, false );
+
+		/* Assert. */
+		$this->assertSame( '<input type="hidden" name="param_1" value="value_1">', $result );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes the "Continue" course action button when using plain permalinks.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set the site permalinks to "plain".
1. Create a course with a few lessons.
2. Add the "Course Actions" block to the course.
4. Go to the front end and take the course.
5. Go to the course page, you should see a "Continue" button.
6. Make sure when you press the "Continue" button, you are redirected to a lesson.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
