### PR TITLE
Fix draft lessons getting published when Course is updated

### DIFF
--- a/changelog/fix-publishing-lessons-in-course-updates
+++ b/changelog/fix-publishing-lessons-in-course-updates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Lessons being automatically published when Course is updated

--- a/includes/admin/class-sensei-course-pre-publish-panel.php
+++ b/includes/admin/class-sensei-course-pre-publish-panel.php
@@ -100,7 +100,10 @@ class Sensei_Course_Pre_Publish_Panel {
 			return;
 		}
 
-		if ( ! $is_main_publish_call ) {
+		$uri                  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$is_metabox_save_call = strpos( $uri, 'meta-box-loader=1' ) > 0;
+
+		if ( ! $is_main_publish_call && ! $is_metabox_save_call ) {
 			// If it's not the main publish call, then it's the structure saving call that comes immediately after the main publish call.
 			// So we can remove the flag now, because after this iteraction, the whole publishing cycle is complete.
 			delete_post_meta( $course_id, $publishing_meta_key );

--- a/includes/admin/class-sensei-course-pre-publish-panel.php
+++ b/includes/admin/class-sensei-course-pre-publish-panel.php
@@ -95,6 +95,8 @@ class Sensei_Course_Pre_Publish_Panel {
 		$is_publishing_started = get_post_meta( $course_id, $publishing_meta_key, true );
 
 		if ( ! $is_main_publish_call && ! $is_publishing_started ) {
+			// If its not the "Publish" call and the flag is not set, then we don't need to publish lessons.
+			// Because it that case it's just a normal "Update" call.
 			return;
 		}
 

--- a/includes/admin/class-sensei-course-pre-publish-panel.php
+++ b/includes/admin/class-sensei-course-pre-publish-panel.php
@@ -101,6 +101,8 @@ class Sensei_Course_Pre_Publish_Panel {
 		}
 
 		if ( ! $is_main_publish_call ) {
+			// If it's not the main publish call, then it's the structure saving call that comes immediately after the main publish call.
+			// So we can remove the flag now, because after this iteraction, the whole publishing cycle is complete.
 			delete_post_meta( $course_id, $publishing_meta_key );
 		}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -721,6 +721,8 @@ class Sensei_Main {
 
 		Sensei_Temporary_User::init();
 
+		Sensei_Course_Pre_Publish_Panel::instance()->init();
+
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
 			// Load Admin Class.
@@ -732,7 +734,6 @@ class Sensei_Main {
 
 			Sensei_No_Users_Table_Relationship::instance()->init();
 			SenseiLMS_Plugin_Updater::init();
-			Sensei_Course_Pre_Publish_Panel::instance()->init();
 		} else {
 
 			// Load Frontend Class.

--- a/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
+++ b/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
@@ -103,4 +103,21 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertEquals( 'publish', get_post_status( $this->lesson_id ) );
 	}
+
+	/**
+	 * Lessons aren't published if a published course is just being updated.
+	 *
+	 *  @covers Sensei_Course_Pre_Publish_Panel::maybe_publish_lessons
+	 */
+	public function testMaybePublishLessons_WhenPreviousStateAlreadyPublished_DoesNotPublishLessons() {
+		/* Arrange */
+		$this->login_as_admin();
+		update_post_meta( $this->course_id, 'sensei_course_publish_lessons', true );
+
+		/* Act */
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'publish' );
+
+		/* Assert */
+		$this->assertEquals( 'draft', get_post_status( $this->lesson_id ) );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
+++ b/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
@@ -172,8 +172,8 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 
 		/* Assert */
 		$meta_save_call_flag = get_post_meta( $this->course_id, '_sensei_course_publishing_started', true );
-		$this->assertEquals( 1, $meta_save_call_flag );
-		$this->assertEquals( 1, $publish_call_flag );
+		$this->assertEquals( 1, $meta_save_call_flag, 'The flag should not be removed when a meta save call is made.' );
+		$this->assertEquals( 1, $publish_call_flag, 'The flag should be set when the first publish call is made.' );
 
 		$_SERVER['REQUEST_URI'] = '';
 	}
@@ -259,9 +259,9 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'publish' );
 
 		/* Assert */
-		$this->assertEquals( 'publish', get_post_status( $this->lesson_id ) );
-		$this->assertEquals( 'publish', get_post_status( $unsaved_to_draft_lesson_id ) );
-		$this->assertEquals( 'draft', get_post_status( $unsaved_to_draft_lesson_id_2 ) );
-		$this->assertEquals( 'draft', get_post_status( $unsaved_to_draft_lesson_id_3 ) );
+		$this->assertEquals( 'publish', get_post_status( $this->lesson_id ), 'The first lesson should be published, because it was already part of the Course before publishing.' );
+		$this->assertEquals( 'publish', get_post_status( $unsaved_to_draft_lesson_id ), 'The second lesson should be published, because it was added to the Course structure before second update call.' );
+		$this->assertEquals( 'draft', get_post_status( $unsaved_to_draft_lesson_id_2 ), 'The third lesson should not be published, because it was added to the Course structure after the second update call.' );
+		$this->assertEquals( 'draft', get_post_status( $unsaved_to_draft_lesson_id_3 ), 'The fourth lesson should not be published, because it was added to the Course structure after the second update call.' );
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
+++ b/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
@@ -120,4 +120,20 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertEquals( 'draft', get_post_status( $this->lesson_id ) );
 	}
+
+	/**
+	 * Lessons are not published a course is actually publishing but meta is false.
+	 *
+	 *  @covers Sensei_Course_Pre_Publish_Panel::maybe_publish_lessons
+	 */
+	public function testMaybePublishLessons_WhenFirstPublishedButMetaFalse_DoesNotPublishLessons() {
+		/* Arrange */
+		$this->login_as_admin();
+
+		/* Act */
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'draft' );
+
+		/* Assert */
+		$this->assertEquals( 'draft', get_post_status( $this->lesson_id ) );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
+++ b/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
@@ -154,6 +154,31 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When request comes from metabox save call, the flag is not removed.
+	 *
+	 *  @covers Sensei_Course_Pre_Publish_Panel::maybe_publish_lessons
+	 */
+	public function testMaybePublishLessons_WhenCallIsFromMetaboxSave_DoesNotRemoveContinuationFlag() {
+		/* Arrange */
+		$this->login_as_admin();
+		update_post_meta( $this->course_id, 'sensei_course_publish_lessons', true );
+
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'draft' );
+		$publish_call_flag      = get_post_meta( $this->course_id, '_sensei_course_publishing_started', true );
+		$_SERVER['REQUEST_URI'] = 'example.com/test=1&meta-box-loader=1';
+
+		/* Act */
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'publish' );
+
+		/* Assert */
+		$meta_save_call_flag = get_post_meta( $this->course_id, '_sensei_course_publishing_started', true );
+		$this->assertEquals( 1, $meta_save_call_flag );
+		$this->assertEquals( 1, $publish_call_flag );
+
+		$_SERVER['REQUEST_URI'] = '';
+	}
+
+	/**
 	 * In the first subsequent call, the lessons are published.
 	 *
 	 *  @covers Sensei_Course_Pre_Publish_Panel::maybe_publish_lessons

--- a/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
+++ b/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
@@ -49,7 +49,6 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		parent::tearDown();
-
 		$this->factory->tearDown();
 	}
 
@@ -135,5 +134,22 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 
 		/* Assert */
 		$this->assertEquals( 'draft', get_post_status( $this->lesson_id ) );
