### PR TITLE
Show tours only for new Sensei installations

### DIFF
--- a/includes/admin/class-sensei-tour.php
+++ b/includes/admin/class-sensei-tour.php
@@ -71,7 +71,8 @@ class Sensei_Tour {
 			in_array( $hook, [ 'post-new.php', 'post.php' ], true )
 		) {
 			$tour_loaders[ "sensei-$post_type-tour" ] = [
-				'path' => "admin/tour/$post_type-tour/index.js",
+				'minimum_install_version' => '$$next-version$$', // TODO: Add different version for lesson tour later if needed.
+				'path'                    => "admin/tour/$post_type-tour/index.js",
 			];
 		}
 
@@ -91,6 +92,17 @@ class Sensei_Tour {
 		$incomplete_tours = [];
 
 		foreach ( $tour_loaders as $handle => $tour_loader ) {
+			$install_version = \Sensei()->install_version ?? '';
+			$install_version = $install_version ? $install_version : ''; // In case the value is false, null coalescing won't work.
+			$minimum_version = $tour_loader['minimum_install_version'] ?? false;
+
+			if (
+				$minimum_version &&
+				! version_compare( $install_version, $tour_loader['minimum_install_version'] ?? '', '>=' )
+			) {
+				continue;
+			}
+
 			/**
 			 * Filters the tour completion status.
 			 *


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7509

## Proposed Changes
After some discussion, we decided to show the tours only in new installations of Sensei. As we can incrementally add tours in our newer versions, we centrally added a mechanism in the loader so that it loads tours only if Sensei's installation version fulfills the requirement. I am using the version number approach here as we're already utilizing it in Sensei in some other places and it's been there since version 1.0.0. We don't need to save any additional `option` value in the db for it and later check it, so we don't need any extra db call here either. Also, this happens centrally, so we won't need setting up new option flags for each new tour we'll be introducing later. We'll just mention a version number in that tour and it'll work.

Note: As we exactly don't know which version we're going to release it in, I've added a `$$next-version$$` placeholder instead of a hardcoded version. I've also added a TODO comment there to add a separate version for the Lesson Tour later in case we decide to have a separate version requirement for Lesson Tour. To make sure this TODO is taken care of, I'll create a high-priority issue (https://github.com/Automattic/sensei/issues/7520) for it for the next milestone. (cc: @donnapep , please LMK if you think this process/logic is okay)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open a Course with a Course Outline block in it and make sure you see the Course tour
2. Open a Lesson with a Quiz block in it and make sure you see the Quiz tour
3. Now in your local environment, replace the '$$next-version$$' tag in this code to a version like '4.22.1' and in `class-sensei.php`, hardcode the value of `$install_version` to a version smaller than that. (You can also change it in the database, go to `wp-options` table and change the `option_value` of the `sensei-install-version` `option_name` and then refresh your option cache).
4. Make sure you don't see the tours now in Courses and Lessons
5. Now set `$install_version` to a higher version and make sure you see the tours
6. Cross a tour, refresh the page and make sure you don't see the tour again to check that persisting your choice still works.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues