### PR TITLE
Include base event fields for stats and system logs

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -25,10 +25,10 @@ class Sensei_Usage_Tracking_Data {
 	 **/
 	public static function get_usage_data(): array {
 		$usage_data = array_merge(
+			Sensei_Usage_Tracking_Data::get_event_logging_base_fields(),
 			self::get_question_type_count(),
 			self::get_quiz_stats(),
 			[
-				'courses'                        => wp_count_posts( 'course' )->publish,
 				'course_active'                  => self::get_course_active_count(),
 				'course_completed'               => self::get_course_completed_count(),
 				'course_completion_rate'         => self::get_course_completion_rate(),
@@ -41,7 +41,6 @@ class Sensei_Usage_Tracking_Data {
 				'enrolment_first'                => self::get_first_course_enrolment(),
 				'enrolment_last'                 => self::get_last_course_enrolment(),
 				'enrolment_calculated'           => self::get_is_enrolment_calculated() ? 1 : 0,
-				'learners'                       => self::get_learner_count(),
 				'lessons'                        => wp_count_posts( 'lesson' )->publish,
 				'lesson_modules'                 => self::get_lesson_module_count(),
 				'lesson_prereqs'                 => self::get_lesson_prerequisite_count(),

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -25,7 +25,7 @@ class Sensei_Usage_Tracking_Data {
 	 **/
 	public static function get_usage_data(): array {
 		$usage_data = array_merge(
-			Sensei_Usage_Tracking_Data::get_event_logging_base_fields(),
+			self::get_event_logging_base_fields(),
 			self::get_question_type_count(),
 			self::get_quiz_stats(),
 			[

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -393,6 +393,7 @@ abstract class Sensei_Usage_Tracking_Base {
 		$system_data['hpps_repository']      = $hpps_repository;
 
 		$plugin_data = $this->get_plugin_data();
+
 		foreach ( $plugin_data as $plugin_name => $plugin_version ) {
 			if ( $this->do_track_plugin( $plugin_name ) ) {
 				$plugin_friendly_name       = preg_replace( '/[^a-z0-9]/', '_', $plugin_name );
@@ -401,7 +402,10 @@ abstract class Sensei_Usage_Tracking_Base {
 			}
 		}
 
-		return $system_data;
+		return array_merge(
+			Sensei_Usage_Tracking_Data::get_event_logging_base_fields(),
+			$system_data
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes
Previously, fields such as `is_wpcom` and `paid` were not being included in the `sensei_stats_log` and `sensei_system_log` Tracks events. This PR adds those base fields to these events as well.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable usage tracking.
2. Activate the WP Crontrol plugin.
3. In Tools > Cron Events, run the `sensei_usage_tracking_send_usage_data` job.
4. In Tracks, check that the `sensei_stats_log` and `sensei_system_log` events contain the following properties:
-  `is_wpcom`
- `paid`
- `courses`
- `learners`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
