### PR TITLE
Show sell with woo tour

### DIFF
--- a/includes/admin/class-sensei-tour.php
+++ b/includes/admin/class-sensei-tour.php
@@ -70,9 +70,10 @@ class Sensei_Tour {
 			in_array( $post_type, [ 'course', 'lesson' ], true ) &&
 			in_array( $hook, [ 'post-new.php', 'post.php' ], true )
 		) {
-			$tour_loaders[ "sensei-$post_type-tour" ] = [
+			$handle                  = "sensei-$post_type-tour";
+			$tour_loaders[ $handle ] = [
 				'minimum_install_version' => '$$next-version$$', // TODO: Add different version for lesson tour later if needed.
-				'path'                    => "admin/tour/$post_type-tour/index.js",
+				'callback'                => $this->get_course_lesson_tour_enqueue_callback( $post_type, $handle ),
 			];
 		}
 
@@ -126,7 +127,7 @@ class Sensei_Tour {
 		}
 
 		foreach ( $incomplete_tours as $handle => $tour_loader ) {
-			Sensei()->assets->enqueue( $handle, $tour_loader['path'], [], true );
+			is_callable( $tour_loader['callback'] ) && call_user_func( $tour_loader['callback'], $hook );
 		}
 	}
 
@@ -181,5 +182,21 @@ class Sensei_Tour {
 		}
 
 		return $tours[ $tour_id ] ?? false;
+	}
+
+	/**
+	 * Get the callback to enqueue the course or lesson tour.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $post_type The post type.
+	 * @param string $handle    The script handle.
+	 *
+	 * @return callable The callback to enqueue the course or lesson tour.
+	 */
+	public function get_course_lesson_tour_enqueue_callback( $post_type, $handle ) {
+		return function () use ( $post_type, $handle ) {
+			Sensei()->assets->enqueue( $handle, "admin/tour/$post_type-tour/index.js", [], true );
+		};
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-tour.php
+++ b/tests/unit-tests/admin/test-class-sensei-tour.php
@@ -141,7 +141,7 @@ class Sensei_Tour_Test extends WP_UnitTestCase {
 			'sensei_tour_loaders',
 			function () {
 				$modified_scripts['modified-course-tour'] = [
-					'path' => 'modified-course-tour.js',
+					'callback' => $this->get_callback_for_handle( 'modified-course-tour' ),
 				];
 				return $modified_scripts;
 			}
@@ -167,18 +167,18 @@ class Sensei_Tour_Test extends WP_UnitTestCase {
 			function () {
 				$modified_scripts['modified-course-tour'] = [
 					'minimum_install_version' => '4.21.1',
-					'path'                    => 'modified-course-tour.js',
+					'callback'                => $this->get_callback_for_handle( 'modified-course-tour' ),
 				];
 				$modified_scripts['modified-lesson-tour'] = [
 					'minimum_install_version' => '4.21.2',
-					'path'                    => 'modified-lesson-tour.js',
+					'callback'                => $this->get_callback_for_handle( 'modified-lesson-tour' ),
 				];
 				$modified_scripts['modified-sell-tour']   = [
 					'minimum_install_version' => '4.21.4',
-					'path'                    => 'modified-sell-tour.js',
+					'callback'                => $this->get_callback_for_handle( 'modified-sell-tour' ),
 				];
 				$modified_scripts['tour-without-version'] = [
-					'path' => 'tour-without-version.js',
+					'callback' => $this->get_callback_for_handle( 'tour-without-version' ),
 				];
 				return $modified_scripts;
 			}
@@ -251,5 +251,11 @@ class Sensei_Tour_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertFalse( $is_complete );
 		$this->assertTrue( $is_complete_1 );
+	}
+
+	public function get_callback_for_handle( $handle ) {
+		return function () use ( $handle ) {
+			Sensei()->assets->enqueue( $handle, $handle . '.js', [], true );
+		};
 	}
 }


### PR DESCRIPTION
Resolves part of https://github.com/Automattic/sensei-pro/issues/2549

## Proposed Changes
We were using Sensei's assets loader to load js paths. This will work for Sensei, but when Sensei-pro or any other third party tries to do the same, this won't work. So to make it more widely useable, we're now using callbacks for loading the tours. This will allow more extensibility.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Please check https://github.com/Automattic/sensei-pro/pull/2555

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
