### PR TITLE
Create sensei pages on plugin activation without depending on onboarding completion

### DIFF
--- a/changelog/add-create-sensei-pages-on-activation
+++ b/changelog/add-create-sensei-pages-on-activation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Create all necessary Sensei pages on plugin activation

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -55,7 +55,7 @@ class Sensei_Setup_Wizard {
 	/**
 	 * Creation of Sensei pages.
 	 *
-	 * @var Sensei_Setup Wizard_Pages
+	 * @var Sensei_Setup_Wizard_Pages
 	 */
 	public $pages;
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1671,6 +1671,7 @@ class Sensei_Main {
 		$this->add_sensei_admin_caps();
 		$this->add_editor_caps();
 		$this->assign_role_caps();
+		Sensei()->setup_wizard->pages->create_pages();
 
 		// Flush rules.
 		add_action( 'activated_plugin', array( __CLASS__, 'activation_flush_rules' ), 10 );

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -258,11 +258,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->manuallyEnrolStudentInCourse( $student, $this->course2->ID );
 		$this->prevent_wp_redirect();
 
-		try {
-			Sensei_Utils::update_course_status( $student, $this->course2->ID, 'complete' );
-		} catch ( Sensei_WP_Redirect_Exception $e ) {
-			assert( true );
-		}
+		$this->expectException( Sensei_WP_Redirect_Exception::class );
+		Sensei_Utils::update_course_status( $student, $this->course2->ID, 'complete' );
 
 		$_GET['course-list-student-course-filter-13'] = 'completed';
 
@@ -287,11 +284,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		// Complete.
 		$this->prevent_wp_redirect();
 
-		try {
-			Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
-		} catch ( Sensei_WP_Redirect_Exception $e ) {
-			assert( true );
-		}
+		$this->expectException( Sensei_WP_Redirect_Exception::class );
+		Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
 
 		// Featured.
 		update_post_meta( $this->course1->ID, '_course_featured', 'featured' );
@@ -323,11 +317,8 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 
 		$this->prevent_wp_redirect();
 
-		try {
-			Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
-		} catch ( Sensei_WP_Redirect_Exception $e ) {
-			assert( true );
-		}
+		$this->expectException( Sensei_WP_Redirect_Exception::class );
+		Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
 
 		// Featured.
 		update_post_meta( $this->course1->ID, '_course_featured', 'featured' );

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -9,6 +9,7 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;
 	use Sensei_Test_Login_Helpers;
+	use Sensei_Test_Redirect_Helpers;
 
 	/**
 	 * Factory for setting up testing data.
@@ -63,6 +64,7 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 	 * Set up the test.
 	 */
 	public function setUp(): void {
+		Sensei()->setup_wizard->pages->create_pages();
 		global $wp_version;
 
 		$version = str_replace( '-src', '', $wp_version );
@@ -254,7 +256,14 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->login_as( $student );
 		$this->manuallyEnrolStudentInCourse( $student, $this->course1->ID );
 		$this->manuallyEnrolStudentInCourse( $student, $this->course2->ID );
-		Sensei_Utils::update_course_status( $student, $this->course2->ID, 'complete' );
+		$this->prevent_wp_redirect();
+
+		try {
+			Sensei_Utils::update_course_status( $student, $this->course2->ID, 'complete' );
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			assert( true );
+		}
+
 		$_GET['course-list-student-course-filter-13'] = 'completed';
 
 		/* ACT */
@@ -276,7 +285,13 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->manuallyEnrolStudentInCourse( $student, $this->course1->ID );
 		$this->manuallyEnrolStudentInCourse( $student, $this->course2->ID );
 		// Complete.
-		Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
+		$this->prevent_wp_redirect();
+
+		try {
+			Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			assert( true );
+		}
 
 		// Featured.
 		update_post_meta( $this->course1->ID, '_course_featured', 'featured' );
@@ -305,7 +320,14 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->manuallyEnrolStudentInCourse( $student, $this->course1->ID );
 		$this->manuallyEnrolStudentInCourse( $student, $this->course2->ID );
 		// Complete.
-		Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
+
+		$this->prevent_wp_redirect();
+
+		try {
+			Sensei_Utils::update_course_status( $student, $this->course1->ID, 'complete' );
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			assert( true );
+		}
 
 		// Featured.
 		update_post_meta( $this->course1->ID, '_course_featured', 'featured' );

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -130,8 +130,10 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 	 * @param string $url URL.
 	 */
 	public function go_to( $url ) {
+		ob_start();
 		wp_set_current_user( $this->get_user_by_role( 'administrator' ) );
 		parent::go_to( $url );
+		ob_end_clean();
 	}
 
 

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -200,7 +200,7 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 		$this->assertTrue( ( (int) Sensei()->settings->get( 'course_page' ) ) > 0 );
 		$this->assertTrue( ( (int) Sensei()->settings->get( 'my_course_page' ) ) > 0 );
 		$this->assertTrue( ( (int) Sensei()->settings->get( 'course_completed_page' ) ) > 0 );
-  	}
+	}
 
 	public function testConstructor_Always_InitializesClockProperty() {
 		/* Arrange. */

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -195,6 +195,13 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( Migration_Job_Scheduler::class, $sensei->migration_scheduler );
 	}
 
+	public function testActivate_WhenSenseiIsActivated_CreatesAllSenseiPages() {
+		/* Assert. */
+		$this->assertTrue( ( (int) Sensei()->settings->get( 'course_page' ) ) > 0 );
+		$this->assertTrue( ( (int) Sensei()->settings->get( 'my_course_page' ) ) > 0 );
+		$this->assertTrue( ( (int) Sensei()->settings->get( 'course_completed_page' ) ) > 0 );
+	}
+
 	/**
 	 * Create courses and comments for the course.
 	 *

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -200,7 +200,7 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 		$this->assertTrue( ( (int) Sensei()->settings->get( 'course_page' ) ) > 0 );
 		$this->assertTrue( ( (int) Sensei()->settings->get( 'my_course_page' ) ) > 0 );
 		$this->assertTrue( ( (int) Sensei()->settings->get( 'course_completed_page' ) ) > 0 );
-  }
+  	}
 
 	public function testConstructor_Always_InitializesClockProperty() {
 		/* Arrange. */


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7187

## Proposed Changes
Previously we created the sensei pages only when the user completed the onboarding. If for some reason the user didn't complete the onboarding or skipped it, the pages didn't get created, resulting in the users not finding the Courses page, they My Courses page etc. So now we are changing the logic to create the pages on Activation of the plugin. I haven't removed it from the onboarding though because if the pages are already there, it already skips creating them, so if a user somehow deletes those pages or wants to recreate these pages for some reason, we can just tell them to go through the onboarding URL.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site
2. Install a build of sensei from this branch
3. Skip the onboarding
4. Go to _Pages_
5. Check that the Sensei pages are created (Courses, My Courses, Course Completed etc)
6. Now install it on a new site again
7. This time complete the onboarding
8. Make sure it completes as expected

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
