### PR TITLE
Fix 'Contact Teacher' and 'Conditional Content' block not appearing in site editor when Gutenberg enabled

### DIFF
--- a/assets/blocks/shared.js
+++ b/assets/blocks/shared.js
@@ -27,7 +27,7 @@ let postType = null;
 const unsubscribe = subscribe( () => {
 	postType = select( 'core/editor' )?.getCurrentPostType();
 
-	if ( ! postType ) {
+	if ( ! postType || 'wp_template' === postType ) {
 		return;
 	}
 

--- a/changelog/fix-contact-teacher-and-conditional-block-not-appearing
+++ b/changelog/fix-contact-teacher-and-conditional-block-not-appearing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Teacher and Conditional Content block not appearing in Site Editor when Gutenberg is enabled


### PR DESCRIPTION
Resolves issue of Contact Teacher button not appearing in site editor

Reported here 7876558-zd-a8c

## Proposed Changes
Gutenberg recently added a change where it returns `wp_template` as current post ID in site editor instead of null when `getCurrentPostType` is called. So the checks that depended on this value being 'null' to detect if it's site editor, stopped working properly. This was a similar issue.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install and activate latest Gutenberg
2. Disable Sensei Pro
3. Go to Site Editor
4. Open the Lesson template for Learning Mode 
5. Try finding the `Contact Teacher` block in the inserter, make sure it is there
6. Try finding the 'Conditional Content' block and make sure it is there
7. Now enable Sensei Pro
8. Go to Site editor again
9. Now make sure 'Contact Teacher' block is still available in the inserter but 'Conditional Content' is not
10. Disable Gutenberg and make sure this behavior still remains

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues