### PR TITLE
Fix emails with special characters being displayed incorrectly in the subject line

### DIFF
--- a/changelog/fix-encoded-email-subject
+++ b/changelog/fix-encoded-email-subject
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Course Completed email subject with special characters being displayed incorrectly

--- a/changelog/fix-encoded-email-subject
+++ b/changelog/fix-encoded-email-subject
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Course Completed email subject with special characters being displayed incorrectly
+Email subject with special characters not being displayed correctly

--- a/includes/internal/emails/generators/class-course-completed.php
+++ b/includes/internal/emails/generators/class-course-completed.php
@@ -62,6 +62,7 @@ class Course_Completed extends Email_Generators_Abstract {
 			return;
 		}
 
+		$course    = get_post( $course_id );
 		$student   = new \WP_User( $student_id );
 		$recipient = stripslashes( $student->user_email );
 
@@ -71,7 +72,7 @@ class Course_Completed extends Email_Generators_Abstract {
 					'student:id'          => $student_id,
 					'student:displayname' => $student->display_name,
 					'course:id'           => $course_id,
-					'course:name'         => get_the_title( $course_id ),
+					'course:name'         => $course->post_title,
 					'completed:url'       => esc_url(
 						\Sensei_Course::get_course_completed_page_url( $course_id ) ?? get_permalink( $course_id )
 					),

--- a/includes/internal/emails/generators/class-course-completed.php
+++ b/includes/internal/emails/generators/class-course-completed.php
@@ -62,7 +62,6 @@ class Course_Completed extends Email_Generators_Abstract {
 			return;
 		}
 
-		$course    = get_post( $course_id );
 		$student   = new \WP_User( $student_id );
 		$recipient = stripslashes( $student->user_email );
 
@@ -72,7 +71,7 @@ class Course_Completed extends Email_Generators_Abstract {
 					'student:id'          => $student_id,
 					'student:displayname' => $student->display_name,
 					'course:id'           => $course_id,
-					'course:name'         => $course->post_title,
+					'course:name'         => html_entity_decode( get_the_title( $course_id ) ),
 					'completed:url'       => esc_url(
 						\Sensei_Course::get_course_completed_page_url( $course_id ) ?? get_permalink( $course_id )
 					),

--- a/includes/internal/emails/generators/class-new-course-assigned.php
+++ b/includes/internal/emails/generators/class-new-course-assigned.php
@@ -82,7 +82,7 @@ class New_Course_Assigned extends Email_Generators_Abstract {
 			[
 				$recipient => [
 					'teacher:displayname' => $teacher->display_name,
-					'course:name'         => get_the_title( $course_id ),
+					'course:name'         => html_entity_decode( get_the_title( $course_id ) ),
 					'editcourse:url'      => esc_url( $edit_link ),
 				],
 			]

--- a/includes/internal/emails/generators/class-quiz-graded.php
+++ b/includes/internal/emails/generators/class-quiz-graded.php
@@ -94,7 +94,7 @@ class Quiz_Graded extends Email_Generators_Abstract {
 				$recipient => [
 					'grade:validation' => $pass_or_fail,
 					'course:name'      => get_the_title( $course->ID ),
-					'lesson:name'      => get_the_title( $lesson->ID ),
+					'lesson:name'      => html_entity_decode( get_the_title( $lesson->ID ) ),
 					'grade:percentage' => $grade . '%',
 					'quiz:url'         => $quiz_url,
 				],

--- a/includes/internal/emails/generators/class-student-completes-course.php
+++ b/includes/internal/emails/generators/class-student-completes-course.php
@@ -85,7 +85,7 @@ class Student_Completes_Course extends Email_Generators_Abstract {
 			'student:id'          => $student_id,
 			'student:displayname' => $student->display_name,
 			'course:id'           => $course_id,
-			'course:name'         => get_the_title( $course_id ),
+			'course:name'         => html_entity_decode( get_the_title( $course_id ) ),
 			'grade:percentage'    => $grade,
 			'manage:students'     => $manage_url,
 		];

--- a/includes/internal/emails/generators/class-student-completes-lesson.php
+++ b/includes/internal/emails/generators/class-student-completes-lesson.php
@@ -110,7 +110,7 @@ class Student_Completes_Lesson extends Email_Generators_Abstract {
 			'course:id'           => (int) $course_id,
 			'course:name'         => get_the_title( $course_id ),
 			'lesson:id'           => (int) $lesson_id,
-			'lesson:name'         => get_the_title( $lesson_id ),
+			'lesson:name'         => html_entity_decode( get_the_title( $lesson_id ) ),
 			'manage:students'     => $manage_url,
 		];
 

--- a/includes/internal/emails/generators/class-student-message-reply.php
+++ b/includes/internal/emails/generators/class-student-message-reply.php
@@ -102,7 +102,7 @@ class Student_Message_Reply extends Email_Generators_Abstract {
 					'teacher:displayname'    => esc_html( $teacher->display_name ),
 					'course:name'            => esc_html( get_the_title( $course_id ) ),
 					'message:displaymessage' => esc_html( $comment->comment_content ),
-					'subject:displaysubject' => esc_html( $message->post_title ),
+					'subject:displaysubject' => html_entity_decode( esc_html( $message->post_title ) ),
 					'reply:url'              => esc_url( get_comment_link( $comment ) ),
 				],
 			]

--- a/includes/internal/emails/generators/class-student-sends-message.php
+++ b/includes/internal/emails/generators/class-student-sends-message.php
@@ -79,7 +79,7 @@ class Student_Sends_Message extends Email_Generators_Abstract {
 					'student:displayname'    => esc_html( $student->display_name ),
 					'course:name'            => esc_html( get_the_title( $course->ID ) ),
 					'message:displaymessage' => esc_html( $message->post_content ),
-					'subject:displaysubject' => esc_html( $message->post_title ),
+					'subject:displaysubject' => html_entity_decode( esc_html( $message->post_title ) ),
 					'reply:url'              => esc_url( get_permalink( absint( $message_id ) ) ),
 				],
 			]

--- a/includes/internal/emails/generators/class-teacher-message-reply.php
+++ b/includes/internal/emails/generators/class-teacher-message-reply.php
@@ -79,7 +79,7 @@ class Teacher_Message_Reply extends Email_Generators_Abstract {
 					'student:displayname'    => esc_html( $commenter->display_name ),
 					'course:name'            => esc_html( get_the_title( $course->ID ) ),
 					'message:displaymessage' => esc_html( $comment->comment_content ),
-					'subject:displaysubject' => esc_html( $message->post_title ),
+					'subject:displaysubject' => html_entity_decode( esc_html( $message->post_title ) ),
 					'reply:url'              => esc_url( get_comment_link( $comment ) ),
 				],
 			]

--- a/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-completed.php
@@ -57,7 +57,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		);
 		$course        = $this->factory->course->create_and_get(
 			[
-				'post_title' => 'Test Course',
+				'post_title' => '“Course with Special Characters…?”',
 			]
 		);
 		$completed_url = \Sensei_Course::get_course_completed_page_url( $course->ID );
