### PR TITLE
Prevent selecting the same page for the page settings

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -48,7 +48,8 @@ jQuery( document ).ready( function ( $ ) {
 	function updateReferer( url ) {
 		const urlObject = new URL( url );
 
-		$senseiSettings.find( 'input[name="_wp_http_referer"]' )
+		$senseiSettings
+			.find( 'input[name="_wp_http_referer"]' )
 			.val( urlObject.pathname + urlObject.search );
 	}
 
@@ -56,8 +57,7 @@ jQuery( document ).ready( function ( $ ) {
 	 * Hide all sections.
 	 */
 	function hideAllSections() {
-		$senseiSettings.find( 'section' )
-			.hide();
+		$senseiSettings.find( 'section' ).hide();
 	}
 
 	/**
@@ -69,11 +69,9 @@ jQuery( document ).ready( function ( $ ) {
 		hideAllSections();
 		hideSettingsFormElements( sectionId );
 
-		$senseiSettings.find( `section#${ sectionId }` )
-			.show();
+		$senseiSettings.find( `section#${ sectionId }` ).show();
 
-		$senseiSettings.find( 'a.tab.current' )
-			.removeClass( 'current' );
+		$senseiSettings.find( 'a.tab.current' ).removeClass( 'current' );
 
 		$senseiSettings
 			.find( `a.tab[href*="tab=${ sectionId }"]` )
@@ -101,9 +99,11 @@ jQuery( document ).ready( function ( $ ) {
 	function getSectionIdFromUrl( url ) {
 		const urlParams = new URLSearchParams( url );
 
-		return urlParams.get( 'tab' )
-			|| url.split( '#' )[1]
-			|| 'default-settings';
+		return (
+			urlParams.get( 'tab' ) ||
+			url.split( '#' )[ 1 ] ||
+			'default-settings'
+		);
 	}
 
 	/**
@@ -199,6 +199,7 @@ jQuery( document ).ready( function ( $ ) {
 				.filter( function () {
 					const optionValue = $( this ).val();
 					return (
+						optionValue !== '0' &&
 						optionValue !== currentValue &&
 						selectedPageIds.includes( optionValue )
 					);

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -73,7 +73,7 @@ jQuery( document ).ready( function ( $ ) {
 			.show();
 
 		$senseiSettings.find( 'a.tab.current' )
-			.removeClass( 'current' )
+			.removeClass( 'current' );
 
 		$senseiSettings
 			.find( `a.tab[href*="tab=${ sectionId }"]` )
@@ -171,6 +171,43 @@ jQuery( document ).ready( function ( $ ) {
 		data.append( 'nonce', window.senseiSettingsSectionVisitNonce );
 		fetch( ajaxurl, { method: 'POST', body: data } );
 	}
+
+	/***** Unique Page Settings *****/
+
+	$( '.sensei-settings-unique-page select' ).on(
+		'change',
+		disableSelectedUniquePageOptions
+	);
+
+	/**
+	 * Disable page options that are already selected in another setting.
+	 */
+	function disableSelectedUniquePageOptions() {
+		const selectedPageIds = [];
+		const $inputs = $( '.sensei-settings-unique-page select' );
+
+		$inputs.each( function () {
+			selectedPageIds.push( $( this ).val() );
+		} );
+
+		$inputs.each( function () {
+			const currentValue = $( this ).val();
+
+			$( this )
+				.find( 'option' )
+				.prop( 'disabled', false )
+				.filter( function () {
+					const optionValue = $( this ).val();
+					return (
+						optionValue !== currentValue &&
+						selectedPageIds.includes( optionValue )
+					);
+				} )
+				.prop( 'disabled', true );
+		} );
+	}
+
+	disableSelectedUniquePageOptions();
 
 	/***** Colour pickers *****/
 

--- a/changelog/update-improve-settings-page-select
+++ b/changelog/update-improve-settings-page-select
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent selecting the same page for the Course Archive, My Courses, and Course Completed settings

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -395,6 +395,12 @@ class Sensei_Settings_API {
 				$name   = $v['name'];
 				if ( $v['type'] == 'info' ) {
 					$name = ''; }
+
+				$class = '';
+				if ( ! empty( $v['unique_page'] ) ) {
+					$class = 'sensei-settings-unique-page';
+				}
+
 				add_settings_field(
 					$k,
 					$name,
@@ -402,8 +408,9 @@ class Sensei_Settings_API {
 					$this->token,
 					$v['section'],
 					array(
-						'key'  => $k,
-						'data' => $v,
+						'key'   => $k,
+						'data'  => $v,
+						'class' => $class,
 					)
 				);
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -367,6 +367,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,
+			'unique_page' => true,
 		);
 
 		$fields['my_course_page'] = array(
@@ -377,6 +378,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,
+			'unique_page' => true,
 		);
 
 		$fields['course_completed_page'] = array(
@@ -387,6 +389,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,
+			'unique_page' => true,
 		);
 
 		$fields['placeholder_images_enable'] = array(

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -785,7 +785,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$fields['email_bcc'] = array(
 			'name'          => __( 'BCC', 'sensei-lms' ),
 			'description'   => __( 'Enter email addresses to BCC on all emails. Separate multiple email addresses with commas.', 'sensei-lms' ),
-			'type'          => 'email_list',
 			'type'          => 'email',
 			'multiple'      => true,
 			'default'       => '',

--- a/tests/unit-tests/test-class-sensei-settings-api.php
+++ b/tests/unit-tests/test-class-sensei-settings-api.php
@@ -129,4 +129,54 @@ class Sensei_Settings_Api_Test extends \WP_UnitTestCase {
 		/** Assert. */
 		$this->assertStringContainsString( '<a href="http://example.org/wp-admin/admin.php?page=sensei-settings&#038;tab=other-settings" class="tab external">Other Settings</a>', $tabs );
 	}
+
+	public function testCreateFields_WhenUniquePageIsTrue_AddsClass() {
+		/* Arrange. */
+		$settings           = new Sensei_Settings_Api();
+		$settings->sections = array(
+			'default-settings' => array(
+				'name' => 'Default Settings',
+			),
+		);
+		$settings->fields   = array(
+			'test' => array(
+				'name'        => 'Test',
+				'type'        => 'select',
+				'section'     => 'default-settings',
+				'unique_page' => true,
+			),
+		);
+
+		/* Act. */
+		$settings->create_fields();
+
+		/* Assert. */
+		global $wp_settings_fields;
+		$this->assertStringContainsString( 'sensei-settings-unique-page', $wp_settings_fields['sensei-settings']['default-settings']['test']['args']['class'] );
+	}
+
+	public function testCreateFields_WhenUniquePageIsFalse_NoClassIsAdded() {
+		/* Arrange. */
+		$settings           = new Sensei_Settings_Api();
+		$settings->sections = array(
+			'default-settings' => array(
+				'name' => 'Default Settings',
+			),
+		);
+		$settings->fields   = array(
+			'test' => array(
+				'name'        => 'Test',
+				'type'        => 'select',
+				'section'     => 'default-settings',
+				'unique_page' => false,
+			),
+		);
+
+		/* Act. */
+		$settings->create_fields();
+
+		/* Assert. */
+		global $wp_settings_fields;
+		$this->assertStringNotContainsString( 'sensei-settings-unique-page', $wp_settings_fields['sensei-settings']['default-settings']['test']['args']['class'] );
+	}
 }


### PR DESCRIPTION
This PR fixes a bug allowing the user to select the same page for the Course Archive, My Courses, and Course Completed settings which causes other bugs.

## Proposed Changes
* If a page is selected on one setting, disable it for the others.


https://github.com/Automattic/sensei/assets/1612178/c0a0193f-3404-4bfe-82e9-633c26581245


## Context

p1708014451312029-slack-C02P7FHLVR9

## Testing Instructions
1. Go to Sensei LMS -> Settings.
2. Select a page for "Course Archive Page", "My Courses Page", and "Course Completed Page".
3. Make sure when selecting a page, that page is disabled on the other 2 settings.
4. Save the form and make sure the settings are saved. 
5. Make sure the selected options are disabled when initially loading the page.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues