### PR TITLE
Don't send Course Completion email twice (course already complete)

### DIFF
--- a/changelog/fix-course-completion-email-duplicates
+++ b/changelog/fix-course-completion-email-duplicates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't send Course Completion email twice (when the course is already completed)

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1930,6 +1930,9 @@ class Sensei_Utils {
 	public static function update_course_status( $user_id, $course_id, $status = 'in-progress', $metadata = array() ) {
 		$comment_id = false;
 		if ( ! empty( $status ) ) {
+			$existing_status_comment = self::user_course_status( $course_id, $user_id );
+			$previous_status         = $existing_status_comment ? $existing_status_comment->comment_approved : null;
+
 			$args = array(
 				'user_id'  => $user_id,
 				'username' => get_userdata( $user_id )->user_login ?? null,
@@ -1945,7 +1948,22 @@ class Sensei_Utils {
 					update_comment_meta( $comment_id, $key, $value );
 				}
 			}
-			do_action( 'sensei_course_status_updated', $status, $user_id, $course_id, $comment_id );
+
+			/**
+			 * Fires when a course status is updated.
+			 *
+			 * @hook sensei_course_status_updated
+			 *
+			 * @since 1.7.0
+			 * @since $$next-version$$ $old_status parameter added.
+			 *
+			 * @param string      $status          The status.
+			 * @param int         $user_id         The user ID.
+			 * @param int         $course_id       The course ID.
+			 * @param int         $comment_id      The comment ID.
+			 * @param string|null $previous_status The old status. Null if previous status was not set.
+			 */
+			do_action( 'sensei_course_status_updated', $status, $user_id, $course_id, $comment_id, $previous_status );
 		}
 		return $comment_id;
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1955,13 +1955,13 @@ class Sensei_Utils {
 			 * @hook sensei_course_status_updated
 			 *
 			 * @since 1.7.0
-			 * @since $$next-version$$ $old_status parameter added.
+			 * @since $$next-version$$ $previous_status parameter added.
 			 *
 			 * @param string      $status          The status.
 			 * @param int         $user_id         The user ID.
 			 * @param int         $course_id       The course ID.
 			 * @param int         $comment_id      The comment ID.
-			 * @param string|null $previous_status The old status. Null if previous status was not set.
+			 * @param string|null $previous_status The previous status. Null if previous status was not set.
 			 */
 			do_action( 'sensei_course_status_updated', $status, $user_id, $course_id, $comment_id, $previous_status );
 		}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1930,8 +1930,8 @@ class Sensei_Utils {
 	public static function update_course_status( $user_id, $course_id, $status = 'in-progress', $metadata = array() ) {
 		$comment_id = false;
 		if ( ! empty( $status ) ) {
-			$existing_status_comment = self::user_course_status( $course_id, $user_id );
-			$previous_status         = $existing_status_comment ? $existing_status_comment->comment_approved : null;
+			$course_progress = Sensei()->course_progress_repository->get( $course_id, $user_id );
+			$previous_status = $course_progress ? $course_progress->get_status() : null;
 
 			$args = array(
 				'user_id'  => $user_id,

--- a/includes/internal/emails/generators/class-course-completed.php
+++ b/includes/internal/emails/generators/class-course-completed.php
@@ -42,21 +42,22 @@ class Course_Completed extends Email_Generators_Abstract {
 	 * @return void
 	 */
 	public function init() {
-		$this->maybe_add_action( 'sensei_course_status_updated', [ $this, 'completed_course_mail_to_student' ], 10, 3 );
+		$this->maybe_add_action( 'sensei_course_status_updated', [ $this, 'completed_course_mail_to_student' ], 10, 4 );
 	}
 
 	/**
 	 * Send email to student when a course is completed.
 	 *
-	 * @param string $status     The status.
-	 * @param int    $student_id The learner ID.
-	 * @param int    $course_id  The course ID.
+	 * @param string      $status     The status.
+	 * @param int         $student_id The learner ID.
+	 * @param int         $course_id  The course ID.
+	 * @param string|null $previous_status The previous status.
 	 *
 	 * @access private
 	 */
-	public function completed_course_mail_to_student( $status = 'in-progress', $student_id = 0, $course_id = 0 ) {
+	public function completed_course_mail_to_student( $status = 'in-progress', $student_id = 0, $course_id = 0, $previous_status = null ) {
 
-		if ( 'complete' !== $status || ! \Sensei_Course::is_user_enrolled( $course_id, $student_id ) ) {
+		if ( $this->should_skip_sending( $status, $previous_status, $course_id, $student_id ) ) {
 			return;
 		}
 
@@ -76,5 +77,24 @@ class Course_Completed extends Email_Generators_Abstract {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Returns true if the email should be skipped.
+	 *
+	 * @param string      $status     The status.
+	 * @param string|null $previous_status The previous status.
+	 * @param int         $student_id The learner ID.
+	 * @param int         $course_id  The course ID.
+	 * @return bool
+	 */
+	private function should_skip_sending( $status, $previous_status, $course_id, $student_id ) {
+		// Skip sending if the status is not complete or if the status was already complete.
+		if ( 'complete' !== $status || 'complete' === $previous_status) {
+			return true;
+		}
+
+		// Skip sending if the user is not enrolled in the course.
+		return ! \Sensei_Course::is_user_enrolled( $course_id, $student_id );
 	}
 }

--- a/includes/internal/emails/generators/class-course-completed.php
+++ b/includes/internal/emails/generators/class-course-completed.php
@@ -82,15 +82,15 @@ class Course_Completed extends Email_Generators_Abstract {
 	/**
 	 * Returns true if the email should be skipped.
 	 *
-	 * @param string      $status     The status.
+	 * @param string      $status          The status.
 	 * @param string|null $previous_status The previous status.
-	 * @param int         $student_id The learner ID.
-	 * @param int         $course_id  The course ID.
+	 * @param int         $course_id       The course ID.
+	 * @param int         $student_id      The learner ID.
 	 * @return bool
 	 */
 	private function should_skip_sending( $status, $previous_status, $course_id, $student_id ) {
 		// Skip sending if the status is not complete or if the status was already complete.
-		if ( 'complete' !== $status || 'complete' === $previous_status) {
+		if ( 'complete' !== $status || 'complete' === $previous_status ) {
 			return true;
 		}
 

--- a/includes/internal/emails/generators/class-course-completed.php
+++ b/includes/internal/emails/generators/class-course-completed.php
@@ -42,7 +42,7 @@ class Course_Completed extends Email_Generators_Abstract {
 	 * @return void
 	 */
 	public function init() {
-		$this->maybe_add_action( 'sensei_course_status_updated', [ $this, 'completed_course_mail_to_student' ], 10, 4 );
+		$this->maybe_add_action( 'sensei_course_status_updated', [ $this, 'completed_course_mail_to_student' ], 10, 5 );
 	}
 
 	/**
@@ -51,11 +51,12 @@ class Course_Completed extends Email_Generators_Abstract {
 	 * @param string      $status     The status.
 	 * @param int         $student_id The learner ID.
 	 * @param int         $course_id  The course ID.
+	 * @param int         $comment_id The comment ID.
 	 * @param string|null $previous_status The previous status.
 	 *
 	 * @access private
 	 */
-	public function completed_course_mail_to_student( $status = 'in-progress', $student_id = 0, $course_id = 0, $previous_status = null ) {
+	public function completed_course_mail_to_student( $status = 'in-progress', $student_id = 0, $course_id = 0, $comment_id = 0, $previous_status = null ) {
 
 		if ( $this->should_skip_sending( $status, $previous_status, $course_id, $student_id ) ) {
 			return;

--- a/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
@@ -85,7 +85,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 
 		/* Act. */
-		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 'in-progress' );
+		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 0, 'in-progress' );
 
 		/* Assert. */
 		self::assertEquals( 'course_completed', $email_data['name'] );
@@ -123,7 +123,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 
 		/* Act. */
-		do_action( 'sensei_course_status_updated', 'in-progress', $student_id, $course->ID, 'in-progress' );
+		do_action( 'sensei_course_status_updated', 'in-progress', $student_id, $course->ID, 0, 'in-progress' );
 
 		/* Assert. */
 		self::assertEmpty( $email_data['name'] );
@@ -156,7 +156,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 
 		/* Act. */
-		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 'in-progress' );
+		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 0, 'in-progress' );
 
 		/* Assert. */
 		self::assertEmpty( $email_data['name'] );
@@ -190,7 +190,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 
 		/* Act. */
-		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 'complete' );
+		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 0, 'complete' );
 
 		/* Assert. */
 		self::assertEmpty( $email_data['name'] );

--- a/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
@@ -47,7 +47,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		self::resetEnrolmentProviders();
 	}
 
-	public function testGenerateEmail_WhenCalledByStudentCompletedCourseEvent_CallsStudentEmailSendingActionWithRightData() {
+	public function testGenerateEmail_WhenStudentEnrolledAndCompletedTheCourse_CallsStudentEmailSendingActionWithRightData() {
 		/* Arrange. */
 		$student_id    = $this->factory->user->create(
 			[
@@ -85,7 +85,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 
 		/* Act. */
-		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID );
+		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 'in-progress' );
 
 		/* Assert. */
 		self::assertEquals( 'course_completed', $email_data['name'] );
@@ -96,7 +96,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		self::assertNotEmpty( $email_data['data']['test@a.com']['completed:url'] );
 	}
 
-	public function testGenerateEmail_WhenCalledByStudentUpdatedCourseEvent_DoesNotCallStudentEmailIfCourseNotCompleted() {
+	public function testGenerateEmail_WhenCourseNotCompleted_DoesNotCallStudentEmail() {
 		/* Arrange. */
 		$student_id = $this->factory->user->create(
 			[
@@ -123,13 +123,13 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 
 		/* Act. */
-		do_action( 'sensei_course_status_updated', 'in-progress', $student_id, $course->ID );
+		do_action( 'sensei_course_status_updated', 'in-progress', $student_id, $course->ID, 'in-progress' );
 
 		/* Assert. */
 		self::assertEmpty( $email_data['name'] );
 	}
 
-	public function testGenerateEmail_WhenCalledByStudentUpdatedCourseEvent_DoesNotCallStudentEmailIfStudentNotEnrolled() {
+	public function testGenerateEmail_WhenStudentNotEnrolled_DoesNotCallStudentEmail() {
 		/* Arrange. */
 		$student_id = $this->factory->user->create(
 			[
@@ -156,9 +156,44 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 
 		/* Act. */
-		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID );
+		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 'in-progress' );
 
 		/* Assert. */
 		self::assertEmpty( $email_data['name'] );
 	}
+
+	public function testGenerateEmail_WhenCourseWasCompletedEarlier_DoesNotCallStudentEmail() {
+		/* Arrange. */
+		$student_id = $this->factory->user->create(
+			[
+				'user_email' => 'test@a.com',
+			]
+		);
+		$course     = $this->factory->course->create_and_get();
+		$this->manuallyEnrolStudentInCourse( $student_id, $course->ID );
+
+		( new Course_Completed( $this->email_repository ) )->init();
+
+		$email_data = [
+			'name' => '',
+			'data' => null,
+		];
+
+		add_action(
+			'sensei_email_send',
+			function ( $email_name, $replacements ) use ( &$email_data ) {
+				$email_data['name'] = $email_name;
+				$email_data['data'] = $replacements;
+			},
+			10,
+			2
+		);
+
+		/* Act. */
+		do_action( 'sensei_course_status_updated', 'complete', $student_id, $course->ID, 'complete' );
+
+		/* Assert. */
+		self::assertEmpty( $email_data['name'] );
+	}
+
 }

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -643,7 +643,7 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 	public function testUpdateCourseStatus_WhenPreviousStatusNotFound_PassesNullAsPreviousStatusToTheAction(): void {
 		/* Arrange. */
 		$previous_status = 'not-set';
-		$action = function ( $status, $user_id, $course_id, $comment_id, $prev_status ) use ( &$previous_status ) {
+		$action          = function ( $status, $user_id, $course_id, $comment_id, $prev_status ) use ( &$previous_status ) {
 			$previous_status = $prev_status;
 		};
 		add_action( 'sensei_course_status_updated', $action, 10, 5 );
@@ -660,7 +660,7 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		Sensei()->course_progress_repository->create( 2, 1 );
 
 		$previous_status = 'not-set';
-		$action = function ( $status, $user_id, $course_id, $comment_id, $prev_status ) use ( &$previous_status ) {
+		$action          = function ( $status, $user_id, $course_id, $comment_id, $prev_status ) use ( &$previous_status ) {
 			$previous_status = $prev_status;
 		};
 		add_action( 'sensei_course_status_updated', $action, 10, 5 );


### PR DESCRIPTION
Resolves #7404 

## Proposed Changes
* Add additional argument to `sensei_course_status_updated` hook, providing previous status.
* Don't send Course Completion email if the previous status is "complete".

## Testing Instructions

1. Create a course with at least two lessons.
2. As a student, complete both lessons.
3. When you appear on the Course Complete page, use browser navigation to go back to the first lesson in the course, then use browser navigation to go forward to the end.
4. It is expected to get a single Course Completion email.

## New/Updated Hooks

* `sensei_course_status_updated` — fourth param added: `$previous_status` — status before updating to the new one.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
