### PR TITLE
Scope CSS to Learning Mode templates only

### DIFF
--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -3,8 +3,8 @@
 $breakpoint: 782px;
 
 /*
-  This style files are only required when the current theme don't provide learning mode customizations.
-  Block based themes should declare add_theme_support('sensei-learning-mode'); to enable customization via theme.json
+  This style file is only required when the current theme doesn't provide customizations for Learning Mode.
+  Block based themes should declare add_theme_support('sensei-learning-mode'); to enable customization via theme.json.
 */
 @import 'sensei-course-theme/theme-fixes';
 @import 'sensei-course-theme/buttons';

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -14,7 +14,7 @@ $breakpoint: 782px;
 	font-size: 100%;
 }
 
-.editor-styles-wrapper .wp-block,
+.editor-styles-wrapper .sensei-course-theme__main-content,
 .sensei-course-theme {
 	--wp--preset--font-family--body-font: -apple-system, BlinkMacSystemFont, Inter, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-family: var(--wp--preset--font-family--body-font);

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -21,6 +21,7 @@ body, .editor-styles-wrapper {
 	--border-color: rgba(125, 125, 125, 0.3);
 }
 
+.editor-styles-wrapper .sensei-course-theme__frame,
 .editor-styles-wrapper .sensei-course-theme__main-content,
 .sensei-course-theme {
 	-moz-osx-font-smoothing: grayscale;

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -19,8 +19,12 @@ body, .editor-styles-wrapper {
 	--sensei-text-color: var(--sensei-text-color-global, var(--sensei-course-theme-foreground-color, var(--wp--preset--color--text, var(--wp--preset--color--foreground, #1E1E1E))));
 
 	--border-color: rgba(125, 125, 125, 0.3);
-	-webkit-font-smoothing: antialiased;
+}
+
+.editor-styles-wrapper .sensei-course-theme__main-content,
+.sensei-course-theme {
 	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
 }
 
 .sensei-course-theme__frame {

--- a/changelog/fix-non-learning-mode-template-styles
+++ b/changelog/fix-non-learning-mode-template-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Scope CSS to Learning Mode templates only


### PR DESCRIPTION
Resolves #7226.

## Proposed Changes
Some Learning Mode CSS is affecting non-Learning Mode templates. Given that it's not possible to conditionally load CSS for some templates but not for others, this PR scopes the CSS better. This problem was introduced by https://github.com/Automattic/sensei/commit/997bbf8e6f1e8a07b501fa6e23bd6f83d2169845. Although I tried to reproduce, I didn't see any issue with Astra in the editor after reverting that change.

Having said that, I think an argument could be made as to whether we should be so opinionated about our CSS in the first place, especially for block themes. In the future, we may want to consider defaulting to the theme's fonts, colors etc., and just provide sensible defaults to classic themes (or maybe not even for classic themes either 🤷🏻‍♀️ ).

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. See #7226 to ensure it's fixed for block themes.
2. Activate Astra.
3. Check the Lesson and Quiz Learning Mode templates. They should look the same or similar as before.
4. Repeat for Divi or any other classic theme.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
