### PR TITLE
Add translations for lessons and quizzes that were created while saving the course structure

### DIFF
--- a/changelog/fix-wpml-save-course-structure
+++ b/changelog/fix-wpml-save-course-structure
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Add translations for lessons and quizzes that were created while saving the course structure
+WPML compatibility fix: Add translations for lessons and quizzes that were created while saving the course structure.

--- a/changelog/fix-wpml-save-course-structure
+++ b/changelog/fix-wpml-save-course-structure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add translations for lessons and quizzes that were created while saving the course structure

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -531,8 +531,8 @@ class Sensei_Course_Structure {
 		 *
 		 * @hook sensei_course_structure_lesson_created
 		 *
-		 * @param int $lesson_id Lesson post ID.
-		 * @param int $course_id Course post ID.
+		 * @param {int} $lesson_id Lesson post ID.
+		 * @param {int} $course_id Course post ID.
 		 */
 		do_action( 'sensei_course_structure_lesson_created', $lesson_id, $this->course_id );
 
@@ -574,8 +574,8 @@ class Sensei_Course_Structure {
 		 *
 		 * @hook sensei_course_structure_quiz_created
 		 *
-		 * @param int $quiz_id   Quiz post ID.
-		 * @param int $lesson_id Course post ID.
+		 * @param {int} $quiz_id   Quiz post ID.
+		 * @param {int} $lesson_id Course post ID.
 		 */
 		do_action( 'sensei_course_structure_quiz_created', $quiz_id, $lesson_id );
 	}

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -529,6 +529,8 @@ class Sensei_Course_Structure {
 		 *
 		 * @since $$next-version$$
 		 *
+		 * @hook sensei_course_structure_lesson_created
+		 *
 		 * @param int $lesson_id Lesson post ID.
 		 * @param int $course_id Course post ID.
 		 */
@@ -569,6 +571,8 @@ class Sensei_Course_Structure {
 		 * Fires after a quiz is created while saving the course structure.
 		 *
 		 * @since $$next-version$$
+		 *
+		 * @hook sensei_course_structure_quiz_created
 		 *
 		 * @param int $quiz_id   Quiz post ID.
 		 * @param int $lesson_id Course post ID.

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -519,14 +519,24 @@ class Sensei_Course_Structure {
 			],
 		];
 
-		$post_id = wp_insert_post( $post_args );
-		if ( ! $post_id ) {
+		$lesson_id = wp_insert_post( $post_args );
+		if ( ! $lesson_id ) {
 			return false;
 		}
 
-		$this->create_quiz( $post_id );
+		/**
+		 * Fires after a lesson is created while saving the course structure.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $lesson_id Lesson post ID.
+		 * @param int $course_id Course post ID.
+		 */
+		do_action( 'sensei_course_structure_lesson_created', $lesson_id, $this->course_id );
 
-		return $post_id;
+		$this->create_quiz( $lesson_id );
+
+		return $lesson_id;
 	}
 
 	/**
@@ -549,8 +559,21 @@ class Sensei_Course_Structure {
 		];
 
 		$quiz_id = wp_insert_post( $post_args );
+		if ( ! $quiz_id ) {
+			return;
+		}
+
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
+		/**
+		 * Fires after a quiz is created while saving the course structure.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $quiz_id   Quiz post ID.
+		 * @param int $lesson_id Course post ID.
+		 */
+		do_action( 'sensei_course_structure_quiz_created', $quiz_id, $lesson_id );
 	}
 
 	/**

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -68,8 +68,8 @@ class Sensei_WPML {
 	public function set_language_details_when_lesson_created( $lesson_id, $course_id ) {
 
 		// Get course language_code.
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$language_code = apply_filters(
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			'wpml_element_language_code',
 			null,
 			array(
@@ -106,8 +106,8 @@ class Sensei_WPML {
 	public function set_language_details_when_quiz_created( $quiz_id, $lesson_id ) {
 
 		// Get lesson language_code.
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$language_code = apply_filters(
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			'wpml_element_language_code',
 			null,
 			array(

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -38,7 +38,7 @@ class Sensei_WPML {
 		*
 		* @param string  $email_address Recipient's email address
 		*/
-		do_action( 'wpml_switch_language_for_email', $email_address );
+		do_action( 'wpml_switch_language_for_email', $email_address ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 	}
 
 	/**
@@ -55,7 +55,7 @@ class Sensei_WPML {
 		*
 		* @since 1.9.7
 		*/
-		do_action( 'wpml_restore_language_from_email' );
+		do_action( 'wpml_restore_language_from_email' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 	}
 
 	/**
@@ -68,6 +68,7 @@ class Sensei_WPML {
 	public function set_language_details_when_lesson_created( $lesson_id, $course_id ) {
 
 		// Get course language_code.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$language_code = apply_filters(
 			'wpml_element_language_code',
 			null,
@@ -78,6 +79,7 @@ class Sensei_WPML {
 		);
 		if ( ! $language_code ) {
 			// Use current language if course language is not set.
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			$language_code = apply_filters( 'wpml_current_language', null );
 		}
 
@@ -89,6 +91,7 @@ class Sensei_WPML {
 		);
 
 		// Set language details for the lesson.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		do_action( 'wpml_set_element_language_details', $args );
 	}
 
@@ -103,6 +106,7 @@ class Sensei_WPML {
 	public function set_language_details_when_quiz_created( $quiz_id, $lesson_id ) {
 
 		// Get lesson language_code.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$language_code = apply_filters(
 			'wpml_element_language_code',
 			null,
@@ -113,6 +117,7 @@ class Sensei_WPML {
 		);
 		if ( ! $language_code ) {
 			// Use current language if lesson language is not set.
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			$language_code = apply_filters( 'wpml_current_language', null );
 		}
 
@@ -124,6 +129,7 @@ class Sensei_WPML {
 		);
 
 		// Set language details for the lesson.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		do_action( 'wpml_set_element_language_details', $args );
 	}
 }

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -62,6 +62,9 @@ class Sensei_WPML {
 	 * Set language details for the lesson when it is created.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
 	 * @param int $lesson_id Lesson ID.
 	 * @param int $course_id Course ID.
 	 */
@@ -74,7 +77,7 @@ class Sensei_WPML {
 			null,
 			array(
 				'element_id'   => $course_id,
-				'element_type' => 'post_course',
+				'element_type' => 'course',
 			)
 		);
 		if ( ! $language_code ) {
@@ -96,9 +99,11 @@ class Sensei_WPML {
 	}
 
 	/**
-	 * Set language details for the lesson when it is created.
+	 * Set language details for the quiz when it is created.
 	 *
 	 * @since $$next-version$$
+	 *
+	 * @internal
 	 *
 	 * @param int $quiz_id   Quiz ID.
 	 * @param int $lesson_id Lesson ID.
@@ -112,7 +117,7 @@ class Sensei_WPML {
 			null,
 			array(
 				'element_id'   => $lesson_id,
-				'element_type' => 'post_lesson',
+				'element_type' => 'lesson',
 			)
 		);
 		if ( ! $language_code ) {

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -1,10 +1,30 @@
 <?php
+/**
+ * File containing the Sensei_WPML class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_WPML
+ */
 class Sensei_WPML {
 	public function __construct() {
 		add_action( 'sensei_before_mail', array( $this, 'sensei_before_mail' ) );
 		add_action( 'sensei_after_sending_email', array( $this, 'sensei_after_sending_email' ) );
+		add_action( 'sensei_course_structure_lesson_created', array( $this, 'set_language_details_when_lesson_created' ), 10, 2 );
+		add_action( 'sensei_course_structure_quiz_created', array( $this, 'set_language_details_when_quiz_created' ), 10, 2 );
 	}
 
+	/**
+	 * Switch language for email.
+	 *
+	 * @param string $email_address Recipient's email address.
+	 */
 	public function sensei_before_mail( $email_address ) {
 		/**
 		* Switch language for email
@@ -21,6 +41,9 @@ class Sensei_WPML {
 		do_action( 'wpml_switch_language_for_email', $email_address );
 	}
 
+	/**
+	 * Restore language after sending email.
+	 */
 	public function sensei_after_sending_email() {
 		/**
 		* Restore language after sending email
@@ -33,5 +56,74 @@ class Sensei_WPML {
 		* @since 1.9.7
 		*/
 		do_action( 'wpml_restore_language_from_email' );
+	}
+
+	/**
+	 * Set language details for the lesson when it is created.
+	 *
+	 * @since $$next-version$$
+	 * @param int $lesson_id Lesson ID.
+	 * @param int $course_id Course ID.
+	 */
+	public function set_language_details_when_lesson_created( $lesson_id, $course_id ) {
+
+		// Get course language_code.
+		$language_code = apply_filters(
+			'wpml_element_language_code',
+			null,
+			array(
+				'element_id'   => $course_id,
+				'element_type' => 'post_course',
+			)
+		);
+		if ( ! $language_code ) {
+			// Use current language if course language is not set.
+			$language_code = apply_filters( 'wpml_current_language', null );
+		}
+
+		$args = array(
+			'element_id'    => $lesson_id,
+			'element_type'  => 'post_lesson',
+			'trid'          => false,
+			'language_code' => $language_code,
+		);
+
+		// Set language details for the lesson.
+		do_action( 'wpml_set_element_language_details', $args );
+	}
+
+	/**
+	 * Set language details for the lesson when it is created.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $quiz_id   Quiz ID.
+	 * @param int $lesson_id Lesson ID.
+	 */
+	public function set_language_details_when_quiz_created( $quiz_id, $lesson_id ) {
+
+		// Get lesson language_code.
+		$language_code = apply_filters(
+			'wpml_element_language_code',
+			null,
+			array(
+				'element_id'   => $lesson_id,
+				'element_type' => 'post_lesson',
+			)
+		);
+		if ( ! $language_code ) {
+			// Use current language if lesson language is not set.
+			$language_code = apply_filters( 'wpml_current_language', null );
+		}
+
+		$args = array(
+			'element_id'    => $quiz_id,
+			'element_type'  => 'post_quiz',
+			'trid'          => false,
+			'language_code' => $language_code,
+		);
+
+		// Set language details for the lesson.
+		do_action( 'wpml_set_element_language_details', $args );
 	}
 }

--- a/tests/unit-tests/wpml/test-class-sensei-wpml.php
+++ b/tests/unit-tests/wpml/test-class-sensei-wpml.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace SenseiTest\WPML;
+
+use \Sensei_WPML;
+
+/**
+* Class Sensei_WPML_Test.
+*
+* @covers \Sensei_WPML
+*/
+class Sensei_WPML_Test extends \WP_UnitTestCase {
+	public function testSetLanguageDetailsWhenLessonCreated_WhenCalled_AppliesWpmlElementLangugeCodeFilter() {
+		/* Arrange. */
+		$wpml = new Sensei_WPML();
+
+		$filter_applied = false;
+		$filter_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+			$filter_applied = true;
+			return $language_code;
+		};
+
+		add_filter( 'wpml_element_language_code', $filter_funtction, 10, 2 );
+
+		/* Act. */
+		$wpml->set_language_details_when_lesson_created( 1, 2 );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $filter_funtction, 10 );
+
+		$this->assertTrue( $filter_applied );
+	}
+
+	public function testSetLanguageDetailsWhenLessonCreated_WhenCalled_AppliesWpmlCurrentLangugeFilter() {
+		/* Arrange. */
+		$wpml = new Sensei_WPML();
+
+		$filter_language_code_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+			return null;
+		};
+		add_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10, 2 );
+
+		$filter_applied = false;
+		$filter_funtction = function( $language_code ) use ( &$filter_applied ) {
+			$filter_applied = true;
+			return $language_code;
+		};
+		add_filter( 'wpml_current_language', $filter_funtction, 10, 1 );
+
+		/* Act. */
+		$wpml->set_language_details_when_lesson_created( 1, 2 );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10 );
+		remove_filter( 'wpml_current_language', $filter_funtction, 10 );
+
+		$this->assertTrue( $filter_applied );
+	}
+
+	public function testSetLanguageDetailsWhenLessonCreated_WhenCalled_AppliesWpmlSetElementLanguageDetails() {
+		/* Arrange. */
+		$wpml = new Sensei_WPML();
+
+		$filter_applied = false;
+		$filter_funtction = function( $data ) use ( &$filter_applied ) {
+			$filter_applied = true;
+			return $data;
+		};
+
+		add_filter( 'wpml_set_element_language_details', $filter_funtction, 10, 1 );
+
+		/* Act. */
+		$wpml->set_language_details_when_lesson_created( 1, 2 );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_set_element_language_details', $filter_funtction, 10 );
+
+		$this->assertTrue( $filter_applied );
+	}
+
+	public function testSetLanguageDetailsWhenQuizCreated_WhenCalled_AppliesWpmlElementLangugeCodeFilter() {
+		/* Arrange. */
+		$wpml = new Sensei_WPML();
+
+		$filter_applied = false;
+		$filter_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+			$filter_applied = true;
+			return $language_code;
+		};
+
+		add_filter( 'wpml_element_language_code', $filter_funtction, 10, 2 );
+
+		/* Act. */
+		$wpml->set_language_details_when_quiz_created( 1, 2 );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $filter_funtction, 10 );
+
+		$this->assertTrue( $filter_applied );
+	}
+
+	public function testSetLanguageDetailsWhenQuizCreated_WhenCalled_AppliesWpmlCurrentLangugeFilter() {
+		/* Arrange. */
+		$wpml = new Sensei_WPML();
+
+		$filter_language_code_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+			return null;
+		};
+		add_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10, 2 );
+
+		$filter_applied = false;
+		$filter_funtction = function( $language_code ) use ( &$filter_applied ) {
+			$filter_applied = true;
+			return $language_code;
+		};
+		add_filter( 'wpml_current_language', $filter_funtction, 10, 1 );
+
+		/* Act. */
+		$wpml->set_language_details_when_quiz_created( 1, 2 );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10 );
+		remove_filter( 'wpml_current_language', $filter_funtction, 10 );
+
+		$this->assertTrue( $filter_applied );
+	}
+	public function testSetLanguageDetailsWhenQuizCreated_WhenCalled_AppliesWpmlSetElementLanguageDetails() {
+		/* Arrange. */
+		$wpml = new Sensei_WPML();
+
+		$filter_applied = false;
+		$filter_funtction = function( $data ) use ( &$filter_applied ) {
+			$filter_applied = true;
+			return $data;
+		};
+
+		add_filter( 'wpml_set_element_language_details', $filter_funtction, 10, 1 );
+
+		/* Act. */
+		$wpml->set_language_details_when_quiz_created( 1, 2 );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_set_element_language_details', $filter_funtction, 10 );
+
+		$this->assertTrue( $filter_applied );
+	}
+}

--- a/tests/unit-tests/wpml/test-class-sensei-wpml.php
+++ b/tests/unit-tests/wpml/test-class-sensei-wpml.php
@@ -14,7 +14,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied = false;
+		$filter_applied   = false;
 		$filter_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -40,7 +40,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10, 2 );
 
-		$filter_applied = false;
+		$filter_applied   = false;
 		$filter_funtction = function( $language_code ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -61,7 +61,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied = false;
+		$filter_applied   = false;
 		$filter_funtction = function( $data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $data;
@@ -82,7 +82,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied = false;
+		$filter_applied   = false;
 		$filter_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -108,7 +108,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10, 2 );
 
-		$filter_applied = false;
+		$filter_applied   = false;
 		$filter_funtction = function( $language_code ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -128,7 +128,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied = false;
+		$filter_applied   = false;
 		$filter_funtction = function( $data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $data;

--- a/tests/unit-tests/wpml/test-class-sensei-wpml.php
+++ b/tests/unit-tests/wpml/test-class-sensei-wpml.php
@@ -10,23 +10,23 @@ use \Sensei_WPML;
 * @covers \Sensei_WPML
 */
 class Sensei_WPML_Test extends \WP_UnitTestCase {
-	public function testSetLanguageDetailsWhenLessonCreated_WhenCalled_AppliesWpmlElementLangugeCodeFilter() {
+	public function testSetLanguageDetailsWhenLessonCreated_WhenCalled_AppliesWpmlElementLanguageCodeFilter() {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
 		$filter_applied   = false;
-		$filter_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+		$filter_function = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
 		};
 
-		add_filter( 'wpml_element_language_code', $filter_funtction, 10, 2 );
+		add_filter( 'wpml_element_language_code', $filter_function, 10, 2 );
 
 		/* Act. */
 		$wpml->set_language_details_when_lesson_created( 1, 2 );
 
 		/* Clean up & Assert. */
-		remove_filter( 'wpml_element_language_code', $filter_funtction, 10 );
+		remove_filter( 'wpml_element_language_code', $filter_function, 10 );
 
 		$this->assertTrue( $filter_applied );
 	}
@@ -35,24 +35,24 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_language_code_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+		$filter_language_code_function = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			return null;
 		};
-		add_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10, 2 );
+		add_filter( 'wpml_element_language_code', $filter_language_code_function, 10, 2 );
 
 		$filter_applied   = false;
-		$filter_funtction = function( $language_code ) use ( &$filter_applied ) {
+		$filter_function = function( $language_code ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
 		};
-		add_filter( 'wpml_current_language', $filter_funtction, 10, 1 );
+		add_filter( 'wpml_current_language', $filter_function, 10, 1 );
 
 		/* Act. */
 		$wpml->set_language_details_when_lesson_created( 1, 2 );
 
 		/* Clean up & Assert. */
-		remove_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10 );
-		remove_filter( 'wpml_current_language', $filter_funtction, 10 );
+		remove_filter( 'wpml_element_language_code', $filter_language_code_function, 10 );
+		remove_filter( 'wpml_current_language', $filter_function, 10 );
 
 		$this->assertTrue( $filter_applied );
 	}
@@ -62,39 +62,39 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		$wpml = new Sensei_WPML();
 
 		$filter_applied   = false;
-		$filter_funtction = function( $data ) use ( &$filter_applied ) {
+		$filter_function = function( $data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $data;
 		};
 
-		add_filter( 'wpml_set_element_language_details', $filter_funtction, 10, 1 );
+		add_filter( 'wpml_set_element_language_details', $filter_function, 10, 1 );
 
 		/* Act. */
 		$wpml->set_language_details_when_lesson_created( 1, 2 );
 
 		/* Clean up & Assert. */
-		remove_filter( 'wpml_set_element_language_details', $filter_funtction, 10 );
+		remove_filter( 'wpml_set_element_language_details', $filter_function, 10 );
 
 		$this->assertTrue( $filter_applied );
 	}
 
-	public function testSetLanguageDetailsWhenQuizCreated_WhenCalled_AppliesWpmlElementLangugeCodeFilter() {
+	public function testSetLanguageDetailsWhenQuizCreated_WhenCalled_AppliesWpmlElementLanguageCodeFilter() {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
 		$filter_applied   = false;
-		$filter_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+		$filter_function = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
 		};
 
-		add_filter( 'wpml_element_language_code', $filter_funtction, 10, 2 );
+		add_filter( 'wpml_element_language_code', $filter_function, 10, 2 );
 
 		/* Act. */
 		$wpml->set_language_details_when_quiz_created( 1, 2 );
 
 		/* Clean up & Assert. */
-		remove_filter( 'wpml_element_language_code', $filter_funtction, 10 );
+		remove_filter( 'wpml_element_language_code', $filter_function, 10 );
 
 		$this->assertTrue( $filter_applied );
 	}
@@ -103,24 +103,24 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_language_code_funtction = function( $language_code, $element_data ) use ( &$filter_applied ) {
+		$filter_language_code_function = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			return null;
 		};
-		add_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10, 2 );
+		add_filter( 'wpml_element_language_code', $filter_language_code_function, 10, 2 );
 
 		$filter_applied   = false;
