### PR TITLE
Show one generic message in case HPPS functionality is disabled

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -854,7 +854,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		if ( Sensei()->feature_flags->is_enabled( 'experimental_features_ui' ) ) {
 			$fields['experimental_progress_storage']                 = array(
 				'name'        => __( 'High-Performance Progress Storage', 'sensei-lms' ),
-				'description' => __( 'Store the progress of your students in separate tables. This feature is currently in development and should be used with caution.', 'sensei-lms' ),
+				'description' => __( 'Store the progress of your students in separate tables.', 'sensei-lms' ),
 				'form'        => 'render_progress_storage_feature',
 				'type'        => 'checkbox',
 				'default'     => false,
@@ -1212,7 +1212,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 				<input type="hidden" name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 				<p>
 					<?php
-					echo esc_html( __( 'While HPPS is in its early experimental stage, the functionalities may be temporarily unavailable.', 'sensei-lms' ) );
+					echo esc_html( __( 'As this feature is currently experimental, it may not be available yet on some sites.', 'sensei-lms' ) );
 					?>
 				</p>
 			<?php endif; ?>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1180,11 +1180,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Disable the checkbox if we can't set time limit. That's our current limitation for running migrations.
 		$disabled_feature            = true;
-		$disabled_messages           = array();
 		$original_max_execution_time = (int) ini_get( 'max_execution_time' );
 		$disabled_php_functions      = array_map( 'trim', explode( ',', ini_get( 'disable_functions' ) ) );
 		$set_time_limit_disabled     = in_array( 'set_time_limit', $disabled_php_functions, true );
-		$xdebug_enabled              = extension_loaded( 'xdebug' );
 		if ( 0 !== $original_max_execution_time && ! $set_time_limit_disabled ) {
 			// Set max execution time to 0 to check if we can set it in migrtions.
 			$disabled_feature           = ! set_time_limit( 0 );
@@ -1194,23 +1192,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 			}
 			// Restore original max execution time.
 			set_time_limit( $original_max_execution_time );
-		}
-
-		if ( $disabled_feature ) {
-			if ( $set_time_limit_disabled ) {
-				$disabled_messages[] = sprintf(
-					// translators: Placeholder is a link to `set_time_limit` function documentation.
-					__( "The feature can't be enabled because the %s function is disabled in your PHP configuration.", 'sensei-lms' ),
-					'<a href="https://www.php.net/manual/en/function.set-time-limit.php" target="_blank" rel="noopener noreferrer">set_time_limit</a>'
-				);
-			}
-			if ( $xdebug_enabled ) {
-				$disabled_messages[] = sprintf(
-					// translators: Placeholder is a link to Xdebug website.
-					__( '%s is interfering with this feature. Please, consider disabling it.', 'sensei-lms' ),
-					'<a href="https://xdebug.org/" target="_blank" rel="noopener noreferrer">Xdebug</a>'
-				);
-			}
 		}
 		?>
 		<div>
@@ -1230,9 +1211,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<?php if ( $disabled_feature ) : ?>
 				<input type="hidden" name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 				<p>
-					<?php if ( ! empty( $disabled_messages ) ) : ?>
-						<?php echo wp_kses_post( implode( '<br />', $disabled_messages ) ); ?>
-					<?php endif; ?>
+					<?php
+					echo esc_html( __( 'While HPPS is in its early experimental stage, the functionalities may be temporarily unavailable.', 'sensei-lms' ) );
+					?>
 				</p>
 			<?php endif; ?>
 		<?php if ( ! $value ) : ?>


### PR DESCRIPTION
Resolves #7362 

## Proposed Changes
* Show a generic message when HPPS is disabled.

## Testing Instructions

1. Add 'set_time_limit' to `disable_functions` in your php.ini (Like that: `disable_functions = set_time_limit, get_resources`)
2. Enable experimental UI feature flag: `add_filter( 'sensei_feature_flag_experimental_features_ui', '__return_true' );`
3. Go to Sensei LMS > Settings > Experimental Features.
4. Make sure you see a message like in the screenshot below.

![CleanShot 2023-12-09 at 10 44 34@2x](https://github.com/Automattic/sensei/assets/329356/9f7f3d28-7bdb-4dca-b5a9-3abcfcfb30d2)


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