@@ -91,7 +91,7 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		self::assertEquals( 'course_completed', $email_data['name'] );
 		self::assertArrayHasKey( 'test@a.com', $email_data['data'] );
 		self::assertEquals( 'Test Student', $email_data['data']['test@a.com']['student:displayname'] );
-		self::assertEquals( 'Test Course', $email_data['data']['test@a.com']['course:name'] );
+		self::assertEquals( '“Course with Special Characters…?”', $email_data['data']['test@a.com']['course:name'] );
 		self::assertArrayHasKey( 'completed:url', $email_data['data']['test@a.com'] );
 		self::assertNotEmpty( $email_data['data']['test@a.com']['completed:url'] );
 	}
@@ -195,5 +195,4 @@ class Course_Completed_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		self::assertEmpty( $email_data['name'] );
 	}
-
 }

--- a/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
@@ -91,7 +91,7 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 		);
 		$course_id  = $factory->course->create(
 			[
-				'post_title'  => 'Test Course',
+				'post_title'  => '“Course with Special Characters…?”',
 				'post_author' => $teacher_id,
 			]
 		);
@@ -123,7 +123,7 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 					'student:id'          => $student_id,
 					'student:displayname' => 'Test Student',
 					'course:id'           => $course_id,
-					'course:name'         => 'Test Course',
+					'course:name'         => '“Course with Special Characters…?”',
 					'course:url'          => esc_url(
 						get_permalink( $course_id )
 					),