+	}
+
+	/**
+	 * When Course is switched to publish state, the flag is set.
+	 *
+	 *  @covers Sensei_Course_Pre_Publish_Panel::maybe_publish_lessons
+	 */
+	public function testMaybePublishLessons_WhenFirstPublished_SetsThePublishContinuationFlag() {
+		/* Arrange */
+		$this->login_as_admin();
+		update_post_meta( $this->course_id, 'sensei_course_publish_lessons', true );
+
+		/* Act */
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'draft' );
+
+		/* Assert */
+		$this->assertEquals( 1, get_post_meta( $this->course_id, '_sensei_course_publishing_started', true ) );
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
+++ b/tests/unit-tests/admin/test-class-sensei-course-pre-publish-panel.php
@@ -64,7 +64,7 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 		update_post_meta( $this->course_id, 'sensei_course_publish_lessons', true );
 
 		/* Act */
-		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id );
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'draft' );
 
 		/* Assert */
 		$this->assertEquals( 'draft', get_post_status( $this->lesson_id ) );
@@ -81,7 +81,7 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 		update_post_meta( $this->course_id, 'sensei_course_publish_lessons', false );
 
 		/* Act */
-		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id );
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'draft' );
 
 		/* Assert */
 		$this->assertEquals( 'draft', get_post_status( $this->lesson_id ) );
