### PR TITLE
Add initial lesson content for lessons when saving outline

### DIFF
--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { Button } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,6 +25,19 @@ const LessonDetailsStep = ( { wizardData, setWizardData } ) => {
 		wizardData,
 		setWizardData
 	);
+
+	const lessonMeta = useSelect( ( select ) =>
+		select( 'core/editor' ).getCurrentPostAttribute( 'meta' )
+	);
+
+	useEffect( () => {
+		if ( lessonMeta && lessonMeta._initial_content ) {
+			setWizardData( {
+				...wizardData,
+				description: lessonMeta._initial_content,
+			} );
+		}
+	}, [ lessonMeta ] );
 
 	return (
 		<div className="sensei-editor-wizard-modal__columns">

--- a/assets/admin/editor-wizard/steps/lesson-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.test.js
@@ -80,6 +80,27 @@ describe( '<LessonDetailsStep />', () => {
 			ANY_LESSON_TITLE
 		);
 	} );
+
+	it( 'Should call initial lesson content setter when available', () => {
+		const wizardDataSetter = jest.fn();
+		const initialContent = 'test content';
+		useDispatch.mockReturnValue( { editPost: jest.fn() } );
+		useSelect.mockReturnValue( {
+			postTitle: ANY_LESSON_TITLE,
+			_initial_content: initialContent,
+		} );
+
+		render(
+			<LessonDetailsStep
+				wizardData={ {} }
+				setWizardData={ wizardDataSetter }
+			/>
+		);
+
+		expect( wizardDataSetter ).toBeCalledWith( {
+			description: initialContent,
+		} );
+	} );
 } );
 
 describe( '<LessonDetailsStep.Actions />', () => {

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -24,6 +24,10 @@ const LessonPatternsStep = ( { wizardData, ...props } ) => {
 		replaces[ 'sensei-content-title' ] = wizardData.title;
 	}
 
+	if ( wizardData.description ) {
+		replaces[ 'sensei-content-description' ] = wizardData.description;
+	}
+
 	const shouldHideEditorWizardUpsell = useHideEditorWizardUpsell();
 
 	return (

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.test.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { when } from 'jest-when';
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import LessonPatternsStep from './lesson-patterns-step';
+import PatternsStep from './patterns-step';
+
+jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/editor' );
+jest.mock( './patterns-step' );
+
+const mockFunction = jest.fn();
+
+describe( '<LessonPatternsStep />', () => {
+	beforeAll( () => {
+		when( PatternsStep ).mockImplementation( ( props ) => {
+			mockFunction( props );
+			return (
+				<div>
+					<h1>Tailored Course Outline</h1>
+				</div>
+			);
+		} );
+	} );
+
+	it( 'Should set pattern replacer value as expected when property is present.', () => {
+		const lessonContent = 'Some lesson content.';
+		useSelect.mockReturnValue( {
+			senseiProExtension: jest.fn(),
+		} );
+
+		PatternsStep.UpsellFill.mockReturnValue( <div>Upsell Fill</div> );
+
+		const expectedOutput = {
+			replaces: {
+				'sensei-content-description': lessonContent,
+			},
+			title: 'Lesson Layout',
+		};
+
+		render(
+			<SlotFillProvider>
+				<LessonPatternsStep
+					wizardData={ { description: lessonContent } }
+				/>
+			</SlotFillProvider>
+		);
+
+		expect( mockFunction ).toBeCalledWith( expectedOutput );
+	} );
+} );

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.test.js
@@ -18,13 +18,13 @@ import LessonPatternsStep from './lesson-patterns-step';
 import PatternsStep from './patterns-step';
 
 jest.mock( '@wordpress/data' );
-jest.mock( '@wordpress/editor' );
 jest.mock( './patterns-step' );
 
 const mockFunction = jest.fn();
 
 describe( '<LessonPatternsStep />', () => {
 	beforeAll( () => {
+		jest.clearAllMocks();
 		when( PatternsStep ).mockImplementation( ( props ) => {
 			mockFunction( props );
 			return (

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -24,9 +24,10 @@ import { curry, invert } from 'lodash';
  */
 /**
  * @typedef CourseLessonData
- * @param {string}  type  Block type ('lesson')
- * @param {string?} title Lesson title
- * @param {number?} id    Lesson ID
+ * @param {string}  type           Block type ('lesson')
+ * @param {string?} title          Lesson title
+ * @param {number?} id             Lesson ID
+ * @param {string?} initialContent Initial lesson content.
  */
 
 export const blockNames = {
@@ -141,6 +142,7 @@ export const extractStructure = ( blocks ) => {
 		lesson: ( block ) => ( {
 			draft: block.attributes.draft,
 			preview: block.attributes.preview,
+			initialContent: block.attributes.initialContent,
 		} ),
 	};
 

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -28,13 +28,16 @@ describe( 'extractStructure', () => {
 				innerBlocks: [
 					{
 						name: 'sensei-lms/course-outline-lesson',
-						attributes: { title: 'M1L1' },
+						attributes: {
+							title: 'M1L1',
+							initialContent: 'M1L1 content',
+						},
 						innerBlocks: [],
 						isValid: true,
 					},
 					{
 						name: 'sensei-lms/course-outline-lesson',
-						attributes: { title: 'M1L2' },
+						attributes: { title: 'M1L2', initialContent: '' },
 						innerBlocks: [],
 						isValid: true,
 					},
@@ -43,7 +46,7 @@ describe( 'extractStructure', () => {
 			},
 			{
 				name: 'sensei-lms/course-outline-lesson',
-				attributes: { title: 'L2' },
+				attributes: { title: 'L2', initialContent: 'L2 content' },
 				innerBlocks: [],
 				isValid: true,
 			},
@@ -57,16 +60,46 @@ describe( 'extractStructure', () => {
 
 		expect( data ).toEqual( [
 			{
+				id: undefined,
+				lastTitle: undefined,
 				type: 'module',
 				description: 'Module 1',
 				title: 'M1',
 				lessons: [
-					{ type: 'lesson', title: 'M1L1' },
-					{ type: 'lesson', title: 'M1L2' },
+					{
+						draft: undefined,
+						id: undefined,
+						initialContent: 'M1L1 content',
+						preview: undefined,
+						title: 'M1L1',
+						type: 'lesson',
+					},
+					{
+						draft: undefined,
+						id: undefined,
+						initialContent: '',
+						preview: undefined,
+						title: 'M1L2',
+						type: 'lesson',
+					},
 				],
 			},
-			{ type: 'lesson', title: 'L2' },
-			{ type: 'lesson', title: 'L3', draft: true, preview: true },
+			{
+				draft: undefined,
+				id: undefined,
+				initialContent: 'L2 content',
+				preview: undefined,
+				title: 'L2',
+				type: 'lesson',
+			},
+			{
+				draft: true,
+				id: undefined,
+				preview: true,
+				initialContent: undefined,
+				title: 'L3',
+				type: 'lesson',
+			},
 		] );
 	} );
 } );
@@ -87,6 +120,7 @@ describe( 'syncStructureToBlocks', () => {
 						title: 'M1L1',
 						id: 3,
 						style: { color: 'red' },
+						initialContent: 'M1L1 content',
 					} ),
 					createBlock( 'sensei-lms/course-outline-lesson', {
 						title: 'M1L3 New',
@@ -102,11 +136,17 @@ describe( 'syncStructureToBlocks', () => {
 				title: 'L2',
 				id: 8,
 				style: { color: 'red' },
+				initialContent: 'L2 content',
 			} ),
 		];
 
 		const changed = [
-			{ type: 'lesson', title: 'L2', id: 8 },
+			{
+				type: 'lesson',
+				title: 'L2',
+				id: 8,
+				initialContent: 'L2 content1',
+			},
 			{
 				type: 'module',
 				description: 'Module 1',
@@ -114,7 +154,12 @@ describe( 'syncStructureToBlocks', () => {
 				title: 'M1',
 				lessons: [
 					{ type: 'lesson', title: 'M1L2', id: 4 },
-					{ type: 'lesson', title: 'M1L1', id: 3 },
+					{
+						type: 'lesson',
+						title: 'M1L1',
+						id: 3,
+						initialContent: 'M1L1 content',
+					},
 				],
 			},
 		];
@@ -124,7 +169,12 @@ describe( 'syncStructureToBlocks', () => {
 		expect( newBlocks ).toEqual( [
 			{
 				name: 'sensei-lms/course-outline-lesson',
-				attributes: { title: 'L2', id: 8, style: { color: 'red' } },
+				attributes: {
+					title: 'L2',
+					id: 8,
+					style: { color: 'red' },
+					initialContent: 'L2 content1',
+				},
 				innerBlocks: [],
 				clientId: blocks[ 1 ].clientId,
 				isValid: true,
@@ -146,6 +196,7 @@ describe( 'syncStructureToBlocks', () => {
 							title: 'M1L2',
 							id: 4,
 							style: {},
+							initialContent: '',
 						},
 						innerBlocks: [],
 						isValid: true,
@@ -157,6 +208,7 @@ describe( 'syncStructureToBlocks', () => {
 							title: 'M1L1',
 							id: 3,
 							style: { color: 'red' },
+							initialContent: 'M1L1 content',
 						},
 						innerBlocks: [],
 						clientId: blocks[ 0 ].innerBlocks[ 1 ].clientId,
@@ -325,6 +377,7 @@ describe( 'syncStructureToBlocks', () => {
 				description: 'Lesson 1 description updated',
 				id: 99,
 				style: { color: 'blue' },
+				initialContent: '',
 			},
 			innerBlocks: [],
 			isValid: true,

--- a/assets/blocks/course-outline/lesson-block/block.json
+++ b/assets/blocks/course-outline/lesson-block/block.json
@@ -20,6 +20,10 @@
       "type": "string",
       "default": ""
     },
+    "initialContent": {
+      "type": "string",
+      "default": ""
+    },
     "draft": {
       "type": "boolean",
       "default": true

--- a/assets/blocks/course-outline/test-helpers.js
+++ b/assets/blocks/course-outline/test-helpers.js
@@ -19,6 +19,10 @@ export const registerTestLessonBlock = ( settings = {} ) => {
 				type: 'string',
 				default: '',
 			},
+			initialContent: {
+				type: 'string',
+				default: '',
+			},
 			style: {
 				type: 'object',
 				default: {},

--- a/includes/block-patterns/lesson/templates/default-with-quiz.php
+++ b/includes/block-patterns/lesson/templates/default-with-quiz.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write lesson content...', 'sensei-lms' ); ?>"} -->
-<p></p>
+<!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write lesson content...', 'sensei-lms' ); ?>","className":"sensei-content-description"} -->
+<p class="sensei-content-description"></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:sensei-lms/lesson-actions -->

--- a/includes/block-patterns/lesson/templates/default.php
+++ b/includes/block-patterns/lesson/templates/default.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write lesson content...', 'sensei-lms' ); ?>"} -->
-<p></p>
+<!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write lesson content...', 'sensei-lms' ); ?>","className":"sensei-content-description"} -->
+<p class="sensei-content-description"></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:sensei-lms/lesson-actions -->

--- a/includes/block-patterns/lesson/templates/discussion-question.php
+++ b/includes/block-patterns/lesson/templates/discussion-question.php
@@ -11,8 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <!-- wp:group {"backgroundColor":"tertiary"} -->
-<div class="wp-block-group has-tertiary-background-color has-background"><!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write your discussion question topic or prompt here.', 'sensei-lms' ); ?>"} -->
-<p></p>
+<div class="wp-block-group has-tertiary-background-color has-background"><!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write your discussion question topic or prompt here.', 'sensei-lms' ); ?>","className":"sensei-content-description"} -->
+<p class="sensei-content-description"></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 

--- a/includes/block-patterns/lesson/templates/files-to-download.php
+++ b/includes/block-patterns/lesson/templates/files-to-download.php
@@ -10,6 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
+<!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write lesson content...', 'sensei-lms' ); ?>","className":"sensei-content-description"} -->
+<p class="sensei-content-description"></p>
+<!-- /wp:paragraph -->
 <!-- wp:heading {"textAlign":"center"} -->
 <h2 class="has-text-align-center"><?php esc_html_e( 'Lesson Resources', 'sensei-lms' ); ?></h2>
 <!-- /wp:heading -->

--- a/includes/block-patterns/lesson/templates/video-lesson.php
+++ b/includes/block-patterns/lesson/templates/video-lesson.php
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- wp:sensei-lms/featured-video /-->
 
-<!-- wp:paragraph {"placeholder":"<?php esc_attr_e( 'Include a transcript, link to a transcript, or a summary of the video.', 'sensei-lms' ); ?>"} -->
-<p></p>
+<!-- wp:paragraph {"placeholder":"<?php esc_attr_e( 'Include a transcript, link to a transcript, or a summary of the video.', 'sensei-lms' ); ?>","className":"sensei-content-description"} -->
+<p class="sensei-content-description"></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:sensei-lms/lesson-actions -->

--- a/includes/block-patterns/lesson/templates/zoom-meeting.php
+++ b/includes/block-patterns/lesson/templates/zoom-meeting.php
@@ -10,6 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
+<!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write lesson content...', 'sensei-lms' ); ?>","className":"sensei-content-description"} -->
+<p class="sensei-content-description"></p>
+<!-- /wp:paragraph -->
 <!-- wp:group {"align":"wide","style":{"color":{"background":"#f6f6f6"}}} -->
 <div class="wp-block-group alignwide has-background" style="background-color:#f6f6f6"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 	<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -182,11 +182,12 @@ class Sensei_Course_Structure {
 	 */
 	private function prepare_lesson( WP_Post $lesson_post ) : array {
 		return [
-			'type'    => 'lesson',
-			'id'      => $lesson_post->ID,
-			'title'   => $lesson_post->post_title,
-			'draft'   => 'draft' === $lesson_post->post_status,
-			'preview' => Sensei_Utils::is_preview_lesson( $lesson_post->ID ),
+			'type'           => 'lesson',
+			'id'             => $lesson_post->ID,
+			'title'          => $lesson_post->post_title,
+			'draft'          => 'draft' === $lesson_post->post_status,
+			'preview'        => Sensei_Utils::is_preview_lesson( $lesson_post->ID ),
+			'initialContent' => get_post_meta( $lesson_post->ID, '_initial_content', true ),
 		];
 	}
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -502,6 +502,23 @@ class Sensei_Course_Structure {
 	}
 
 	/**
+	 * Get initial content markup.
+	 * This is the content that is shown to the user when they first view the lesson.
+	 *
+	 * @param string $text_content Text content.
+	 *
+	 * @return string Markup or empty.
+	 */
+	private function get_lesson_content_markup( $text_content ) {
+		$markup = '';
+		if ( $text_content ) {
+			$markup = '<!-- wp:paragraph -->' . wpautop( $text_content ) . '<!-- /wp:paragraph -->';
+		}
+
+		return $markup;
+	}
+
+	/**
 	 * Create a lesson.
 	 *
 	 * @param array $item Item to create.
@@ -510,16 +527,19 @@ class Sensei_Course_Structure {
 	 */
 	private function create_lesson( array $item ) {
 		$post_args = [
-			'post_title'  => $item['title'],
-			'post_type'   => 'lesson',
-			'post_status' => 'draft',
-			'meta_input'  => [
-				'_lesson_course' => $this->course_id,
-				'_new_post'      => true,
+			'post_title'   => $item['title'],
+			'post_type'    => 'lesson',
+			'post_status'  => 'draft',
+			'post_content' => $this->get_lesson_content_markup( $item['initialContent'] ?? '' ),
+			'meta_input'   => [
+				'_lesson_course'   => $this->course_id,
+				'_new_post'        => true,
+				'_initial_content' => $item['initialContent'],
 			],
 		];
 
 		$lesson_id = wp_insert_post( $post_args );
+
 		if ( ! $lesson_id ) {
 			return false;
 		}

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -834,6 +834,7 @@ class Sensei_Course_Structure {
 					);
 				}
 			}
+			$item['initialContent'] = ! empty( $raw_item['initialContent'] ) ? trim( wp_kses_post( $raw_item['initialContent'] ) ) : null;
 		}
 
 		return $item;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5390,7 +5390,7 @@ class Sensei_Lesson {
 	 * @return boolean Whether the user can edit the meta.
 	 */
 	public function post_meta_auth_callback( $allowed, $meta_key, $post_id ) {
-		return current_user_can( 'edit_post', $post_id );
+		return current_user_can( 'edit_lessons', $post_id );
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -158,6 +158,7 @@ class Sensei_Lesson {
 
 		// Log event on the initial publish for a lesson.
 		add_action( 'sensei_lesson_initial_publish', [ $this, 'log_initial_publish_event' ] );
+		add_action( 'init', [ $this, 'set_up_meta_fields' ] );
 	}
 
 	/**
@@ -5357,6 +5358,39 @@ class Sensei_Lesson {
 
 		return false;
 
+	}
+
+	/**
+	 * Register the meta fields for the lesson post type.
+	 *
+	 * @return void
+	 */
+	public function set_up_meta_fields() {
+		register_post_meta(
+			'lesson',
+			'_initial_content',
+			[
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'string',
+				'auth_callback' => [ $this, 'post_meta_auth_callback' ],
+			]
+		);
+	}
+
+	/**
+	 * Check if user can update lesson meta.
+	 *
+	 * @internal
+	 *
+	 * @param bool   $allowed  Whether the user can add the meta.
+	 * @param string $meta_key The meta key.
+	 * @param int    $post_id  The post ID where the meta key is being edited.
+	 *
+	 * @return boolean Whether the user can edit the meta.
+	 */
+	public function post_meta_auth_callback( $allowed, $meta_key, $post_id ) {
+		return current_user_can( 'edit_post', $post_id );
 	}
 
 	/**

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
@@ -640,4 +640,63 @@ class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_Tes
 		// But the teacher for another course without that common module will be updated.
 		$this->assertEquals( get_post( $course_c['course_id'] )->post_author, $teacher_id );
 	}
+
+	public function testSaveCourseStructure_WhenCalledWithInitialContent_SavesInitialContentInLessonWhenCreating() {
+		/* Arrange */
+		$this->login_as_teacher();
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$structure = array(
+			array(
+				'type'           => 'lesson', // Tests that the initial content is only saved.
+				'title'          => 'Lesson 1',
+				'draft'          => true,
+				'preview'        => false,
+				'initialContent' => 'Test Content 1',
+			),
+			array(
+				'type'           => 'lesson',
+				'title'          => 'Lesson 2',
+				'draft'          => true,
+				'preview'        => false,
+				'initialContent' => '', // Tests that it doesn't cause any problem if initialContent is empty.
+			),
+			array(
+				'type'    => 'lesson',
+				'title'   => 'Lesson 3',
+				'draft'   => true,
+				'preview' => false, // Tests that it doesn't cause any problem if initialContent is not set.
+			),
+			array(
+				'type'           => 'lesson',
+				'title'          => 'Lesson 4',
+				'draft'          => true,
+				'preview'        => false,
+				'id'             => $lesson_id,
+				'initialContent' => 'Test Content 4', // Tests that it doesn't save initialContent for existing lesson.
+			),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-structure/' . $course_id );
+		$request->set_body( wp_json_encode( [ 'structure' => $structure ] ) );
+
+		/* Act */
+		$response = $this->server->dispatch( $request );
+
+		/* Assert */
+		$response_data = $response->get_data();
+
+		$this->assertEquals( $response->get_status(), 200 );
+		$this->assertEquals( 'Test Content 1', $response_data[0]['initialContent'] );
+		$this->assertEmpty( $response_data[1]['initialContent'] );
+		$this->assertEmpty( $response_data[2]['initialContent'] );
+		$this->assertEmpty( $response_data[3]['initialContent'] );
+		$this->assertEquals(
+			'<!-- wp:paragraph --><p>Test Content 1</p>
+<!-- /wp:paragraph -->',
+			get_post( $response_data[0]['id'] )->post_content
+		);
+	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
@@ -650,6 +650,19 @@ class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_Tes
 		);
 		$structure = array(
 			array(
+				'type'    => 'module',       // Tests that it works when lesson is in a module.
+				'title'   => 'Module with Some Lessons',
+				'lessons' => [
+					[
+						'type'           => 'lesson',
+						'title'          => 'Lesson in Module',
+						'draft'          => true,
+						'preview'        => false,
+						'initialContent' => 'Test Content M1',
+					],
+				],
+			),
+			array(
 				'type'           => 'lesson', // Tests that the initial content is only saved.
 				'title'          => 'Lesson 1',
 				'draft'          => true,
@@ -689,14 +702,20 @@ class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_Tes
 		$response_data = $response->get_data();
 
 		$this->assertEquals( $response->get_status(), 200 );
-		$this->assertEquals( 'Test Content 1', $response_data[0]['initialContent'] );
-		$this->assertEmpty( $response_data[1]['initialContent'] );
+		$this->assertEquals( 'Test Content M1', $response_data[0]['lessons'][0]['initialContent'] );
+		$this->assertEquals( 'Test Content 1', $response_data[1]['initialContent'] );
 		$this->assertEmpty( $response_data[2]['initialContent'] );
 		$this->assertEmpty( $response_data[3]['initialContent'] );
+		$this->assertEmpty( $response_data[4]['initialContent'] );
 		$this->assertEquals(
 			'<!-- wp:paragraph --><p>Test Content 1</p>
 <!-- /wp:paragraph -->',
-			get_post( $response_data[0]['id'] )->post_content
+			get_post( $response_data[1]['id'] )->post_content
+		);
+		$this->assertEquals(
+			'<!-- wp:paragraph --><p>Test Content M1</p>
+<!-- /wp:paragraph -->',
+			get_post( $response_data[0]['lessons'][0]['id'] )->post_content
 		);
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2498

## Proposed Changes
Enables the lesson outline block and structure saving API to take in and save initialContent for lessons.

More details here https://github.com/Automattic/sensei-pro/pull/2525

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please check https://github.com/Automattic/sensei-pro/pull/2525

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
