### PR TITLE
Improve visibility of focused elements in Course and Lesson tours

### DIFF
--- a/assets/admin/tour/course-tour/steps.js
+++ b/assets/admin/tour/course-tour/steps.js
@@ -21,6 +21,17 @@ import {
 	waitForElement,
 } from '../helper';
 
+const scrollToCenter = ( selector ) => {
+	const element = document.querySelector( selector );
+	if ( element ) {
+		element.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'center',
+			inline: 'center',
+		} );
+	}
+};
+
 export const getCourseOutlineBlock = () =>
 	getFirstBlockByName(
 		'sensei-lms/course-outline',
@@ -36,7 +47,7 @@ function insertLessonBlock( lessonTitle ) {
 			createBlock( 'sensei-lms/course-outline-lesson', {
 				title: lessonTitle,
 			} ),
-			undefined,
+			0,
 			courseOutlineBlock.clientId
 		);
 	}
@@ -131,6 +142,7 @@ function getTourSteps() {
 							highlightElementsWithBorders( [
 								courseOutlineBlockSelector,
 							] );
+							scrollToCenter( courseOutlineBlockSelector );
 						},
 						delay: 0,
 					},

--- a/assets/admin/tour/course-tour/steps.js
+++ b/assets/admin/tour/course-tour/steps.js
@@ -19,18 +19,8 @@ import {
 	performStepActionsAsync,
 	removeHighlightClasses,
 	waitForElement,
+	scrollToCenter,
 } from '../helper';
