### PR TITLE
Add legacy course test to the PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,7 @@ Both the PR author and reviewer are responsible for ensuring the checklist is co
 - [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
 - [ ] New UIs match the designs
 - [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
+- [ ] Legacy courses (course without blocks) are tested
 - [ ] Code is tested on the minimum supported PHP and WordPress versions
 - [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
 - [ ] "Needs Documentation" label is added if this change requires updates to documentation


### PR DESCRIPTION
## Proposed Changes

I propose the addition of a new item to our GitHub checklist to make sure we test the legacy courses. The reason is that I forget it many times, like in https://github.com/Automattic/sensei/pull/7403#issuecomment-1868257348, and it's an important thing to keep in mind to not break old sites.

> Legacy courses (course without blocks) are tested