-		$filter_funtction = function( $language_code ) use ( &$filter_applied ) {
+		$filter_function = function( $language_code ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
 		};
-		add_filter( 'wpml_current_language', $filter_funtction, 10, 1 );
+		add_filter( 'wpml_current_language', $filter_function, 10, 1 );
 
 		/* Act. */
 		$wpml->set_language_details_when_quiz_created( 1, 2 );
 
 		/* Clean up & Assert. */
-		remove_filter( 'wpml_element_language_code', $filter_language_code_funtction, 10 );
-		remove_filter( 'wpml_current_language', $filter_funtction, 10 );
+		remove_filter( 'wpml_element_language_code', $filter_language_code_function, 10 );
+		remove_filter( 'wpml_current_language', $filter_function, 10 );
 
 		$this->assertTrue( $filter_applied );
 	}
@@ -129,18 +129,18 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		$wpml = new Sensei_WPML();
 
 		$filter_applied   = false;
-		$filter_funtction = function( $data ) use ( &$filter_applied ) {
+		$filter_function = function( $data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $data;
 		};
 
-		add_filter( 'wpml_set_element_language_details', $filter_funtction, 10, 1 );
+		add_filter( 'wpml_set_element_language_details', $filter_function, 10, 1 );
 
 		/* Act. */
 		$wpml->set_language_details_when_quiz_created( 1, 2 );
 
 		/* Clean up & Assert. */
-		remove_filter( 'wpml_set_element_language_details', $filter_funtction, 10 );
+		remove_filter( 'wpml_set_element_language_details', $filter_function, 10 );
 
 		$this->assertTrue( $filter_applied );
 	}

