### PR TITLE
Make customize template task point to Learning Mode template

### DIFF
--- a/changelog/add-update-customize-template-task
+++ b/changelog/add-update-customize-template-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Take user to Learning Mode Lesson Template in Setup task instead of only site editor

--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -38,7 +38,7 @@ class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	 * @return string
 	 */
 	public function get_title(): string {
-		return __( 'Customize your theme', 'sensei-lms' );
+		return __( 'Customize your lesson template', 'sensei-lms' );
 	}
 
 	/**

--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -47,7 +47,7 @@ class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	 * @return string
 	 */
 	public function get_url(): ?string {
-		return admin_url( 'site-editor.php' );
+		return Sensei_Course_Theme::get_learning_mode_fse_url();
 	}
 
 	/**

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1888,7 +1888,8 @@ class Sensei_Admin {
 		// the site editor or the customizer with the Course theme installed.
 		if ( Sensei_Home_Task_Customize_Course_Theme::is_active() ) {
 			if ( in_array( $pagenow, [ 'site-editor.php', 'customize.php' ], true ) ) {
-				$post_id = isset( $_GET['postId'] ) ? sanitize_text_field( $_GET['postId'] ) : '';
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$post_id = isset( $_GET['postId'] ) ? sanitize_text_field( wp_unslash( $_GET['postId'] ) ) : '';
 
 				if ( $post_id === Sensei_Course_Theme::get_learning_mode_template_id( 'lesson' ) ) {
 					Sensei_Home_Task_Customize_Course_Theme::mark_completed();

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1891,7 +1891,7 @@ class Sensei_Admin {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$post_id = isset( $_GET['postId'] ) ? sanitize_text_field( wp_unslash( $_GET['postId'] ) ) : '';
 
-				if ( $post_id === Sensei_Course_Theme::get_learning_mode_template_id( 'lesson' ) ) {
+				if ( Sensei_Course_Theme::get_learning_mode_template_id( 'lesson' ) === $post_id ) {
 					Sensei_Home_Task_Customize_Course_Theme::mark_completed();
 				}
 			}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1888,7 +1888,11 @@ class Sensei_Admin {
 		// the site editor or the customizer with the Course theme installed.
 		if ( Sensei_Home_Task_Customize_Course_Theme::is_active() ) {
 			if ( in_array( $pagenow, [ 'site-editor.php', 'customize.php' ], true ) ) {
-				Sensei_Home_Task_Customize_Course_Theme::mark_completed();
+				$post_id = isset( $_GET['postId'] ) ? sanitize_text_field( $_GET['postId'] ) : '';
+
+				if ( $post_id === Sensei_Course_Theme::get_learning_mode_template_id( 'lesson' ) ) {
+					Sensei_Home_Task_Customize_Course_Theme::mark_completed();
+				}
 			}
 		}
 	}

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -443,7 +443,7 @@ class Sensei_Course_Theme {
 	 *
 	 * @param string|null $post_type The post type to customize.
 	 *
-	 * @return The customization url
+	 * @return string The customization url.
 	 */
 	public static function get_learning_mode_fse_url( string $post_type = null ) : string {
 		// Get the post type manually if not provided.

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -456,7 +456,18 @@ class Sensei_Course_Theme {
 			$post_type = 'lesson';
 		}
 
-		return admin_url( 'site-editor.php?postType=wp_template&postId=' . self::THEME_NAME . '//' . $post_type );
+		return admin_url( 'site-editor.php?postType=wp_template&postId=' . self::get_learning_mode_template_id( $post_type ) );
+	}
+
+	/**
+	 * Returns the template ID of the post type for Learning Mode.
+	 *
+	 * @param string|null $post_type The post type to generate the template ID for.
+	 *
+	 * @return string The template ID.
+	 */
+	public static function get_learning_mode_template_id ( $post_type = null ) : string {
+		return self::THEME_NAME . '//' . $post_type;
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -466,7 +466,7 @@ class Sensei_Course_Theme {
 	 *
 	 * @return string The template ID.
 	 */
-	public static function get_learning_mode_template_id ( $post_type = null ) : string {
+	public static function get_learning_mode_template_id( $post_type = null ) : string {
 		return self::THEME_NAME . '//' . $post_type;
 	}
 

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -460,7 +460,7 @@ class Sensei_Course_Theme {
 	}
 
 	/**
-	 * Returnds the url for customizing Learning Mode template colors.
+	 * Returns the url for customizing Learning Mode template colors.
 	 */
 	public static function get_learning_mode_customizer_url(): string {
 			// Get the last modified lesson.

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
@@ -66,4 +66,14 @@ class Sensei_Home_Task_Customize_Course_Theme_Test extends WP_UnitTestCase {
 		// Assert.
 		$this->assertTrue( $this->task->is_active() );
 	}
+
+	public function testGetTitle_WhenCalled_ReturnsProperTitle() {
+		// Assert.
+		$this->assertEquals( 'Customize your lesson template', $this->task->get_title() );
+	}
+
+	public function testGetURL_WhenCalled_ReturnsFSETemplateURLOfLesson() {
+		// Assert.
+		$this->assertStringContainsString( 'sensei-course-theme//lesson', $this->task->get_url() );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7376

## Proposed Changes
* After setting up the site in onboarding flow, clicking on the _Customize your theme_ task took the user to the site editor which sometimes can confuse the user, now we are taking them to edit the Lesson template instead.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site with Sensei
2. Install and activate the Course theme
3. In Sensei LMS -> Home, make sure you see the task _Customize your lesson template_ instead of _Customize your theme_ 
4. Click on the task
5. Make sure you are taken the Learning Mode's Lesson Template editor page

#### Before
![Screenshot 2023-12-16 at 3 47 38 PM](https://github.com/Automattic/sensei/assets/6820724/c4f84d55-45f2-45c6-ada6-065252de08f3)

#### After
![Screenshot 2023-12-16 at 3 51 26 PM](https://github.com/Automattic/sensei/assets/6820724/f7faf035-c2de-4b60-ad24-957fae43915e)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
