### PR TITLE
Log event when task on Sensei Home is completed

### DIFF
--- a/changelog/update-log-completed-home-tasks
+++ b/changelog/update-log-completed-home-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Log event when task on Sensei Home is completed

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -183,9 +183,12 @@ class Sensei_Home_Tasks_Provider {
 		if ( self::$attached_hooks ) {
 			return;
 		}
+
 		self::$attached_hooks = true;
 
-		// Attach the hooks only on atomic sites.
+		add_action( 'save_post_course', [ $this, 'log_course_completion_tasks' ], 10, 3 );
+
+		// Attach some hooks only for Atomic sites.
 		if ( ! Sensei_Utils::is_atomic_platform() ) {
 			return;
 		}
@@ -193,7 +196,6 @@ class Sensei_Home_Tasks_Provider {
 		// Attach the update_tasks_statuses method to filters and actions
 		// that can affect the status of the Sensei Home tasks.
 		add_action( 'save_post_course', [ $this, 'update_tasks_statuses' ] );
-		add_action( 'save_post_course', [ $this, 'log_course_completion_tasks' ], 10, 3 );
 		add_action( 'wp_ajax_sensei_settings_section_visited', [ $this, 'update_tasks_statuses' ] );
 	}
 

--- a/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
@@ -66,8 +66,8 @@ class Sensei_Home_Task_Create_First_Course implements Sensei_Home_Task {
 
 		// Option does not exist.
 		if ( -1 === $task_completed ) {
-			$prefix         = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
+			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe-ish and should only run once.
 			$result         = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s", "{$prefix}%" ) );
 			$task_completed = ( $result > 0 ) ? 1 : 0;
 

--- a/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-create-first-course.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.8.0
  */
 class Sensei_Home_Task_Create_First_Course implements Sensei_Home_Task {
+	const CREATED_FIRST_COURSE_OPTION_KEY = 'sensei_home_task_created_first_course';
+
 	/**
 	 * The ID for the task.
 	 *
@@ -59,21 +61,19 @@ class Sensei_Home_Task_Create_First_Course implements Sensei_Home_Task {
 	 */
 	public function is_completed(): bool {
 		global $wpdb;
-		$cache_key   = 'home/tasks/create-first-course';
-		$cache_group = 'sensei/temporary';
-		$result      = wp_cache_get( $cache_key, $cache_group );
-		if ( false === $result ) {
-			$prefix = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
-			$result = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s", "{$prefix}%" ) );
-			if ( null === $result ) {
-				$result = 0;
-			} else {
-				$result = (int) $result;
-				wp_cache_set( $cache_key, $result, $cache_group, 60 );
-			}
-		}
-		return $result > 0;
-	}
 
+		$task_completed = get_option( self::CREATED_FIRST_COURSE_OPTION_KEY, -1 );
+
+		// Option does not exist.
+		if ( -1 === $task_completed ) {
+			$prefix         = $wpdb->esc_like( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe-ish and rare query.
+			$result         = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type='course' AND post_status IN ('publish', 'draft') AND post_name NOT LIKE %s", "{$prefix}%" ) );
+			$task_completed = ( $result > 0 ) ? 1 : 0;
+
+			update_option( self::CREATED_FIRST_COURSE_OPTION_KEY, $task_completed, false );
+		}
+
+		return (bool) $task_completed;
+	}
 }

--- a/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-customize-course-theme.php
@@ -71,6 +71,7 @@ class Sensei_Home_Task_Customize_Course_Theme implements Sensei_Home_Task {
 	 */
 	public static function mark_completed() {
 		update_option( self::CUSTOMIZED_COURSE_THEME_OPTION_KEY, true, false );
+		sensei_log_event( 'home_task_complete', [ 'type' => self::get_id() ] );
 	}
 
 	/**

--- a/includes/admin/home/tasks/task/class-sensei-home-task-publish-first-course.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-publish-first-course.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.8.0
  */
 class Sensei_Home_Task_Publish_First_Course implements Sensei_Home_Task {
+	const PUBLISHED_FIRST_COURSE_OPTION_KEY = 'sensei_home_task_published_first_course';
+
 	/**
 	 * The ID for the task.
 	 *
@@ -67,8 +69,17 @@ class Sensei_Home_Task_Publish_First_Course implements Sensei_Home_Task {
 	 * @return bool
 	 */
 	public function is_completed(): bool {
-		$result = $this->load_result();
-		return null !== $result && '1' === $result->published;
+		$task_completed = get_option( self::PUBLISHED_FIRST_COURSE_OPTION_KEY, -1 );
+
+		// Option does not exist.
+		if ( -1 === $task_completed ) {
+			$result         = $this->load_result();
+			$task_completed = ( null !== $result && '1' === $result->published ) ? 1 : 0;
+
+			update_option( self::PUBLISHED_FIRST_COURSE_OPTION_KEY, $task_completed, false );
+		}
+
+		return (bool) $task_completed;
 	}
 
 	/**

--- a/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
@@ -66,6 +66,7 @@ class Sensei_Home_Task_Sell_Course_With_WooCommerce implements Sensei_Home_Task 
 	 */
 	public static function mark_completed() {
 		update_option( self::VISITED_WOOCOMMERCE_ADMIN_OPTION_KEY, true, false );
+		sensei_log_event( 'home_task_complete', [ 'type' => self::get_id() ] );
 	}
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -92,10 +92,12 @@ class Sensei_Data_Cleaner {
 		'sensei-cancelled-wccom-connect-dismissed',
 		'sensei_course_theme_query_var_flushed',
 		'sensei_settings_sections_visited',
-		'sensei_home_tasks_list_is_completed',
-		'sensei_home_tasks_dismissed',
-		'sensei_home_task_visited_woocommerce',
+		'sensei_home_task_created_first_course',
+		'sensei_home_task_published_first_course',
 		'sensei_home_task_visited_course_theme_customizer',
+		'sensei_home_task_visited_woocommerce',
+		'sensei_home_tasks_dismissed',
+		'sensei_home_tasks_list_is_completed',
 	);
 
 	/**

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1546,9 +1546,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 			if ( isset( $_POST['section_id'] ) ) {
 				$section_id = sanitize_key( $_POST['section_id'] );
 				$visited    = get_option( self::VISITED_SECTIONS_OPTION_KEY, [] );
+
 				if ( ! in_array( $section_id, $visited, true ) ) {
 					$visited[] = $section_id;
 					update_option( self::VISITED_SECTIONS_OPTION_KEY, $visited );
+
+					if ( 'appearance-settings' === $section_id ) {
+						sensei_log_event( 'home_task_complete', [ 'type' => Sensei_Home_Task_Configure_Learning_Mode::get_id() ] );
+					}
 				}
 			}
 		}

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-create-first-course.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-create-first-course.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @covers Sensei_Home_Task_Create_First_Course
  */
-class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
+class Sensei_Home_Task_Create_First_Course_Test extends WP_UnitTestCase {
 	/**
 	 * The task under test
 	 *
@@ -36,7 +36,17 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 		parent::setUp();
 		$this->task    = new Sensei_Home_Task_Create_First_Course();
 		$this->factory = new Sensei_Factory();
-		self::flush_cache();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	/**
+	 * Verify that is_completed returns false initially.
+	 */
+	public function testIsCompleted_Initially_ReturnsFalse() {
 		$this->assertFalse( $this->task->is_completed() );
 	}
 
@@ -51,7 +61,6 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -59,6 +68,7 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 		// Assert
 		$this->assertTrue( $is_completed );
 	}
+
 	/**
 	 * Verify if is_completed returns false when a course that doesn't have the sample course slug is on trash.
 	 */
@@ -70,7 +80,6 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'trash',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -90,7 +99,6 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -116,7 +124,6 @@ class Sensei_Home_Task_Create_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-publish-first-course.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-publish-first-course.php
@@ -36,13 +36,12 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 		parent::setUp();
 		$this->task    = new Sensei_Home_Task_Publish_First_Course();
 		$this->factory = new Sensei_Factory();
-		self::flush_cache();
-		$this->assertFalse( $this->task->is_completed() );
 	}
 
-	/*
-	 * Tests for the method isCompleted:
-	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
 
 	/**
 	 * Verifies if isCompleted returns false when there is no course registered.
@@ -50,9 +49,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 	 * @covers Sensei_Home_Task_Publish_First_Course::is_completed
 	 */
 	public function testIsCompleted_NoCourseIsRegistered_ReturnsFalse() {
-		// Arrange
-		self::flush_cache();
-
 		// Act
 		$is_completed = $this->task->is_completed();
 
@@ -73,7 +69,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -96,7 +91,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -124,7 +118,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -146,7 +139,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'publish',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -168,7 +160,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'publish',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -196,7 +187,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'publish',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -225,7 +215,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$is_completed = $this->task->is_completed();
@@ -253,7 +242,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'publish',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$url = $this->task->get_url();
@@ -275,7 +263,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'publish',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$url = $this->task->get_url();
@@ -290,9 +277,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 	 * @covers Sensei_Home_Task_Publish_First_Course::get_url
 	 */
 	public function testGetUrl_NoCourseIsRegistered_ReturnsCreateANewPost() {
-		// Arrange
-		self::flush_cache();
-
 		// Act
 		$url = $this->task->get_url();
 
@@ -315,7 +299,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$url = $this->task->get_url();
@@ -338,7 +321,6 @@ class Sensei_Home_Task_Publish_First_Course_Test  extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
-		self::flush_cache();
 
 		// Act
 		$url = $this->task->get_url();

--- a/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
+++ b/tests/unit-tests/admin/home/tasks/test-class-sensei-home-tasks-provider.php
@@ -67,7 +67,7 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( Sensei_Home_Task_Publish_First_Course::get_id(), $items );
 	}
 
-	public function testGetTasks_WhenCalledWhileCourseThemeActive_IncludesCourseThemeCustomizationTask() {
+	public function testGet_WhenCalledWhileCourseThemeActive_IncludesCourseThemeCustomizationTask() {
 		// Arrange
 		switch_theme( 'course' );
 
@@ -261,4 +261,35 @@ class Sensei_Home_Tasks_Provider_Test extends WP_UnitTestCase {
 		$this->assertTrue( get_option( Sensei_Home_Tasks_Provider::COMPLETED_TASKS_OPTION_KEY, false ) );
 	}
 
+	public function testLogCourseCompletionTasks_FirstDraftCourse_SetsOption() {
+		// Arrange
+		$course = new WP_Post(
+			(object) [
+				'post_type'   => 'course',
+				'post_status' => 'draft',
+			]
+		);
+
+		// Act
+		$this->provider->log_course_completion_tasks( $course->ID, $course, true );
+
+		// Assert
+		$this->assertEquals( get_option( Sensei_Home_Task_Create_First_Course::CREATED_FIRST_COURSE_OPTION_KEY, false ), 1 );
+	}
+
+	public function testLogCourseCompletionTasks_FirstPublishedCourse_SetsOption() {
+		// Arrange
+		$course = new WP_Post(
+			(object) [
+				'post_type'   => 'course',
+				'post_status' => 'publish',
+			]
+		);
+
+		// Act
+		$this->provider->log_course_completion_tasks( $course->ID, $course, true );
+
+		// Assert
+		$this->assertEquals( get_option( Sensei_Home_Task_Publish_First_Course::PUBLISHED_FIRST_COURSE_OPTION_KEY, false ), 1 );
+	}
 }


### PR DESCRIPTION
Resolves #7417.

## Proposed Changes
- Adds logging for when the Sensei Home tasks are completed (except for _Set up course site_, which doesn't require any action from the user).
- Adds new options for storing completion of the _Create your first course_ and _Publish your first course_ tasks. This was necessary because the logging was happening multiple times otherwise, but it means that the tasks will no longer be unchecked if all courses are later trashed, for example. I thought about this and determined that it's fine, perhaps even the optimal behaviour.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Setup:
1. Enable usage tracking.
2. Run the following query `delete from wp_options where option_name like 'sensei_home%'`.
3. Move all courses to the Trash.
4. Verify that only the _Set up course site_ task is checked on Sensei's Home page.

Testing:
1. Switch to this branch.
2. Click on each task in the checklist and fulfill the criteria, if necessary (most tasks just require a click).
3. After completing each one, confirm that it's checked in the checklist.
4. In Tracks, verify that the `sensei_home_task_complete` is fired for each completed task, and that the `type` property is set appropriately.

Cleanup:
1. Disable usage tracking.
2. Restore your trashed courses.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
