### PR TITLE
Fix inconsistency between Pass Required and Passing Grade for answer feedback

### DIFF
--- a/changelog/fix-answer-feedback
+++ b/changelog/fix-answer-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Don't show answer feedback wrapper when feedback will not be displayed
+Ignore Passing Grade for answer feedback when Pass Required is turned off

--- a/changelog/fix-answer-feedback
+++ b/changelog/fix-answer-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't show answer feedback wrapper when feedback will not be displayed

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1038,7 +1038,7 @@ class Sensei_Question {
 		$has_answer_notes = $answer_notes && wp_strip_all_tags( $answer_notes );
 
 		?>
-		<?php if ( $$indicate_incorrect || $has_answer_notes || $correct_answer ) { ?>
+		<?php if ( $indicate_incorrect || $has_answer_notes || $correct_answer ) { ?>
 			<div class="sensei-lms-question__answer-feedback <?php echo esc_attr( implode( ' ', $answer_notes_classnames ) ); ?>">
 				<?php if ( $indicate_incorrect ) { ?>
 					<div class="sensei-lms-question__answer-feedback__header">

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1240,16 +1240,16 @@ class Sensei_Question {
 	 */
 	public static function get_template_data( $question_id, $quiz_id ) {
 
-		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
-		$user_id   = get_current_user_id();
+		$lesson_id = (int) Sensei()->quiz->get_lesson_id( $quiz_id );
+		$user_id   = (int) get_current_user_id();
 
 		$reset_allowed = get_post_meta( $quiz_id, '_enable_quiz_reset', true );
-		// backwards compatibility
+		// Backwards compatibility.
 		if ( 'on' === $reset_allowed ) {
 			$reset_allowed = 1;
 		}
 
-		// setup the question data
+		// Setup the question data.
 		$data                           = [];
 		$data['ID']                     = $question_id;
 		$data['title']                  = get_the_title( $question_id );

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -923,7 +923,7 @@ class Sensei_Question {
 		$quiz_graded        = $user_quiz_progress && ! in_array( $user_quiz_progress->get_status(), array( 'ungraded', 'in-progress' ) );
 
 		$quiz_required_pass_grade = intval( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
-		$succeeded                = $user_quiz_grade >= $quiz_required_pass_grade;
+		$succeeded                = ! Sensei_Quiz::is_pass_required( $lesson_id ) || $user_quiz_grade >= $quiz_required_pass_grade;
 
 		if ( ! $quiz_graded ) {
 			return;

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1038,33 +1038,35 @@ class Sensei_Question {
 		$has_answer_notes = $answer_notes && wp_strip_all_tags( $answer_notes );
 
 		?>
-		<div class="sensei-lms-question__answer-feedback <?php echo esc_attr( implode( ' ', $answer_notes_classnames ) ); ?>">
-			<?php if ( $indicate_incorrect ) { ?>
-				<div class="sensei-lms-question__answer-feedback__header">
-					<span class="sensei-lms-question__answer-feedback__icon"></span>
-					<span
-						class="sensei-lms-question__answer-feedback__title"><?php echo wp_kses_post( $answer_feedback_title ); ?></span>
-					<?php if ( $grade && $question_grade > 0 ) { ?>
-						<span class="sensei-lms-question__answer-feedback__points"><?php echo wp_kses_post( $grade ); ?></span>
-					<?php } ?>
-				</div>
-			<?php } ?>
-			<?php if ( $has_answer_notes || $correct_answer ) { ?>
-				<div class="sensei-lms-question__answer-feedback__content">
-					<?php if ( $correct_answer ) { ?>
-						<div class="sensei-lms-question__answer-feedback__correct-answer">
-							<?php echo wp_kses_post( __( 'Right Answer:', 'sensei-lms' ) ); ?>
-							<?php echo wp_kses_post( $correct_answer ); ?>
-						</div>
-					<?php } ?>
-					<?php if ( $has_answer_notes ) { ?>
-						<div class="sensei-lms-question__answer-feedback__answer-notes">
-							<?php echo wp_kses_post( $answer_notes ); ?>
-						</div>
-					<?php } ?>
-				</div>
-			<?php } ?>
-		</div>
+		<?php if ( $$indicate_incorrect || $has_answer_notes || $correct_answer ) { ?>
+			<div class="sensei-lms-question__answer-feedback <?php echo esc_attr( implode( ' ', $answer_notes_classnames ) ); ?>">
+				<?php if ( $indicate_incorrect ) { ?>
+					<div class="sensei-lms-question__answer-feedback__header">
+						<span class="sensei-lms-question__answer-feedback__icon"></span>
+						<span
+							class="sensei-lms-question__answer-feedback__title"><?php echo wp_kses_post( $answer_feedback_title ); ?></span>
+						<?php if ( $grade && $question_grade > 0 ) { ?>
+							<span class="sensei-lms-question__answer-feedback__points"><?php echo wp_kses_post( $grade ); ?></span>
+						<?php } ?>
+					</div>
+				<?php } ?>
+				<?php if ( $has_answer_notes || $correct_answer ) { ?>
+					<div class="sensei-lms-question__answer-feedback__content">
+						<?php if ( $correct_answer ) { ?>
+							<div class="sensei-lms-question__answer-feedback__correct-answer">
+								<?php echo wp_kses_post( __( 'Right Answer:', 'sensei-lms' ) ); ?>
+								<?php echo wp_kses_post( $correct_answer ); ?>
+							</div>
+						<?php } ?>
+						<?php if ( $has_answer_notes ) { ?>
+							<div class="sensei-lms-question__answer-feedback__answer-notes">
+								<?php echo wp_kses_post( $answer_notes ); ?>
+							</div>
+						<?php } ?>
+					</div>
+				<?php } ?>
+			</div>
+		<?php } ?>
 		<?php if ( $grade ) { ?>
 			<style> .question-title .grade { display: none; } </style>
 		<?php } ?>

--- a/tests/unit-tests/test-class-sensei-question.php
+++ b/tests/unit-tests/test-class-sensei-question.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Tests for Sensei_Question class.
+ */
+class Sensei_Question_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	protected $factory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * This behavior comes from the UI because in the UI the settings related to answer feedback are hidden when pass is not required.
+	 */
+	public function testTheAnswerFeedback_WhenPassIsNotRequired_ReturnAnswerFeedbackRegardlessOtherSettings() {
+		/* Arrange */
+		$this->login_as_student();
+
+		$this->create_graded_quiz_with_metas(
+			[
+				'_pass_required'               => '',
+				'_quiz_passmark'               => '80',
+				'_failed_indicate_incorrect'   => 'no',
+				'_failed_show_correct_answers' => 'no',
+				'_failed_show_answer_feedback' => 'no',
+			]
+		);
+
+		/* Act */
+		ob_start();
+		Sensei_Question::the_answer_feedback( $question_id );
+		$output = ob_get_clean();
+
+		/* Assert */
+		$this->assertStringContainsString( '<div class="sensei-lms-question__answer-feedback__header">', $output );
+	}
+
+	public function testTheAnswerFeedback_WhenPassIsRequiredAndPassmarkIsAchieved_RespectAnswerFeedbackSettings() {
+		/* Arrange */
+		$this->login_as_student();
+
+		$this->create_graded_quiz_with_metas(
+			[
+				'_pass_required'               => 'on',
+				'_quiz_passmark'               => '80',
+				'_failed_indicate_incorrect'   => 'yes',
+				'_failed_show_correct_answers' => 'no',
+				'_failed_show_answer_feedback' => 'yes',
+			]
+		);
+
+		/* Act */
+		ob_start();
+		Sensei_Question::the_answer_feedback( $question_id );
+		$output = ob_get_clean();
+
+		/* Assert */
+		$this->assertStringContainsString( '<div class="sensei-lms-question__answer-feedback__header">', $output );
+		$this->assertStringNotContainsString( '<div class="sensei-lms-question__answer-feedback__correct-answer">', $output );
+		$this->assertStringContainsString( '<div class="sensei-lms-question__answer-feedback__answer-notes">', $output );
+	}
+
+	private function create_graded_quiz_with_metas( $metas ) {
+		// Create a quiz with a question.
+		$lesson_id   = $this->factory->lesson->create();
+		$meta_input  = wp_parse_args(
+			$metas,
+			[
+				'_quiz_lesson' => $lesson_id,
+			]
+		);
+		$quiz_id     = $this->factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => $meta_input,
+			]
+		);
+		$question_id = $this->factory->question->create( [ 'quiz_id' => $quiz_id ] );
+		$user_id     = wp_get_current_user()->ID;
+
+		// Set current post as the quiz.
+		$GLOBALS['post'] = get_post( $quiz_id );
+
+		// Create quiz answers.
+		$user_quiz_answers = $this->factory->generate_user_quiz_answers( $quiz_id );
+		Sensei()->quiz->save_user_answers( $user_quiz_answers, array(), $lesson_id, $user_id );
+
+		// Grade the quiz.
+		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
+		$quiz_progress->grade();
+		Sensei()->quiz_progress_repository->save( $quiz_progress );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-question.php
+++ b/tests/unit-tests/test-class-sensei-question.php
@@ -21,7 +21,7 @@ class Sensei_Question_Test extends WP_UnitTestCase {
 		/* Arrange */
 		$this->login_as_student();
 
-		$this->create_graded_quiz_with_metas(
+		$question_id = $this->create_graded_quiz_with_metas_including_one_question_and_return_question_id(
 			[
 				'_pass_required'               => '',
 				'_quiz_passmark'               => '80',
@@ -44,7 +44,7 @@ class Sensei_Question_Test extends WP_UnitTestCase {
 		/* Arrange */
 		$this->login_as_student();
 
-		$this->create_graded_quiz_with_metas(
+		$question_id = $this->create_graded_quiz_with_metas_including_one_question_and_return_question_id(
 			[
 				'_pass_required'               => 'on',
 				'_quiz_passmark'               => '80',
@@ -65,7 +65,7 @@ class Sensei_Question_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<div class="sensei-lms-question__answer-feedback__answer-notes">', $output );
 	}
 
-	private function create_graded_quiz_with_metas( $metas ) {
+	private function create_graded_quiz_with_metas_including_one_question_and_return_question_id( $metas ) {
 		// Create a quiz with a question.
 		$lesson_id   = $this->factory->lesson->create();
 		$meta_input  = wp_parse_args(
@@ -94,5 +94,7 @@ class Sensei_Question_Test extends WP_UnitTestCase {
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
 		$quiz_progress->grade();
 		Sensei()->quiz_progress_repository->save( $quiz_progress );
+
+		return $question_id;
 	}
 }


### PR DESCRIPTION
Related with https://github.com/Automattic/sensei/pull/7524

## Proposed Changes

It's a little complicated to explain. So to understand the context, I'd like you to use `trunk` and create a new course with a quiz, following the normal flow (through the Course Outline) and only turning on the setting "Auto Grade" on the quiz. Add to the quiz a multiple choice question with an answer feedback.

Answer the quiz as a student, and check that you will see the answer feedback. So I think we could consider it as the default behavior of a normal user, right?

The course creators could see different behaviors if they check the "Pass Required" setting, change the related settings, and turn it off.

The current behavior also has some issues like displaying the answer feedback wrapper and not displaying the content of it. See it when changing the passing grade to 100, unchecking the "Pass Required", and grading the quiz with wrong answers (not achieving the configured passing grade).

This PR fixes this inconsistency with the answers feedback by always displaying it if the "Pass Required" is turned off.

**Cons:** Users that changed the settings that are displayed when "Pass Required" is checked, and then turn it off again might see a behavior change depending on their settings.

For more context, see this: https://github.com/Automattic/sensei/blob/735df53b9062112f1e9d350db605d473f8b1f49d/includes/class-sensei-question.php#L1122-L1124

I suspect the pass required check was missed as part of this refactor: https://github.com/Automattic/sensei/pull/4408

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch.
2. Create a course with a lesson and a quiz.
3. Add at least a question with answer feedback.
4. In the quiz settings, check the option "Pass Required".
5. Change the Passing Grade to "100" and make sure the 3 toggles for Answer Feedback are unchecked.
6. Now uncheck the "Pass Required" and publish the lesson.
7. As a student, navigate to the quiz and answer it.
8. Make sure you see the answer feedback.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
