### PR TITLE
Flush rewrite rules when language changed or translation updated

### DIFF
--- a/changelog/fix-404-after-language-switch
+++ b/changelog/fix-404-after-language-switch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Flush rewrite rules when the website language was changed or the translation was updated.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -434,11 +434,45 @@ class Sensei_Main {
 		// Localisation
 		$this->load_plugin_textdomain();
 		add_action( 'init', array( $this, 'load_localisation' ), 0 );
+		add_action( 'update_option_WPLANG', array( $this, 'maybe_initiate_rewrite_rules_flush_after_language_change' ), 10, 2 );
+		add_action( 'upgrader_process_complete', array( $this, 'maybe_initiate_rewrite_rules_flush_on_translation_update' ), 10, 2 );
 
 		$this->initialize_cache_groups();
 		$this->initialize_global_objects();
 		$this->initialize_cli();
 		$this->initialize_3rd_party_compatibility();
+	}
+
+	/**
+	 * Maybe initiate rewrite rules flush when WordPress language has been changed.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed $old_value Old value.
+	 * @param mixed $new_value New value.
+	 */
+	public function maybe_initiate_rewrite_rules_flush_after_language_change( $old_value, $new_value ) {
+		if ( $old_value !== $new_value ) {
+			$this->initiate_rewrite_rules_flush();
+		}
+	}
+
+	/**
+	 * Maybe initiate rewrite rules flush when WordPress translation has been updated.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param WP_Upgrader $upgrader_object Upgrader object.
+	 * @param array       $options Options.
+	 */
+	public function maybe_initiate_rewrite_rules_flush_on_translation_update( $upgrader_object, $options ) {
+		if ( $options['type'] == 'translation' ) {
+			$this->initiate_rewrite_rules_flush();
+		}
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -470,7 +470,7 @@ class Sensei_Main {
 	 * @param array       $options Options.
 	 */
 	public function maybe_initiate_rewrite_rules_flush_on_translation_update( $upgrader_object, $options ) {
-		if ( $options['type'] == 'translation' ) {
+		if ( 'translation' === $options['type'] ) {
 			$this->initiate_rewrite_rules_flush();
 		}
 	}

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -210,6 +210,70 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( Clock_Interface::class, $sensei->clock );
 	}
 
+	public function testConstruct_Always_AddsActionOnUpdateOptionWplang() {
+		/* Arrange. */
+		$sensei = Sensei();
+
+		/* Assert. */
+		$this->assertSame( 10, has_action( 'update_option_WPLANG', [ $sensei, 'maybe_initiate_rewrite_rules_flush_after_language_change' ] ) );
+	}
+
+	public function testConstruct_Always_AddsActionOnUpgraderProcessComplete() {
+		/* Arrange. */
+		$sensei = Sensei();
+
+		/* Assert. */
+		$this->assertSame( 10, has_action( 'upgrader_process_complete', [ $sensei, 'maybe_initiate_rewrite_rules_flush_on_translation_update' ] ) );
+	}
+
+	public function testMaybeInitiateRewriteRulesFlushAfterLanguageChange_WhenLanguageChanged_UpdatesOption() {
+		/* Arrange. */
+		$sensei = Sensei();
+		update_option( 'sensei_flush_rewrite_rules', '0' );
+
+		/* Act. */
+		$sensei->maybe_initiate_rewrite_rules_flush_after_language_change( 'a', 'b' );
+
+		/* Assert. */
+		$this->assertSame( '1', get_option( 'sensei_flush_rewrite_rules' ) );
+	}
+
+	public function testMaybeInitiateRewriteRulesFlushAfterLanguageChange_WhenLanguageNotChanged_DoesntUpdateOption() {
+		/* Arrange. */
+		$sensei = Sensei();
+		update_option( 'sensei_flush_rewrite_rules', '0' );
+
+		/* Act. */
+		$sensei->maybe_initiate_rewrite_rules_flush_after_language_change( 'a', 'a' );
+
+		/* Assert. */
+		$this->assertSame( '0', get_option( 'sensei_flush_rewrite_rules' ) );
+	}
+
+	public function testMaybeInitiateRewriteRulesFlushOnTranslationUpdate_WhenNonTranslationUpdate_DoesntUpdateOption() {
+		/* Arrange. */
+		$sensei = Sensei();
+		update_option( 'sensei_flush_rewrite_rules', '0' );
+
+		/* Act. */
+		$sensei->maybe_initiate_rewrite_rules_flush_on_translation_update( new stdClass(), array( 'type' => 'a' ) );
+
+		/* Assert. */
+		$this->assertSame( '0', get_option( 'sensei_flush_rewrite_rules' ) );
+	}
+
+	public function testMaybeInitiateRewriteRulesFlushOnTranslationUpdate_WhenTranslationUpdate_UpdatesOption() {
+		/* Arrange. */
+		$sensei = Sensei();
+		update_option( 'sensei_flush_rewrite_rules', '0' );
+
+		/* Act. */
+		$sensei->maybe_initiate_rewrite_rules_flush_on_translation_update( new stdClass(), array( 'type' => 'translation' ) );
+
+		/* Assert. */
+		$this->assertSame( '1', get_option( 'sensei_flush_rewrite_rules' ) );
+	}
+
 	/**
 	 * Create courses and comments for the course.
 	 *


### PR DESCRIPTION
Resolves #7432

## Proposed Changes
* Flush rewrite rules when the language was changed or the translation was updated.

## Testing Instructions

0. Let's assume your current Site Language is English (US) and you don't have other languages "installed".
1. Create a course, publish it.
2. Open it on the frontend following the link in the sidebar. Make sure it opened successfully.
3. Go to General Settings and change Site Language to German.
4. Go to Dashboard > Updates and update the translation.
5. Go to the course, open the course on the frontend following the link in the sidebar. Make sure it opened without 404 error.
6. Go to General Settings, change the language back to English (US). That means you don't need to update the translation.
7. Go to the course, open the course on the frontend following the link in the sidebar. Make sure it opened without 404 error.

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
