### PR TITLE
Fix Sensei Email template not displayed in site editor

### DIFF
--- a/changelog/fix-no-email-template-in-site-editor
+++ b/changelog/fix-no-email-template-in-site-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Sensei Email template not available in site editor

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -11,9 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-
-
-
 /**
  * The class responsible for handling the email page template.
  *
@@ -58,7 +55,6 @@ class Email_Page_Template {
 	public function init(): void {
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_from_file' ], 10, 3 );
 		add_filter( 'get_block_templates', [ $this, 'add_email_template' ], 10, 3 );
-
 		add_filter( 'get_block_template', [ $this, 'get_template' ], 10, 3 );
 	}
 
@@ -107,35 +103,39 @@ class Email_Page_Template {
 	}
 
 	/**
-	 * Return sensei email's template from file when there is no template on the database.
+	 * Add Sensei email template.
 	 *
 	 * @internal
 	 *
-	 * @param WP_Block_Template $original_templates Original template.
-	 * @param string            $query          Original query to load the template.
-	 * @param string            $template_type     The template type "wp_template" or "wp_template_part".
+	 * @param WP_Block_Template $query_result   Array of found block templates.
+	 * @param array             $query          Arguments to retrieve templates.
+	 * @param string            $template_type  wp_template or wp_template_part.
 	 *
 	 * @return WP_Block_Template The original or the email template.
 	 */
-	public function add_email_template( $original_templates, $query, $template_type ) {
+	public function add_email_template( $query_result, $query, $template_type ) {
+		if ( ! \Sensei_Course_Theme_Editor::is_site_editor_request() ) {
+			return $query_result;
+		}
+
 		if ( 'wp_template' !== $template_type || ! empty( $query['theme'] ) ) {
-			return $original_templates;
+			return $query_result;
 		}
 
 		$post_type = $query['post_type'] ?? get_post_type();
 
-		if ( empty( $post_type ) || Email_Post_Type::POST_TYPE !== $post_type ) {
-			return $original_templates;
+		if ( ! empty( $post_type ) && Email_Post_Type::POST_TYPE !== $post_type ) {
+			return $query_result;
 		}
 
 		$from_db = $this->repository->get( self::ID );
 
 		if ( ! empty( $from_db ) ) {
-			$original_templates[] = $from_db;
-		} else {
-			$original_templates[] = $this->repository->get_from_file( self::TEMPLATE_PATH, self::ID );
+			$query_result[] = $from_db;
+		} else {  // Use the PHP email template.
+			$query_result[] = $this->repository->get_from_file( self::TEMPLATE_PATH, self::ID );
 		}
 
-		return $original_templates;
+		return $query_result;
 	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-page-template.php
+++ b/tests/unit-tests/internal/emails/test-class-email-page-template.php
@@ -23,7 +23,8 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
-		self::$initial_request_uri = $_SERVER['REQUEST_URI'];
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		self::$initial_request_uri = wp_unslash( $_SERVER['REQUEST_URI'] );
 	}
 
 	public function setUp(): void {

--- a/tests/unit-tests/internal/emails/test-class-email-page-template.php
+++ b/tests/unit-tests/internal/emails/test-class-email-page-template.php
@@ -13,7 +13,18 @@ use WP_Post;
  * @covers \Sensei\Internal\Emails\Email_Page_Template
  */
 class Email_Page_Template_Test extends \WP_UnitTestCase {
+	/**
+	 * The URI which was given in order to access this page.
+	 *
+	 * @var string
+	 */
+	private static $initial_request_uri;
 
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$initial_request_uri = $_SERVER['REQUEST_URI'];
+	}
 
 	public function setUp(): void {
 		parent::setUp();
@@ -22,6 +33,11 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 		add_filter( 'get_block_templates', [ $this, 'get_block_templates' ], 10, 3 );
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$_SERVER['REQUEST_URI'] = self::$initial_request_uri;
+	}
 
 	public function testHasInit_Always_RegistersFilters() {
 
@@ -94,10 +110,11 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 	public function testAddEmailTemplate_TemplateGiven_ReturnsUpdatedList() {
 
 		/* Arrange. */
-		$repository           = $this->createMock( Email_Page_Template_Repository::class );
-		$page_template        = new Email_Page_Template( $repository );
-		$default_list         = [ $this->createMock( \WP_Block_Template::class ) ];
-		$template_to_be_added = $this->createMock( \WP_Block_Template::class );
+		$_SERVER['REQUEST_URI'] = '/wp-admin/site-editor.php';
+		$repository             = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template          = new Email_Page_Template( $repository );
+		$default_list           = [ $this->createMock( \WP_Block_Template::class ) ];
+		$template_to_be_added   = $this->createMock( \WP_Block_Template::class );
 
 		$repository
 			->method( 'get' )
@@ -132,7 +149,7 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 		self::assertSame( $default_list, $result );
 	}
 
-	public function testAddEmailTemplate_GivenQuerySpecifPostType_ReturnsDefaultTemplate() {
+	public function testAddEmailTemplate_GivenQuerySpecificPostType_ReturnsDefaultTemplate() {
 
 		/* Arrange. */
 		$repository    = $this->createMock( Email_Page_Template_Repository::class );
@@ -146,18 +163,23 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 		self::assertSame( $default_list, $result );
 	}
 
-	public function testAddEmailTemplate_GivenQueryWithoutPostType_ReturnsDefaultTemplate() {
-
+	public function testAddEmailTemplate_GivenQueryWithoutPostType_ReturnsUpdatedList() {
 		/* Arrange. */
-		$repository    = $this->createMock( Email_Page_Template_Repository::class );
-		$page_template = new Email_Page_Template( $repository );
-		$default_list  = [ $this->createMock( \WP_Block_Template::class ) ];
+		$_SERVER['REQUEST_URI'] = '/wp-admin/site-editor.php';
+		$repository             = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template          = new Email_Page_Template( $repository );
+		$default_list           = [ $this->createMock( \WP_Block_Template::class ) ];
+		$template_to_be_added   = $this->createMock( \WP_Block_Template::class );
+
+		$repository
+			->method( 'get' )
+			->willReturn( $template_to_be_added );
 
 		/* Act. */
 		$result = $page_template->add_email_template( $default_list, [], 'wp_template' );
 
 		/* Assert. */
-		self::assertSame( $default_list, $result );
+		self::assertSame( $template_to_be_added, $result[1] );
 	}
 
 	public function testAddEmailTemplate_WhenPostTypeIsIncorrect_ReturnsDefaultList() {
@@ -201,10 +223,11 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 	public function testAddEmailTemplate_WhenThereIsNoTemplateStoredOnDB_ReturnsFromFile() {
 
 		/* Arrange. */
-		$repository           = $this->createMock( Email_Page_Template_Repository::class );
-		$page_template        = new Email_Page_Template( $repository );
-		$default_list         = [ $this->createMock( \WP_Block_Template::class ) ];
-		$template_to_be_added = $this->createMock( \WP_Block_Template::class );
+		$_SERVER['REQUEST_URI'] = '/wp-admin/site-editor.php';
+		$repository             = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template          = new Email_Page_Template( $repository );
+		$default_list           = [ $this->createMock( \WP_Block_Template::class ) ];
+		$template_to_be_added   = $this->createMock( \WP_Block_Template::class );
 
 		$repository
 			->method( 'get' )


### PR DESCRIPTION
Resolves #7460.

## Proposed Changes
Revert https://github.com/Automattic/sensei/pull/7402/commits/198145c7c35434e0b2c77e970a21d3ae0041259d and add an additional check to return early and not add the email template if we're not in the site editor.

## Testing Instructions

- Go to Appearance > Editor > Templates.
- Look for _Sensei Email_ in the list of templates.
- Click to edit the template and ensure you're able to.
- Go to WP Admin > Posts > Tags.
- Add a new tag and click on View. The tag should remain empty.
- You shouldn't see the email template, but an empty tag listing.
- Go to Sensei LMS > Settings > Emails and ensure you are able to preview and edit emails.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues