### PR TITLE
Add info and disabled state for tasks

### DIFF
--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -59,7 +59,7 @@ const TaskItem = ( { title, url, done, info, disabled } ) => {
 				) }
 				<span className="sensei-home-tasks__item-title">
 					{ title }
-					{ isExternal && (
+					{ isExternal && isActive && (
 						<Icon
 							icon={ externalIcon }
 							className="sensei-home-tasks__external-icon sensei-home-tasks__icon-with-current-color"

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -65,15 +65,15 @@ const TaskItem = ( { title, url, done, info, disabled } ) => {
 							className="sensei-home-tasks__external-icon sensei-home-tasks__icon-with-current-color"
 						/>
 					) }
-					{ info && (
-						<Tooltip text={ info }>
-							<Icon
-								className="sensei-home-tasks__icon-with-current-color"
-								icon={ infoIcon }
-							/>
-						</Tooltip>
-					) }
 				</span>
+				{ info && (
+					<Tooltip text={ info }>
+						<Icon
+							className="sensei-home-tasks__icon-with-current-color"
+							icon={ infoIcon }
+						/>
+					</Tooltip>
+				) }
 				{ isActive && (
 					<ChevronRightIcon className="sensei-home-tasks__link-chevron" />
 				) }

--- a/assets/home/tasks-section/task-item.js
+++ b/assets/home/tasks-section/task-item.js
@@ -4,6 +4,12 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { Icon, info as infoIcon } from '@wordpress/icons';
+import { Tooltip } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import CheckIcon from '../../icons/checked.svg';
@@ -13,13 +19,16 @@ import { isUrlExternal } from '../utils';
 /**
  * Tasks item component.
  *
- * @param {Object}  props       Component props.
- * @param {string}  props.title Item title.
- * @param {string}  props.url   Item URL.
- * @param {boolean} props.done  Whether item is completed.
+ * @param {Object}  props          Component props.
+ * @param {string}  props.title    Item title.
+ * @param {string}  props.url      Item URL.
+ * @param {boolean} props.done     Whether item is completed.
+ * @param {boolean} props.disabled Whether item is disabled.
+ * @param {boolean} props.info     Info text.
  */
-const TaskItem = ( { title, url, done } ) => {
-	const Tag = done ? 'span' : 'a';
+const TaskItem = ( { title, url, done, info, disabled } ) => {
+	const isActive = ! done && ! disabled;
+	const Tag = isActive ? 'a' : 'span';
 	const isExternal = isUrlExternal( url );
 
 	const linkProps = ! done && {
@@ -31,7 +40,7 @@ const TaskItem = ( { title, url, done } ) => {
 	return (
 		<li
 			className={ classnames( 'sensei-home-tasks__item', {
-				'sensei-home-tasks__item--done': done,
+				'sensei-home-tasks__item--disabled': ! isActive,
 			} ) }
 		>
 			<Tag className="sensei-home-tasks__link" { ...linkProps }>
@@ -39,7 +48,15 @@ const TaskItem = ( { title, url, done } ) => {
 					<CheckIcon className="sensei-home-tasks__check-icon" />
 				) }
 				<span className="sensei-home-tasks__item-title">{ title }</span>
-				{ ! done && (
+				{ info && (
+					<Tooltip text={ info }>
+						<Icon
+							className="sensei-home-tasks__icon-with-current-color"
+							icon={ infoIcon }
+						/>
+					</Tooltip>
+				) }
+				{ isActive && (
 					<ChevronRightIcon className="sensei-home-tasks__link-chevron" />
 				) }
 			</Tag>

--- a/assets/home/tasks-section/task-item.test.js
+++ b/assets/home/tasks-section/task-item.test.js
@@ -63,6 +63,22 @@ describe( '<TaskItem />', () => {
 		expect( externalIcon ).toBeNull();
 	} );
 
+	it( 'Should not render external icon when task is not active', () => {
+		const { container } = render(
+			<TaskItem
+				url="www.example.com/something?this=false&external=true"
+				showExternalIcon
+				disabled
+			/>
+		);
+
+		const externalIcon = container.querySelector(
+			'.sensei-home-tasks__external-icon'
+		);
+
+		expect( externalIcon ).toBeNull();
+	} );
+
 	it( 'Should render a span when item is disabled', () => {
 		const { container } = render( <TaskItem url="#" disabled /> );
 

--- a/assets/home/tasks-section/task-item.test.js
+++ b/assets/home/tasks-section/task-item.test.js
@@ -4,9 +4,16 @@
 import { render } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { Tooltip } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import TaskItem from './task-item';
+
+jest.mock( '@wordpress/components' );
 
 describe( '<TaskItem />', () => {
 	it( 'Should render an anchor when item is not completed', () => {
@@ -27,5 +34,23 @@ describe( '<TaskItem />', () => {
 		).tagName;
 
 		expect( renderedTag ).toEqual( 'SPAN' );
+	} );
+
+	it( 'Should render a span when item is disabled', () => {
+		const { container } = render( <TaskItem url="#" disabled /> );
+
+		const renderedTag = container.querySelector(
+			'.sensei-home-tasks__link'
+		).tagName;
+
+		expect( renderedTag ).toEqual( 'SPAN' );
+	} );
+
+	it( 'Should render a task with the info', () => {
+		Tooltip.mockImplementation( ( { text } ) => text );
+
+		const { queryByText } = render( <TaskItem url="#" info="Info text" /> );
+
+		expect( queryByText( 'Info text' ) ).toBeTruthy();
 	} );
 } );

--- a/assets/home/tasks-section/tasks.js
+++ b/assets/home/tasks-section/tasks.js
@@ -34,6 +34,8 @@ const Tasks = ( { items } ) => (
 					title={ task.title }
 					url={ task.url }
 					done={ task.done }
+					disabled={ task.disabled }
+					info={ task.info }
 				/>
 			) ) }
 		</ul>

--- a/assets/home/tasks-section/tasks.scss
+++ b/assets/home/tasks-section/tasks.scss
@@ -32,7 +32,7 @@
 			border-top: none;
 		}
 
-		&--done {
+		&--disabled {
 			color: $gray-50;
 		}
 	}
@@ -58,5 +58,9 @@
 		width: 25px;
 		height: 25px;
 		justify-self: end;
+	}
+
+	&__icon-with-current-color {
+		fill: currentColor;
 	}
 }

--- a/includes/admin/class-sensei-home.php
+++ b/includes/admin/class-sensei-home.php
@@ -143,7 +143,7 @@ final class Sensei_Home {
 
 		if ( self::SCREEN_ID === $screen->id ) {
 			Sensei()->assets->enqueue( 'sensei-home', 'home/index.js', [], true );
-			Sensei()->assets->enqueue( 'sensei-home-style', 'home/home.css', [ 'sensei-wp-components' ] );
+			Sensei()->assets->enqueue( 'sensei-home-style', 'home/home.css', [ 'sensei-wp-components', 'wp-components' ] );
 			Sensei()->assets->enqueue( 'sensei-dismiss-notices', 'js/admin/sensei-notice-dismiss.js', [] );
 			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin', '/sensei-internal/v1/home' ] );
 
@@ -276,5 +276,4 @@ final class Sensei_Home {
 		}
 		return self::$instance;
 	}
-
 }

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -100,6 +100,8 @@ class Sensei_Home_Tasks_Provider {
 		 * @property {string} `$tasks[]['url']`      Optional. Destination URL for users when clicking on the task.
 		 * @property {string} `$tasks[]['image']`    Optional. Source url or path for the featured image when this task is the first pending one.
 		 * @property {bool}   `$tasks[]['done']`     Whether the task is considered done or not.
+		 * @property {bool}   `$tasks[]['disabled']` Whether the task is considered disabled or not.
+		 * @property {bool}   `$tasks[]['info']`     A text to describe something about the task in an `info` icon.
 		 * @return {array} Filtered tasks.
 		 */
 		return apply_filters( 'sensei_home_tasks', $tasks );


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei-pro/issues/2540

## Proposed Changes

* It adds info prop for tasks. With this, we can add an info icon with a tooltip.
* It adds a disabled state for tasks, so the task is not clickable.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See https://github.com/Automattic/sensei-pro/pull/2565

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
