### PR TITLE
Change Setup Wizard redirect to work on all relevant pages

### DIFF
--- a/changelog/change-setup-wizard-redirect
+++ b/changelog/change-setup-wizard-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Open Setup Wizard when navigating through relevant pages on admin if it didn't open yet

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -198,7 +198,7 @@ class Sensei_Setup_Wizard {
 			// Only redirects for admin users.
 			|| ! current_user_can( 'manage_sensei' )
 			// Check if it's an admin screen that should redirect.
-			|| ! $this->should_current_page_display_wizard()
+			|| ! $this->should_current_page_redirect_to_wizard()
 		) {
 			return;
 		}
@@ -234,18 +234,39 @@ class Sensei_Setup_Wizard {
 	}
 
 	/**
-	 * Check if current screen is selected to display the wizard notice and
-	 * automatically open the wizard.
+	 * Check if current screen is selected to display the wizard notice.
 	 *
 	 * @return boolean
 	 */
-	private function should_current_page_display_wizard() {
-		$screen = get_current_screen();
+	private function should_current_page_display_wizard_notice() {
+		// Dashboard, plugins, and Sensei pages, except Sensei Home.
+		$screens_without_sensei_prefix = [
+			'dashboard',
+			'plugins',
+			'edit-sensei_message',
+			'edit-course',
+			'edit-course-category',
+			'admin_page_course-order',
+			'edit-module',
+			'admin_page_module-order',
+			'edit-lesson',
+			'edit-lesson-tag',
+			'admin_page_lesson-order',
+			'edit-question',
+			'question',
+			'edit-question-category',
+		];
 
-		if ( false !== strpos( $screen->id, 'sensei-lms_page_sensei' ) ) {
-			return true;
-		}
+		return $this->check_sensei_screen( $screens_without_sensei_prefix );
+	}
 
+	/**
+	 * Check if current screen is selected to redirect to the wizard.
+	 *
+	 * @return boolean
+	 */
+	private function should_current_page_redirect_to_wizard() {
+		// Dashboard, plugins, and Sensei pages.
 		$screens_without_sensei_prefix = [
 			'dashboard',
 			'plugins',
@@ -264,7 +285,26 @@ class Sensei_Setup_Wizard {
 			'edit-question-category',
 		];
 
-		return in_array( $screen->id, $screens_without_sensei_prefix, true );
+		return $this->check_sensei_screen( $screens_without_sensei_prefix );
+	}
+
+	/**
+	 * Check if current screen is a Sensei screen.
+	 * The default check verifies if the screen ID contains 'sensei-lms_page_sensei'.
+	 * For more screens to be checked, pass the IDs as an array.
+	 *
+	 * @param array $other_screens Other screens to check.
+	 *
+	 * @return boolean
+	 */
+	private function check_sensei_screen( $other_screens = [] ) {
+		$screen = get_current_screen();
+
+		if ( false !== strpos( $screen->id, 'sensei-lms_page_sensei' ) ) {
+			return true;
+		}
+
+		return in_array( $screen->id, $other_screens, true );
 	}
 
 	/**
@@ -274,7 +314,7 @@ class Sensei_Setup_Wizard {
 	 */
 	public function setup_wizard_notice() {
 		if (
-			! $this->should_current_page_display_wizard()
+			! $this->should_current_page_display_wizard_notice()
 			|| ! get_option( self::SUGGEST_SETUP_WIZARD_OPTION, 0 )
 			|| ! current_user_can( 'manage_sensei' )
 		) {

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -249,6 +249,7 @@ class Sensei_Setup_Wizard {
 		$screens_without_sensei_prefix = [
 			'dashboard',
 			'plugins',
+			'toplevel_page_sensei',
 			'edit-sensei_message',
 			'edit-course',
 			'edit-course-category',

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -194,7 +194,10 @@ class Sensei_Setup_Wizard {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 			|| ( isset( $_REQUEST['action'] ) && 'as_async_request_queue_runner' === $_REQUEST['action'] )
 			// On these pages, or during these events, postpone the redirect.
-			|| wp_doing_ajax() || wp_doing_cron() || is_network_admin() || ! current_user_can( 'manage_sensei' )
+			|| wp_doing_ajax() || wp_doing_cron() || is_network_admin()
+			// Only redirects for admin users.
+			|| ! current_user_can( 'manage_sensei' )
+			// Check if it's an admin screen that should redirect.
 			|| ! $this->should_current_page_display_wizard()
 		) {
 			return;

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -545,7 +545,7 @@ class Sensei_Setup_Wizard {
 
 		if (
 			isset( $_SERVER['HTTP_REFERER'] ) &&
-			0 === strpos( $_SERVER['HTTP_REFERER'], 'https://woocommerce.com/checkout' ) && // phpcs:ignore sanitization ok.
+			0 === strpos( $_SERVER['HTTP_REFERER'], 'https://woocommerce.com/checkout' ) && // phpcs:ignore -- sanitization ok.
 			false !== get_transient( $wccom_installing_transient )
 		) {
 			delete_transient( $wccom_installing_transient );

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -99,6 +99,7 @@ class Sensei_Data_Cleaner {
 		'sensei_home_tasks_dismissed',
 		'sensei_home_tasks_list_is_completed',
 		'sensei-home-task-pro-upsell',
+		'sensei_activation_redirect',
 	);
 
 	/**
@@ -233,7 +234,7 @@ class Sensei_Data_Cleaner {
 		'sensei_answers_feedback_[0-9]+_[0-9]+',
 		'quiz_grades_[0-9]+_[0-9]+',
 		'sensei_comment_counts_[0-9]+',
-		'sensei_activation_redirect',
+		'sensei_activation_redirect', // @deprecated $$next-version$$ Changed to an option.
 		'sensei_woocommerce_plugin_information',
 		'sensei_extensions_.*',
 		'sensei_background_job_.*',

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1166,7 +1166,7 @@ class Sensei_Main {
 			// Do not enable the wizard for sites that are created with the onboarding flow.
 			if ( 'sensei' !== get_option( 'site_intent' ) ) {
 
-				set_transient( 'sensei_activation_redirect', 1, 30 );
+				update_option( 'sensei_activation_redirect', 1 );
 				update_option( Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 
 			} else {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -81,4 +81,13 @@
 		<exclude-pattern>**/views/*</exclude-pattern>
 		<exclude-pattern>tests/bootstrap.php</exclude-pattern>
 	</rule>
+
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="manage_sensei"/>
+			</property>
+		</properties>
+	</rule>
+
 </ruleset>

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -214,8 +214,9 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
+		set_current_screen( 'dashboard' );
 
-		set_transient( 'sensei_activation_redirect', 1, 30 );
+		update_option( 'sensei_activation_redirect', 1 );
 
 		$setup_wizard_mock = $this->getMockBuilder( 'Sensei_Setup_Wizard' )
 			->setMethods( [ 'redirect_to_setup_wizard' ] )
@@ -225,8 +226,27 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			->method( 'redirect_to_setup_wizard' );
 
 		$setup_wizard_mock->activation_redirect();
+	}
 
-		$this->assertFalse( get_transient( 'sensei_activation_redirect' ), 'Transient should be removed' );
+	/*
+	 * Testing if activation doesn't redirect for no Sensei screens.
+	 */
+	public function testActivationRedirectNoSenseiScreen() {
+		// Create and login as administrator.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		set_current_screen( 'any_other' );
+
+		update_option( 'sensei_activation_redirect', 1 );
+
+		$setup_wizard_mock = $this->getMockBuilder( 'Sensei_Setup_Wizard' )
+			->setMethods( [ 'redirect_to_setup_wizard' ] )
+			->getMock();
+
+		$setup_wizard_mock->expects( $this->never() )
+			->method( 'redirect_to_setup_wizard' );
+
+		$setup_wizard_mock->activation_redirect();
 	}
 
 	/**
@@ -237,7 +257,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $subscriber_id );
 
-		set_transient( 'sensei_activation_redirect', 1, 30 );
+		update_option( 'sensei_activation_redirect', 1 );
 
 		$setup_wizard_mock = $this->getMockBuilder( 'Sensei_Setup_Wizard' )
 			->setMethods( [ 'redirect_to_setup_wizard' ] )
@@ -247,8 +267,6 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			->method( 'redirect_to_setup_wizard' );
 
 		$setup_wizard_mock->activation_redirect();
-
-		$this->assertNotFalse( get_transient( 'sensei_activation_redirect' ), 'Transient should not be removed' );
 	}
 
 	/**
@@ -267,6 +285,17 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			->method( 'redirect_to_setup_wizard' );
 
 		$setup_wizard_mock->activation_redirect();
+	}
+
+	/**
+	 * Testing if redirect option is cleared on setup wizard rendering.
+	 */
+	public function testRenderWizardPageClearsRedirectOption() {
+		update_option( 'sensei_activation_redirect', 1 );
+
+		Sensei()->setup_wizard->render_wizard_page();
+
+		$this->assertFalse( get_option( 'sensei_activation_redirect', false ) );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -12,6 +12,8 @@
  * @covers Sensei_Setup_Wizard
  */
 class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
+	use Sensei_Test_Redirect_Helpers;
+
 	/**
 	 * Set up before the class.
 	 */
@@ -238,22 +240,24 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	public function testActivationRedirect_WhenRedirectOptionIsOne_CallsRedirect() {
 		// Arrange.
 		// Create and login as administrator.
-		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$expected_redirect = admin_url( 'admin.php?page=sensei_setup_wizard' );
+		$admin_id          = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->prevent_wp_redirect();
 		wp_set_current_user( $admin_id );
 		set_current_screen( 'dashboard' );
 
 		update_option( 'sensei_activation_redirect', 1 );
 
-		$setup_wizard_mock = $this->getMockBuilder( 'Sensei_Setup_Wizard' )
-			->setMethods( [ 'redirect_to_setup_wizard' ] )
-			->getMock();
+		// Act.
+		$redirect_location = '';
+		try {
+			Sensei()->setup_wizard->activation_redirect();
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
 
 		// Assert.
-		$setup_wizard_mock->expects( $this->once() )
-			->method( 'redirect_to_setup_wizard' );
-
-		// Act.
-		$setup_wizard_mock->activation_redirect();
+		$this->assertSame( $expected_redirect, $redirect_location );
 	}
 
 	/*
@@ -263,21 +267,22 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		// Arrange.
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->prevent_wp_redirect();
 		wp_set_current_user( $admin_id );
 		set_current_screen( 'any_other' );
 
 		update_option( 'sensei_activation_redirect', 1 );
 
-		$setup_wizard_mock = $this->getMockBuilder( 'Sensei_Setup_Wizard' )
-			->setMethods( [ 'redirect_to_setup_wizard' ] )
-			->getMock();
+		// Act.
+		$redirect_location = '';
+		try {
+			Sensei()->setup_wizard->activation_redirect();
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
 
 		// Assert.
-		$setup_wizard_mock->expects( $this->never() )
-			->method( 'redirect_to_setup_wizard' );
-
-		// Act.
-		$setup_wizard_mock->activation_redirect();
+		$this->assertEmpty( $redirect_location );
 	}
 
 	/**
@@ -287,20 +292,21 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		// Arrange.
 		// Create and login as subscriber.
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$this->prevent_wp_redirect();
 		wp_set_current_user( $subscriber_id );
 
 		update_option( 'sensei_activation_redirect', 1 );
 
-		$setup_wizard_mock = $this->getMockBuilder( 'Sensei_Setup_Wizard' )
-			->setMethods( [ 'redirect_to_setup_wizard' ] )
-			->getMock();
+		// Act.
+		$redirect_location = '';
+		try {
+			Sensei()->setup_wizard->activation_redirect();
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
 
 		// Assert.
-		$setup_wizard_mock->expects( $this->never() )
-			->method( 'redirect_to_setup_wizard' );
-
-		// Act.
-		$setup_wizard_mock->activation_redirect();
+		$this->assertEmpty( $redirect_location );
 	}
 
 	/**
@@ -310,18 +316,19 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		// Arrange.
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->prevent_wp_redirect();
 		wp_set_current_user( $admin_id );
 
-		$setup_wizard_mock = $this->getMockBuilder( 'Sensei_Setup_Wizard' )
-			->setMethods( [ 'redirect_to_setup_wizard' ] )
-			->getMock();
+		// Act.
+		$redirect_location = '';
+		try {
+			Sensei()->setup_wizard->activation_redirect();
+		} catch ( Sensei_WP_Redirect_Exception $e ) {
+			$redirect_location = $e->getMessage();
+		}
 
 		// Assert.
-		$setup_wizard_mock->expects( $this->never() )
-			->method( 'redirect_to_setup_wizard' );
-
-		// Act.
-		$setup_wizard_mock->activation_redirect();
+		$this->assertEmpty( $redirect_location );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -58,14 +58,16 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	/**
 	 * Testing the setup wizard class to make sure it is loaded.
 	 */
-	public function testClassInstance() {
+	public function testClassInstance_Always_Exists() {
+		// Assert.
 		$this->assertTrue( class_exists( 'Sensei_Setup_Wizard' ), 'Sensei Setup Wizard class does not exist' );
 	}
 
 	/**
 	 * Test setup wizard notice in dashboard.
 	 */
-	public function testSetupWizardNoticeInDashboard() {
+	public function testSetupWizardNotice_WhenSuggestSetupWizardOptionIsOneAndScreenIsDashboard_DisplaysNotice() {
+		// Arrange.
 		// Create and login as admin.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -73,19 +75,22 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		set_current_screen( 'dashboard' );
 		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 
+		// Act.
 		ob_start();
 		Sensei()->setup_wizard->setup_wizard_notice();
 		$html = ob_get_clean();
 
 		$pos_setup_button = strpos( $html, 'Run the Setup Wizard' );
 
+		// Assert.
 		$this->assertNotFalse( $pos_setup_button, 'Should return the notice HTML' );
 	}
 
 	/**
 	 * Test setup wizard notice in screen with Sensei prefix.
 	 */
-	public function testSetupWizardNoticeInSenseiScreen() {
+	public function testSetupWizardNotice_WhenSuggestSetupWizardOptionIsOneAndScreenIsSenseiPage_DisplaysNotice() {
+		// Arrange.
 		// Create and login as admin.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -93,19 +98,22 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		set_current_screen( 'sensei-lms_page_sensei_test' );
 		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 
+		// Act.
 		ob_start();
 		Sensei()->setup_wizard->setup_wizard_notice();
 		$html = ob_get_clean();
 
 		$pos_setup_button = strpos( $html, 'Run the Setup Wizard' );
 
+		// Assert.
 		$this->assertNotFalse( $pos_setup_button, 'Should return the notice HTML' );
 	}
 
 	/**
 	 * Test setup wizard notice in no Sensei screen.
 	 */
-	public function testSetupWizardNoticeInOtherScreen() {
+	public function testSetupWizardNotice_WhenInOtherScreen_DoesNotDisplayNotice() {
+		// Arrange.
 		// Create and login as admin.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -113,17 +121,20 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		set_current_screen( 'other' );
 		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 
+		// Act.
 		ob_start();
 		Sensei()->setup_wizard->setup_wizard_notice();
 		$html = ob_get_clean();
 
+		// Assert.
 		$this->assertEmpty( $html, 'Should return empty string' );
 	}
 
 	/**
 	 * Test setup wizard notice with suggest option as 0.
 	 */
-	public function testSetupWizardNoticeSuggestOptionAsZero() {
+	public function testSetupWizardNotice_WhenSuggestOptionIsZero_DoesNotDisplayNotice() {
+		// Arrange.
 		// Create and login as admin.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -131,52 +142,61 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		set_current_screen( 'dashboard' );
 		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 0 );
 
+		// Act.
 		ob_start();
 		Sensei()->setup_wizard->setup_wizard_notice();
 		$html = ob_get_clean();
 
+		// Assert.
 		$this->assertEmpty( $html, 'Should return empty string' );
 	}
 
 	/**
 	 * Test setup wizard notice with suggest option empty.
 	 */
-	public function testSetupWizardNoticeSuggestOptionEmpty() {
+	public function testSetupWizardNotice_WhenSuggestOptionIsEmpty_DoesNotDisplayNotice() {
+		// Arrange.
 		// Create and login as admin.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
 
 		set_current_screen( 'dashboard' );
 
+		// Act.
 		ob_start();
 		Sensei()->setup_wizard->setup_wizard_notice();
 		$html = ob_get_clean();
 
+		// Assert.
 		$this->assertEmpty( $html, 'Should return empty string' );
 	}
 
 	/**
 	 * Test setup wizard notice for no admin user.
 	 */
-	public function testSetupWizardNoticeNoAdmin() {
+	public function testSetupWizardNotice_WhenUserIsNoAdmin_DoesNotDisplayNotice() {
+		// Arrange.
 		// Create and login as teacher.
 		$teacher_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
 		wp_set_current_user( $teacher_id );
 
 		set_current_screen( 'dashboard' );
-		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 0 );
+		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 
+		// Act.
 		ob_start();
 		Sensei()->setup_wizard->setup_wizard_notice();
 		$html = ob_get_clean();
 
+		// Assert.
 		$this->assertEmpty( $html, 'Should return empty string' );
 	}
 
 	/**
 	 * Test skip setup wizard.
 	 */
-	public function testSkipSetupWizard() {
+	public function testSkipSetupWizard_WhenArgumentsAreSet_UpdatesOptionToZero() {
+		// Arrange.
 		// Create and login as admin.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -184,16 +204,19 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		$_GET['sensei_skip_setup_wizard'] = '1';
 		$_GET['_wpnonce']                 = wp_create_nonce( 'sensei_skip_setup_wizard' );
 
+		// Act.
 		Sensei()->setup_wizard->skip_setup_wizard();
 		$option_value = get_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, false );
 
+		// Assert.
 		$this->assertEquals( '0', $option_value, 'Should update option to 0' );
 	}
 
 	/**
 	 * Test skip setup wizard.
 	 */
-	public function testSkipSetupWizardNoAdmin() {
+	public function testSkipSetupWizard_WhenUserIsNoAdmin_DoesNotUpdateOption() {
+		// Arrange.
 		// Create and login as teacher.
 		$teacher_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
 		wp_set_current_user( $teacher_id );
@@ -201,16 +224,19 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		$_GET['sensei_skip_setup_wizard'] = '1';
 		$_GET['_wpnonce']                 = wp_create_nonce( 'sensei_skip_setup_wizard' );
 
+		// Act.
 		Sensei()->setup_wizard->skip_setup_wizard();
 		$option_value = get_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, false );
 
+		// Assert.
 		$this->assertFalse( $option_value, 'Should not update option' );
 	}
 
 	/*
 	 * Testing if activation redirect works properly.
 	 */
-	public function testActivationRedirect() {
+	public function testActivationRedirect_WhenRedirectOptionIsOne_CallsRedirect() {
+		// Arrange.
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -222,16 +248,19 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			->setMethods( [ 'redirect_to_setup_wizard' ] )
 			->getMock();
 
+		// Assert.
 		$setup_wizard_mock->expects( $this->once() )
 			->method( 'redirect_to_setup_wizard' );
 
+		// Act.
 		$setup_wizard_mock->activation_redirect();
 	}
 
 	/*
 	 * Testing if activation doesn't redirect for no Sensei screens.
 	 */
-	public function testActivationRedirectNoSenseiScreen() {
+	public function testActivationRedirect_WhenInAPageNotRelatedToSensei_DoesNotCallRedirect() {
+		// Arrange.
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -243,16 +272,19 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			->setMethods( [ 'redirect_to_setup_wizard' ] )
 			->getMock();
 
+		// Assert.
 		$setup_wizard_mock->expects( $this->never() )
 			->method( 'redirect_to_setup_wizard' );
 
+		// Act.
 		$setup_wizard_mock->activation_redirect();
 	}
 
 	/**
 	 * Testing if activation doesn't redirect for no admin user.
 	 */
-	public function testActivationRedirectNoAdmin() {
+	public function testActivationRedirect_WhenUserIsNoAdmin_DoesNotCallRedirect() {
+		// Arrange.
 		// Create and login as subscriber.
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $subscriber_id );
@@ -263,16 +295,19 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			->setMethods( [ 'redirect_to_setup_wizard' ] )
 			->getMock();
 
+		// Assert.
 		$setup_wizard_mock->expects( $this->never() )
 			->method( 'redirect_to_setup_wizard' );
 
+		// Act.
 		$setup_wizard_mock->activation_redirect();
 	}
 
 	/**
-	 * Testing if activation doesn't redirect when transient is not defined.
+	 * Testing if activation doesn't redirect when option does not exist.
 	 */
-	public function testActivationRedirectWithoutTransient() {
+	public function testActivationRedirect_WhenRedirectOptionDoesNotExist_DoesNotCallRedirect() {
+		// Arrange.
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -281,29 +316,36 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			->setMethods( [ 'redirect_to_setup_wizard' ] )
 			->getMock();
 
+		// Assert.
 		$setup_wizard_mock->expects( $this->never() )
 			->method( 'redirect_to_setup_wizard' );
 
+		// Act.
 		$setup_wizard_mock->activation_redirect();
 	}
 
 	/**
 	 * Testing if redirect option is cleared on setup wizard rendering.
 	 */
-	public function testRenderWizardPageClearsRedirectOption() {
+	public function testRenderWizardPage_WhenRendered_ClearsRedirectOption() {
+		// Arrange.
 		update_option( 'sensei_activation_redirect', 1 );
 
+		// Act.
 		Sensei()->setup_wizard->render_wizard_page();
 
+		// Assert.
 		$this->assertFalse( get_option( 'sensei_activation_redirect', false ) );
 	}
 
 	/**
 	 * Test if WooCommerce help tab is being prevented in the Sensei pages.
 	 */
-	public function testShouldEnableWooCommerceHelpTab() {
+	public function testWooCommerceHelpTab_WhenOnCoursePage_ShouldNotPreventTab() {
+		// Arrange.
 		$_GET['post_type'] = 'course';
 
+		// Act & Assert.
 		$this->assertFalse(
 			Sensei()->setup_wizard->should_enable_woocommerce_help_tab( true ),
 			'Should not allow WooCommerce help tab for course post type'
@@ -313,9 +355,11 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	/**
 	 * Test if WooCommerce help tab is being untouched in no Sensei pages.
 	 */
-	public function testShouldEnableWooCommerceHelpTabNoSenseiPage() {
+	public function testWooCommerceHelpTab_WhenOnNoSenseiPage_ShouldNotChangeValue() {
+		// Arrange.
 		$_GET['post_type'] = 'woocommerce';
 
+		// Act & Assert.
 		$this->assertTrue(
 			Sensei()->setup_wizard->should_enable_woocommerce_help_tab( true ),
 			'Should not touch WooCommerce help tab for no Sensei pages'
@@ -325,7 +369,8 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	/**
 	 * Test add setup wizard help tab to edit course screen.
 	 */
-	public function testAddSetupWizardHelpTab() {
+	public function testAddSetupWizardHelpTab_WhenInEditCourse_ShouldAddTab() {
+		// Arrange.
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -334,16 +379,20 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		$screen = get_current_screen();
 
 		$screen->remove_help_tab( 'sensei_lms_setup_wizard_tab' );
+
+		// Act.
 		Sensei()->setup_wizard->add_setup_wizard_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_setup_wizard_tab' );
 
+		// Assert.
 		$this->assertNotNull( $created_tab, 'Should create the setup wizard tab to edit course screens.' );
 	}
 
 	/**
 	 * Test add setup wizard help tab in non edit course screens.
 	 */
-	public function testAddSetupWizardHelpTabNonEditCourseScreen() {
+	public function testAddSetupWizardHelpTab_WhenNotInEditCourse_ShouldNotAddTab() {
+		// Arrange.
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -352,16 +401,20 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		$screen = get_current_screen();
 
 		$screen->remove_help_tab( 'sensei_lms_setup_wizard_tab' );
+
+		// Act.
 		Sensei()->setup_wizard->add_setup_wizard_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_setup_wizard_tab' );
 
+		// Assert.
 		$this->assertNull( $created_tab, 'Should not create the setup wizard tab to non edit course screens.' );
 	}
 
 	/**
 	 * Test add setup wizard help tab for no admin user.
 	 */
-	public function testAddSetupWizardHelpTabNoAdmin() {
+	public function testAddSetupWizardHelpTab_WhenUserIsNoAdmin_ShouldNotAddTab() {
+		// Arrange.
 		// Create and login as teacher.
 		$teacher_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
 		wp_set_current_user( $teacher_id );
@@ -370,9 +423,12 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		$screen = get_current_screen();
 
 		$screen->remove_help_tab( 'sensei_lms_setup_wizard_tab' );
+
+		// Act.
 		Sensei()->setup_wizard->add_setup_wizard_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_setup_wizard_tab' );
 
+		// Assert.
 		$this->assertNull( $created_tab, 'Should not create the setup wizard tab to no admin user.' );
 	}
 


### PR DESCRIPTION
## Proposed Changes

There was [a change on WP 6.5](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/), where it doesn't reload the page when installing a plugin from the plugins directory through _"Plugins > Add New"_. If the plugin is uploaded from a zip file the behavior continues the same as previously.

The Sensei Setup Wizard used to work immediately after we activate the plugin. With the recent change, our logic doesn't work anymore.

After a discussion (p1712321247992169-slack-C02NWDZBL0H), we decided to keep [the intended behavior from WordPress core](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/), and the Setup Wizard will only open after the user navigate in the WP admin.

## Considered alternative

I thought of using this JS event https://github.com/WordPress/WordPress/blob/9bb63fd66503d139e0b3e8498c2a5a80cb3507a1/wp-admin/js/updates.js#L1123 and force a redirect when it's the Sensei activation, but it doesn't align with what WP core is proposing.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Deactivate Sensei LMS plugin.
2. Remove the option `sensei_installed` from the database.
3. Navigate to WP Admin > Plugins > Add New Plugin.
4. Search for "Sensei LMS".
5. Click on "Activate" (notice the new behavior for WP 6.5, where it's an ajax request and won't redirect to the setup wizard).
6. Click on "Users" in the menu.
7. Check that you are not redirected to the Setup Wizard.
8. Click on Sensei LMS, and check that you are redirected to the Setup Wizard (the same should happen when clicking on Sensei pages, Dashboard page and Plugins page).
9. Repeat the test in WP 6.4, and make sure it continues working properly when clicking on "Activate", as it used to work.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues

## Context

* See p1712321247992169-slack-C02NWDZBL0H