### PR TITLE
Improve lesson tour experience

### DIFF
--- a/assets/admin/tour/lesson-tour/steps.js
+++ b/assets/admin/tour/lesson-tour/steps.js
@@ -465,11 +465,14 @@ export default function getTourSteps() {
 					// Focus on answer feedback field and highlight answer feedback areas.
 					{
 						action: () => {
-							document
-								.querySelector(
-									'.sensei-lms-question__answer-feedback__content .block-editor-rich-text__editable'
-								)
-								.focus();
+							const correctAnswerField = document.querySelector(
+								'.sensei-lms-question__answer-feedback__content .block-editor-rich-text__editable'
+							);
+
+							correctAnswerField.focus();
+							correctAnswerField.scrollIntoView( {
+								block: 'center',
+							} );
 
 							highlightElementsWithBorders( [
 								'.sensei-lms-question__answer-feedback--correct',

--- a/assets/admin/tour/style.scss
+++ b/assets/admin/tour/style.scss
@@ -5,6 +5,10 @@
 
 .wpcom-tour-kit .tour-kit-frame__container {
 	box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.25);
+
+	&:hover {
+		z-index: 9999999999;
+	}
 }
 
 .wpcom-tour-kit-step-card {


### PR DESCRIPTION
Reported in p1710872211977359-slack-C02NWDZBL0H

## Proposed Changes

* It adds a special index when the mouse is over the Sensei tour.
* It moves the correct answer field from the answer feedback to the center of the screen during the tour.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a lesson with a quiz.
2. Navigate through the tour, and make sure the effects described above work properly and feel good.

## Recording

https://github.com/Automattic/sensei/assets/876340/1ec712e8-e8b8-4836-8603-d8c795893afd

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues