### PR TITLE
When task "Customize your lesson template" is clicked, open Lesson template in 'edit' mode

### DIFF
--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -47,7 +47,12 @@ class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	 * @return string
 	 */
 	public function get_url(): ?string {
-		return Sensei_Course_Theme::get_learning_mode_fse_url();
+		return add_query_arg(
+			[
+				'canvas' => 'edit',
+			],
+			Sensei_Course_Theme::get_learning_mode_fse_url()
+		);
 	}
 
 	/**

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-customize-course-theme.php
@@ -74,6 +74,6 @@ class Sensei_Home_Task_Customize_Course_Theme_Test extends WP_UnitTestCase {
 
 	public function testGetURL_WhenCalled_ReturnsFSETemplateURLOfLesson() {
 		// Assert.
-		$this->assertStringContainsString( 'sensei-course-theme//lesson', $this->task->get_url() );
+		$this->assertStringContainsString( 'sensei-course-theme%2F%2Flesson&canvas=edit', $this->task->get_url() );
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7376

## Proposed Changes
* Added a param in the "`Customize your lesson template`" task's URL so that when the user clicks it, it opens the Learning mode lesson template in edit mode

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site with Sensei
2. Install and activate the Course theme
3. In Sensei LMS -> Home, click on the task _Customize your lesson template_
5. Make sure you are taken to the Learning Mode's Lesson Template editor page and it's opening in edit mode

https://github.com/Automattic/sensei/assets/6820724/f759e286-6500-44e6-b8bc-1eeb371c3e27

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