@@ -98,7 +98,7 @@ class Sensei_Sensei_Course_Pre_Publish_Panel_Test extends WP_UnitTestCase {
 		update_post_meta( $this->course_id, 'sensei_course_publish_lessons', true );
 
 		/* Act */
-		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id );
+		Sensei_Course_Pre_Publish_Panel::instance()->maybe_publish_lessons( $this->course_id, null, 'draft' );
 
 		/* Assert */
 		$this->assertEquals( 'publish', get_post_status( $this->lesson_id ) );


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7555

## Proposed Changes
Even though the lessons were supposed to get published only at the time of the Course getting published, they were getting published on all updates of course.

If we look at the [code](https://github.com/Automattic/sensei/blob/0132d5c48c67abb440bab859fd83d7c4654d75df/includes/admin/class-sensei-course-pre-publish-panel.php#L48), it's attached to the `publish_course` hook, so it should get called ONLY when the Course is getting published, right?

Well, no! If we look at the [documentation](https://developer.wordpress.org/reference/hooks/new_status_post-post_type/) of the hook, in the bottom, it says -

> Please note: When this action is hooked using a particular post status (like ‘publish’, as publish_{$post->post_type}), it will fire both when a post is first transitioned to that status from something else, as well as upon subsequent post updates (old and new status are both the same).

So it was getting called everytime for a published Course, and lessons were getting published.

But luckily, there's an `old_status` param, which shows which status this post is transitioning from. So it should be just as simple as just checking if the _Course_ is getting _Published_ from an old status of `!== 'publish'` right?

Well, no! To understand the reason, you need to know how we save our Course structure from GB editor. When you create a Course, add a bunch of lessons and click on Publish, or when you edit the Course outline block, and click on Update in an existing course, first a call is initiated by GB to save the Course markup (it doesn't save the lessons, modules, or the course structure), parallelly, another call is initiated to save the Metabox values. Once these two are completed, Sensei sends an API call with the payload of the Course structure in JSON, this is when the Lessons get created/updated. After that, an  (or multiple) update calls are made to sync the frontend and backend Course structure.

So, even if we try to publish the lessons at the time of the transition of the Course, it won't work, because, the lessons do not even exist at the time of the Course getting published! (The first GB call).

So we can do it in the later call right? Yap, but how do you differentiate it from a normal Update call? To do that, we've set a flag that's set at the time of the transition, and gets cleared after the subsequent call. Is that all?

Well, no! because if we attach the hook inside the `is_admin()` check, it will not get attached for the first GB call, so inside the hook, we won't even know that it's transitioning to Publish. Why does a GB call from the editor made inside Admin panel is getting `is_admin()` to return `false` you ask? I don't know, haven't looked into it yet (planning to do later after publishing this PR).

A couple of things I've noticed:
If lessons are already in draft (not unsaved, draft) in a draft course, then clicking on publish doesn't immediately update the UI of the lessons remove the `draft` tag from below them. But it's not newly introduced, it was existing, I haven't fixed it here.
And it's technically possible to still publish a lesson in a subsequent update if you follow a special sequence (but you kinda have to intentionally try it). So I haven't covered that case. For general testing and use case flows, it should be enough.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Course
2. Add lessons
3. Publish with the publish lessons Checkbox active
4. Lessons should get published
5. Add another lesson in that Course
6. Update the Course
7. The new Lesson should not get published
8. Try in a similar manner with existing Courses

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
