### PR TITLE
When tour is closed or skipped, persist the choice and don't load that tour for that user

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -38,7 +38,7 @@ const EditorWizardModal = () => {
 
 	const showSenseiTour = ( show ) => {
 		if ( setTourShowStatus ) {
-			setTourShowStatus( show );
+			setTourShowStatus( show, true );
 		}
 	};
 

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -38,7 +38,7 @@ const EditorWizardModal = () => {
 
 	const showSenseiTour = ( show ) => {
 		if ( setTourShowStatus ) {
-			setTourShowStatus( show, true );
+			setTourShowStatus( show );
 		}
 	};
 

--- a/assets/admin/tour/components/sensei-tour-kit/index.js
+++ b/assets/admin/tour/components/sensei-tour-kit/index.js
@@ -35,7 +35,7 @@ function SenseiTourKit( { tourName, steps, extraConfig = {} } ) {
 
 	const config = {
 		steps,
-		closeHandler: () => setTourShowStatus( false, false, tourName ),
+		closeHandler: () => setTourShowStatus( false, true, tourName ),
 		options: {
 			effects: {
 				spotlight: null,

--- a/assets/admin/tour/components/sensei-tour-kit/index.js
+++ b/assets/admin/tour/components/sensei-tour-kit/index.js
@@ -19,10 +19,11 @@ import { TourStep } from '../../types';
  * Renders a tour kit component using Sensei.
  *
  * @param {Object}     props                  - Component props.
+ * @param {string}     props.tourName         - The unique name of the tour.
  * @param {TourStep[]} props.steps            - An array of steps to include in the tour.
  * @param {Object}     [props.extraConfig={}] - Additional configuration options for the tour kit.
  */
-function SenseiTourKit( { steps, extraConfig = {} } ) {
+function SenseiTourKit( { tourName, steps, extraConfig = {} } ) {
 	const { showTour } = useSelect( ( select ) => {
 		const { getIfShowTour } = select( SENSEI_TOUR_STORE );
 		return {
@@ -34,7 +35,7 @@ function SenseiTourKit( { steps, extraConfig = {} } ) {
 
 	const config = {
 		steps,
-		closeHandler: () => setTourShowStatus( false ),
+		closeHandler: () => setTourShowStatus( false, false, tourName ),
 		options: {
 			effects: {
 				spotlight: null,

--- a/assets/admin/tour/course-tour/index.js
+++ b/assets/admin/tour/course-tour/index.js
@@ -17,14 +17,16 @@ export const getOutlineBlock = () =>
 		select( 'core/block-editor' ).getBlocks()
 	);
 
+const tourName = 'sensei-course-tour';
+
 export default function CourseTour() {
 	if ( ! getOutlineBlock() ) {
 		return null;
 	}
 
-	return <SenseiTourKit steps={ getTourSteps() } />;
+	return <SenseiTourKit tourName={ tourName } steps={ getTourSteps() } />;
 }
 
-registerPlugin( 'sensei-course-tour', {
+registerPlugin( tourName, {
 	render: () => <CourseTour />,
 } );

--- a/assets/admin/tour/data/store.js
+++ b/assets/admin/tour/data/store.js
@@ -22,14 +22,14 @@ export const actions = {
 	/**
 	 * Sets whether the tour should be shown.
 	 *
-	 * @param {boolean} show      The lesson status.
-	 * @param {boolean} onlyLocal If the action should only be local.
-	 * @param {string}  tourName  The unique name of the tour.
+	 * @param {boolean} show            The lesson status.
+	 * @param {boolean} persistOnServer If the action should be persisted.
+	 * @param {string}  tourName        The unique name of the tour.
 	 *
 	 * @return {Object} The setTourShowStatus action.
 	 */
-	setTourShowStatus( show, onlyLocal, tourName ) {
-		if ( ! onlyLocal ) {
+	setTourShowStatus( show, persistOnServer, tourName ) {
+		if ( persistOnServer ) {
 			apiFetch( {
 				path: 'sensei-internal/v1/tour',
 				method: 'POST',

--- a/assets/admin/tour/data/store.js
+++ b/assets/admin/tour/data/store.js
@@ -11,14 +11,14 @@ import apiFetch from '@wordpress/api-fetch';
 
 export const SENSEI_TOUR_STORE = 'sensei/tour';
 
-const DEFAULT_STATE = {
+export const DEFAULT_STATE = {
 	showTour: true,
 };
 
 /**
  * Tour store actions.
  */
-const actions = {
+export const actions = {
 	/**
 	 * Sets whether the tour should be shown.
 	 *
@@ -46,7 +46,7 @@ const actions = {
 /**
  * Tour store selectors.
  */
-const selectors = {
+export const selectors = {
 	/**
 	 * Get if the tour should be shown.
 	 *
@@ -61,7 +61,7 @@ const selectors = {
 /**
  * Tour store reducer.
  */
-const reducers = {
+export const reducers = {
 	/**
 	 * Sets the show tour status.
 	 *
@@ -80,7 +80,7 @@ const reducers = {
 	DEFAULT: ( action, state ) => state,
 };
 
-const store = createReduxStore( SENSEI_TOUR_STORE, {
+export const store = createReduxStore( SENSEI_TOUR_STORE, {
 	reducer: createReducerFromActionMap( reducers, DEFAULT_STATE ),
 	actions,
 	selectors,

--- a/assets/admin/tour/data/store.js
+++ b/assets/admin/tour/data/store.js
@@ -7,6 +7,7 @@ import { createReduxStore, register } from '@wordpress/data';
  */
 import { createReducerFromActionMap } from '../../../shared/data/store-helpers';
 import { controls } from '@wordpress/data-controls';
+import apiFetch from '@wordpress/api-fetch';
 
 export const SENSEI_TOUR_STORE = 'sensei/tour';
 
@@ -21,11 +22,20 @@ const actions = {
 	/**
 	 * Sets whether the tour should be shown.
 	 *
-	 * @param {boolean} show The lesson status.
+	 * @param {boolean} show      The lesson status.
+	 * @param {boolean} onlyLocal If the action should only be local.
+	 * @param {string}  tourName  The unique name of the tour.
 	 *
 	 * @return {Object} The setTourShowStatus action.
 	 */
-	setTourShowStatus( show ) {
+	setTourShowStatus( show, onlyLocal, tourName ) {
+		if ( ! onlyLocal ) {
+			apiFetch( {
+				path: 'sensei-internal/v1/tour',
+				method: 'POST',
+				data: { complete: ! show, tour_id: tourName },
+			} );
+		}
 		return {
 			type: 'SET_TOUR_SHOW_STATUS',
 			showTour: show,

--- a/assets/admin/tour/data/store.test.js
+++ b/assets/admin/tour/data/store.test.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch, select } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { SENSEI_TOUR_STORE } from './store'; // Replace 'your-file-path' with the correct path to your file
+
+describe( 'Sensei Tour Store', () => {
+	it( 'should set the tour show value properly', () => {
+		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
+			false,
+			true,
+			'test-tour'
+		);
+		const showTour = select( SENSEI_TOUR_STORE ).getIfShowTour();
+		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
+			true,
+			true,
+			'test-tour'
+		);
+		const showTourAfter = select( SENSEI_TOUR_STORE ).getIfShowTour();
+
+		expect( showTour ).toBe( false );
+		expect( showTourAfter ).toBe( true );
+	} );
+} );

--- a/assets/admin/tour/data/store.test.js
+++ b/assets/admin/tour/data/store.test.js
@@ -12,6 +12,10 @@ import { SENSEI_TOUR_STORE } from './store';
 jest.mock( '@wordpress/api-fetch' );
 
 describe( 'Sensei Tour Store', () => {
+	beforeEach( () => {
+		apiFetch.mockClear();
+	} );
+
 	it( 'should set the tour show value properly', () => {
 		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
 			false,
@@ -44,5 +48,17 @@ describe( 'Sensei Tour Store', () => {
 			method: 'POST',
 			path: 'sensei-internal/v1/tour',
 		} );
+	} );
+
+	it( 'should not call API fetch when onlyLocal is true', () => {
+		apiFetch.mockReturnValue( {} );
+
+		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
+			false,
+			true,
+			'test-tour'
+		);
+
+		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
 } );

--- a/assets/admin/tour/data/store.test.js
+++ b/assets/admin/tour/data/store.test.js
@@ -77,4 +77,18 @@ describe( 'Sensei Tour Store', () => {
 			path: 'sensei-internal/v1/tour',
 		} );
 	} );
+
+	it( 'should not call API fetch but set local value as expected when persistOnServer param not set', () => {
+		apiFetch.mockReturnValue( {} );
+
+		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus( false );
+		const showTour = select( SENSEI_TOUR_STORE ).getIfShowTour();
+
+		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus( true );
+		const showTourAfter = select( SENSEI_TOUR_STORE ).getIfShowTour();
+
+		expect( showTour ).toBe( false );
+		expect( showTourAfter ).toBe( true );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
 } );

--- a/assets/admin/tour/data/store.test.js
+++ b/assets/admin/tour/data/store.test.js
@@ -2,10 +2,14 @@
  * WordPress dependencies
  */
 import { dispatch, select } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
 /**
  * Internal dependencies
  */
-import { SENSEI_TOUR_STORE } from './store'; // Replace 'your-file-path' with the correct path to your file
+import { SENSEI_TOUR_STORE } from './store';
+
+jest.mock( '@wordpress/api-fetch' );
 
 describe( 'Sensei Tour Store', () => {
 	it( 'should set the tour show value properly', () => {
@@ -24,5 +28,21 @@ describe( 'Sensei Tour Store', () => {
 
 		expect( showTour ).toBe( false );
 		expect( showTourAfter ).toBe( true );
+	} );
+
+	it( 'should call API fetch when onlyLocal is false', () => {
+		apiFetch.mockReturnValue( {} );
+
+		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
+			false,
+			false,
+			'test-tour'
+		);
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			data: { complete: true, tour_id: 'test-tour' },
+			method: 'POST',
+			path: 'sensei-internal/v1/tour',
+		} );
 	} );
 } );

--- a/assets/admin/tour/data/store.test.js
+++ b/assets/admin/tour/data/store.test.js
@@ -19,7 +19,7 @@ describe( 'Sensei Tour Store', () => {
 	it( 'should set the tour show value properly', () => {
 		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
 			false,
-			true,
+			false,
 			'test-tour'
 		);
 		const showTour = select( SENSEI_TOUR_STORE ).getIfShowTour();
@@ -34,12 +34,12 @@ describe( 'Sensei Tour Store', () => {
 		expect( showTourAfter ).toBe( true );
 	} );
 
-	it( 'should call API fetch when onlyLocal is false', () => {
+	it( 'should call API fetch when persistOnServer is true', () => {
 		apiFetch.mockReturnValue( {} );
 
 		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
 			false,
-			false,
+			true,
 			'test-tour'
 		);
 
@@ -50,15 +50,31 @@ describe( 'Sensei Tour Store', () => {
 		} );
 	} );
 
-	it( 'should not call API fetch when onlyLocal is true', () => {
+	it( 'should not call API fetch when persistOnServer is false', () => {
 		apiFetch.mockReturnValue( {} );
 
 		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
 			false,
-			true,
+			false,
 			'test-tour'
 		);
 
 		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should API fetch with complete = false when show and persistOnServer is true', () => {
+		apiFetch.mockReturnValue( {} );
+
+		dispatch( SENSEI_TOUR_STORE ).setTourShowStatus(
+			true,
+			true,
+			'test-tour'
+		);
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			data: { complete: false, tour_id: 'test-tour' },
+			method: 'POST',
+			path: 'sensei-internal/v1/tour',
+		} );
 	} );
 } );

--- a/assets/admin/tour/lesson-tour/index.js
+++ b/assets/admin/tour/lesson-tour/index.js
@@ -17,14 +17,16 @@ export const getQuizBlock = () =>
 		select( 'core/block-editor' ).getBlocks()
 	);
 
+const tourName = 'sensei-lesson-tour';
+
 export default function LessonTour() {
 	if ( ! getQuizBlock() ) {
 		return null;
 	}
 
-	return <SenseiTourKit steps={ getTourSteps() } />;
+	return <SenseiTourKit tourName={ tourName } steps={ getTourSteps() } />;
 }
 
-registerPlugin( 'sensei-lesson-tour', {
+registerPlugin( tourName, {
 	render: () => <LessonTour />,
 } );

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -5908,4 +5908,14 @@
       <code>function wp_remote_request($url, $args = array())</code>
     </InvalidDocblock>
   </file>
+  <file src="includes/rest-api/class-sensei-rest-api-tour-controller.php">
+	<PropertyNotSetInConstructor occurrences="1">
+	  <code>Sensei_REST_API_Tour_Controller</code>
+	</PropertyNotSetInConstructor>
+  </file>
+  <file src="includes/rest-api/class-sensei-rest-api-internal.php">
+	<PossiblyNullArgument occurrences="1">
+	  <code>Sensei()->tour</code>
+	</PossiblyNullArgument>
+  </file>
 </files>

--- a/includes/admin/class-sensei-tour.php
+++ b/includes/admin/class-sensei-tour.php
@@ -117,4 +117,31 @@ class Sensei_Tour {
 			Sensei()->assets->enqueue( $handle, $tour_loader['path'], [], true );
 		}
 	}
+
+	/**
+	 * Set tour status for user.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $tour_id The tour ID.
+	 * @param bool   $status  The tour status.
+	 * @param int    $user_id The user ID.
+	 */
+	public function set_tour_completion_status( $tour_id, $status, $user_id = 0 ) {
+		$user_id = $user_id ? $user_id : get_current_user_id();
+
+		if ( ! $user_id ) {
+			return;
+		}
+
+		$tours = get_user_meta( $user_id, 'sensei_tours', true );
+
+		if ( ! is_array( $tours ) ) {
+			$tours = [];
+		}
+
+		$tours[ $tour_id ] = $status;
+
+		update_user_meta( $user_id, 'sensei_tours', $tours );
+	}
 }

--- a/includes/admin/class-sensei-tour.php
+++ b/includes/admin/class-sensei-tour.php
@@ -71,7 +71,8 @@ class Sensei_Tour {
 			in_array( $hook, [ 'post-new.php', 'post.php' ], true )
 		) {
 			$tour_loaders[ "sensei-$post_type-tour" ] = [
-				'path' => "admin/tour/$post_type-tour/index.js",
+				'minimum_install_version' => '$$next-version$$', // TODO: Add different version for lesson tour later if needed.
+				'path'                    => "admin/tour/$post_type-tour/index.js",
 			];
 		}
 
@@ -91,6 +92,17 @@ class Sensei_Tour {
 		$incomplete_tours = [];
 
 		foreach ( $tour_loaders as $handle => $tour_loader ) {
+			$install_version = \Sensei()->install_version ?? '';
+			$install_version = $install_version ? $install_version : ''; // In case the value is false, null coalescing won't work.
+			$minimum_version = $tour_loader['minimum_install_version'] ?? false;
+
+			if (
+				$minimum_version &&
+				! version_compare( $install_version, $tour_loader['minimum_install_version'] ?? '', '>=' )
+			) {
+				continue;
+			}
+
 			/**
 			 * Filters the tour completion status.
 			 *

--- a/includes/admin/class-sensei-tour.php
+++ b/includes/admin/class-sensei-tour.php
@@ -88,11 +88,32 @@ class Sensei_Tour {
 		 */
 		$tour_loaders = apply_filters( 'sensei_tour_loaders', $tour_loaders );
 
-		if ( ! empty( $tour_loaders ) ) {
+		$incomplete_tours = [];
+
+		foreach ( $tour_loaders as $handle => $tour_loader ) {
+			/**
+			 * Filters the tour completion status.
+			 *
+			 * @hook sensei_tour_is_complete Check if a tour is complete.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param {bool}  $is_tour_complete The tour completion status.
+			 * @param {string} $tour_id The tour ID.
+			 *
+			 * @return {bool} Filtered tour completion status.
+			 */
+			$is_tour_complete = apply_filters( 'sensei_tour_is_complete', $this->get_tour_completion_status( $handle, get_current_user_id() ), $handle );
+			if ( ! $is_tour_complete ) {
+				$incomplete_tours[ $handle ] = $tour_loader;
+			}
+		}
+
+		if ( ! empty( $incomplete_tours ) ) {
 			Sensei()->assets->enqueue( 'sensei-tour-styles', 'admin/tour/style.css', [] );
 		}
 
-		foreach ( $tour_loaders as $handle => $tour_loader ) {
+		foreach ( $incomplete_tours as $handle => $tour_loader ) {
 			Sensei()->assets->enqueue( $handle, $tour_loader['path'], [], true );
 		}
 	}

--- a/includes/admin/class-sensei-tour.php
+++ b/includes/admin/class-sensei-tour.php
@@ -144,4 +144,30 @@ class Sensei_Tour {
 
 		update_user_meta( $user_id, 'sensei_tours', $tours );
 	}
+
+	/**
+	 * Get tour status for user.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $tour_id The tour ID.
+	 * @param int    $user_id The user ID.
+	 *
+	 * @return bool The tour status.
+	 */
+	public function get_tour_completion_status( $tour_id, $user_id = 0 ) {
+		$user_id = $user_id ? $user_id : get_current_user_id();
+
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$tours = get_user_meta( $user_id, 'sensei_tours', true );
+
+		if ( ! is_array( $tours ) ) {
+			$tours = [];
+		}
+
+		return $tours[ $tour_id ] ?? false;
+	}
 }

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -59,6 +59,10 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Course_Utils_Controller( $this->namespace ),
 		];
 
+		if ( Sensei()->tour ) {
+			$this->controllers[] = new Sensei\Admin\Tour\Sensei_REST_API_Tour_Controller( $this->namespace, Sensei()->tour );
+		}
+
 		foreach ( $this->controllers as $controller ) {
 			$controller->register_routes();
 		}

--- a/includes/rest-api/class-sensei-rest-api-tour-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-tour-controller.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Sensei Tour API.
+ *
+ * @package sensei
+ * @since   $$next-version$$
+ */
+
+namespace Sensei\Admin\Tour;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei Tour REST API endpoints.
+ *
+ * @since   $$next-version$$
+ */
+class Sensei_REST_API_Tour_Controller extends \WP_REST_Controller {
+
+	/**
+	 * Routes namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * Routes prefix.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'tour';
+
+	/**
+	 * Sensei Tour.
+	 *
+	 * @var Sensei_Tour
+	 */
+	private $tour;
+
+	/**
+	 * Sensei_REST_API_Tour_Controller constructor.
+	 *
+	 * @param string      $rest_namespace REST API namespace.
+	 * @param Sensei_Tour $tour           Sensei Tour.
+	 */
+	public function __construct( $rest_namespace, Sensei_Tour $tour ) {
+		$this->namespace = $rest_namespace;
+		$this->tour      = $tour;
+	}
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => [ $this, 'set_tour_completion_status' ],
+					'permission_callback' => [ $this, 'get_tour_permissions_check' ],
+					'args'                => [
+						'tour_id'  => [
+							'required' => true,
+							'type'     => 'string',
+						],
+						'complete' => [
+							'required' => true,
+							'type'     => 'boolean',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Set tour status.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function set_tour_completion_status( $request ) {
+		$complete = ! ! $request->get_param( 'complete' );
+		$tour_id  = sanitize_text_field( $request->get_param( 'tour_id' ) );
+
+		$this->tour->set_tour_completion_status( $tour_id, $complete, get_current_user_id() );
+
+		return new \WP_REST_Response( true, 200 );
+	}
+
+	/**
+	 * Check if a given request has access to get tour.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function get_tour_permissions_check( $request ) {
+		return current_user_can( \Sensei_Admin::get_top_menu_capability() );
+	}
+}

--- a/includes/rest-api/class-sensei-rest-api-tour-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-tour-controller.php
@@ -87,7 +87,7 @@ class Sensei_REST_API_Tour_Controller extends \WP_REST_Controller {
 	 */
 	public function set_tour_completion_status( $request ) {
 		$complete = ! ! $request->get_param( 'complete' );
-		$tour_id  = sanitize_text_field( $request->get_param( 'tour_id' ) );
+		$tour_id  = sanitize_text_field( $request->get_param( 'tour_id' ) ?? '' );
 
 		$this->tour->set_tour_completion_status( $tour_id, $complete, get_current_user_id() );
 

--- a/tests/unit-tests/admin/test-class-sensei-tour.php
+++ b/tests/unit-tests/admin/test-class-sensei-tour.php
@@ -143,4 +143,18 @@ class Sensei_Tour_Test extends WP_UnitTestCase {
 		$this->assertFalse( wp_script_is( 'sensei-course-tour' ) );
 		$this->assertTrue( wp_style_is( 'sensei-tour-styles' ) );
 	}
+
+	public function testSetTourCompletionStatus_WhenCalled_SetsNewMetaProperly() {
+		/* Arrange */
+		$this->login_as_admin();
+		$user_id = get_current_user_id();
+		$before  = get_user_meta( $user_id, 'sensei_tours', true );
+
+		/* Act */
+		$this->instance->set_tour_completion_status( 'test-tour-id', true, $user_id );
+
+		/* Assert */
+		$this->assertNotEquals( $before, get_user_meta( $user_id, 'sensei_tours', true ) );
+		$this->assertTrue( get_user_meta( $user_id, 'sensei_tours', true )['test-tour-id'] );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-tour.php
+++ b/tests/unit-tests/admin/test-class-sensei-tour.php
@@ -157,4 +157,23 @@ class Sensei_Tour_Test extends WP_UnitTestCase {
 		$this->assertNotEquals( $before, get_user_meta( $user_id, 'sensei_tours', true ) );
 		$this->assertTrue( get_user_meta( $user_id, 'sensei_tours', true )['test-tour-id'] );
 	}
+
+	public function testSetTourCompletionStatus_WhenCalled_UpdatesExistingMetaProperly() {
+		/* Arrange */
+		$this->login_as_admin();
+		$user_id = get_current_user_id();
+		$before  = get_user_meta( $user_id, 'sensei_tours', true );
+
+		/* Act */
+		$this->instance->set_tour_completion_status( 'test-tour-id', true, $user_id );
+		$after_true = get_user_meta( $user_id, 'sensei_tours', true );
+
+		$this->instance->set_tour_completion_status( 'test-tour-id', false, $user_id );
+		$after_false = get_user_meta( $user_id, 'sensei_tours', true );
+
+		/* Assert */
+		$this->assertEmpty( $before );
+		$this->assertTrue( $after_true['test-tour-id'] );
+		$this->assertFalse( $after_false['test-tour-id'] );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-tour.php
+++ b/tests/unit-tests/admin/test-class-sensei-tour.php
@@ -176,4 +176,31 @@ class Sensei_Tour_Test extends WP_UnitTestCase {
 		$this->assertTrue( $after_true['test-tour-id'] );
 		$this->assertFalse( $after_false['test-tour-id'] );
 	}
+
+	public function testGetTourCompletionStatus_WhenMetaDoesNotExist_ReturnsFalse() {
+		/* Arrange */
+		$this->login_as_admin();
+		$user_id = get_current_user_id();
+
+		/* Act */
+		$is_complete = $this->instance->get_tour_completion_status( 'test-tour-id', $user_id );
+
+		/* Assert */
+		$this->assertFalse( $is_complete );
+	}
+
+	public function testGetTourCompletionStatus_WhenMetaSetToTrue_ReturnsTrueForCorrectId() {
+		/* Arrange */
+		$this->login_as_admin();
+		$user_id = get_current_user_id();
+		$this->instance->set_tour_completion_status( 'test-tour-id_1', true, $user_id );
+
+		/* Act */
+		$is_complete   = $this->instance->get_tour_completion_status( 'test-tour-id', $user_id );
+		$is_complete_1 = $this->instance->get_tour_completion_status( 'test-tour-id_1', $user_id );
+
+		/* Assert */
+		$this->assertFalse( $is_complete );
+		$this->assertTrue( $is_complete_1 );
+	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-tour-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-tour-controller.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Tour_Controller tests
+ *
+ * @package sensei
+ * @since   $$next-version$$
+ */
+
+use Sensei\Admin\Tour\Sensei_Tour;
+
+/**
+ * Class Sensei_REST_API_Tour_Controller tests.
+ *
+ * @covers Sensei\Admin\Tour\Sensei_REST_API_Tour_Controller
+ */
+class Sensei_Rest_Api_Tour_Controller_Test extends \WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * A server instance that we use in tests to dispatch requests.
+	 *
+	 * @var WP_REST_Server $server
+	 */
+	protected $server;
+
+	const REST_ROUTE = '/sensei-internal/v1/tour';
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Setup REST server for integration tests.
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		$controller     = new \Sensei\Admin\Tour\Sensei_REST_API_Tour_Controller( 'sensei-internal/v1', Sensei_Tour::instance() );
+
+		add_action( 'rest_api_init', [ $controller, 'register_routes' ] );
+
+		do_action( 'rest_api_init' );
+	}
+
+	public function tearDown(): void {
+		// Unregister REST server.
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	public function testSetTourCompletionStatus_WhenRequestSent_SetsMetaCorrectly() {
+		$this->login_as_teacher();
+
+		$request = new \WP_REST_Request( 'POST', self::REST_ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'tour_id'  => 'test_id',
+					'complete' => true,
+				]
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( Sensei_Tour::instance()->get_tour_completion_status( 'test_id', get_current_user_id() ) );
+		$this->assertFalse( Sensei_Tour::instance()->get_tour_completion_status( 'test_id_1', get_current_user_id() ) );
+	}
+}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-tour-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-tour-controller.php
@@ -51,6 +51,7 @@ class Sensei_Rest_Api_Tour_Controller_Test extends \WP_UnitTestCase {
 	}
 
 	public function testSetTourCompletionStatus_WhenRequestSent_SetsMetaCorrectly() {
+		/* Arrange */
 		$this->login_as_teacher();
 
 		$request = new \WP_REST_Request( 'POST', self::REST_ROUTE );
@@ -63,9 +64,40 @@ class Sensei_Rest_Api_Tour_Controller_Test extends \WP_UnitTestCase {
 				]
 			)
 		);
-		$response = $this->server->dispatch( $request );
 
+		/* Act */
+		$this->server->dispatch( $request );
+
+		/* Assert */
 		$this->assertTrue( Sensei_Tour::instance()->get_tour_completion_status( 'test_id', get_current_user_id() ) );
 		$this->assertFalse( Sensei_Tour::instance()->get_tour_completion_status( 'test_id_1', get_current_user_id() ) );
+	}
+
+	public function testSetTourCompletionStatus_WhenRequestSentForExistingMeta_UpdatesExistingMetaCorrectly() {
+		/* Arrange */
+		$this->login_as_teacher();
+		$user_id = get_current_user_id();
+		$tour_id = 'test_id_1';
+
+		Sensei_Tour::instance()->set_tour_completion_status( $tour_id, true, $user_id );
+		$initial_status = Sensei_Tour::instance()->get_tour_completion_status( $tour_id, $user_id );
+
+		$request = new \WP_REST_Request( 'POST', self::REST_ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'tour_id'  => $tour_id,
+					'complete' => false,
+				]
+			)
+		);
+
+		/* Act */
+		$this->server->dispatch( $request );
+
+		/* Assert */
+		$this->assertTrue( $initial_status );
+		$this->assertFalse( Sensei_Tour::instance()->get_tour_completion_status( $tour_id, $user_id ) );
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7501

## Proposed Changes
When a user closes or skips a tour, we're presenting that data here so that the user does not see that specific tour again.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm` and `composer` installation
2. Go to Course editor by creating a new Course
3. Make sure the the Tour does not appear until you complete/close the Course creation modals
4. Make sure you see a tour loaded
5. Without doing anything else, just refresh the page
6. Make sure the tour still loads
7. Now click on the skip button or the Cross button on that tour modal
8. Refresh the page
9. Make sure you don't see the Course tour loading again
10. Now go to a lesson
11. Make sure you see the lesson tour. Seeing the lesson tour confirms that Persisting status for one tour isn't affecting another tour
12. Now skip or Cross the lesson tour
13. Now refresh the page
14. Make sure you don't see the lesson tour
15. Go back to Course edit page again
16. Make sure you don't see the tour

If you want to retest, open database table `wp_usermeta` and delete the rows with key `sensei_tours`. The tour will appear again.

https://github.com/Automattic/sensei/assets/6820724/0e5434b3-58ad-4681-bd91-94efd703d2b9

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* `sensei_tour_is_complete` - Allows user to override the status of a tour being complete, to either load or not load it.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
