### PR TITLE
Add clock interface

### DIFF
--- a/changelog/fix-time-based-tests
+++ b/changelog/fix-time-based-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: development
+
+Introduce Clock interface and corresponding public property for Sensei object.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2835,7 +2835,7 @@ class Sensei_Utils {
 	 */
 	public static function format_last_activity_date( string $date ) {
 		$timezone     = new DateTimeZone( 'GMT' );
-		$now          = new DateTime( 'now', $timezone );
+		$now          = Sensei()->clock->now( $timezone );
 		$date         = new DateTime( $date, $timezone );
 		$diff_in_days = $now->diff( $date )->days;
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1,5 +1,7 @@
 <?php
 
+use Sensei\Clock\Clock;
+use Sensei\Clock\Clock_Interface;
 use Sensei\Internal\Action_Scheduler\Action_Scheduler;
 use Sensei\Internal\Emails\Email_Customization;
 use Sensei\Internal\Installer\Updates_Factory;
@@ -351,6 +353,13 @@ class Sensei_Main {
 	public $action_scheduler;
 
 	/**
+	 * Clock.
+	 *
+	 * @var Clock_Interface
+	 */
+	public $clock;
+
+	/**
 	 * Constructor method.
 	 *
 	 * @param  string $file The base file of the plugin.
@@ -376,6 +385,20 @@ class Sensei_Main {
 		// Only set the install version if it is included in alloptions. This prevents a query on every page load.
 		$alloptions            = wp_load_alloptions();
 		$this->install_version = $alloptions['sensei-install-version'] ?? null;
+
+		// Init the clock.
+		/**
+		 * Filter the clock.
+		 *
+		 * @hook sensei_clock_init
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param {Clock_Interface} $clock The clock.
+		 * @return {Clock_Interface} Filtered clock.
+		 */
+		$clock       = apply_filters( 'sensei_clock_init', new Clock( wp_timezone() ) );
+		$this->clock = $clock;
 
 		// Initialize the core Sensei functionality
 		$this->init();

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -386,7 +386,6 @@ class Sensei_Main {
 		$alloptions            = wp_load_alloptions();
 		$this->install_version = $alloptions['sensei-install-version'] ?? null;
 
-		// Init the clock.
 		/**
 		 * Filter the clock.
 		 *
@@ -397,8 +396,7 @@ class Sensei_Main {
 		 * @param {Clock_Interface} $clock The clock.
 		 * @return {Clock_Interface} Filtered clock.
 		 */
-		$clock       = apply_filters( 'sensei_clock_init', new Clock( wp_timezone() ) );
-		$this->clock = $clock;
+		$this->clock = apply_filters( 'sensei_clock_init', new Clock( wp_timezone() ) );
 
 		// Initialize the core Sensei functionality
 		$this->init();

--- a/includes/clock/class-clock-interface.php
+++ b/includes/clock/class-clock-interface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File containing the Clock_Interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Clock;
+
+use DateTimeZone;
+
+/**
+ * Interface Clock_Interface
+ *
+ * @since $$next-version$$
+ */
+interface Clock_Interface {
+	/**
+	 * Get the current time.
+	 *
+	 * @param DateTimeZone|null $timezone The timezone to use. Uses the default timezone if not provided.
+	 * @return \DateTimeImmutable
+	 */
+	public function now( DateTimeZone $timezone = null );
+}

--- a/includes/clock/class-clock.php
+++ b/includes/clock/class-clock.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * File containing the Clock class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Clock;
+
+use DateTimeZone;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Clock
+ *
+ * @since $$next-version$$
+ */
+class Clock implements Clock_Interface {
+	/**
+	 * The timezone to use.
+	 *
+	 * @var DateTimeZone
+	 */
+	private DateTimeZone $timezone;
+
+	/**
+	 * Clock constructor.
+	 *
+	 * @param DateTimeZone $timezone The timezone to use.
+	 */
+	public function __construct( DateTimeZone $timezone ) {
+		$this->timezone = $timezone;
+	}
+
+	/**
+	 * Get the current time.
+	 *
+	 * @param DateTimeZone|null $timezone The timezone to use.
+	 * @return \DateTimeImmutable
+	 */
+	public function now( DateTimeZone $timezone = null ) {
+		return new \DateTimeImmutable( 'now', $timezone ?? $this->timezone );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -93,8 +93,7 @@ class Sensei_Unit_Tests_Bootstrap {
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-clock-stub.php';
 
 		// Set the clock to a fixed time.
-		$clock = new Sensei_Clock_Stub();
-		return $clock;
+		return new Sensei_Clock_Stub();
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,6 +43,9 @@ class Sensei_Unit_Tests_Bootstrap {
 		// Enable features.
 		tests_add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
 
+		// Init clock.
+		tests_add_filter( 'sensei_clock_init', [ $this, 'init_clock' ] );
+
 		/*
 		* Load PHPUnit Polyfills for the WP testing suite.
 		* @see https://github.com/WordPress/wordpress-develop/pull/1563/
@@ -85,6 +88,15 @@ class Sensei_Unit_Tests_Bootstrap {
 		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_shim' ] );
 	}
 
+	public function init_clock() {
+		// Testing setup for clock.
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-clock-stub.php';
+
+		// Set the clock to a fixed time.
+		$clock = new Sensei_Clock_Stub();
+		return $clock;
+	}
+
 	/**
 	 * Scheduler: Use shim.
 	 *
@@ -120,6 +132,7 @@ class Sensei_Unit_Tests_Bootstrap {
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-scheduler-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-test-redirect-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-hpps-helpers.php';
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-clock-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-background-job-stub.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/factories/class-sensei-factory.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/factories/class-wp-unittest-factory-for-post-sensei.php';

--- a/tests/framework/class-sensei-clock-stub.php
+++ b/tests/framework/class-sensei-clock-stub.php
@@ -17,6 +17,6 @@ class Sensei_Clock_Stub implements Clock_Interface {
 	 * @return \DateTimeImmutable
 	 */
 	public function now( \DateTimeZone $timezone = null ) {
-		return new \DateTimeImmutable( '@0', $timezone ?? new \DateTimeZone( 'UTC' ) );
+		return ( new \DateTimeImmutable( '@0' ) )->setTimezone( $timezone ?? new \DateTimeZone( 'UTC' ) );
 	}
 }

--- a/tests/framework/class-sensei-clock-stub.php
+++ b/tests/framework/class-sensei-clock-stub.php
@@ -1,0 +1,22 @@
+<?php
+/**
+* Stub for Clock_Interface.
+*
+* @package sensei-tests
+*/
+
+use Sensei\Clock\Clock_Interface;
+
+/**
+ * Class Sensei_Clock_Stub.
+ */
+class Sensei_Clock_Stub implements Clock_Interface {
+	/**
+	 * Get the current time. This is a stub that always returns the beginning of the Unix epoch.
+	 *
+	 * @return \DateTimeImmutable
+	 */
+	public function now( \DateTimeZone $timezone = null ) {
+		return new \DateTimeImmutable( '@0', $timezone ?? new \DateTimeZone( 'UTC' ) );
+	}
+}

--- a/tests/framework/trait-sensei-clock-helpers.php
+++ b/tests/framework/trait-sensei-clock-helpers.php
@@ -36,7 +36,6 @@ trait Sensei_Clock_Helpers {
 			$return_values[] = new \DateTimeImmutable( "@$ts", new \DateTimeZone( $timezone ) );
 		}
 
-
 		$clock = $this->createMock( Clock_Interface::class );
 		$clock->method( 'now' )
 			->willReturnOnConsecutiveCalls(

--- a/tests/framework/trait-sensei-clock-helpers.php
+++ b/tests/framework/trait-sensei-clock-helpers.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * File with trait Sensei_Clock_Helpers.
+ *
+ * @package sensei-tests
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+
+use Sensei\Clock\Clock_Interface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helpers related to the clock.
+ *
+ * @since $$next-version$$
+ */
+trait Sensei_Clock_Helpers {
+
+	/**
+	* Set the clock to a specific time.
+	*
+	* @param int|int[] $timestamp The timestamp or an array of timestamp clock will return on consecutive calls.
+	* @param string    $timezone  The timezone to use. UTC by default.
+	*/
+	private function set_clock_to( $timestamp, $timezone = 'UTC' ) {
+		$return_values = array();
+
+		$timestamp = is_array( $timestamp ) ? $timestamp : array( $timestamp );
+		$timestamp = array_map( 'intval', $timestamp );
+
+		foreach ( $timestamp as $ts ) {
+			$return_values[] = new \DateTimeImmutable( "@$ts", new \DateTimeZone( $timezone ) );
+		}
+
+
+		$clock = $this->createMock( Clock_Interface::class );
+		$clock->method( 'now' )
+			->willReturnOnConsecutiveCalls(
+				...$return_values
+			);
+
+		Sensei()->clock = $clock;
+	}
+
+	/**
+	 * Reset the clock to the default.
+	 */
+	private function reset_clock() {
+		Sensei()->clock = new Sensei_Clock_Stub();
+	}
+}

--- a/tests/unit-tests/clock/test-class-clock.php
+++ b/tests/unit-tests/clock/test-class-clock.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SenseiTest\Clock;
+
+use Sensei\Clock\Clock;
+
+/**
+ * @covers Sensei\Clock\Clock
+ */
+class Clock_Test extends \WP_UnitTestCase {
+	public function testNow_Always_ReturnsImmutableDateTime() {
+		// Arrange.
+		$clock = new Clock( new \DateTimeZone( 'UTC' ) );
+
+		// Act.
+		$now = $clock->now();
+
+		// Assert.
+		$this->assertInstanceOf( \DateTimeImmutable::class, $now );
+	}
+
+	public function testNow_DateTimeZoneGiven_ReturnsDateTimeInGivenTimeZone() {
+		// Arrange.
+		$clock = new Clock( new \DateTimeZone( 'America/New_York' ) );
+
+		// Act.
+		$now = $clock->now();
+
+		// Assert.
+		$this->assertEquals( 'America/New_York', $now->getTimezone()->getName() );
+	}
+}

--- a/tests/unit-tests/clock/test-class-clock.php
+++ b/tests/unit-tests/clock/test-class-clock.php
@@ -5,6 +5,8 @@ namespace SenseiTest\Clock;
 use Sensei\Clock\Clock;
 
 /**
+ * Test the Clock class.
+ *
  * @covers Sensei\Clock\Clock
  */
 class Clock_Test extends \WP_UnitTestCase {

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -16,6 +16,7 @@ require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-file-system-helper.php';
  */
 class Sensei_Utils_Test extends WP_UnitTestCase {
 	use \Sensei_File_System_Helper;
+	use \Sensei_Clock_Helpers;
 
 	/**
 	 * Setup function.
@@ -286,10 +287,14 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider lastActivityDateTestingData
 	 */
-	public function testFormatLastActivityDate_WhenCalled_ReturnsCorrectlyFormattedDates( $minutes_count, $expected_output ) {
+	public function testFormatLastActivityDate_WhenCalled_ReturnsCorrectlyFormattedDates( $seconds_count, $expected_output ) {
 		/* Arrange */
-		$gmt_time           = gmdate( 'Y-m-d H:i:s', strtotime( '-' . $minutes_count . ' seconds' ) );
-		$date_as_per_format = wp_date( get_option( 'date_format' ), ( new DateTime( $gmt_time ) )->getTimestamp(), new DateTimeZone( 'GMT' ) );
+		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'GMT' ) );
+		$this->set_clock_to( $current_datetime->getTimestamp() );
+
+		$test_time          = $current_datetime->getTimestamp() - $seconds_count;
+		$gmt_time           = gmdate( 'Y-m-d H:i:s', $test_time );
+		$date_as_per_format = wp_date( get_option( 'date_format' ), $test_time, new DateTimeZone( 'GMT' ) );
 
 		/* Act */
 		$actual = Sensei_Utils::format_last_activity_date( $gmt_time );
@@ -297,6 +302,8 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		/* Assert */
 		$expected = empty( $expected_output ) ? $date_as_per_format : $expected_output;
 		self::assertEquals( $expected, $actual, 'Last activity date is not being formatted correctly' );
+
+		$this->reset_clock();
 	}
 
 	public function testSenseiGradeQuiz_WhenCalled_UpdatesTheFinalGrade() {

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -1,6 +1,6 @@
 <?php
 
-use Sensei\Installer\Installer;
+use Sensei\Clock\Clock_Interface;
 use Sensei\Internal\Action_Scheduler\Action_Scheduler;
 use Sensei\Internal\Migration\Migration_Job_Scheduler;
 
@@ -193,6 +193,14 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertInstanceOf( Migration_Job_Scheduler::class, $sensei->migration_scheduler );
+	}
+
+	public function testConstructor_Always_InitializesClockProperty() {
+		/* Arrange. */
+		$sensei = Sensei();
+
+		/* Assert. */
+		$this->assertInstanceOf( Clock_Interface::class, $sensei->clock );
 	}
 
 	/**


### PR DESCRIPTION
The added interface is similar to [PSR-20](https://www.php-fig.org/psr/psr-20/). The difference is that we can pass the timezone to `now()` method as it is a common use-case in our codebase.

The implementation is pretty straightforward and returns an immutable instance of current date and time.

There is a default test stub, which always returns the beginning of the Unix epoch (1970-01-01 00:00:00 in UTC). That's a shortcut to simplify testing.

However, if you need to run more complex tests you can replace the `clock` property in `Sensei_Main` with a custom mock or just use helper methods. See an example in the updated test.

How it helps with time-based flaky tests? Those tests usually fail unexpectedly when time changed while test was running. To control time in our tests we add an abstraction over the system time function. Since this moment we can set expectations from time without being worry if time has changed.

Now, whenever you want to call `time()`, you should use `Sensei()->clock->now()` instead.

## Proposed Changes
* Add clock interface and implementation, 
* Add test stub and test helpers.
* Update a flaky test and corresponding code to use Clock_Interface.

## Testing Instructions

1. Go to Sensei LMS > Reports.
2. Check `Last Activity` column contains correct values.
3. No errors expected.

## New/Updated Hooks

* `sensei_clock_init` — Filter clock object.


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
