### PR TITLE
Remove opinionated CSS class from login form

### DIFF
--- a/changelog/remove-opinionated-block-editor-class
+++ b/changelog/remove-opinionated-block-editor-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove opinionated CSS class from login form

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1069,7 +1069,7 @@ class Sensei_Frontend {
 		 */
 
 		?>
-		<div id="my-courses" class="alignwide">
+		<div id="my-courses">
 			<?php Sensei()->notices->maybe_print_notices(); ?>
 			<div class="col2-set" id="customer_login">
 


### PR DESCRIPTION
Resolves https://wordpress.org/support/topic/class-alignwide-is-hardcoded-in-output-of-my-courses-content/.

## Proposed Changes
We shouldn't be using the `alignwide` class on the login form. Ideally, the login form should be the same width as the rest of the site's content.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to the My Courses page as a logged out user.
2. Check that the login form is the same width as page / post content.
3. Test on different themes.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
