### PR TITLE
Fix restart quiz redirects to the course complete page if the course was completed

### DIFF
--- a/changelog/fix-redirect-reset-quiz
+++ b/changelog/fix-redirect-reset-quiz
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restart quiz redirects to the course complete page if the course was completed

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -844,11 +844,9 @@ class Sensei_Quiz {
 		$course_id       = Sensei()->lesson->get_course_id( $lesson_id );
 		$course_progress = Sensei()->course_progress_repository->get( $course_id, $user_id );
 		if ( $course_progress ) {
-			if ( ! $course_progress->get_started_at() ) {
-				$course_progress->start();
+			$course_progress->start( $course_progress->get_started_at() );
 
-				Sensei()->course_progress_repository->save( $course_progress );
-			}
+			Sensei()->course_progress_repository->save( $course_progress );
 
 			// Reset the course progress metadata.
 			$course_progress_metadata = [

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1490,11 +1490,6 @@ class Sensei_Utils {
 		}
 
 		$lessons_completed  = 0;
-		$lesson_status_args = array(
-			'user_id' => $user_id,
-			'status'  => 'any',
-			'type'    => 'sensei_lesson_status', /* FIELD SIZE 20 */
-		);
 
 		// Grab all of this Courses' lessons, looping through each...
 		$lesson_ids    = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
@@ -1508,7 +1503,6 @@ class Sensei_Utils {
 			// .........then the lesson is 'passed'
 			// ...if all lessons 'passed' then update the course status to complete
 		// The below checks if a lesson is fully completed, though maybe should be Utils::user_completed_lesson()
-		$lesson_status_args['post__in'] = $lesson_ids;
 		$lesson_progress_args           = array(
 			'user_id'   => $user_id,
 			'lesson_id' => $lesson_ids,

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1489,7 +1489,7 @@ class Sensei_Utils {
 			$course_progress->start();
 		}
 
-		$lessons_completed  = 0;
+		$lessons_completed = 0;
 
 		// Grab all of this Courses' lessons, looping through each...
 		$lesson_ids    = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
@@ -1503,11 +1503,11 @@ class Sensei_Utils {
 			// .........then the lesson is 'passed'
 			// ...if all lessons 'passed' then update the course status to complete
 		// The below checks if a lesson is fully completed, though maybe should be Utils::user_completed_lesson()
-		$lesson_progress_args           = array(
+		$lesson_progress_args = array(
 			'user_id'   => $user_id,
 			'lesson_id' => $lesson_ids,
 		);
-		$all_lesson_progress            = Sensei()->lesson_progress_repository->find( $lesson_progress_args );
+		$all_lesson_progress  = Sensei()->lesson_progress_repository->find( $lesson_progress_args );
 
 		foreach ( $all_lesson_progress as $lesson_progress ) {
 			if ( $lesson_progress->is_complete() ) {


### PR DESCRIPTION
Resolves #7212

## Proposed Changes

Fix a bug that causes the reset quiz button to redirect to the course complete page if the course was completed. This was happening because the course progress was in the wrong state after a reset.

## Testing Instructions
1. Create a course with lessons.
1. Create a quiz with the "Allow Retakes" setting enabled.
1. Complete the course.
1. Return to the quiz and click on "Restart Quiz".
2. You should be redirected to the back to the quiz.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