-
-const scrollToCenter = ( selector ) => {
-	const element = document.querySelector( selector );
-	if ( element ) {
-		element.scrollIntoView( {
-			behavior: 'smooth',
-			block: 'center',
-			inline: 'center',
-		} );
-	}
-};
 
 export const getCourseOutlineBlock = () =>
 	getFirstBlockByName(

--- a/assets/admin/tour/course-tour/steps.js
+++ b/assets/admin/tour/course-tour/steps.js
@@ -175,8 +175,10 @@ function getTourSteps() {
 				await performStepActionsAsync( [
 					{
 						action: () => {
+							const lessonSelector =
+								'[data-type="sensei-lms/course-outline-lesson"]';
 							const lesson = document.querySelector(
-								'[data-type="sensei-lms/course-outline-lesson"]'
+								lessonSelector
 							);
 							if ( lesson ) {
 								lesson.focus();
@@ -185,8 +187,11 @@ function getTourSteps() {
 					},
 					{
 						action: () => {
+							const firstLessonTextAreaSelector =
+								'[data-type="sensei-lms/course-outline-lesson"] textarea';
+
 							const lesson = document.querySelector(
-								'[data-type="sensei-lms/course-outline-lesson"] textarea'
+								firstLessonTextAreaSelector
 							);
 							if ( lesson ) {
 								lesson.focus();
@@ -196,6 +201,14 @@ function getTourSteps() {
 							] );
 						},
 						delay: 100,
+					},
+					{
+						action: () => {
+							const lessonSelector =
+								'[data-type="sensei-lms/course-outline-lesson"] .wp-block-sensei-lms-course-outline-lesson';
+							scrollToCenter( lessonSelector );
+						},
+						delay: 200,
 					},
 				] );
 			},
@@ -233,6 +246,7 @@ function getTourSteps() {
 					},
 					{
 						action: () => {
+							scrollToCenter( inserterSelector );
 							const inserter = document.querySelector(
 								inserterSelector
 							);
@@ -297,6 +311,7 @@ function getTourSteps() {
 					},
 					{
 						action: () => {
+							scrollToCenter( inserterSelector );
 							const inserter = document.querySelector(
 								inserterSelector
 							);
@@ -311,6 +326,7 @@ function getTourSteps() {
 							highlightElementsWithBorders( [
 								inserterSelector,
 							] );
+							scrollToCenter( inserterSelector );
 						},
 					},
 					{
@@ -318,12 +334,13 @@ function getTourSteps() {
 							highlightElementsWithBorders( [
 								insertLessonSelector,
 							] );
-							const module = document.querySelector(
+							const lesson = document.querySelector(
 								insertLessonSelector
 							);
-							if ( module ) {
-								module.focus();
+							if ( lesson ) {
+								lesson.focus();
 							}
+							scrollToCenter( insertLessonSelector );
 						},
 						delay: 400,
 					},
@@ -368,6 +385,9 @@ function getTourSteps() {
 					},
 					{
 						action: () => {
+							const lessonSelector =
+								'.wp-block-sensei-lms-course-outline-lesson';
+							scrollToCenter( lessonSelector );
 							highlightElementsWithBorders( [ optionSelector ] );
 						},
 						delay: 400,
@@ -465,6 +485,7 @@ function getTourSteps() {
 					{
 						action: () => {
 							highlightElementsWithBorders( [ buttonSelector ] );
+							scrollToCenter( buttonSelector );
 						},
 						delay: 400,
 					},
@@ -523,6 +544,7 @@ function getTourSteps() {
 					{
 						action: () => {
 							highlightElementsWithBorders( [ buttonSelector ] );
+							scrollToCenter( buttonSelector );
 						},
 						delay: 400,
 					},

--- a/assets/admin/tour/helper.js
+++ b/assets/admin/tour/helper.js
@@ -120,3 +120,19 @@ export async function waitForElement( selector, maxChecks = 10, delay = 300 ) {
 		checkElement();
 	} );
 }
+
+/**
+ * Scrolls element to the center for better visibility.
+ *
+ * @param {string} selector
+ */
+export const scrollToCenter = ( selector ) => {
+	const element = document.querySelector( selector );
+	if ( element ) {
+		element.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'center',
+			inline: 'center',
+		} );
+	}
+};

--- a/assets/admin/tour/lesson-tour/steps.js
+++ b/assets/admin/tour/lesson-tour/steps.js
@@ -18,6 +18,7 @@ import { getFirstBlockByName } from '../../../blocks/course-outline/data';
 import {
 	highlightElementsWithBorders,
 	performStepActionsAsync,
+	scrollToCenter,
 } from '../helper';
 
 export const getQuizBlock = () =>
@@ -465,14 +466,15 @@ export default function getTourSteps() {
 					// Focus on answer feedback field and highlight answer feedback areas.
 					{
 						action: () => {
+							const correctAnswerFieldSelector =
+								'.sensei-lms-question__answer-feedback__content .block-editor-rich-text__editable';
 							const correctAnswerField = document.querySelector(
-								'.sensei-lms-question__answer-feedback__content .block-editor-rich-text__editable'
+								correctAnswerFieldSelector
 							);
 
 							correctAnswerField.focus();
-							correctAnswerField.scrollIntoView( {
-								block: 'center',
-							} );
+
+							scrollToCenter( correctAnswerFieldSelector );
 
 							highlightElementsWithBorders( [
 								'.sensei-lms-question__answer-feedback--correct',

--- a/assets/admin/tour/lesson-tour/steps.js
+++ b/assets/admin/tour/lesson-tour/steps.js
@@ -296,6 +296,7 @@ export default function getTourSteps() {
 							if ( titleField ) {
 								titleField.focus();
 							}
+							scrollToCenter( titleFieldSelector );
 						},
 						delay: 400,
 					},
@@ -341,6 +342,7 @@ export default function getTourSteps() {
 							if ( descriptionField ) {
 								descriptionField.focus();
 							}
+							scrollToCenter( descriptionFieldSelector );
 						},
 						delay: 400,
 					},
@@ -534,6 +536,7 @@ export default function getTourSteps() {
 					// Highlight inserter button.
 					{
 						action: () => {
+							scrollToCenter( inserterSelector );
 							highlightElementsWithBorders( [
 								inserterSelector,
 							] );
@@ -663,6 +666,7 @@ export default function getTourSteps() {
 							const settingsButton = document.querySelector(
 								settingsButtonSelector
 							);
+
 							if ( settingsButton ) {
 								settingsButton.focus();
 								settingsButton.click();

--- a/changelog/add-make-sure-focused-elements-are-visible
+++ b/changelog/add-make-sure-focused-elements-are-visible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Visibility improved for focus elements of Course tour


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7556

## Proposed Changes
In some scenarios (especially when using the Astra theme), for a couple of steps in the Course tour (especially when there are many lessons in the Course outline block, for example, when the user installs the dummy Course from Sensei home and then takes the Tour using that particular course), and particularly when the screen size is small, the focused element got partially hidden behind the Tour modal, especially the `Save Lessons` step. We've added some improvements here by scrolling the action area to the center to make them more visible to the user.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site with new installation of Sensei
2. Use your laptop's display for testing (Or any small monitor)
3. Set Astra as your theme
4. Go to SenseiLMS -> Home -> Click on "Install a demo Course"
5. Then click on "Edit Demo Course"
6. You'll be taken to the Course and the tour should start
7. Take the whole tour and make sure none of them get significantly hidden behind the tour modal
8. Try with other popular themes
9. Try editing any of the lessons and take the lesson tour, make sure all of the steps are visible

https://github.com/Automattic/sensei/assets/6820724/9cec2e57-1840-4533-85c4-d72ec7b9e3cd

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
