### PR TITLE
Don't display "Complete Lesson" button if student doesn't have access

### DIFF
--- a/changelog/fix-viewing-lesson-content
+++ b/changelog/fix-viewing-lesson-content
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Add additional check to determine if student can view lesson content
+Ensure student can view the lesson content when rendering the Complete Lesson button

--- a/changelog/fix-viewing-lesson-content
+++ b/changelog/fix-viewing-lesson-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add additional check to determine if student can view lesson content

--- a/includes/blocks/class-sensei-complete-lesson-block.php
+++ b/includes/blocks/class-sensei-complete-lesson-block.php
@@ -37,7 +37,11 @@ class Sensei_Complete_Lesson_Block {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes, string $content ) : string {
+	public function render( array $attributes, string $content ): string {
+		if ( ! sensei_can_user_view_lesson() ) {
+			return '';
+		}
+
 		$lesson = get_post();
 
 		if ( empty( $lesson ) ) {
@@ -51,7 +55,6 @@ class Sensei_Complete_Lesson_Block {
 		}
 
 		if ( false === Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson->ID ) ) {
-
 			return $this->render_with_form( $attributes, $content );
 		}
 
@@ -66,7 +69,7 @@ class Sensei_Complete_Lesson_Block {
 	 *
 	 * @return string The HTML to render.
 	 */
-	private function render_with_form( array $attributes, string $content ) : string {
+	private function render_with_form( array $attributes, string $content ): string {
 		wp_enqueue_script( 'sensei-stop-double-submission' );
 		$nonce     = wp_nonce_field( 'woothemes_sensei_complete_lesson_noonce', 'woothemes_sensei_complete_lesson_noonce', false, false );
 		$permalink = esc_url( get_permalink() );

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -53,6 +53,10 @@ class Lesson_Actions {
 	 * @return string The complete lesson button.
 	 */
 	private function render_complete_lesson( string $button_class, bool $is_outline_style, bool $is_disabled ): string {
+		if ( ! sensei_can_user_view_lesson() ) {
+			return '';
+		}
+
 		$button_style_class = $is_outline_style ? 'is-style-outline' : '';
 		$disabled_attribute = $is_disabled ? 'disabled' : '';
 

--- a/tests/unit-tests/blocks/course-theme/test-class-lesson-actions.php
+++ b/tests/unit-tests/blocks/course-theme/test-class-lesson-actions.php
@@ -191,9 +191,9 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test lesson actions block for a lesson with a pre-requisite lesson.
+	 * Test lesson actions block for a lesson with an unmet prerequisite.
 	 */
-	public function testHasPreRequisite() {
+	public function testHasPrerequisite() {
 		list( $lesson1, $course ) = $this->create_enrolled_lesson_with_quiz();
 		$lesson2                  = $this->factory->lesson->create_and_get(
 			[
@@ -212,9 +212,7 @@ class Lesson_Actions_Test extends WP_UnitTestCase {
 		$GLOBALS['post'] = $lesson2;
 		$block           = new Lesson_Actions();
 
-		// Check for disabled button.
-		$this->assertStringContainsString( ' disabled', $block->render(), 'Should render disabled button if lesson has a pre-requisite.' );
-		$this->assertStringContainsString( 'aria-disabled="true"', $block->render(), 'Should render disabled button if lesson has a pre-requisite.' );
+		$this->assertStringNotContainsString( 'Complete Lesson', $block->render(), 'Should not render button if lesson has an unmet prerequisite.' );
 	}
 
 	/**


### PR DESCRIPTION
Related https://github.com/Automattic/sensei-pro/pull/2562.

## Proposed Changes
This PR adds an additional check when rendering the _Complete Lesson_ button to ensure that the student is actually supposed to be able to view the lesson in the first place. This basically further hardens the `render` function.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out https://github.com/Automattic/sensei-pro/pull/2562.
2. With Sensei Pro activated, enrol in a course as a student.
3. Set _Access Expiration_ for that student to a date in the past.
4. Ensure that the student can't view the lesson content.
5. Disable Sensei Pro.
6. Ensure that the student can view the lesson content.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues