### PR TITLE
Fix memory issue on the student courses reports screen

### DIFF
--- a/changelog/fix-reports-memory-issue
+++ b/changelog/fix-reports-memory-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Memory issue on the student reports screen

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -919,9 +919,8 @@ class Sensei_Analysis {
 
 		if (
 			$user_id
-			&& (
-				! in_array( $user_id, Sensei()->teacher->get_learner_ids_for_courses_with_edit_permission(), true )
-			)
+			&& ! current_user_can( 'manage_options' ) // Admins can access any user.
+			&& ! in_array( $user_id, Sensei()->teacher->get_learner_ids_for_courses_with_edit_permission(), true )
 		) {
 			wp_die( esc_html__( 'Invalid user', 'sensei-lms' ), 404 );
 		}

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1216,7 +1216,7 @@ AND comments.comment_type = 'sensei_course_status'";
 					"SELECT DISTINCT user_id
 					FROM {$wpdb->prefix}sensei_lms_progress
 					WHERE type = 'course'
-					AND post_id IN ( $course_ids_placeholder )",
+					AND post_id IN ( $course_ids_placeholder )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
 					$course_ids
 				)
 			);
@@ -1227,7 +1227,7 @@ AND comments.comment_type = 'sensei_course_status'";
 					"SELECT DISTINCT user_id
 					FROM {$wpdb->comments}
 					WHERE comment_type = 'sensei_course_status'
-					AND comment_post_ID IN ( $course_ids_placeholder )",
+					AND comment_post_ID IN ( $course_ids_placeholder )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
 					$course_ids
 				)
 			);

--- a/tests/framework/trait-sensei-hpps-helpers.php
+++ b/tests/framework/trait-sensei-hpps-helpers.php
@@ -7,7 +7,13 @@
 
 // phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
 
+use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
+use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory;
+use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory;
 use Sensei\Internal\Services\Progress_Storage_Settings;
+use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Factory;
+use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Factory;
+use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -21,9 +27,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 trait Sensei_HPPS_Helpers {
 	private function enable_hpps_tables_repository() {
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::TABLES_STORAGE;
+
+		$this->_course_progress_repository = Sensei()->course_progress_repository;
+		$this->_lesson_progress_repository = Sensei()->lesson_progress_repository;
+		$this->_quiz_progress_repository   = Sensei()->quiz_progress_repository;
+		$this->_quiz_submission_repository = Sensei()->quiz_submission_repository;
+		$this->_quiz_answer_repository     = Sensei()->quiz_answer_repository;
+		$this->_quiz_grade_repository      = Sensei()->quiz_grade_repository;
+
+		Sensei()->course_progress_repository = ( new Course_Progress_Repository_Factory( true, true ) )->create();
+		Sensei()->lesson_progress_repository = ( new Lesson_Progress_Repository_Factory( true, true ) )->create();
+		Sensei()->quiz_progress_repository   = ( new Quiz_Progress_Repository_Factory( true, true ) )->create();
+		Sensei()->quiz_submission_repository = ( new Submission_Repository_Factory( true, true ) )->create();
+		Sensei()->quiz_answer_repository     = ( new Answer_Repository_Factory( true, true ) )->create();
+		Sensei()->quiz_grade_repository      = ( new Grade_Repository_Factory( true, true ) )->create();
 	}
 
 	private function reset_hpps_repository() {
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
+
+		Sensei()->course_progress_repository = $this->_course_progress_repository;
+		Sensei()->lesson_progress_repository = $this->_lesson_progress_repository;
+		Sensei()->quiz_progress_repository   = $this->_quiz_progress_repository;
+		Sensei()->quiz_submission_repository = $this->_quiz_submission_repository;
+		Sensei()->quiz_answer_repository     = $this->_quiz_answer_repository;
+		Sensei()->quiz_grade_repository      = $this->_quiz_grade_repository;
 	}
 }

--- a/tests/unit-tests/test-class-teacher.php
+++ b/tests/unit-tests/test-class-teacher.php
@@ -577,4 +577,43 @@ AND comments.comment_post_ID IN (0)
 AND comments.comment_type = 'sensei_course_status'";
 		$this->assertSame( $expected, $sql );
 	}
+
+	public function testGetLearnerIdsForCoursesWithEditPermission_WhenHPPSIsDisabled_ReturnsCorrectLearnerIds() {
+		// Arrange.
+		$course_1 = $this->factory->course->create();
+		$course_2 = $this->factory->course->create();
+		$user_1   = $this->factory->user->create();
+		$user_2   = $this->factory->user->create();
+
+		Sensei_Utils::start_user_on_course( $user_1, $course_1 );
+		Sensei_Utils::start_user_on_course( $user_2, $course_2 );
+
+		// Act.
+		$learner_ids = Sensei()->teacher->get_learner_ids_for_courses_with_edit_permission();
+
+		// Assert.
+		$this->assertSame( [ $user_1, $user_2 ], $learner_ids );
+	}
+
+	public function testGetLearnerIdsForCoursesWithEditPermission_WhenHPPSIsEnabled_ReturnsCorrectLearnerIds() {
+		// Arrange.
+		$this->enable_hpps_tables_repository();
+
+		$course_1 = $this->factory->course->create();
+		$course_2 = $this->factory->course->create();
+		$user_1   = $this->factory->user->create();
+		$user_2   = $this->factory->user->create();
+
+		Sensei_Utils::start_user_on_course( $user_1, $course_1 );
+		Sensei_Utils::start_user_on_course( $user_2, $course_2 );
+
+		// Act.
+		$learner_ids = Sensei()->teacher->get_learner_ids_for_courses_with_edit_permission();
+
+		// Assert.
+		$this->assertSame( [ $user_1, $user_2 ], $learner_ids );
+
+		// Reset.
+		$this->reset_hpps_repository();
+	}
 }


### PR DESCRIPTION
Resolves #7439

This PR fixes an "out of memory" error on the student courses reports screen on sites with many students.

The main issue was when checking if the current user has access to the student's report screen. For that, the code was fetching the course status for all students for all courses. To make it worse, `WP_Metadata_Lazyloader` tries to fetch all the comment metas at once and fills the memory of the server.

Before:

![dCI64X.png](https://github.com/Automattic/sensei/assets/1612178/d61c58c7-3b65-46c2-8454-4bff9146ba28)

After:

![image](https://github.com/Automattic/sensei/assets/1612178/f85c817f-731f-488d-b68a-7f06f33211fa)


## Proposed Changes

* Optimize the `Sensei_Teacher::get_learner_ids_for_courses_with_edit_permission` method so it will fetch the needed data in a more efficient way.
* Prepare the `Sensei_Teacher::get_learner_ids_for_courses_with_edit_permission` method for HPPS. This method is not used on the front-end so the HPPS logic is not in use currently.
* Bypass checking for screen access permission if the current user is an admin. This skips the unnecessary call to `Sensei_Teacher::get_learner_ids_for_courses_with_edit_permission` for admin users.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable the WP Query plugin.
1. Go to Sensei LMS -> Reports -> Students and select a student.
2. The screen should be loading as before.
3. Notice a decrease in the memory usage on that screen compared to `trunk`. For me, the decrease was around 5% because my local database is not that big.
4. If you have a big database at hand, test with that.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues