### PR TITLE
Don't show Gutenberg welcome tour for course on wpcom

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -3,7 +3,7 @@
  */
 import { useDispatch } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
@@ -46,6 +46,17 @@ const EditorWizardModal = () => {
 		setDefaultPattern();
 		onWizardCompletion();
 	};
+
+	const { setShowWelcomeGuide } =
+		useDispatch( 'automattic/wpcom-welcome-guide' ) ?? {};
+
+	useEffect( () => {
+		if ( setShowWelcomeGuide ) {
+			setShowWelcomeGuide( false, {
+				onlyLocal: true,
+			} );
+		}
+	}, [ setShowWelcomeGuide ] );
 
 	return (
 		open && (

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
@@ -50,13 +50,23 @@ const EditorWizardModal = () => {
 	const { setShowWelcomeGuide } =
 		useDispatch( 'automattic/wpcom-welcome-guide' ) ?? {};
 
+	const { isShowWelcomeGuide } = useSelect( ( select ) => {
+		const { isWelcomeGuideShown } =
+			select( 'automattic/wpcom-welcome-guide' ) ?? {};
+		return {
+			isShowWelcomeGuide: isWelcomeGuideShown
+				? isWelcomeGuideShown()
+				: false,
+		};
+	}, [] );
+
 	useEffect( () => {
-		if ( setShowWelcomeGuide ) {
-			setShowWelcomeGuide( false, {
+		if ( setShowWelcomeGuide && isShowWelcomeGuide ) {
+			setShowWelcomeGuide( undefined, {
 				onlyLocal: true,
 			} );
 		}
-	}, [ setShowWelcomeGuide ] );
+	}, [ setShowWelcomeGuide, isShowWelcomeGuide ] );
 
 	return (
 		open && (

--- a/changelog/add-dont-show-gutenberg-tour-for-course-wpcom
+++ b/changelog/add-dont-show-gutenberg-tour-for-course-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Hide Gutenberg tour modal in Sensei new Course editor


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7398

## Proposed Changes
* When a new Course is created, on wpcom, if the user hasn't taken the Gutenberg tour yet, they see two modals on the screen. So it looks messy. Now, when creating a new Course, we don't show the user the Gutenberg tour modal.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new course locally with the console open
2. Make sure you see no error in the console
3. Make sure the editor works as expected
4. Now create a new WPCOM site with Sensei
5. Create a new Course
6. Make sure you see only the Course modal
7. Now open any post in the GB editor
8. Make sure you see the Gutenberg tour modal now

#### New Course Editor
![image](https://github.com/Automattic/sensei/assets/6820724/20e470e7-f96d-4c29-8861-abb4c5cab5dc)

#### Other Post Editor
![image](https://github.com/Automattic/sensei/assets/6820724/4acdc991-524f-4715-8f0d-0d15f002906c)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