--- a/tests/unit-tests/internal/emails/generators/test-class-new-course-assigned.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-new-course-assigned.php
@@ -47,7 +47,7 @@ class New_Course_Assigned_Test extends \WP_UnitTestCase {
 		);
 		$course     = $this->factory->course->create_and_get(
 			[
-				'post_title'  => 'Test Course',
+				'post_title'  => '“Course with Special Characters…?”',
 				'post_author' => $teacher_id,
 			]
 		);
@@ -85,7 +85,7 @@ class New_Course_Assigned_Test extends \WP_UnitTestCase {
 		self::assertEquals( 'new_course_assigned', $email_data['name'] );
 		self::assertArrayHasKey( 'test@a.com', $email_data['data'] );
 		self::assertEquals( $user_name, $email_data['data']['test@a.com']['teacher:displayname'] );
-		self::assertEquals( 'Test Course', $email_data['data']['test@a.com']['course:name'] );
+		self::assertEquals( '“Course with Special Characters…?”', $email_data['data']['test@a.com']['course:name'] );
 		self::assertArrayHasKey( 'editcourse:url', $email_data['data']['test@a.com'] );
 		self::assertEquals( $edit_link, $email_data['data']['test@a.com']['editcourse:url'] );
 	}
@@ -101,7 +101,7 @@ class New_Course_Assigned_Test extends \WP_UnitTestCase {
 		);
 		$course     = $this->factory->course->create_and_get(
 			[
-				'post_title'  => 'Test Course',
+				'post_title'  => '“Course with Special Characters…?”',
 				'post_author' => $teacher_id,
 			]
 		);

--- a/tests/unit-tests/internal/emails/generators/test-class-student-completes-course.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-student-completes-course.php
@@ -61,7 +61,7 @@ class Student_Completes_Course_Test extends \WP_UnitTestCase {
 		);
 		$course     = $this->factory->course->create_and_get(
 			[
-				'post_title'  => 'Test Course',
+				'post_title'  => '“Course with Special Characters…?”',
 				'post_author' => $teacher_id,
 			]
 		);
@@ -92,7 +92,7 @@ class Student_Completes_Course_Test extends \WP_UnitTestCase {
 		self::assertEquals( 'student_completes_course', $email_data['name'] );
 		self::assertArrayHasKey( 'test@a.com', $email_data['data'] );
 		self::assertEquals( 'Test Student', $email_data['data']['test@a.com']['student:displayname'] );
-		self::assertEquals( 'Test Course', $email_data['data']['test@a.com']['course:name'] );
+		self::assertEquals( '“Course with Special Characters…?”', $email_data['data']['test@a.com']['course:name'] );
 		self::assertArrayHasKey( 'manage:students', $email_data['data']['test@a.com'] );
 		self::assertNotEmpty( $email_data['data']['test@a.com']['manage:students'] );
 	}
@@ -116,7 +116,7 @@ class Student_Completes_Course_Test extends \WP_UnitTestCase {
 		);
 		$course      = $this->factory->course->create_and_get(
 			[
-				'post_title'  => 'Test Course',
+				'post_title'  => '“Course with Special Characters…?”',
 				'post_author' => $teacher1_id,
 			]
 		);