--- a/tests/unit-tests/wpml/test-class-sensei-wpml.php
+++ b/tests/unit-tests/wpml/test-class-sensei-wpml.php
@@ -14,7 +14,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied   = false;
+		$filter_applied  = false;
 		$filter_function = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -40,7 +40,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $filter_language_code_function, 10, 2 );
 
-		$filter_applied   = false;
+		$filter_applied  = false;
 		$filter_function = function( $language_code ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -61,7 +61,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied   = false;
+		$filter_applied  = false;
 		$filter_function = function( $data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $data;
@@ -82,7 +82,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied   = false;
+		$filter_applied  = false;
 		$filter_function = function( $language_code, $element_data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -108,7 +108,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $filter_language_code_function, 10, 2 );
 
-		$filter_applied   = false;
+		$filter_applied  = false;
 		$filter_function = function( $language_code ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $language_code;
@@ -128,7 +128,7 @@ class Sensei_WPML_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$wpml = new Sensei_WPML();
 
-		$filter_applied   = false;
+		$filter_applied  = false;
 		$filter_function = function( $data ) use ( &$filter_applied ) {
 			$filter_applied = true;
 			return $data;


### PR DESCRIPTION
Resolves #6978 

When we create a lesson or a quiz while saving the course structure, the translation is not created in WPML. Unfortunately, I didn't find why it works that way specifically for this case: if you create a course or a lesson in UI, everything work fine. I suppose it might happen with loading meta boxes or saving data from them.

## Proposed Changes
* Add translations for lessons and quizzes that were created while saving the course structure

## Testing Instructions

1. Install and activate WPML.
2. Go to Sensei LMS > Courses, create a new course.
3. Start with a blank (or default?) course structure (when 3 default lessons pre-filled). That's for simplicity, and you can play at this point.
4. Save draft or publish the course.
5. It is expected that the status of lessons changed from Unsaved to Draft.
6. You can also check if a translation entry was created in database: `SELECT * FROM wp_icl_translations WHERE element_id=7686; -- 7686 is Lesson ID`

## New/Updated Hooks

* `sensei_course_structure_lesson_created` - Fires after a lesson is created while saving the course structure.
* `sensei_course_structure_quiz_created` - Fires after a quiz is created while saving the course structure.


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
