### PR TITLE
Fix importer not finding existing users if their username is different

### DIFF
--- a/changelog/fix-importer-user-not-found
+++ b/changelog/fix-importer-user-not-found
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Importer not finding existing users in some cases

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -26,7 +26,14 @@ class Sensei_Data_Port_Utilities {
 	 * @return WP_User|WP_Error  WP_User on success, WP_Error on failure.
 	 */
 	public static function create_user( $username, $email = '', $role = '' ) {
-		$user = get_user_by( 'login', $username );
+		$user = null;
+		if ( $email ) {
+			$user = get_user_by( 'email', $email );
+		}
+
+		if ( ! $user ) {
+			$user = get_user_by( 'login', $username );
+		}
 
 		if ( ! $user ) {
 			$user_id = wp_create_user( $username, wp_generate_password(), $email );

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -42,6 +42,30 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 		$this->assertContains( 'teacher', $user->roles );
 	}
 
+	public function testCreateUser_WhenUsernameIsNotMatching_FindsUserByEmail() {
+		$user_id       = $this->factory->user->create(
+			[
+				'user_login' => 'test',
+				'user_email' => 'test@example.com',
+			]
+		);
+		$found_user_id = Sensei_Data_Port_Utilities::create_user( 'handsome_potato', 'test@example.com' )->ID;
+
+		$this->assertEquals( $user_id, $found_user_id );
+	}
+
+	public function testCreateUser_WhenEmailIsNotMatching_FindsUserByUsername() {
+		$user_id       = $this->factory->user->create(
+			[
+				'user_login' => 'test',
+				'user_email' => 'test@example.com',
+			]
+		);
+		$found_user_id = Sensei_Data_Port_Utilities::create_user( 'test', 'notfound@example.com' )->ID;
+
+		$this->assertEquals( $user_id, $found_user_id );
+	}
+
 	/**
 	 * Tests a simple term name path with one entry.
 	 */


### PR DESCRIPTION
The importer looks for existing users by username only. This causes an issue when the user has created a user, on a new instance, with the same email but with a different username.

## Proposed Changes

Fix the importer to look for existing users by their email as well.

## Testing Instructions
1. Go to Sensei LMS -> Tools -> Export Content and do an export. 
2. Note some of the usernames and emails that are exported. For example username: test, email: test@example.com.
3. Create a new WP instance.
4. Create a user with an email of some of the exported users but use a different username. For example username: handsome_potato, email: test@example.com.
5. Go to Sensei LMS -> Tools -> Import Content and import the data.
6. There should be no error saying "Sorry, that email address is already used".
7. The data should be associated correctly to the user.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues
