### PR TITLE
Fix Sensei Pro question type not displaying in filter and table on Questions page

### DIFF
--- a/changelog/fix-ordering-question-type
+++ b/changelog/fix-ordering-question-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Sensei Pro question type not displaying in filter and table on Questions page

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -29,20 +29,12 @@ class Sensei_Question {
 	public $meta_fields;
 
 	/**
-	 * Question types.
-	 *
-	 * @var array
-	 */
-	public $question_types;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since  1.0.0
 	 */
 	public function __construct() {
 		$this->token          = 'question';
-		$this->question_types = $this->question_types();
 		$this->meta_fields    = array( 'question_right_answer', 'question_wrong_answers' );
 		if ( is_admin() ) {
 			// Custom Write Panel Columns
@@ -50,7 +42,7 @@ class Sensei_Question {
 			add_action( 'manage_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
 			add_action( 'add_meta_boxes', array( $this, 'question_edit_panel_metabox' ), 10, 2 );
 
-			// Quesitno list table filters
+			// Question list table filters
 			add_action( 'restrict_manage_posts', array( $this, 'filter_options' ) );
 			add_filter( 'request', array( $this, 'filter_actions' ) );
 
@@ -201,11 +193,14 @@ class Sensei_Question {
 				break;
 
 			case 'question-type':
-				$question_type = strip_tags( get_the_term_list( $id, 'question-type', '', ', ', '' ) );
-				$output        = '&mdash;';
-				if ( isset( $this->question_types[ $question_type ] ) ) {
-					$output = $this->question_types[ $question_type ];
+				$question_types = $this->question_types();
+				$question_type  = strip_tags( get_the_term_list( $id, 'question-type', '', ', ', '' ) );
+				$output         = '&mdash;';
+
+				if ( isset( $question_types[ $question_type ] ) ) {
+					$output = $question_types[ $question_type ];
 				}
+
 				echo esc_html( $output );
 				break;
 
@@ -234,7 +229,9 @@ class Sensei_Question {
 				$question_type = Sensei()->question->get_question_type( $post->ID );
 
 				if ( $question_type ) {
-					$type = $this->question_types[ $question_type ];
+					$question_types = $this->question_types();
+					$type           = $question_types[ $question_type ];
+
 					if ( $type ) {
 						$metabox_title = $type;
 					}
@@ -464,9 +461,11 @@ class Sensei_Question {
 			$output = '';
 
 			// Question type
-			$selected     = isset( $_GET['question_type'] ) ? $_GET['question_type'] : '';
-			$type_options = '<option value="">' . esc_html__( 'All types', 'sensei-lms' ) . '</option>';
-			foreach ( $this->question_types as $label => $type ) {
+			$selected       = isset( $_GET['question_type'] ) ? $_GET['question_type'] : '';
+			$type_options   = '<option value="">' . esc_html__( 'All types', 'sensei-lms' ) . '</option>';
+			$question_types = $this->question_types();
+
+			foreach ( $question_types as $label => $type ) {
 				$type_options .= '<option value="' . esc_attr( $label ) . '" ' . selected( $selected, $label, false ) . '>' . esc_html( $type ) . '</option>';
 			}
 
@@ -561,6 +560,7 @@ class Sensei_Question {
 
 		$question_type  = 'multiple-choice';
 		$question_types = wp_get_post_terms( $question_id, 'question-type' );
+
 		foreach ( $question_types as $type ) {
 			$question_type = $type->slug;
 		}

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -34,8 +34,9 @@ class Sensei_Question {
 	 * @since  1.0.0
 	 */
 	public function __construct() {
-		$this->token          = 'question';
-		$this->meta_fields    = array( 'question_right_answer', 'question_wrong_answers' );
+		$this->token       = 'question';
+		$this->meta_fields = array( 'question_right_answer', 'question_wrong_answers' );
+
 		if ( is_admin() ) {
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-question_columns', array( $this, 'add_column_headings' ), 20, 1 );


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2553.

## Proposed Changes
Calling the `question_types` function in the `Sensei_Question` constructor calls the `sensei_question_types` filter before Sensei Pro has a chance to add a callback function for it. Instead, this PR calls `question_types()` in the functions later on as needed.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable Sensei Pro.
2. Add an Ordering question to a lesson.
3. Go to Sensei LMS > Questions.
4. Ensure that _Ordering_ appears in the _Type_ column for that question.
5. Check that you can filter the questions by the _Ordering_ type.
6. Enable the Classic Editor plugin.
7. Edit the ordering question from Sensei LMS > Questions.
8. Ensure _Ordering_ appears as the title of the edit question panel (note that you can't add answers here as this type is not supported in the classic editor).

![Screenshot 2024-03-15 at 8 28 01 PM](https://github.com/Automattic/sensei/assets/1190420/b262b48a-9abe-4f77-9854-a47a62a146fa)

![Screenshot 2024-03-15 at 8 27 19 PM](https://github.com/Automattic/sensei/assets/1190420/7c92f196-a962-4f74-a7d0-584a56e7f158)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues