### PR TITLE
Fix lesson bulk edit

### DIFF
--- a/changelog/fix-lesson-bulk-edit
+++ b/changelog/fix-lesson-bulk-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix lesson bulk edit.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -139,7 +139,7 @@ class Sensei_Lesson {
 			add_action( 'manage_lesson_posts_custom_column', array( $this, 'set_quick_edit_admin_defaults' ), 11, 2 );
 
 			// save bulk edit fields
-			add_action( 'wp_ajax_save_bulk_edit_book', array( $this, 'save_all_lessons_edit_fields' ) );
+			add_action( 'save_post', array( $this, 'save_all_lessons_edit_fields' ) );
 
 			add_action( 'admin_head', array( $this, 'add_custom_link_to_course' ) );
 
@@ -706,7 +706,6 @@ class Sensei_Lesson {
 		$this->save_quiz_settings( $post_id, $new_settings );
 
 		return $post_id;
-
 	}
 
 	/**
@@ -4323,38 +4322,47 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Respond to the ajax call from the bulk edit save function. This comes
-	 * from the admin all lesson screen.
+	 * Respond to the ajax call from the bulk edit save function.
+	 * This comes from the admin all lesson screen.
 	 *
 	 * @since 1.8.0
+	 *
+	 * @internal
 	 */
-	function save_all_lessons_edit_fields() {
-
-		// verify all the data before attempting to save
-		if ( ! isset( $_POST['security'] ) || ! check_ajax_referer( 'bulk-edit-lessons', 'security' ) || empty( $_POST['post_ids'] ) || ! is_array( $_POST['post_ids'] ) ) {
-			die();
+	public function save_all_lessons_edit_fields() {
+		// Verify all the data before attempting to save.
+		if ( ! isset( $_REQUEST['_edit_lessons_nonce'] )
+			|| ! check_ajax_referer( 'bulk-edit-lessons', '_edit_lessons_nonce' )
+			|| empty( $_REQUEST['post'] )
+			|| ! is_array( $_REQUEST['post'] ) ) {
+			return;
 		}
 
-		// get our variables
-		$new_course            = isset( $_POST['sensei_edit_lesson_course'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_lesson_course'] ) ) : '';
-		$new_complexity        = isset( $_POST['sensei_edit_complexity'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_complexity'] ) ) : '';
-		$new_pass_required     = isset( $_POST['sensei_edit_pass_required'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_pass_required'] ) ) : '';
-		$new_pass_percentage   = isset( $_POST['sensei_edit_pass_percentage'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_pass_percentage'] ) ) : '';
-		$new_enable_quiz_reset = isset( $_POST['sensei_edit_enable_quiz_reset'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_enable_quiz_reset'] ) ) : '';
-		$show_questions        = isset( $_POST['sensei_edit_show_questions'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_show_questions'] ) ) : '';
-		$random_question_order = isset( $_POST['sensei_edit_random_question_order'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_random_question_order'] ) ) : '';
-		$quiz_grade_type       = isset( $_POST['sensei_edit_quiz_grade_type'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_quiz_grade_type'] ) ) : '';
-		// store the values for all selected posts.
-		foreach ( $_POST['post_ids'] as $lesson_id ) {
+		// Get our variables.
+		$new_course            = isset( $_REQUEST['lesson_course'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['lesson_course'] ) ) : '';
+		$new_complexity        = isset( $_REQUEST['lesson_complexity'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['lesson_complexity'] ) ) : '';
+		$new_pass_required     = isset( $_REQUEST['pass_required'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['pass_required'] ) ) : '';
+		$new_pass_percentage   = isset( $_REQUEST['quiz_passmark'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['quiz_passmark'] ) ) : '';
+		$new_enable_quiz_reset = isset( $_REQUEST['enable_quiz_reset'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['enable_quiz_reset'] ) ) : '';
+		$show_questions        = isset( $_REQUEST['show_questions'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['show_questions'] ) ) : '';
+		$random_question_order = isset( $_REQUEST['random_question_order'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['random_question_order'] ) ) : '';
+		$quiz_grade_type       = isset( $_REQUEST['quiz_grade_type'] ) ? sanitize_text_field( (string) wp_unslash( $_REQUEST['quiz_grade_type'] ) ) : '';
 
-			// do not save the items if the value is -1 as this
-			// means it was not changed
-			// update lesson course
-			if ( - 1 !== $new_course ) {
+		// Store the values for all selected posts.
+		$lesson_ids = $_REQUEST['post'] ?? array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Input is sanitized in the next lines.
+		$lesson_ids = array_map( 'wp_unslash', $lesson_ids );
+		$lesson_ids = array_map( 'sanitize_text_field', $lesson_ids );
+		$lesson_ids = array_map( 'intval', $lesson_ids );
+		foreach ( $lesson_ids as $lesson_id ) {
+			// Do not save the items if the value is -1 as this means it was not changed.
+
+			// Update lesson course.
+			if ( '-1' !== $new_course ) {
 				update_post_meta( $lesson_id, '_lesson_course', $new_course );
 			}
-			// update lesson complexity
-			if ( -1 !== $new_complexity ) {
+
+			// Update lesson complexity.
+			if ( '-1' !== $new_complexity ) {
 				update_post_meta( $lesson_id, '_lesson_complexity', $new_complexity );
 			}
 
@@ -4368,11 +4376,7 @@ class Sensei_Lesson {
 			);
 
 			$this->save_quiz_settings( $lesson_id, $new_settings );
-
 		}
-
-		die();
-
 	}
 
 	/**


### PR DESCRIPTION
Resolves #6992 

I suppose something has changed in how the form works a few years ago. Updated the processing of data.

## Proposed Changes

* Fix lesson bulk edit. 

## Testing Instructions

1. Create a lesson. 
2. Create a few lessons without assigning them to a course.
3. Open lesson list in WP admin, check lessons and choose Edit as a bulk action, then Apply.
4. Update Sensei specific properties (you can test WP properties as well, they are managed by WP), click Update. 
5. Make sure lessons have updated data.

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
