### PR TITLE
Fix test_WPUserQuery_HasNoTemporaryUsers for WP nightly build

### DIFF
--- a/tests/unit-tests/test-class-sensei-temporary-user.php
+++ b/tests/unit-tests/test-class-sensei-temporary-user.php
@@ -28,7 +28,6 @@ class Sensei_Temporary_User_Test extends WP_UnitTestCase {
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Temporary_User::init();
-
 	}
 
 	private function create_learners() {
@@ -63,7 +62,6 @@ class Sensei_Temporary_User_Test extends WP_UnitTestCase {
 		Sensei_Utils::update_course_status( $guestuser1_id, $course2_id );
 
 		return [ $course1_id ];
-
 	}
 
 	/**
@@ -160,9 +158,8 @@ class Sensei_Temporary_User_Test extends WP_UnitTestCase {
 	public function test_WPUserQuery_HasNoTemporaryUsers() {
 		$this->create_learners();
 
-		$learners = get_users();
+		$learners = get_users( array( 'fields' => 'user_email' ) );
 
-		self::assertSame( [ 'admin@example.org', 'user1@example.com', 'user2@example.com' ], wp_list_pluck( $learners, 'user_email' ) );
+		self::assertSame( array( 'admin@example.org', 'user1@example.com', 'user2@example.com' ), $learners );
 	}
-
 }


### PR DESCRIPTION
There are some changes in the WP nightly build that affect how wp_list_plunk works with an array of users. I didn't find the exact changes there, but found a way to fix tests being even more native :)

## Proposed Changes
* Fix `Sensei_Temporary_User_Test::test_WPUserQuery_HasNoTemporaryUsers` for WP nightly build.

## Testing Instructions
1. Check unit tests in CI for WP nightly.
2. Test locally. First remove you current WP build: `rm -rf /tmp/wordpress`.
3. Install WP nightly: `./tests/bin/install-wp-tests.sh wptest wptest wptest localhost nightly true` (last param to skip DB creation).
4. Run tests `npm run test-php`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [X] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
