### PR TITLE
Remove Sell Course with WooCommerce task and deprecate task class

### DIFF
--- a/changelog/add-deprecate-sell-course-wth-woocommerce-task
+++ b/changelog/add-deprecate-sell-course-wth-woocommerce-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Remove Sell your course with WooCommerce task from core

--- a/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
+++ b/includes/admin/home/tasks/class-sensei-home-tasks-provider.php
@@ -67,10 +67,6 @@ class Sensei_Home_Tasks_Provider {
 			new Sensei_Home_Task_Publish_First_Course(),
 		];
 
-		if ( Sensei_Home_Task_Sell_Course_With_WooCommerce::is_active() ) {
-			$core_tasks[] = new Sensei_Home_Task_Sell_Course_With_WooCommerce();
-		}
-
 		if ( Sensei_Home_Task_Pro_Upsell::is_active() ) {
 			$core_tasks[] = new Sensei_Home_Task_Pro_Upsell();
 		}

--- a/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
@@ -17,6 +17,17 @@ class Sensei_Home_Task_Sell_Course_With_WooCommerce implements Sensei_Home_Task 
 	const VISITED_WOOCOMMERCE_ADMIN_OPTION_KEY = 'sensei_home_task_visited_woocommerce';
 
 	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		if ( is_wp_version_compatible( '6.4' ) ) {
+			_deprecated_class( __CLASS__, '$$next-version$$', 'Sensei_Home_Task_Pro_Upsell' );
+		} else {
+			_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Home_Task_Pro_Upsell' );
+		}
+	}
+
+	/**
 	 * The ID for the task.
 	 *
 	 * @return string

--- a/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
@@ -23,7 +23,7 @@ class Sensei_Home_Task_Sell_Course_With_WooCommerce implements Sensei_Home_Task 
 		if ( is_wp_version_compatible( '6.4' ) ) {
 			_deprecated_class( __CLASS__, '$$next-version$$', 'Sensei_Home_Task_Pro_Upsell' );
 		} else {
-			_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Home_Task_Pro_Upsell' );
+			_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Home_Task_Pro_Upsell::__construct' );
 		}
 	}
 

--- a/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
+++ b/includes/admin/home/tasks/task/class-sensei-home-task-sell-course-with-woocommerce.php
@@ -9,6 +9,8 @@
 /**
  * Sensei_Home_Task_Sell_Course_With_WooCommerce class.
  *
+ * @deprecated $$next-version$$ We're now showing the "Sell your course with Sensei Pro" (Sensei_Home_Task_Pro_Upsell) task instead of this task.
+ *
  * @since 4.8.0
  */
 class Sensei_Home_Task_Sell_Course_With_WooCommerce implements Sensei_Home_Task {

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -55,7 +55,6 @@ class Sensei_Admin {
 		add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
 		add_action( 'admin_head', array( $this, 'admin_menu_highlight' ) );
 		add_action( 'admin_init', array( $this, 'sensei_add_custom_menu_items' ) );
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'admin_print_scripts', array( $this, 'sensei_set_plugin_url' ) );
 
 		// Duplicate lesson & courses
@@ -1593,24 +1592,6 @@ class Sensei_Admin {
 		}
 
 		return $course_structure;
-	}
-
-	/**
-	 * Registers the hook to call mark_completed on tasks that have been
-	 * completed.
-	 *
-	 * @access private
-	 * @return void
-	 */
-	public function admin_init() {
-		global $pagenow;
-
-		if ( Sensei_Home_Task_Sell_Course_With_WooCommerce::is_active() ) {
-			$hook = get_plugin_page_hook( 'wc-admin', 'woocommerce' );
-			if ( null !== $hook ) {
-				add_action( $hook, [ Sensei_Home_Task_Sell_Course_With_WooCommerce::class, 'mark_completed' ] );
-			}
-		}
 	}
 
 	function sensei_add_custom_menu_items() {


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7571

## Proposed Changes
Removed usage of Sell your course with WooCommerce task's class and deprecated it.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new installation of Sensei.
2. Install WooCommerce
3. Go to Sensei LMS -> Home
4. Make sure you see the task `Sell your course with Sensei Pro` instead of `Sell your course with WooCommerce`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
