### PR TITLE
Fix default quiz passing grade

### DIFF
--- a/assets/blocks/quiz/quiz-block/block.json
+++ b/assets/blocks/quiz/quiz-block/block.json
@@ -24,7 +24,7 @@
 			"type": "object",
 			"default": {
 				"passRequired": false,
-				"quizPassmark": 100,
+				"quizPassmark": 0,
 				"autoGrade": true,
 				"allowRetakes": true,
 				"randomQuestionOrder": false,

--- a/changelog/fix-default-quiz-passmark
+++ b/changelog/fix-default-quiz-passmark
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that default passing grade will be "0" for any situation


### PR DESCRIPTION
## Proposed Changes

* It fixes an issue noticed on Learnomattic where the default passing grade was `100` eventually (probably because ajax requests work in a different way/order there).
* The default [value on the server is `0`](https://github.com/Automattic/sensei/blob/91c69406ebf041614325de38c6da8c80e86fe227/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php#L382C1-L382C5) and the block was setting the default attribute to `100`, so when it tried to sync front/server, it was updating to `0` (this update to `0` was failing in the situation mentioned above).
* Notice that this behavior didn't happen in an unsaved new lesson (created through WP Admin > Sensei LMS > Lessons) because this time the lesson doesn't have an associated quiz yet, and [the endpoint returns earlier](https://github.com/Automattic/sensei/blob/91c69406ebf041614325de38c6da8c80e86fe227/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php#L340).

## Pending

I'll still explore some scenarios to check if weird behaviors related to this won't hide the answer feedback in the quiz (the original issue related to this).

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Update the `QuizSettings` adding a `console.log( { quizPassmark } );`.
2. Create a lesson through the course outline, and make sure the `quizPassmark` is always `0`.
3. Create a lesson through WP Admin > Sensei LMS > Lessons, and make sure the `quizPassmark` is always `0`.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
