### PR TITLE
Update course notices to have a CTA for course editors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/changelog/change-course-notices
+++ b/changelog/change-course-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update course notices to have a CTA for course editors

--- a/changelog/fix-cannot-register-unpublished-course-notice
+++ b/changelog/fix-cannot-register-unpublished-course-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix issue with the message "Cannot register for an unpublished course" that was not being displayed

--- a/changelog/fix-cannot-register-unpublished-course-notice
+++ b/changelog/fix-cannot-register-unpublished-course-notice
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix issue with the message "Cannot register for an unpublished course" that was not being displayed
+Message "Cannot register for an unpublished course" was not being displayed

--- a/changelog/fix-redirect-on-enrollment-with-draft-lessons
+++ b/changelog/fix-redirect-on-enrollment-with-draft-lessons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an redirect issue when course editor enroll to a course containing only draft lessons

--- a/changelog/fix-redirect-on-enrollment-with-draft-lessons
+++ b/changelog/fix-redirect-on-enrollment-with-draft-lessons
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix an redirect issue when course editor enroll to a course containing only draft lessons
+Redirect properly when course editor enrols in a course containing only draft lessons

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -259,7 +259,7 @@ class Sensei_Course_Outline_Block {
 		if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
 			$cta = sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( get_edit_post_link( $course_id ) || '' ),
+				esc_url( get_edit_post_link( $course_id ) ?? '' ),
 				__( 'your lessons', 'sensei-lms' )
 			);
 
@@ -288,7 +288,7 @@ class Sensei_Course_Outline_Block {
 			if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
 				$cta = sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( get_edit_post_link( $course_id ) || '' ),
+					esc_url( get_edit_post_link( $course_id ) ?? '' ),
 					__( 'publish the course', 'sensei-lms' )
 				);
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -305,7 +305,7 @@ class Sensei_Course_Outline_Block {
 
 		} elseif ( $has_draft ) {
 			// Notice for draft lessons. It only happens for who can read private posts, otherwise draft lessons aren't returned.
-			$message = __( 'Unpublished lessons are only visible in preview mode.', 'sensei-lms' );
+			$message = __( 'Draft lessons are only visible in preview mode.', 'sensei-lms' );
 			if ( $edit_lessons_message ) {
 				$message = $edit_lessons_message . ' ' . $message;
 			}

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -246,7 +246,7 @@ class Sensei_Course_Outline_Block {
 	public function frontend_notices() {
 		$post = get_post();
 
-		if ( ! $post || 'course' !== $post->post_type || is_admin() ) {
+		if ( ! is_object( $post ) || 'course' !== $post->post_type || is_admin() ) {
 			return;
 		}
 
@@ -259,7 +259,7 @@ class Sensei_Course_Outline_Block {
 		if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
 			$cta = sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( get_edit_post_link( $course_id ) ),
+				esc_url( get_edit_post_link( $course_id ) || '' ),
 				__( 'your lessons', 'sensei-lms' )
 			);
 
@@ -288,7 +288,7 @@ class Sensei_Course_Outline_Block {
 			if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
 				$cta = sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( get_edit_post_link( $course_id ) ),
+					esc_url( get_edit_post_link( $course_id ) || '' ),
 					__( 'publish the course', 'sensei-lms' )
 				);
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -62,6 +62,8 @@ class Sensei_Course_Outline_Block {
 		$this->module = new Sensei_Course_Outline_Module_Block();
 
 		$this->register_blocks();
+
+		add_action( 'wp', [ $this, 'frontend_notices' ] );
 	}
 
 	/**
@@ -174,10 +176,6 @@ class Sensei_Course_Outline_Block {
 
 		$structure = Sensei_Course_Structure::instance( $post->ID )->get( $context );
 
-		if ( $is_preview ) {
-			$attributes['preview_drafts'] = $this->has_draft( $structure );
-		}
-
 		$this->add_block_attributes( $structure );
 
 		return [
@@ -236,6 +234,84 @@ class Sensei_Course_Outline_Block {
 		$this->block_content = $this->course->render_course_outline_block( $outline );
 		return $this->block_content;
 
+	}
+
+	/**
+	 * Initialize notices.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 */
+	public function frontend_notices() {
+		$post = get_post();
+
+		if ( ! $post || 'course' !== $post->post_type || is_admin() ) {
+			return;
+		}
+
+		$course_id        = $post->ID;
+		$structure        = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
+		$has_draft        = $this->has_draft( $structure );
+		$edit_cta_message = '';
+
+		// Complete message with CTA if user can edit the course.
+		if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
+			$edit_cta = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_edit_post_link( $course_id ) ),
+				__( 'your lessons', 'sensei-lms' )
+			);
+
+			$edit_cta_message = sprintf(
+				/* translators: %s: Edit course link. */
+				__( "When you're ready, let's publish %s in order to make them available to your students.", 'sensei-lms' ),
+				$edit_cta
+			);
+		}
+
+		// Notice for empty structure. Notice that draft lessons don't return for students, so it's considered empty.
+		if ( empty( $structure ) ) {
+			$message = __( 'There are no published lessons in this course yet.', 'sensei-lms' );
+			if ( $edit_cta_message ) {
+				$message = $edit_cta_message . ' ' . $message;
+			}
+
+			Sensei()->notices->add_notice( $message, 'info', 'sensei-course-outline-no-content' );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_GET['draftcourse'] ) && 'true' === $_GET['draftcourse'] ) {
+			// Notice when trying to register in a draft course.
+			$message = __( 'Cannot register for an unpublished course.', 'sensei-lms' );
+
+			if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
+				$edit_cta = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( get_edit_post_link( $course_id ) ),
+					__( 'publish the course', 'sensei-lms' )
+				);
+
+				$edit_cta_message = sprintf(
+					/* translators: %s: Link to publish the course. */
+					__( 'Please %s first.', 'sensei-lms' ),
+					$edit_cta
+				);
+
+				$message .= ' ' . $edit_cta_message;
+			}
+
+			Sensei()->notices->add_notice( $message, 'info', 'sensei-course-outline-drafts' );
+
+		} elseif ( $has_draft ) {
+			// Notice for draft lessons. It only happens for who can read private posts, otherwise draft lessons aren't returned.
+			$message = __( 'Unpublished lessons are only visible in preview mode.', 'sensei-lms' );
+			if ( $edit_cta_message ) {
+				$message = $edit_cta_message . ' ' . $message;
+			}
+
+			Sensei()->notices->add_notice( $message, 'info', 'sensei-course-outline-drafts' );
+		}
 	}
 
 }

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -310,7 +310,7 @@ class Sensei_Course_Outline_Block {
 				);
 				$cta  = sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( $link ?? '' ),
+					esc_url( $link ),
 					__( 'your lessons', 'sensei-lms' )
 				);
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -260,9 +260,17 @@ class Sensei_Course_Outline_Block {
 			$message = __( 'There are no published lessons in this course yet.', 'sensei-lms' );
 
 			if ( $can_edit_course ) {
-				$cta = sprintf(
+				$link = add_query_arg(
+					[
+						'post_type'     => 'lesson',
+						'lesson_course' => $course_id,
+					],
+					admin_url( 'edit.php' )
+				);
+
+				$cta  = sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( get_edit_post_link( $course_id ) ?? '' ),
+					esc_url( $link ),
 					__( 'Add some now.', 'sensei-lms' )
 				);
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -250,31 +250,31 @@ class Sensei_Course_Outline_Block {
 			return;
 		}
 
-		$course_id        = $post->ID;
-		$structure        = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
-		$has_draft        = $this->has_draft( $structure );
-		$edit_cta_message = '';
+		$course_id            = $post->ID;
+		$structure            = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
+		$has_draft            = $this->has_draft( $structure );
+		$edit_lessons_message = '';
 
 		// Complete message with CTA if user can edit the course.
 		if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
-			$edit_cta = sprintf(
+			$cta = sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( get_edit_post_link( $course_id ) ),
 				__( 'your lessons', 'sensei-lms' )
 			);
 
-			$edit_cta_message = sprintf(
+			$edit_lessons_message = sprintf(
 				/* translators: %s: Edit course link. */
 				__( "When you're ready, let's publish %s in order to make them available to your students.", 'sensei-lms' ),
-				$edit_cta
+				$cta
 			);
 		}
 
 		// Notice for empty structure. Notice that draft lessons don't return for students, so it's considered empty.
 		if ( empty( $structure ) ) {
 			$message = __( 'There are no published lessons in this course yet.', 'sensei-lms' );
-			if ( $edit_cta_message ) {
-				$message = $edit_cta_message . ' ' . $message;
+			if ( $edit_lessons_message ) {
+				$message = $edit_lessons_message . ' ' . $message;
 			}
 
 			Sensei()->notices->add_notice( $message, 'info', 'sensei-course-outline-no-content' );
@@ -286,19 +286,19 @@ class Sensei_Course_Outline_Block {
 			$message = __( 'Cannot register for an unpublished course.', 'sensei-lms' );
 
 			if ( Sensei_Course::can_current_user_edit_course( $course_id ) ) {
-				$edit_cta = sprintf(
+				$cta = sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( get_edit_post_link( $course_id ) ),
 					__( 'publish the course', 'sensei-lms' )
 				);
 
-				$edit_cta_message = sprintf(
+				$publish_message = sprintf(
 					/* translators: %s: Link to publish the course. */
 					__( 'Please %s first.', 'sensei-lms' ),
-					$edit_cta
+					$cta
 				);
 
-				$message .= ' ' . $edit_cta_message;
+				$message .= ' ' . $publish_message;
 			}
 
 			Sensei()->notices->add_notice( $message, 'info', 'sensei-course-outline-drafts' );
@@ -306,8 +306,8 @@ class Sensei_Course_Outline_Block {
 		} elseif ( $has_draft ) {
 			// Notice for draft lessons. It only happens for who can read private posts, otherwise draft lessons aren't returned.
 			$message = __( 'Unpublished lessons are only visible in preview mode.', 'sensei-lms' );
-			if ( $edit_cta_message ) {
-				$message = $edit_cta_message . ' ' . $message;
+			if ( $edit_lessons_message ) {
+				$message = $edit_lessons_message . ' ' . $message;
 			}
 
 			Sensei()->notices->add_notice( $message, 'info', 'sensei-course-outline-drafts' );

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -267,7 +267,6 @@ class Sensei_Course_Outline_Block {
 					],
 					admin_url( 'edit.php' )
 				);
-
 				$cta  = sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( $link ),

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -55,20 +55,11 @@ class Sensei_Course_Outline_Course_Block {
 		$post_id    = $outline['post_id'];
 
 		if ( empty( $blocks ) ) {
-			Sensei()->notices->add_notice( __( 'There are no published lessons in this course yet.', 'sensei-lms' ), 'info', 'sensei-course-outline-no-content' );
 			return '';
 		}
 
 		$class_name = Sensei_Block_Helpers::block_class_with_default_style( $attributes );
 		$css        = Sensei_Block_Helpers::build_styles( $attributes );
-
-		if ( ! empty( $attributes['preview_drafts'] ) ) {
-			Sensei()->notices->add_notice( __( 'One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to students.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
-		}
-		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( isset( $_GET['draftcourse'] ) && 'true' === $_GET['draftcourse'] ) {
-			Sensei()->notices->add_notice( __( 'Cannot register for an unpublished course.  Please publish the course first.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
-		}
 
 		return '
 			<section ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-outline', 'sensei-block-wrapper', $class_name ], $css ) . '>

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4462,6 +4462,10 @@ class Sensei_Course {
 	 * @return String
 	 */
 	public static function alter_redirect_url_after_enrolment( $url, $post ) {
+		// Only redirect to the lesson if the course is published.
+		if ( $post->post_status !== 'publish' ) {
+			return $url;
+		}
 
 		$course_id = $post->ID;
 		if ( Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -4463,7 +4463,7 @@ class Sensei_Course {
 	 */
 	public static function alter_redirect_url_after_enrolment( $url, $post ) {
 		// Only redirect to the lesson if the course is published.
-		if ( $post->post_status !== 'publish' ) {
+		if ( 'publish' !== $post->post_status ) {
 			return $url;
 		}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1264,7 +1264,7 @@ class Sensei_Frontend {
 				if ( false !== $redirect_url ) {
 					?>
 
-					<script type="text/javascript"> window.location = '<?php echo esc_url( $redirect_url ); ?>'; </script>
+					<script type="text/javascript"> window.location = '<?php echo esc_url_raw( $redirect_url ); ?>'; </script>
 
 					<?php
 				}

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -56,7 +56,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 
 		// Assert.
 		$this->assertStringContainsString( 'There are no published lessons in this course yet.', $result );
-		$this->assertStringContainsString( "When you're ready, let's publish", $result );
+		$this->assertStringContainsString( 'Add some now.', $result );
 	}
 
 	public function testOutlineNotices_WhenHavingDraftLessonsAsAdmin_PrintsMessageWithCTA() {

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -81,7 +81,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		$result = $this->render_and_get_frontend_notices();
 
 		// Assert.
-		$this->assertStringContainsString( 'Unpublished lessons are only visible in preview mode.', $result );
+		$this->assertStringContainsString( 'Draft lessons are only visible in preview mode.', $result );
 		$this->assertStringContainsString( "When you're ready, let's publish", $result );
 	}
 


### PR DESCRIPTION
Resolves #7374

## Proposed Changes

* Update the course notices, adding a CTA for users that can manage the course.
* I took the opportunity to move the notices logic from the block rendering to a hook because it wasn't using a good practice. More context: pdxWSz-1aV-p2
* It fixes an issue with redirect when taking a course while lessons are in draft.
* Fix an issue with the message "Cannot register for an unpublished course.". It wasn't working because it was redirecting the user to the first lesson.

> Nice-to-have: It would be nice to left-align the notice text. This isn't a mandatory requirement for this issue though. I imagine it will affect all notices (which is probably a good thing).

I was afraid to break other notices, so I didn't do it as part of this PR. Maybe we could have another issue to think it better, reorganizing the HTML and styles of this notice, and maybe having a better design for it?

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Published course containing only draft lessons**

1. Create and publish a course containing at least one draft lesson.
2. Access it in the frontend as a course editor (teacher/admin).
3. Check that you see a message with a link to publish the lessons.
4. Access it as a student, and make sure you see a message that the course doesn't have published lessons, and you don't see any CTA.

**Published course without any lesson**

1. Create and publish a course without any lesson.
2. Access it in the frontend as a course editor (teacher/admin). Check that you see a message that there are no lessons, and the link to publish the lessons.
3. Access it as a student, and make sure you see the message but no link to publish lessons.

**Draft course**

1. Create a draft course.
2. Access it in the frontend as a course editor (teacher/admin).
3. Try to take this course and make sure you see a notice that you can't take the course and a button to publish it.

**Redirect issue**

1. Create and publish a course containing only draft lessons.
2. Access it in the frontend as a course editor (teacher/admin).
3. Try to take the course, and make sure you are properly redirected to the first draft lesson.

Notice that we don't have a message when the lessons are published, but the course is in draft. Should we add a message for this case?

## Screenshots

Student visiting a course with no lessons (or all draft):

<img width="1037" alt="Screenshot 2023-12-22 at 18 07 20" src="https://github.com/Automattic/sensei/assets/876340/0cbe03a5-0a6e-4c02-b3f6-e682655cf224">

Admin visiting a course with at least one draft lesson:

<img width="1070" alt="Screenshot 2023-12-22 at 18 59 46" src="https://github.com/Automattic/sensei/assets/876340/d5602929-a3b0-4b77-b6fe-a173c284fabf">

Admin visiting a course without lessons:

<img width="1096" alt="Screenshot 2023-12-22 at 17 12 43" src="https://github.com/Automattic/sensei/assets/876340/b84c6df6-ecdc-481f-84d0-374ffd963c43">

Admin trying to take a draft course:

<img width="1086" alt="Screenshot 2023-12-22 at 18 06 04" src="https://github.com/Automattic/sensei/assets/876340/720d278e-d214-4e73-88b9-7e45936b40b9">

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

*

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues