### PR TITLE
Add HPPS instructions

### DIFF
--- a/changelog/add-hpps-instructions
+++ b/changelog/add-hpps-instructions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Include instructions to the High-Performance Progress Storage settings screen

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1220,7 +1220,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<div class="notice notice-info inline sensei-settings__progress-storage-settings hidden">
 				<p>
 					<?php
-					echo esc_html( __( 'Save changes to make synchronization setting available.', 'sensei-lms' ) );
+					echo esc_html( __( 'Save changes to make the feature settings available.', 'sensei-lms' ) );
 					?>
 				</p>
 			</div>
@@ -1246,6 +1246,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$migration_incomplete = ! $migration_scheduler || ! $migration_scheduler->is_complete();
 		?>
 		<div class="sensei-settings__progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
+			<h4><?php esc_html_e( 'Instructions', 'sensei-lms' ); ?></h4>
+			<p><?php esc_html_e( 'To enable High-Performance Progress Storage, follow these steps:', 'sensei-lms' ); ?></p>
+			<ol>
+				<li><?php esc_html_e( 'Turn on the storage synchronization.', 'sensei-lms' ); ?></li>
+				<li><?php esc_html_e( 'Wait for the data synchronization migration to complete.', 'sensei-lms' ); ?></li>
+				<li><?php esc_html_e( 'Select the "High-Performance progress storage" option.', 'sensei-lms' ); ?></li>
+			</ol>
+			<p><?php echo wp_kses_post( __( 'Find out more about the feature in the <a href="https://senseilms.com/documentation/high-performance-progress-storage/" target="_blank">docs</a>.', 'sensei-lms' ) ); ?></p>
 			<h4><?php echo esc_html( __( 'Progress storage repository', 'sensei-lms' ) ); ?></h4>
 			<p><?php echo esc_html( $args['data']['description'] ); ?></p>
 			<ul>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1225,6 +1225,16 @@ class Sensei_Settings extends Sensei_Settings_API {
 				</p>
 			</div>
 		<?php endif; ?>
+			<h4><?php esc_html_e( 'Instructions', 'sensei-lms' ); ?></h4>
+			<p><?php esc_html_e( 'To enable High-Performance Progress Storage, follow these steps:', 'sensei-lms' ); ?></p>
+			<ol>
+				<li><?php esc_html_e( 'Select the "Store the progress of your students in separate tables" checkbox and save the changes.', 'sensei-lms' ); ?></li>
+				<li><?php esc_html_e( 'Select the "Synchronize the student progress between storages" checkbox and save the changes.', 'sensei-lms' ); ?></li>
+				<li><?php esc_html_e( 'Wait until the "Migration complete and data synchronization enabled" message is displayed. This may take awhile and you will need to refresh the page to see the updated status.', 'sensei-lms' ); ?></li>
+				<li><?php esc_html_e( 'Select the "High-Performance progress storage (experimental)" option and save the changes.', 'sensei-lms' ); ?></li>
+				<li><?php esc_html_e( 'You are now using High-Performance Progress Storage!', 'sensei-lms' ); ?></li>
+			</ol>
+			<p><?php echo wp_kses_post( __( 'To learn more about the feature, check the <a href="https://senseilms.com/documentation/high-performance-progress-storage/" target="_blank">docs</a>.', 'sensei-lms' ) ); ?></p>
 		</div>
 		<?php
 		Sensei()->assets->enqueue( 'sensei-experimental-features-progress-storage', 'js/admin/settings/experimental-features.js', array( 'jquery' ), true );
@@ -1246,14 +1256,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$migration_incomplete = ! $migration_scheduler || ! $migration_scheduler->is_complete();
 		?>
 		<div class="sensei-settings__progress-storage-settings" style="display: <?php echo esc_attr( $block_display ); ?>">
-			<h4><?php esc_html_e( 'Instructions', 'sensei-lms' ); ?></h4>
-			<p><?php esc_html_e( 'To enable High-Performance Progress Storage, follow these steps:', 'sensei-lms' ); ?></p>
-			<ol>
-				<li><?php esc_html_e( 'Turn on the storage synchronization.', 'sensei-lms' ); ?></li>
-				<li><?php esc_html_e( 'Wait for the data synchronization migration to complete.', 'sensei-lms' ); ?></li>
-				<li><?php esc_html_e( 'Select the "High-Performance progress storage" option.', 'sensei-lms' ); ?></li>
-			</ol>
-			<p><?php echo wp_kses_post( __( 'Find out more about the feature in the <a href="https://senseilms.com/documentation/high-performance-progress-storage/" target="_blank">docs</a>.', 'sensei-lms' ) ); ?></p>
 			<h4><?php echo esc_html( __( 'Progress storage repository', 'sensei-lms' ) ); ?></h4>
 			<p><?php echo esc_html( $args['data']['description'] ); ?></p>
 			<ul>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -860,6 +860,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 				'default'     => false,
 				'section'     => 'sensei-experimental-features',
 			);
+			$fields['experimental_progress_storage_synchronization'] = array(
+				'name'        => '',
+				'description' => __( 'Synchronize the student progress between storages.', 'sensei-lms' ),
+				'form'        => 'render_progress_storage_synchronization',
+				'type'        => 'checkbox',
+				'default'     => false,
+				'section'     => 'sensei-experimental-features',
+			);
 			$fields['experimental_progress_storage_repository']      = array(
 				'name'        => '', // ,
 				'description' => __( 'Choose a repository to store the progress and quiz submissions of your students.', 'sensei-lms' ),
@@ -868,14 +876,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 				'default'     => Progress_Storage_Settings::COMMENTS_STORAGE,
 				'section'     => 'sensei-experimental-features',
 				'options'     => Progress_Storage_Settings::get_storage_repositories(),
-			);
-			$fields['experimental_progress_storage_synchronization'] = array(
-				'name'        => '',
-				'description' => __( 'Synchronize the student progress between storages.', 'sensei-lms' ),
-				'form'        => 'render_progress_storage_synchronization',
-				'type'        => 'checkbox',
-				'default'     => false,
-				'section'     => 'sensei-experimental-features',
 			);
 		}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7415

## Proposed Changes

This PR adds HPPS instructions to the settings screen. It also adds a link to the future docs page.

![jsWU9w.png](https://github.com/Automattic/sensei/assets/1612178/577fa7c6-2d62-4be3-99a2-a995179c9ac3)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei LMS -> Settings -> Experimental Features
2. Enable the HPPS feature.
3. You should see the instructions.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [x] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues