### PR TITLE
Add a test for lesson bulk edit

### DIFF
--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -116,7 +116,6 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
 		// test if the global sensei lesson class is loaded
 		$this->assertTrue( isset( Sensei()->lesson ), 'Sensei lesson class is not loaded on the global sensei Object' );
-
 	}
 
 
@@ -168,7 +167,6 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			Sensei_Lesson::is_prerequisite_complete( $test_lesson_id, $test_user_id, true ),
 			'Users that has completed prerequisite should return true.'
 		);
-
 	}
 
 	/**
@@ -778,7 +776,6 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
 		/* Assert */
 		self::assertEmpty( $output );
-
 	}
 
 	public function providerAddCustomNavigation_WhenWrongScreen_DoesntHaveOutput(): array {
@@ -1653,7 +1650,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			'lesson_course'       => $course_id,
 			'lesson_complexity'   => 'hard',
 		);
-		$lesson   = new Sensei_Lesson();
+		$lesson    = new Sensei_Lesson();
 
 		/* Act */
 		$lesson->save_all_lessons_edit_fields();
@@ -1670,4 +1667,3 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $actual );
 	}
 }
-

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1642,5 +1642,32 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( [ $question_1, $question_2 ], $question_ids );
 	}
+
+	public function testSaveAllLessonsEditFields_WhenCalled_UpdatesPostMeta(): void {
+		/* Arrange */
+		$lesson_id = $this->factory->lesson->create();
+		$course_id = $this->factory->course->create();
+		$_REQUEST  = array(
+			'_edit_lessons_nonce' => wp_create_nonce( 'bulk-edit-lessons' ),
+			'post'                => array( $lesson_id ),
+			'lesson_course'       => $course_id,
+			'lesson_complexity'   => 'hard',
+		);
+		$lesson   = new Sensei_Lesson();
+
+		/* Act */
+		$lesson->save_all_lessons_edit_fields();
+
+		/* Assert */
+		$expected = array(
+			'_lesson_course'     => $course_id,
+			'_lesson_complexity' => 'hard',
+		);
+		$actual   = array(
+			'_lesson_course'     => (int) get_post_meta( $lesson_id, '_lesson_course', true ),
+			'_lesson_complexity' => get_post_meta( $lesson_id, '_lesson_complexity', true ),
+		);
+		self::assertSame( $expected, $actual );
+	}
 }
 


### PR DESCRIPTION
As a follow up for https://github.com/Automattic/sensei/pull/7515
Unfortunately, it is not possible to test integration between frontend and backend here, so I just add a general test for the handler.

## Proposed Changes
* Add a test for lesson bulk edit handler.

## Testing Instructions
1. Make sure CI is green.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