--- a/tests/unit-tests/internal/emails/generators/test-class-student-completes-lesson.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-student-completes-lesson.php
@@ -155,7 +155,7 @@ class Student_Completes_Lesson_Test extends \WP_UnitTestCase {
 		);
 		$lesson_id        = $factory->lesson->create(
 			[
-				'post_title' => 'Test Lesson',
+				'post_title' => '“Lesson with Special Characters…?”',
 				'meta_input' => [
 					'_lesson_course' => $course_id,
 				],
@@ -193,7 +193,7 @@ class Student_Completes_Lesson_Test extends \WP_UnitTestCase {
 					'course:id'           => $course_id,
 					'course:name'         => 'Test Course',
 					'lesson:id'           => $lesson_id,
-					'lesson:name'         => 'Test Lesson',
+					'lesson:name'         => '“Lesson with Special Characters…?”',
 					'manage:students'     => esc_url(
 						admin_url( "admin.php?page=sensei_learners&course_id={$course_id}&lesson_id={$lesson_id}&view=learners" )
 					),
@@ -233,7 +233,7 @@ class Student_Completes_Lesson_Test extends \WP_UnitTestCase {
 		);
 		$lesson_id        = $factory->lesson->create(
 			[
-				'post_title' => 'Test Lesson',
+				'post_title' => '“Lesson with Special Characters…?”',
 				'meta_input' => [
 					'_lesson_course' => $course_id,
 				],
@@ -277,7 +277,7 @@ class Student_Completes_Lesson_Test extends \WP_UnitTestCase {
 					'course:id'           => $course_id,
 					'course:name'         => 'Test Course',
 					'lesson:id'           => $lesson_id,
-					'lesson:name'         => 'Test Lesson',
+					'lesson:name'         => '“Lesson with Special Characters…?”',
 					'manage:students'     => esc_url(
 						admin_url( "admin.php?page=sensei_learners&course_id={$course_id}&lesson_id={$lesson_id}&view=learners" )
 					),
@@ -288,7 +288,7 @@ class Student_Completes_Lesson_Test extends \WP_UnitTestCase {
 					'course:id'           => $course_id,
 					'course:name'         => 'Test Course',
 					'lesson:id'           => $lesson_id,
-					'lesson:name'         => 'Test Lesson',
+					'lesson:name'         => '“Lesson with Special Characters…?”',
 					'manage:students'     => esc_url(
 						admin_url( "admin.php?page=sensei_learners&course_id={$course_id}&lesson_id={$lesson_id}&view=learners" )
 					),

--- a/tests/unit-tests/internal/emails/generators/test-class-student-message-reply.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-student-message-reply.php
@@ -107,7 +107,7 @@ class Student_Message_Reply_Test extends \WP_UnitTestCase {
 				'comment_post_ID'  => $course_id,
 				'user_id'          => $this->teacher_id,
 				'comment_type'     => 'comment',
-				'comment_content'  => 'Test reply',
+				'comment_content'  => '“Message Reply with Special Characters…?”',
 				'comment_approved' => 1,
 			]
 		);
@@ -171,7 +171,7 @@ class Student_Message_Reply_Test extends \WP_UnitTestCase {
 				'comment_post_ID'  => $lesson_id,
 				'user_id'          => $this->teacher_id,
 				'comment_type'     => 'comment',
-				'comment_content'  => 'Test reply',
+				'comment_content'  => '“Message Reply with Special Characters…?”',
 				'comment_approved' => 1,
 			]
 		);
@@ -235,7 +235,7 @@ class Student_Message_Reply_Test extends \WP_UnitTestCase {
 				'comment_post_ID'  => $quiz_id,
 				'user_id'          => $this->teacher_id,
 				'comment_type'     => 'comment',
-				'comment_content'  => 'Test reply',
+				'comment_content'  => '“Message Reply with Special Characters…?”',
 				'comment_approved' => 1,
 			]
 		);
@@ -297,7 +297,7 @@ class Student_Message_Reply_Test extends \WP_UnitTestCase {
 				'comment_post_ID'  => $course_id,
 				'user_id'          => $this->student_id,
 				'comment_type'     => 'comment',
-				'comment_content'  => 'Test reply',
+				'comment_content'  => '“Message Reply with Special Characters…?”',
 				'comment_approved' => 1,
 			]
 		);

--- a/tests/unit-tests/internal/emails/generators/test-class-student-sends-message.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-student-sends-message.php
@@ -66,7 +66,7 @@ class Student_Sends_Message_Test extends \WP_UnitTestCase {
 		$message     = $this->factory->post->create_and_get(
 			[
 				'post_type'   => 'sensei_message',
-				'post_title'  => 'Test message',
+				'post_title'  => '“Message with Special Characters…?”',
 				'post_status' => 'publish',
 				'post_author' => $student_id,
 				'meta_input'  => [
@@ -131,7 +131,7 @@ class Student_Sends_Message_Test extends \WP_UnitTestCase {
 		$message = $this->factory->post->create_and_get(
 			[
 				'post_type'   => 'sensei_message',
-				'post_title'  => 'Test message',
+				'post_title'  => '“Message with Special Characters…?”',
 				'post_status' => 'publish',
 				'post_author' => $student_id,
 				'meta_input'  => [

--- a/tests/unit-tests/internal/emails/generators/test-class-student-starts-course.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-student-starts-course.php
@@ -50,7 +50,7 @@ class Student_Starts_Course_Test extends \WP_UnitTestCase {
 		);
 		$course     = $this->factory->course->create_and_get(
 			[
-				'post_title'  => 'Test Course',
+				'post_title'  => '“Course with Special Characters…?”',
 				'post_author' => $teacher_id,
 			]
 		);
@@ -89,7 +89,7 @@ class Student_Starts_Course_Test extends \WP_UnitTestCase {
 		self::assertEquals( 'student_starts_course', $email_data['name'] );
 		self::assertArrayHasKey( 'test@a.com', $email_data['data'] );
 		self::assertEquals( 'Test Student', $email_data['data']['test@a.com']['student:displayname'] );
-		self::assertEquals( 'Test Course', $email_data['data']['test@a.com']['course:name'] );
+		self::assertEquals( '“Course with Special Characters…?”', $email_data['data']['test@a.com']['course:name'] );
 		self::assertEquals( $manage_url, $email_data['data']['test@a.com']['manage:students'] );
 	}
 }

--- a/tests/unit-tests/internal/emails/generators/test-class-teacher-message-reply.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-teacher-message-reply.php
@@ -84,7 +84,7 @@ class Teacher_Message_Reply_Test extends \WP_UnitTestCase {
 				'comment_post_ID'  => $course_id,
 				'user_id'          => $student_id,
 				'comment_type'     => 'comment',
-				'comment_content'  => 'Test reply',
+				'comment_content'  => '“Message Reply with Special Characters…?”',
 				'comment_approved' => 1,
 			]
 		);
@@ -170,7 +170,7 @@ class Teacher_Message_Reply_Test extends \WP_UnitTestCase {
 				'comment_post_ID'  => $course_id,
 				'user_id'          => $teacher_id,
 				'comment_type'     => 'comment',
-				'comment_content'  => 'Test reply',
+				'comment_content'  => '“Message Reply with Special Characters…?”',
 				'comment_approved' => 1,
 			]
 		);


### PR DESCRIPTION
## Proposed Changes
Resolve a customer reported issue (7774726-zen) where the email subject for the Completed Course email was being displayed incorrectly when the course title contained special characters. This was also affecting the following emails, so I fixed those as well:

### Teacher Emails
- Course Assigned
- Lesson Completed
- Course Completed
- Student Sent Message
- Message Reply Received

### Student Emails
- Course Completed
- Quiz Graded
- Message Reply Received

### Before
![Screenshot 2024-03-18 at 8 28 07 AM](https://github.com/Automattic/sensei/assets/1190420/4c58ed80-2765-4952-afdb-ff6286bc30d0)

### After
![Screenshot 2024-03-18 at 8 27 41 AM](https://github.com/Automattic/sensei/assets/1190420/92c55b40-d379-404d-829b-c9715dbf04b2)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable the emails listed above.
2. Create a course and a lesson named _Converting the “How Much Caller…?”_.
3. Trigger the condition under which the email sends. When sending a message (or a reply to a message), be sure to include special characters in the message.
4. Verify that the emails are sent with the correct subject lines.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
