### PR TITLE
Fix highlight not removed after closing tour

### DIFF
--- a/assets/admin/tour/components/sensei-tour-kit/index.js
+++ b/assets/admin/tour/components/sensei-tour-kit/index.js
@@ -66,7 +66,10 @@ function SenseiTourKit( {
 
 	const config = {
 		steps,
-		closeHandler: () => setTourShowStatus( false, true, tourName ),
+		closeHandler: () => {
+			removeHighlightClasses();
+			setTourShowStatus( false, true, tourName );
+		},
 		options: {
 			effects: {
 				spotlight: null,

--- a/assets/admin/tour/components/sensei-tour-kit/index.test.js
+++ b/assets/admin/tour/components/sensei-tour-kit/index.test.js
@@ -3,6 +3,7 @@
  */
 import SenseiTourKit from './index';
 import getTourSteps from '../../course-tour/steps';
+import { removeHighlightClasses } from '../../helper';
 /**
  * External dependencies
  */
@@ -25,6 +26,8 @@ jest.mock( '@wordpress/data', () => ( {
 	register: jest.fn(),
 	useSelect: jest.fn().mockImplementation( () => ( {} ) ),
 } ) );
+
+jest.mock( '../../helper' );
 
 const mockFunction = jest.fn();
 
@@ -105,6 +108,9 @@ describe( 'SenseiTourKit', () => {
 
 	test( 'should close the tour when closeHandler is called', () => {
 		const setTourShowStatus = jest.fn();
+		const removeHighlight = jest.fn();
+
+		removeHighlightClasses.mockImplementation( removeHighlight );
 
 		useDispatch.mockReturnValue( { setTourShowStatus } );
 
@@ -119,6 +125,7 @@ describe( 'SenseiTourKit', () => {
 			true,
 			'test-tour'
 		);
+		expect( removeHighlight ).toHaveBeenCalled();
 	} );
 
 	test( 'should call the event log function when step is viewed', () => {


### PR DESCRIPTION
Resolves issue https://github.com/Automattic/sensei/pull/7551#pullrequestreview-1948847519

## Proposed Changes
* Removes highlights on closing of tour

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new user and try creating a Course, add a Course outline block
2. When the Tour Appears and at least something is highlighted, close the tour.
3. Make sure Highlight also goes away
4. Try creating a lesson now, add a quiz block
5. When something is highlighted, close the Tour
6. Make sure Highlight goes away

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
