### PR TITLE
Add explanation about the "Display Course Author" setting

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -460,8 +460,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		$fields['course_author'] = array(
-			'name'        => __( 'Display Course Author', 'sensei-lms' ) . ' ' . __( '(legacy pages)', 'sensei-lms' ),
-			'description' => __( 'Output the Course Author on Course archive and My Courses page.', 'sensei-lms' ) . ' ' . __( 'If you are using blocks for these pages, you need to remove the author from the blocks.', 'sensei-lms' ),
+			'name'        => __( 'Course Author', 'sensei-lms' ),
+			'description' => __( 'Display the author on the Course Archive and My Courses pages. This setting does not apply when these pages use blocks.', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => true,
 			'section'     => 'course-settings',

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -460,8 +460,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		$fields['course_author'] = array(
-			'name'        => __( 'Display Course Author', 'sensei-lms' ),
-			'description' => __( 'Output the Course Author on Course archive and My Courses page.', 'sensei-lms' ),
+			'name'        => __( 'Display Course Author', 'sensei-lms' ) . ' ' . __( '(legacy pages)', 'sensei-lms' ),
+			'description' => __( 'Output the Course Author on Course archive and My Courses page.', 'sensei-lms' ) . ' ' . __( 'If you are using blocks for these pages, you need to remove the author from the blocks.', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => true,
 			'section'     => 'course-settings',


### PR DESCRIPTION
## Proposed Changes

* We have a setting to display the author on the Course Archive and My Courses pages. But it only works for the legacy pages (with shortcodes or automatically injected in the template). So I added an extra comment that if they are using blocks, they should remove the author there.

Reported in p1708018654910029-slack-C02P7FHLVR9

## Screenshots

<img width="1071" alt="Screenshot 2024-02-26 at 20 32 27" src="https://github.com/Automattic/sensei/assets/876340/fe29fe7c-9ddb-4f2b-a5f7-9b69606cfb56">


## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the Sensei settings in the course tabs.
2. Check that the text is updated and it looks good enough. cc @donnapep to see if it looks good enough. =)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues