### PR TITLE
Fix Sensei Email template being set as default template in editor when Gutenberg is installed

### DIFF
--- a/changelog/fix-email-post-type-being-set-for-all-posts
+++ b/changelog/fix-email-post-type-being-set-for-all-posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email Template showing up as default template in editor when GB is installed

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -44,7 +44,6 @@ class Email_Page_Template {
 	 */
 	public function __construct( Email_Page_Template_Repository $repository ) {
 		$this->repository = $repository;
-
 	}
 
 	/**
@@ -115,6 +114,14 @@ class Email_Page_Template {
 	 */
 	public function add_email_template( $query_result, $query, $template_type ) {
 		if ( ! \Sensei_Course_Theme_Editor::is_site_editor_request() ) {
+			return $query_result;
+		}
+
+		$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+
+		// Returning early if it's Gutenberg's template lookup ajax request,
+		// otherwise it shows the template in editor as default template.
+		if ( $uri && strpos( $uri, '/wp-json/wp/v2/templates/lookup?slug' ) !== false ) {
 			return $query_result;
 		}
 

--- a/tests/unit-tests/internal/emails/test-class-email-page-template.php
+++ b/tests/unit-tests/internal/emails/test-class-email-page-template.php
@@ -245,5 +245,22 @@ class Email_Page_Template_Test extends \WP_UnitTestCase {
 		self::assertSame( $template_to_be_added, $result[1] );
 	}
 
+	public function testAddEmailTemplate_WhenAjaxLookupRequest_ReturnsListWithoutUpdating() {
+		/* Arrange. */
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/templates/lookup?slug=single-post-hello-world&_locale=user';
+		$repository             = $this->createMock( Email_Page_Template_Repository::class );
+		$page_template          = new Email_Page_Template( $repository );
+		$default_list           = [ $this->createMock( \WP_Block_Template::class ) ];
+		$template_to_be_added   = $this->createMock( \WP_Block_Template::class );
 
+		$repository
+			->method( 'get' )
+			->willReturn( $template_to_be_added );
+
+		/* Act. */
+		$result = $page_template->add_email_template( $default_list, [], 'wp_template' );
+
+		/* Assert. */
+		self::assertSame( $default_list, $result );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7516

## Proposed Changes
The latest GB sends an Ajax request to the server and fetches available templates. When we include the Sensei Email template using the `get_block_templates` filter, we check the Post Type, URL, template type, etc to make sure to only load this template for either `sensei_email` CPT or Site Editor (in which case, the current post type is null). But this ajax request was passing the Site Editor check because of its URL structure. To prevent it, we are returning early without adding Sensei Email to the list when it's a lookup request from the editor.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have latest Gutenberg installed
2. Have DEBUG logging on
3. Open an existing and a new Post in GB editor
4. Make sure Sensei Email is not set as the Template
5. Check the same for Pages, Courses and Lessons
6. Check Sensei LMS -> Settings -> Emails
7. Open and Email and make sure it's appearing as before
8. Send an Email and make sure it's working as before
9. Open site editor and make sure Sensei Email is there
10. Disable Gutenberg and perform the same tests, make sure nothing is breaking
11. Check your debug log and make sure you don't see any error - especially something like `PHP Warning:  Undefined array key "single-sensei_email" in ........`

Bonus: Try thinking about any scenario where it can have side effects and check if it does. LMK if you find any.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
