### PR TITLE
Update Action Scheduler load check to use another constant

### DIFF
--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -74,7 +74,12 @@ require SENSEI_LMS_PLUGIN_PATH . 'vendor/autoload.php';
 /**
  * Load packages and libraries.
  */
-if ( ! defined( 'A8C__IS_A8C_PRIVATE_BLOG' ) || ! A8C__IS_A8C_PRIVATE_BLOG ) {
+if (
+	! (
+		( defined( 'A8C__IS_A8C_PRIVATE_BLOG' ) && A8C__IS_A8C_PRIVATE_BLOG )
+		|| ( defined( 'SENSEI_DO_NOT_LOAD_ACTION_SCHEDULER' ) && SENSEI_DO_NOT_LOAD_ACTION_SCHEDULER )
+	)
+) {
 	require SENSEI_LMS_PLUGIN_PATH . 'vendor/woocommerce/action-scheduler/action-scheduler.php';
 }
 

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -76,6 +76,7 @@ require SENSEI_LMS_PLUGIN_PATH . 'vendor/autoload.php';
  */
 if (
 	! (
+		// Check for Automattic private site in WPCOM (Like Learnomattic).
 		( defined( 'A8C__IS_A8C_PRIVATE_BLOG' ) && A8C__IS_A8C_PRIVATE_BLOG )
 		|| ( defined( 'SENSEI_DO_NOT_LOAD_ACTION_SCHEDULER' ) && SENSEI_DO_NOT_LOAD_ACTION_SCHEDULER )
 	)

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -74,7 +74,7 @@ require SENSEI_LMS_PLUGIN_PATH . 'vendor/autoload.php';
 /**
  * Load packages and libraries.
  */
-if ( ! defined( 'SENSEI_DO_NOT_LOAD_ACTION_SCHEDULER' ) || ! SENSEI_DO_NOT_LOAD_ACTION_SCHEDULER ) {
+if ( ! defined( 'A8C__IS_A8C_PRIVATE_BLOG' ) || ! A8C__IS_A8C_PRIVATE_BLOG ) {
 	require SENSEI_LMS_PLUGIN_PATH . 'vendor/woocommerce/action-scheduler/action-scheduler.php';
 }
 


### PR DESCRIPTION
## Proposed Changes

* Update the constant check to use an existing constant. The reason is that this constant is defined earlier and it's ready to use when adding the plugin files.
* Instead of doing this, I tried to just invert the require files in A8C environment, but it causes other bugs with classes not existing.
* I kept the previous constant only for backward compatibility.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test it on D141360-code and make sure the site continues working properly (these changes are already applied in the diff).
- And check that Action Scheduler is loaded properly in a normal environment.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
