### PR TITLE
Auto-focus the course title field when creating a new course

### DIFF
--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -54,7 +54,7 @@ const CourseDetailsStep = ( { wizardData, setWizardData } ) => {
 						value={ wizardData.title ?? '' }
 						onChange={ updateCourseTitle }
 						maxLength={ 40 }
-						autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 					/>
 					<LimitedTextControl
 						className="sensei-editor-wizard-step__form-control"
@@ -62,7 +62,7 @@ const CourseDetailsStep = ( { wizardData, setWizardData } ) => {
 						value={ wizardData.description ?? '' }
 						onChange={ updateCourseDescription }
 						maxLength={ 350 }
-						multiline={ true }
+						multiline
 					/>
 				</div>
 			</div>

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -54,6 +54,7 @@ const CourseDetailsStep = ( { wizardData, setWizardData } ) => {
 						value={ wizardData.title ?? '' }
 						onChange={ updateCourseTitle }
 						maxLength={ 40 }
+						autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 					/>
 					<LimitedTextControl
 						className="sensei-editor-wizard-step__form-control"

--- a/assets/admin/editor-wizard/steps/course-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.test.js
@@ -82,6 +82,14 @@ describe( '<CourseDetailsStep />', () => {
 			description: NEW_DESCRIPTION,
 		} );
 	} );
+
+	it( 'Focuses the Course Title input.', () => {
+		const { queryByLabelText } = render(
+			<CourseDetailsStep wizardData={ {} } setWizardData={ () => {} } />
+		);
+
+		expect( queryByLabelText( 'Course Title' ) ).toHaveFocus();
+	} );
 } );
 
 describe( '<CourseDetailsStep.Actions />', () => {

--- a/changelog/change-autofocus-course-title
+++ b/changelog/change-autofocus-course-title
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Auto-focus in Course Title field when creating a new course
+Auto-focus the course title field when creating a new course

--- a/changelog/change-autofocus-course-title
+++ b/changelog/change-autofocus-course-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-focus in Course Title field when creating a new course


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7431

## Proposed Changes
* This will auto-focus the course title input when the course editor wizard is open.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei LMS -> Courses -> New Course 
2. Make sure the "Course Title" input is auto-focused.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
