### PR TITLE
Add sensei pro upsell task in home

### DIFF
--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -18,15 +18,15 @@ import { Icon, external } from '@wordpress/icons';
 /**
  * Tasks item component.
  *
- * @param {Object}  props                  Component props.
- * @param {string}  props.title            Item title.
- * @param {string}  props.url              Item URL.
- * @param {boolean} props.done             Whether item is completed.
- * @param {boolean} props.showExternalIcon Whether to show external icon.
+ * @param {Object}  props       Component props.
+ * @param {string}  props.title Item title.
+ * @param {string}  props.url   Item URL.
+ * @param {boolean} props.done  Whether item is completed.
  */
-const TaskItem = ( { title, url, done, showExternalIcon } ) => {
+const TaskItem = ( { title, url, done } ) => {
 	const Tag = done ? 'span' : 'a';
-	const isExternal = isUrlExternal( url );
+	const isExternal =
+		isUrlExternal( url ) || url?.indexOf( 'external=true' ) >= 0;
 
 	const linkProps = ! done && {
 		href: url,
@@ -46,7 +46,7 @@ const TaskItem = ( { title, url, done, showExternalIcon } ) => {
 				) }
 				<span className="sensei-home-tasks__item-title">
 					{ title }
-					{ showExternalIcon && (
+					{ isExternal && (
 						<Icon
 							icon={ external }
 							className="sensei-home-tasks__external-icon sensei-home-tasks__icon-with-current-color"

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -11,14 +11,20 @@ import ChevronRightIcon from '../../icons/chevron-right.svg';
 import { isUrlExternal } from '../utils';
 
 /**
+ * WordPress dependencies
+ */
+import { Icon, external } from '@wordpress/icons';
+
+/**
  * Tasks item component.
  *
- * @param {Object}  props       Component props.
- * @param {string}  props.title Item title.
- * @param {string}  props.url   Item URL.
- * @param {boolean} props.done  Whether item is completed.
+ * @param {Object}  props              Component props.
+ * @param {string}  props.title        Item title.
+ * @param {string}  props.url          Item URL.
+ * @param {boolean} props.done         Whether item is completed.
+ * @param {boolean} props.externalIcon Whether to show external icon.
  */
-const TaskItem = ( { title, url, done } ) => {
+const TaskItem = ( { title, url, done, externalIcon } ) => {
 	const Tag = done ? 'span' : 'a';
 	const isExternal = isUrlExternal( url );
 
@@ -38,7 +44,15 @@ const TaskItem = ( { title, url, done } ) => {
 				{ done && (
 					<CheckIcon className="sensei-home-tasks__check-icon" />
 				) }
-				<span className="sensei-home-tasks__item-title">{ title }</span>
+				<span className="sensei-home-tasks__item-title">
+					{ title }
+					{ externalIcon && (
+						<Icon
+							icon={ external }
+							className="sensei-home-tasks__external-icon"
+						/>
+					) }
+				</span>
 				{ ! done && (
 					<ChevronRightIcon className="sensei-home-tasks__link-chevron" />
 				) }

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -49,7 +49,7 @@ const TaskItem = ( { title, url, done, showExternalIcon } ) => {
 					{ showExternalIcon && (
 						<Icon
 							icon={ external }
-							className="sensei-home-tasks__external-icon"
+							className="sensei-home-tasks__external-icon sensei-home-tasks__icon-with-current-color"
 						/>
 					) }
 				</span>

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -26,7 +26,8 @@ import { Icon, external } from '@wordpress/icons';
 const TaskItem = ( { title, url, done } ) => {
 	const Tag = done ? 'span' : 'a';
 	const isExternal =
-		isUrlExternal( url ) || url?.indexOf( 'external=true' ) >= 0;
+		isUrlExternal( url ) || url?.indexOf( 'external=true' ) >= 0; // If the URL contains 'external=true', we show the external icon,
+	// It's helpful when it's an internal URL (maybe for tracking purpose) but redirecting to an external one.
 
 	const linkProps = ! done && {
 		href: url,

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -18,13 +18,13 @@ import { Icon, external } from '@wordpress/icons';
 /**
  * Tasks item component.
  *
- * @param {Object}  props              Component props.
- * @param {string}  props.title        Item title.
- * @param {string}  props.url          Item URL.
- * @param {boolean} props.done         Whether item is completed.
- * @param {boolean} props.externalIcon Whether to show external icon.
+ * @param {Object}  props                  Component props.
+ * @param {string}  props.title            Item title.
+ * @param {string}  props.url              Item URL.
+ * @param {boolean} props.done             Whether item is completed.
+ * @param {boolean} props.showExternalIcon Whether to show external icon.
  */
-const TaskItem = ( { title, url, done, externalIcon } ) => {
+const TaskItem = ( { title, url, done, showExternalIcon } ) => {
 	const Tag = done ? 'span' : 'a';
 	const isExternal = isUrlExternal( url );
 
@@ -46,7 +46,7 @@ const TaskItem = ( { title, url, done, externalIcon } ) => {
 				) }
 				<span className="sensei-home-tasks__item-title">
 					{ title }
-					{ externalIcon && (
+					{ showExternalIcon && (
 						<Icon
 							icon={ external }
 							className="sensei-home-tasks__external-icon"

--- a/assets/home/tasks-section/task-item.test.js
+++ b/assets/home/tasks-section/task-item.test.js
@@ -30,7 +30,7 @@ describe( '<TaskItem />', () => {
 	} );
 
 	it( 'Should render an external icon when externalIcon prop is true', () => {
-		const { container } = render( <TaskItem url="#" externalIcon /> );
+		const { container } = render( <TaskItem url="#" showExternalIcon /> );
 
 		const externalIcon = container.querySelector(
 			'.sensei-home-tasks__external-icon'

--- a/assets/home/tasks-section/task-item.test.js
+++ b/assets/home/tasks-section/task-item.test.js
@@ -38,4 +38,14 @@ describe( '<TaskItem />', () => {
 
 		expect( externalIcon ).not.toBeNull();
 	} );
+
+	it( 'Should not render external icon when externalIcon prop is not set', () => {
+		const { container } = render( <TaskItem url="#" /> );
+
+		const externalIcon = container.querySelector(
+			'.sensei-home-tasks__external-icon'
+		);
+
+		expect( externalIcon ).toBeNull();
+	} );
 } );

--- a/assets/home/tasks-section/task-item.test.js
+++ b/assets/home/tasks-section/task-item.test.js
@@ -28,4 +28,14 @@ describe( '<TaskItem />', () => {
 
 		expect( renderedTag ).toEqual( 'SPAN' );
 	} );
+
+	it( 'Should render an external icon when externalIcon prop is true', () => {
+		const { container } = render( <TaskItem url="#" externalIcon /> );
+
+		const externalIcon = container.querySelector(
+			'.sensei-home-tasks__external-icon'
+		);
+
+		expect( externalIcon ).not.toBeNull();
+	} );
 } );

--- a/assets/home/tasks-section/task-item.test.js
+++ b/assets/home/tasks-section/task-item.test.js
@@ -29,8 +29,13 @@ describe( '<TaskItem />', () => {
 		expect( renderedTag ).toEqual( 'SPAN' );
 	} );
 
-	it( 'Should render an external icon when externalIcon prop is true', () => {
-		const { container } = render( <TaskItem url="#" showExternalIcon /> );
+	it( 'Should render an external icon when externalIcon is true', () => {
+		const { container } = render(
+			<TaskItem
+				url="www.example.com/something?this=false&external=true"
+				showExternalIcon
+			/>
+		);
 
 		const externalIcon = container.querySelector(
 			'.sensei-home-tasks__external-icon'
@@ -40,7 +45,9 @@ describe( '<TaskItem />', () => {
 	} );
 
 	it( 'Should not render external icon when externalIcon prop is not set', () => {
-		const { container } = render( <TaskItem url="#" /> );
+		const { container } = render(
+			<TaskItem url="www.example.com/something?this=false" />
+		);
 
 		const externalIcon = container.querySelector(
 			'.sensei-home-tasks__external-icon'

--- a/assets/home/tasks-section/tasks.js
+++ b/assets/home/tasks-section/tasks.js
@@ -31,6 +31,7 @@ const Tasks = ( { items } ) => (
 			{ items.map( ( task ) => (
 				<TaskItem
 					key={ task.id }
+					externalIcon={ task.external_icon }
 					title={ task.title }
 					url={ task.url }
 					done={ task.done }

--- a/assets/home/tasks-section/tasks.js
+++ b/assets/home/tasks-section/tasks.js
@@ -31,7 +31,6 @@ const Tasks = ( { items } ) => (
 			{ items.map( ( task ) => (
 				<TaskItem
 					key={ task.id }
-					showExternalIcon={ task.show_external_icon }
 					title={ task.title }
 					url={ task.url }
 					done={ task.done }

--- a/assets/home/tasks-section/tasks.js
+++ b/assets/home/tasks-section/tasks.js
@@ -31,7 +31,7 @@ const Tasks = ( { items } ) => (
 			{ items.map( ( task ) => (
 				<TaskItem
 					key={ task.id }
-					externalIcon={ task.external_icon }
+					showExternalIcon={ task.show_external_icon }
 					title={ task.title }
 					url={ task.url }
 					done={ task.done }

--- a/assets/home/tasks-section/tasks.scss
+++ b/assets/home/tasks-section/tasks.scss
@@ -46,6 +46,8 @@
 
 	&__item-title {
 		flex: 1;
+		display: flex;
+		align-items: center;
 	}
 
 	&__check-icon {
@@ -58,5 +60,17 @@
 		width: 25px;
 		height: 25px;
 		justify-self: end;
+	}
+
+	&__external-icon {
+		width: 20px;
+		height: 20px;
+		margin-left: 5px;
+		color: currentColor;
+
+		path {
+			fill: currentColor;
+			stroke: none;
+		}
 	}
 }

--- a/assets/home/tasks-section/tasks.scss
+++ b/assets/home/tasks-section/tasks.scss
@@ -66,11 +66,9 @@
 		width: 20px;
 		height: 20px;
 		margin-left: 5px;
-		color: currentColor;
+	}
 
-		path {
-			fill: currentColor;
-			stroke: none;
-		}
+	&__icon-with-current-color {
+		fill: currentColor;
 	}
 }

--- a/changelog/add-sensei-pro-upsell-task
+++ b/changelog/add-sensei-pro-upsell-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sensei pro upsell task in Sensei Home

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -465,6 +465,11 @@
       <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
     </MissingFile>
   </file>
+  <file src="includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php">
+	<MissingFile occurrences="1">
+	  <code>require_once ABSPATH . 'wp-admin/includes/plugin.php'</code>
+	</MissingFile>
+  </file>
   <file src="includes/admin/tools/class-sensei-tool-enrolment-debug.php">
     <FalsableReturnStatement occurrences="1">
       <code>$formatted_time</code>

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -103,13 +103,13 @@ final class Sensei_Home {
 	/**
 	 * Gets a REST API controller for Sensei Home.
 	 *
-	 * @param string $namespace The REST API namespace.
+	 * @param string $api_namespace The REST API namespace.
 	 *
 	 * @return Sensei_REST_API_Home_Controller
 	 */
-	public function get_rest_api_controller( $namespace ) {
+	public function get_rest_api_controller( $api_namespace ) {
 		return new Sensei_REST_API_Home_Controller(
-			$namespace,
+			$api_namespace,
 			$this->quick_links_provider,
 			$this->help_provider,
 			$this->promo_provider,
@@ -143,7 +143,7 @@ final class Sensei_Home {
 
 		if ( self::SCREEN_ID === $screen->id ) {
 			Sensei()->assets->enqueue( 'sensei-home', 'home/index.js', [], true );
-			Sensei()->assets->enqueue( 'sensei-home-style', 'home/home.css', [ 'sensei-wp-components' ] );
+			Sensei()->assets->enqueue( 'sensei-home-style', 'home/home.css', [ 'sensei-wp-components', 'wp-components' ] );
 			Sensei()->assets->enqueue( 'sensei-dismiss-notices', 'js/admin/sensei-notice-dismiss.js', [] );
 			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin', '/sensei-internal/v1/home' ] );
 
@@ -276,5 +276,4 @@ final class Sensei_Home {
 		}
 		return self::$instance;
 	}
-
 }

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -71,6 +71,10 @@ class Sensei_Home_Tasks_Provider {
 			$core_tasks[] = new Sensei_Home_Task_Sell_Course_With_WooCommerce();
 		}
 
+		if ( Sensei_Home_Task_Pro_Upsell::is_active() ) {
+			$core_tasks[] = new Sensei_Home_Task_Pro_Upsell();
+		}
+
 		$tasks = [];
 
 		/**

--- a/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
@@ -50,6 +50,7 @@ class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
 	 * @return string
 	 */
 	public function get_url(): ?string {
+		// Here external=true is used to show the external link icon in the frontend component.
 		return rest_url( 'sensei-internal/v1/home/sensei-pro-upsell-redirect?_wpnonce=' . wp_create_nonce( 'wp_rest' ) . '&external=true' );
 	}
 

--- a/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
@@ -117,6 +117,13 @@ class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
 			return false;
 		}
 
+		// If the user does not intend to sell courses, we do not need to add this task.
+		$features = Sensei()->setup_wizard->get_wizard_user_data( 'features' );
+
+		if ( ! in_array( 'woocommerce', $features['selected'], true ) ) {
+			return false;
+		}
+
 		return ! Sensei_Plugins_Installation::instance()->is_plugin_active( 'sensei-pro' ) &&
 			! Sensei_Plugins_Installation::instance()->get_installed_plugin_path( 'woothemes-sensei.php' );
 	}

--- a/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
@@ -21,7 +21,7 @@ class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'sensei_home_tasks', [ $this, 'maybe_add_external_icon_property' ] );
+		add_filter( 'sensei_home_tasks', [ $this, 'maybe_add_show_external_icon_property' ] );
 	}
 
 	/**
@@ -31,11 +31,11 @@ class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
 	 *
 	 * @return array
 	 */
-	public function maybe_add_external_icon_property( $tasks ) {
+	public function maybe_add_show_external_icon_property( $tasks ) {
 		return array_map(
 			function ( $task ): array {
 				if ( self::get_id() === $task['id'] ) {
-						$task['external_icon'] = true;
+						$task['show_external_icon'] = true;
 				}
 				return $task;
 			},

--- a/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * File containing the Sensei_Home_Task_Pro_Upsell class.
+ *
+ * @package sensei-lms
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Home_Task_Pro_Upsell.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'sensei_home_tasks', [ $this, 'maybe_add_external_icon_property' ] );
+	}
+
+	/**
+	 * Maybe add external icon to the task.
+	 *
+	 * @param array $tasks Tasks.
+	 *
+	 * @return array
+	 */
+	public function maybe_add_external_icon_property( $tasks ) {
+		return array_map(
+			function ( $task ): array {
+				if ( self::get_id() === $task['id'] ) {
+						$task['external_icon'] = true;
+				}
+				return $task;
+			},
+			$tasks
+		);
+	}
+
+
+	/**
+	 * The ID for the task.
+	 *
+	 * @return string
+	 */
+	public static function get_id(): string {
+		return 'sensei-home-task-pro-upsell';
+	}
+
+	/**
+	 * Number used to sort in frontend.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return 250;
+	}
+
+	/**
+	 * Task title.
+	 *
+	 * @return string
+	 */
+	public function get_title(): string {
+		return __( 'Sell your course with Sensei Pro', 'sensei-lms' );
+	}
+
+	/**
+	 * Task url.
+	 *
+	 * @return string
+	 */
+	public function get_url(): ?string {
+		return rest_url( 'sensei-internal/v1/home/sensei-pro-upsell-redirect?_wpnonce=' . wp_create_nonce( 'wp_rest' ) );
+	}
+
+	/**
+	 * Whether the task is completed or not.
+	 *
+	 * @return bool
+	 */
+	public function is_completed(): bool {
+		return get_option( self::get_id(), false );
+	}
+
+	/**
+	 * Mark the task as completed.
+	 *
+	 * @internal
+	 */
+	public static function mark_completed_and_redirect() {
+		sensei_log_event( 'home_task_complete', [ 'type' => self::get_id() ] );
+
+		update_option( self::get_id(), true );
+
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- We're redirecting to an external URL.
+		wp_redirect( 'https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=sensei-home' );
+	}
+
+	/**
+	 * Whether the task is active or not.
+	 *
+	 * @return bool
+	 */
+	public static function is_active(): bool {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			return false;
+		}
+
+		return ! Sensei_Plugins_Installation::instance()->is_plugin_active( 'sensei-pro' ) &&
+			! Sensei_Plugins_Installation::instance()->get_installed_plugin_path( 'woothemes-sensei.php' );
+	}
+}

--- a/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
@@ -124,7 +124,7 @@ class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
 			return false;
 		}
 
-		return ! Sensei_Plugins_Installation::instance()->is_plugin_active( 'sensei-pro' ) &&
+		return ! Sensei_Plugins_Installation::instance()->get_installed_plugin_path( 'sensei-pro.php' ) &&
 			! Sensei_Plugins_Installation::instance()->get_installed_plugin_path( 'woothemes-sensei.php' );
 	}
 }

--- a/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-pro-upsell.php
@@ -18,33 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
 
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		add_filter( 'sensei_home_tasks', [ $this, 'maybe_add_show_external_icon_property' ] );
-	}
-
-	/**
-	 * Maybe add external icon to the task.
-	 *
-	 * @param array $tasks Tasks.
-	 *
-	 * @return array
-	 */
-	public function maybe_add_show_external_icon_property( $tasks ) {
-		return array_map(
-			function ( $task ): array {
-				if ( self::get_id() === $task['id'] ) {
-						$task['show_external_icon'] = true;
-				}
-				return $task;
-			},
-			$tasks
-		);
-	}
-
-
-	/**
 	 * The ID for the task.
 	 *
 	 * @return string
@@ -77,7 +50,7 @@ class Sensei_Home_Task_Pro_Upsell implements Sensei_Home_Task {
 	 * @return string
 	 */
 	public function get_url(): ?string {
-		return rest_url( 'sensei-internal/v1/home/sensei-pro-upsell-redirect?_wpnonce=' . wp_create_nonce( 'wp_rest' ) );
+		return rest_url( 'sensei-internal/v1/home/sensei-pro-upsell-redirect?_wpnonce=' . wp_create_nonce( 'wp_rest' ) . '&external=true' );
 	}
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -98,6 +98,7 @@ class Sensei_Data_Cleaner {
 		'sensei_home_task_visited_woocommerce',
 		'sensei_home_tasks_dismissed',
 		'sensei_home_tasks_list_is_completed',
+		'sensei-home-task-pro-upsell',
 	);
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-home-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-home-controller.php
@@ -22,7 +22,7 @@ class Sensei_REST_API_Home_Controller extends \WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $api_namespace;
+	protected $namespace;
 
 	/**
 	 * Routes prefix.
@@ -102,7 +102,7 @@ class Sensei_REST_API_Home_Controller extends \WP_REST_Controller {
 		Sensei_Home_Guides_Provider $guides_provider,
 		Sensei_Home_Notices_Provider $notices_provider
 	) {
-		$this->api_namespace         = $api_namespace;
+		$this->namespace             = $api_namespace;
 		$this->quick_links_provider  = $quick_links_provider;
 		$this->help_provider         = $help_provider;
 		$this->promo_banner_provider = $promo_banner_provider;
@@ -135,7 +135,7 @@ class Sensei_REST_API_Home_Controller extends \WP_REST_Controller {
 	 */
 	public function register_get_data_route() {
 		register_rest_route(
-			$this->api_namespace,
+			$this->namespace,
 			$this->rest_base,
 			[
 				[
@@ -152,7 +152,7 @@ class Sensei_REST_API_Home_Controller extends \WP_REST_Controller {
 	 */
 	public function register_mark_tasks_complete_route() {
 		register_rest_route(
-			$this->api_namespace,
+			$this->namespace,
 			$this->rest_base . '/tasks/complete',
 			[
 				[
@@ -169,7 +169,7 @@ class Sensei_REST_API_Home_Controller extends \WP_REST_Controller {
 	 */
 	public function register_sensei_pro_upsell_redirect_route() {
 		register_rest_route(
-			$this->api_namespace,
+			$this->namespace,
 			$this->rest_base . '/sensei-pro-upsell-redirect',
 			[
 				[

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
@@ -107,7 +107,7 @@ class Sensei_Home_Task_Pro_Upsell_Test extends WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertTrue( isset( $task_array[1]['external_icon'] ) );
-		$this->assertFalse( isset( $task_array[0]['external_icon'] ) );
+		$this->assertTrue( isset( $task_array[1]['show_external_icon'] ) );
+		$this->assertFalse( isset( $task_array[0]['show_external_icon'] ) );
 	}
 }

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
@@ -85,29 +85,4 @@ class Sensei_Home_Task_Pro_Upsell_Test extends WP_UnitTestCase {
 		$this->assertFalse( $before_completed );
 		$this->assertTrue( $after_completed );
 	}
-
-	public function testMaybeAddExternalIconProperty_WhenCalled_ReturnsCorrectArray() {
-		/* Arrange. */
-		$task = new Sensei_Home_Task_Pro_Upsell();
-
-		/* Act. */
-		$task_array = apply_filters(
-			'sensei_home_tasks',
-			[
-				[
-					'id'    => 'test-id',
-					'title' => 'Test Title',
-					'url'   => 'http://example.com',
-				],
-				[
-					'id'    => Sensei_Home_Task_Pro_Upsell::get_id(),
-					'title' => 'Sell your course with Sensei Pro',
-				],
-			]
-		);
-
-		/* Assert. */
-		$this->assertTrue( isset( $task_array[1]['show_external_icon'] ) );
-		$this->assertFalse( isset( $task_array[0]['show_external_icon'] ) );
-	}
 }

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file contains the Sensei_Home_Task_Pro_Upsell_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Tests for Sensei_Home_Task_Pro_Upsell_Test class.
+ *
+ * @covers Sensei_Home_Task_Pro_Upsell
+ */
+class Sensei_Home_Task_Pro_Upsell_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+	use Sensei_Test_Redirect_Helpers;
+
+	/**
+	 * The task under test.
+	 *
+	 * @var Sensei_Home_Task_Pro_Upsell
+	 */
+	private $task;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->task = new Sensei_Home_Task_Pro_Upsell();
+	}
+
+	public function tearDown(): void {
+		delete_option( Sensei_Home_Task_Pro_Upsell::get_id() );
+		parent::tearDown();
+	}
+
+	public function testGetId_WhenCalled_ReturnsCorrectId() {
+		$this->assertSame( 'sensei-home-task-pro-upsell', Sensei_Home_Task_Pro_Upsell::get_id() );
+	}
+
+	public function testGetTitle_WhenCalled_ReturnsCorrectTitle() {
+		$this->assertSame( 'Sell your course with Sensei Pro', $this->task->get_title() );
+	}
+
+	public function testGetUrl_WhenCalled_ReturnsCorrectUrl() {
+		$this->assertStringContainsString( 'sensei-internal/v1/home/sensei-pro-upsell-redirect?_wpnonce=', $this->task->get_url() );
+	}
+
+	public function testIsCompleted_WhenCalled_IsNotCompletedByDefault() {
+		$this->assertFalse( $this->task->is_completed() );
+	}
+}

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
@@ -67,4 +67,22 @@ class Sensei_Home_Task_Pro_Upsell_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 'https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=sensei-home', $redirect_location );
 	}
+
+	public function testMarkCompleteAndRedirect_WhenCalled_SetsTheOptionProperly() {
+		/* Arrange. */
+		$this->login_as_admin();
+		$this->prevent_wp_redirect();
+		$before_completed = $this->task->is_completed();
+
+		/* Act. */
+		try {
+			Sensei_Home_Task_Pro_Upsell::mark_completed_and_redirect();
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$after_completed = $this->task->is_completed();
+		}
+
+		/* Assert. */
+		$this->assertFalse( $before_completed );
+		$this->assertTrue( $after_completed );
+	}
 }

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
@@ -50,4 +50,21 @@ class Sensei_Home_Task_Pro_Upsell_Test extends WP_UnitTestCase {
 	public function testIsCompleted_WhenCalled_IsNotCompletedByDefault() {
 		$this->assertFalse( $this->task->is_completed() );
 	}
+
+	public function testMarkCompleteAndRedirect_WhenCalled_TriesToRedirectToRightPage() {
+		/* Arrange. */
+		$this->login_as_admin();
+		$this->prevent_wp_redirect();
+		$redirect_location = '';
+
+		/* Act. */
+		try {
+			Sensei_Home_Task_Pro_Upsell::mark_completed_and_redirect();
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert. */
+		$this->assertSame( 'https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=sensei-home', $redirect_location );
+	}
 }

--- a/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
+++ b/tests/unit-tests/admin/home/tasks/task/test-class-sensei-home-task-pro-upsell.php
@@ -85,4 +85,29 @@ class Sensei_Home_Task_Pro_Upsell_Test extends WP_UnitTestCase {
 		$this->assertFalse( $before_completed );
 		$this->assertTrue( $after_completed );
 	}
+
+	public function testMaybeAddExternalIconProperty_WhenCalled_ReturnsCorrectArray() {
+		/* Arrange. */
+		$task = new Sensei_Home_Task_Pro_Upsell();
+
+		/* Act. */
+		$task_array = apply_filters(
+			'sensei_home_tasks',
+			[
+				[
+					'id'    => 'test-id',
+					'title' => 'Test Title',
+					'url'   => 'http://example.com',
+				],
+				[
+					'id'    => Sensei_Home_Task_Pro_Upsell::get_id(),
+					'title' => 'Sell your course with Sensei Pro',
+				],
+			]
+		);
+
+		/* Assert. */
+		$this->assertTrue( isset( $task_array[1]['external_icon'] ) );
+		$this->assertFalse( isset( $task_array[0]['external_icon'] ) );
+	}
 }

--- a/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
+++ b/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
@@ -13,6 +13,7 @@
  */
 class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 	use Sensei_Test_Login_Helpers;
+	use Sensei_Test_Redirect_Helpers;
 
 	/**
 	 * A server instance that we use in tests to dispatch requests.
@@ -80,11 +81,28 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function testSenseiProUpsellRedirect_WhenCalled_RedirectsToSenseiProUpsellPage() {
+		/* Arrange */
+		$this->login_as_admin();
+		$redirect_location = '';
+		$this->prevent_wp_redirect();
+
+		/* Act */
+		try {
+			$response = $this->dispatchRequest( 'GET', '/sensei-pro-upsell-redirect' );
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert */
+		$this->assertSame( 'https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=sensei-home', $redirect_location );
+	}
+
 	private function dispatchRequest( $method, $route = '' ) {
 		// Prevent requests.
 		add_filter(
 			'pre_http_request',
-			function() {
+			function () {
 				return [ 'body' => '[]' ];
 			}
 		);

--- a/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
+++ b/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
@@ -96,6 +96,7 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 
 		/* Assert */
 		$this->assertSame( 'https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=sensei-home', $redirect_location );
+		$this->assertTrue( get_option( Sensei_Home_Task_Pro_Upsell::get_id(), false ) );
 	}
 
 	public function testSenseiProUpsellRedirect_WhenCalledWithoutLoggingIn_DoesNotRedirect() {
@@ -112,6 +113,7 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 
 		/* Assert */
 		$this->assertEmpty( $redirect_location );
+		$this->assertFalse( get_option( Sensei_Home_Task_Pro_Upsell::get_id(), false ) );
 	}
 
 	public function testSenseiProUpsellRedirect_WhenLoggedInAsNormalUser_DoesNotRedirect() {
@@ -129,6 +131,7 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 
 		/* Assert */
 		$this->assertEmpty( $redirect_location );
+		$this->assertFalse( get_option( Sensei_Home_Task_Pro_Upsell::get_id(), false ) );
 	}
 
 	private function dispatchRequest( $method, $route = '' ) {

--- a/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
+++ b/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
@@ -113,6 +113,24 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 		/* Assert */
 		$this->assertEmpty( $redirect_location );
 	}
+
+	public function testSenseiProUpsellRedirect_WhenLoggedInAsNormalUser_DoesNotRedirect() {
+		/* Arrange */
+		$this->login_as_student();
+		$redirect_location = '';
+		$this->prevent_wp_redirect();
+
+		/* Act */
+		try {
+			$this->dispatchRequest( 'GET', '/sensei-pro-upsell-redirect' );
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert */
+		$this->assertEmpty( $redirect_location );
+	}
+
 	private function dispatchRequest( $method, $route = '' ) {
 		// Prevent requests.
 		add_filter(

--- a/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
+++ b/tests/unit-tests/rest-api/test-rest-class-sensei-rest-api-home-controller.php
@@ -89,7 +89,7 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 
 		/* Act */
 		try {
-			$response = $this->dispatchRequest( 'GET', '/sensei-pro-upsell-redirect' );
+			$this->dispatchRequest( 'GET', '/sensei-pro-upsell-redirect' );
 		} catch ( Sensei_WP_Redirect_Exception $e ) {
 			$redirect_location = $e->getMessage();
 		}
@@ -98,6 +98,21 @@ class Sensei_REST_API_Home_Controller_REST_Test extends WP_Test_REST_TestCase {
 		$this->assertSame( 'https://senseilms.com/sensei-pro/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=sensei-home', $redirect_location );
 	}
 
+	public function testSenseiProUpsellRedirect_WhenCalledWithoutLoggingIn_DoesNotRedirect() {
+		/* Arrange */
+		$redirect_location = '';
+		$this->prevent_wp_redirect();
+
+		/* Act */
+		try {
+			$this->dispatchRequest( 'GET', '/sensei-pro-upsell-redirect' );
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
+
+		/* Assert */
+		$this->assertEmpty( $redirect_location );
+	}
 	private function dispatchRequest( $method, $route = '' ) {
 		// Prevent requests.
 		add_filter(


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7486

## Proposed Changes
Added a task in Sensei Home for taking users to senseilms.com upsell page when they have woo activated but Sensei pro is not installed.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site with Sensei installed, don't install WooCommerce or Sensei Pro yet
2. Go to Sensei Home and make sure you don't see "Sell your course with Sensei Pro" (because Woo not installed)
3. Now install Woo But don't activate
4. Still shouldn't see the task
5. Activate Woo
6. Should see the task now, but don't click just yet
7. Install Senesi Pro
8. Shouldn't see the task now
9. Deactivate Sensei Pro, but don't delete
10. Still shouldn't see the task (because we don't want to upsell Pro if you have it already installed, doesn't matter if it's activated or not)
11. Now delete Sensei Pro and install a WCPC build
12. Shouldn't see the task
13. Remove WCPC
14. Task should appear again
15. Click on the task, you should be taken to Sensei Pro upsell page
16. Check in `tracks` for `sensei_home_task_complete` event after giving it some time to update
17. Go to Sensei Home page again, refresh it if needed
18. Make sure the task is crossed now
19. Install Sensei Pro again
20. Make sure the Crossed task is removed

<img width="1099" alt="Screenshot 2024-03-26 at 11 02 23 PM" src="https://github.com/Automattic/sensei/assets/6820724/71f83aff-32a9-4aad-b299-fc9326b51c26">

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
