### PR TITLE
Set email template only for sensei_email post type

### DIFF
--- a/changelog/fix-email-template-switch
+++ b/changelog/fix-email-template-switch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set email template only for sensei_email post type.

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -124,7 +124,7 @@ class Email_Page_Template {
 
 		$post_type = $query['post_type'] ?? get_post_type();
 
-		if ( ! empty( $post_type ) && Email_Post_Type::POST_TYPE !== $post_type ) {
+		if ( empty( $post_type ) || Email_Post_Type::POST_TYPE !== $post_type ) {
 			return $original_templates;
 		}
 

--- a/tests/unit-tests/internal/emails/test-class-email-page-template.php
+++ b/tests/unit-tests/internal/emails/test-class-email-page-template.php
@@ -104,7 +104,7 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 			->willReturn( $template_to_be_added );
 
 		/* Act. */
-		$result = $page_template->add_email_template( $default_list, [], 'wp_template' );
+		$result = $page_template->add_email_template( $default_list, array( 'post_type' => 'sensei_email' ), 'wp_template' );
 
 		/* Assert. */
 		self::assertSame( $template_to_be_added, $result[1] );
@@ -141,6 +141,20 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $page_template->add_email_template( $default_list, [ 'post_type' => 'page' ], 'wp_template' );
+
+		/* Assert. */
+		self::assertSame( $default_list, $result );
+	}
+
+	public function testAddEmailTemplate_GivenQueryWithoutPostType_ReturnsDefaultTemplate() {
+
+		/* Arrange. */
+		$repository    = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template = new Email_Page_Template( $repository );
+		$default_list  = [ $this->createMock( \WP_Block_Template::class ) ];
+
+		/* Act. */
+		$result = $page_template->add_email_template( $default_list, [], 'wp_template' );
 
 		/* Assert. */
 		self::assertSame( $default_list, $result );
@@ -201,7 +215,7 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 			->willReturn( $template_to_be_added );
 
 		/* Act. */
-		$result = $page_template->add_email_template( $default_list, [], 'wp_template' );
+		$result = $page_template->add_email_template( $default_list, array( 'post_type' => 'sensei_email' ), 'wp_template' );
 
 		/* Assert. */
 		self::assertSame( $template_to_be_added, $result[1] );


### PR DESCRIPTION
There were specific but unclear cases when our email template was used on the frontend.
[In the forum](https://wordpress.org/support/topic/email-template-overrides-404-template/), we got a well investigated case with clear instructions on how to reproduce it.

## Proposed Changes
* Set email template only for sensei_email post type.

## Testing Instructions

1. Go to WP Admin > Posts > Tags.
2. Add a new tag and click on View. The tag should remain empty.
3. You shouldn't see the email template, but an empty tag listing.
4. Go to Sensei LMS > Settings > Emails and try open preview for email. Should be open the email template as previously.
5. Try to repeat it with `trunk` and see it tries to render the email template.

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
