### PR TITLE
Add is_wpcom property in event log

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -114,7 +114,7 @@ class Sensei_Usage_Tracking_Data {
 			'paid'     => 0,
 			'courses'  => post_type_exists( 'course' ) ? wp_count_posts( 'course' )->publish : 0,
 			'learners' => self::get_learner_count(),
-			'is_wpcom' => get_option( 'wpcom_active_subscriptions', [] ) ? 1 : 0,
+			'is_wpcom' => get_option( 'wpcom_active_subscriptions' ) ? 1 : 0,
 		];
 
 		/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -114,6 +114,7 @@ class Sensei_Usage_Tracking_Data {
 			'paid'     => 0,
 			'courses'  => post_type_exists( 'course' ) ? wp_count_posts( 'course' )->publish : 0,
 			'learners' => self::get_learner_count(),
+			'is_wpcom' => get_option( 'wpcom_active_subscriptions', [] ) ? 1 : 0,
 		];
 
 		/**


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7394

## Proposed Changes
* Adds a is_wpcom property in sensei event logs

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch in your local environment
2. Make sure you have enabled sharing event logs
3. Generate any sensei event, like send an email or something else
4. Check in Tracks for that particular event you have generated. For example, the email event is `sensei_email_send`
5. Your generated event may take a few minutes to appear on Tracks, wait a little
6. After finding your event, make sure there is an is_wpcom property and it's set to 0
7. Now create a build using this branch and upload it on a wpcom site
8. Generate an event and check in Tracks
9. Now is_wpcom value should be 1

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
