### PR TITLE
Fix update version script to support alpha versions

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -26,11 +26,11 @@ if [[ "$OS_TYPE" == "Darwin" ]]; then
     # You are on macOS
 
 	# Update version in sensei-lms.php
-	sed -E -i '' "s/\* Version: [0-9]+\.[0-9]+\.[0-9]+/\* Version: $VERSION/" "$CURRENT_DIR/sensei-lms.php"
+	sed -E -i '' "s/\* Version: .*/\* Version: $VERSION/" "$CURRENT_DIR/sensei-lms.php"
 
 	# Find constant and replace the version in sensei-lms.php:
 	#	define( 'SENSEI_LMS_VERSION', '4.15.0' ); // WRCS: DEFINED_VERSION.
-	sed -E -i '' "s/'SENSEI_LMS_VERSION', '[0-9]+\.[0-9]+\.[0-9]+/'SENSEI_LMS_VERSION', '$VERSION/" "$CURRENT_DIR/sensei-lms.php"
+	sed -E -i '' "s/'SENSEI_LMS_VERSION', '[^']*'/'SENSEI_LMS_VERSION', '$VERSION'/" "$CURRENT_DIR/sensei-lms.php"
 
 	# Update version in the Stable Tag comment in readme.txt
 	# Stable tag: 4.15.0
@@ -39,11 +39,11 @@ elif [[ "$OS_TYPE" == "Linux" ]]; then
 	# You are on Linux
 
 	# Update version in sensei-lms.php
-	sed -E -i'' "s/\* Version: [0-9]+\.[0-9]+\.[0-9]+/\* Version: $VERSION/" "$CURRENT_DIR/sensei-lms.php"
+	sed -E -i'' "s/\* Version: .*/\* Version: $VERSION/" "$CURRENT_DIR/sensei-lms.php"
 
 	# Find constant and replace the version in sensei-lms.php:
 	#	define( 'SENSEI_LMS_VERSION', '4.15.0' ); // WRCS: DEFINED_VERSION.
-	sed -E -i'' "s/'SENSEI_LMS_VERSION', '[0-9]+\.[0-9]+\.[0-9]+/'SENSEI_LMS_VERSION', '$VERSION/" "$CURRENT_DIR/sensei-lms.php"
+	sed -E -i'' "s/'SENSEI_LMS_VERSION', '[^']*'/'SENSEI_LMS_VERSION', '$VERSION'/" "$CURRENT_DIR/sensei-lms.php"
 
 	# Update version in the Stable Tag comment in readme.txt
 	# Stable tag: 4.15.0


### PR DESCRIPTION
## Proposed Changes

* It updates the script that replaces versions, so it supports versions like `4.20.2-a.1` when replacing.
* It's done only for the `sensei-lms.php` occurrences. If we need for the others, we need to update other replaces too.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. If it's not already, update the `sensei-lms.php` versions to `4.20.2-a.1` (in the file header and in the `SENSEI_LMS_VERSION` constant).
2. Run `./scripts/update-version.sh 4.20.2`.
3. Make sure the version is updated to `4.20.2`.
4. Run `./scripts/update-version.sh 4.20.3`.
5. Make sure the version is updated to `4.20.3`.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
