### PR TITLE
Fix patterns flicker on WPCOM

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
@@ -46,27 +46,6 @@ const EditorWizardModal = () => {
 		setDefaultPattern();
 		onWizardCompletion();
 	};
-
-	const { setShowWelcomeGuide } =
-		useDispatch( 'automattic/wpcom-welcome-guide' ) ?? {};
-
-	const { isShowWelcomeGuide } = useSelect( ( select ) => {
-		const { isWelcomeGuideShown } =
-			select( 'automattic/wpcom-welcome-guide' ) ?? {};
-		return {
-			isShowWelcomeGuide: isWelcomeGuideShown
-				? isWelcomeGuideShown()
-				: false,
-		};
-	}, [] );
-
-	useEffect( () => {
-		if ( setShowWelcomeGuide && isShowWelcomeGuide ) {
-			setShowWelcomeGuide( undefined, {
-				onlyLocal: true,
-			} );
-		}
-	}, [ setShowWelcomeGuide, isShowWelcomeGuide ] );
 
 	return (
 		open && (

--- a/assets/admin/editor-wizard/index.js
+++ b/assets/admin/editor-wizard/index.js
@@ -10,7 +10,11 @@ import { addFilter } from '@wordpress/hooks';
 import EditorWizardModal from './editor-wizard-modal';
 
 // Hide welcome tour from WPCOM.
-addFilter( 'a8c.WpcomBlockEditorWelcomeTour.show', false );
+addFilter(
+	'a8c.WpcomBlockEditorWelcomeTour.show',
+	'sensei-lms/editor-wizard',
+	() => false
+);
 
 registerPlugin( 'sensei-editor-wizard-plugin', {
 	render: EditorWizardModal,

--- a/assets/admin/editor-wizard/index.js
+++ b/assets/admin/editor-wizard/index.js
@@ -2,11 +2,15 @@
  * WordPress dependencies
  */
 import { registerPlugin } from '@wordpress/plugins';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
 import EditorWizardModal from './editor-wizard-modal';
+
+// Hide welcome tour from WPCOM.
+addFilter( 'a8c.WpcomBlockEditorWelcomeTour.show', false );
 
 registerPlugin( 'sensei-editor-wizard-plugin', {
 	render: EditorWizardModal,

--- a/changelog/fix-patterns-flicker-on-wpcom
+++ b/changelog/fix-patterns-flicker-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Address the issue of patterns flickering in the editor wizard on WPCOM sites

--- a/includes/admin/class-sensei-editor-wizard.php
+++ b/includes/admin/class-sensei-editor-wizard.php
@@ -47,7 +47,7 @@ class Sensei_Editor_Wizard {
 	public function init() {
 		add_action( 'init', [ $this, 'register_post_metas' ] );
 		// Priority 9 to make sure it will run before the block editor nux on WPCOM. While this code is written, it uses priority 100.
-		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ], 9 );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_wizard_assets' ], 9 );
 	}
 
 	/**
@@ -78,18 +78,18 @@ class Sensei_Editor_Wizard {
 	 *
 	 * @access private
 	 *
-	 * @deprecated $$next-version$$ use Sensei_Editor_Wizard::enqueue_block_editor_assets instead.
+	 * @deprecated $$next-version$$ use Sensei_Editor_Wizard::enqueue_editor_wizard_assets instead.
 	 */
 	public function enqueue_admin_scripts( $hook_suffix ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Editor_Wizard::enqueue_block_editor_assets' );
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Editor_Wizard::enqueue_editor_wizard_assets' );
 
-		$this->enqueue_block_editor_assets();
+		$this->enqueue_editor_wizard_assets();
 	}
 
 	/**
-	 * Enqueue block editor assets.
+	 * Enqueue editor wizard assets.
 	 */
-	public function enqueue_block_editor_assets() {
+	public function enqueue_editor_wizard_assets() {
 		global $pagenow;
 
 		$post_type   = get_post_type();

--- a/includes/admin/class-sensei-editor-wizard.php
+++ b/includes/admin/class-sensei-editor-wizard.php
@@ -80,7 +80,7 @@ class Sensei_Editor_Wizard {
 	 *
 	 * @deprecated $$next-version$$ use Sensei_Editor_Wizard::enqueue_block_editor_assets instead.
 	 */
-	public function create_pages( $hook_suffix ) {
+	public function enqueue_admin_scripts( $hook_suffix ) {
 		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Editor_Wizard::enqueue_block_editor_assets' );
 
 		$this->enqueue_block_editor_assets();

--- a/includes/admin/class-sensei-editor-wizard.php
+++ b/includes/admin/class-sensei-editor-wizard.php
@@ -46,7 +46,8 @@ class Sensei_Editor_Wizard {
 	 */
 	public function init() {
 		add_action( 'init', [ $this, 'register_post_metas' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
+		// Priority 9 to make sure it will run before the block editor nux on WPCOM. While this code is written, it uses priority 100.
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ], 9 );
 	}
 
 	/**
@@ -76,13 +77,26 @@ class Sensei_Editor_Wizard {
 	 * @param string $hook_suffix The current admin page.
 	 *
 	 * @access private
+	 *
+	 * @deprecated $$next-version$$ use Sensei_Editor_Wizard::enqueue_block_editor_assets instead.
 	 */
-	public function enqueue_admin_scripts( $hook_suffix ) {
+	public function create_pages( $hook_suffix ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Editor_Wizard::enqueue_block_editor_assets' );
+
+		$this->enqueue_block_editor_assets();
+	}
+
+	/**
+	 * Enqueue block editor assets.
+	 */
+	public function enqueue_block_editor_assets() {
+		global $pagenow;
+
 		$post_type   = get_post_type();
 		$post_id     = get_the_ID();
 		$new_post    = get_post_meta( $post_id, '_new_post', true );
 		$post_types  = [ 'course', 'lesson' ];
-		$is_new_post = 'post-new.php' === $hook_suffix || $new_post;
+		$is_new_post = 'post-new.php' === $pagenow || $new_post;
 
 		if ( $is_new_post && in_array( $post_type, $post_types, true ) ) {
 			Sensei()->assets->enqueue( 'sensei-editor-wizard-script', 'admin/editor-wizard/index.js' );

--- a/includes/admin/class-sensei-editor-wizard.php
+++ b/includes/admin/class-sensei-editor-wizard.php
@@ -80,7 +80,7 @@ class Sensei_Editor_Wizard {
 	 *
 	 * @deprecated $$next-version$$ use Sensei_Editor_Wizard::enqueue_editor_wizard_assets instead.
 	 */
-	public function enqueue_admin_scripts( $hook_suffix ) {
+	public function enqueue_admin_scripts( $hook_suffix ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Editor_Wizard::enqueue_editor_wizard_assets' );
 
 		$this->enqueue_editor_wizard_assets();


### PR DESCRIPTION
Resolves #7507
Depends on https://github.com/Automattic/wp-calypso/pull/87903

## Proposed Changes

* It updates the current logic to not display the editor welcome tour in the WPCOM editor, while displaying the Course or Lesson wizard.

### Considered alternatives:

* I tried to simulate the same behavior as the page editor on WPCOM, which also hides the welcome tour, but the actions are tied to other behaviors.
* Currently the `setShowWelcomeGuide` is trying to set the value as `undefined`, which creates a loop fetching for the state persisted in the backend.
* If we change to `false`, it works, but even with the `onlyLocal`, it's persisted in the local storage, so if we do it, it's not displayed in the other posts.
* There is a backend filter with the name `wpcom_block_editor_nux_get_status`, but it's an ajax request without context of the current page, so it's not enough for this case. (I thought some other things related to this and documented in the dependency PR, but decided on the JS hook).

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout the dependency.
2. Build it as described in the plugin folder in the dependency repository.
3. Upload it to your atomic test site.
4. Upload the Sensei plugin with this version to your website.
5. Make sure your environment is new (you never dismissed the editor welcome tour) or force it to be displayed with `wp.data.dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true )`.
6. Check that it is displayed on a normal post.
7. Check that it's not displayed in the Course and in the Lesson when the editor wizard is displayed.
8. In the wizard, navigate to the patterns step, and make sure it's not flickering anymore.
9. Check again that it continues being displayed in the normal post (it wasn't dismissed).
10. Now test the Course and Lesson wizard in a normal site (not atomic), and make sure it continues working properly.

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

* `Sensei_Editor_Wizard::enqueue_admin_scripts `

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
