### PR TITLE
Remove "Customize Colors" link for classic themes

### DIFF
--- a/changelog/remove-customize-colors-link
+++ b/changelog/remove-customize-colors-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove "Customize Colors" link for classic themes

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1458,11 +1458,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$key     = $args['key'];
 		$value   = $options[ $key ];
 
-		$color_customizer_url = '';
-		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
-			$color_customizer_url = Sensei_Course_Theme::get_learning_mode_customizer_url();
-		}
-
 		?>
 		<label for="<?php echo esc_attr( $key ); ?>">
 			<input id="<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>" type="checkbox" value="1" <?php checked( $value, '1' ); ?> />
@@ -1471,14 +1466,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		<p>
 			<span class="description"><?php echo esc_html( $args['data']['description'] ); ?></span>
 		</p>
-
-		<?php if ( $color_customizer_url ) : ?>
-			<p class="extra-content">
-				<a href="<?php echo esc_url( $color_customizer_url ); ?>">
-					<?php esc_html_e( 'Customize Colors', 'sensei-lms' ); ?>
-				</a>
-			</p>
-		<?php endif; ?>
 
 		<?php
 	}


### PR DESCRIPTION
## Proposed Changes
Remove _Customize Colors_ link from _Appearance_ settings for classic themes. This takes the user to the Customizer, but it doesn't really work. They can use the site editor to adjust colors instead.

Also updated https://senseilms.com/documentation/customizing-learning-mode-colors/ to remove references to the Customizer.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate a classic theme.
2. Go to _Sensei LMS_ > _Settings_ > _Appearance_.
3. Ensure there is no _Customize Colors_ link.

![Screenshot 2024-02-21 at 1 13 23 PM](https://github.com/Automattic/sensei/assets/1190420/85a59ecc-9d69-4d9f-8c6d-9242a88062ec)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues