### PR TITLE
Add new VideoPress block support

### DIFF
--- a/assets/js/frontend/course-video/videopress-extension.js
+++ b/assets/js/frontend/course-video/videopress-extension.js
@@ -26,6 +26,8 @@ const initVideoPressPlayer = ( iframe ) => {
 
 export const initVideoPressExtension = () => {
 	document
-		.querySelectorAll( '.wp-block-embed-videopress iframe' )
+		.querySelectorAll(
+			'.wp-block-embed-videopress iframe, .wp-block-jetpack-videopress iframe'
+		)
 		.forEach( initVideoPressPlayer );
 };

--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -162,8 +162,10 @@ const useEditorPlayer = ( videoBlock ) => {
 		const doc = editorCanvasIframe?.contentDocument || document;
 		const w = editorCanvasIframe?.contentWindow || window;
 
-		const isJetpackVideoPress = !! videoBlock.attributes
-			.videoPressClassNames;
+		const isJetpackVideoPress =
+			!! videoBlock.attributes.videoPressClassNames ||
+			// VideoPress block (previously VideoPress used the video block).
+			'videopress/video' === videoBlock.name;
 
 		// Video file block.
 		if ( 'core/video' === videoBlock.name && ! isJetpackVideoPress ) {

--- a/changelog/add-new-videopress-block-support
+++ b/changelog/add-new-videopress-block-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add VideoPress block compabitility for the video settings on courses

--- a/includes/course-video/class-sensei-course-video-settings.php
+++ b/includes/course-video/class-sensei-course-video-settings.php
@@ -133,7 +133,7 @@ class Sensei_Course_Video_Settings {
 		wp_add_inline_script( 'sensei-course-video-blocks-extension', $script, 'before' );
 
 		$post = get_post();
-		if ( has_block( 'core/video', $post ) || has_block( 'core/embed', $post ) ) {
+		if ( has_block( 'core/video', $post ) || has_block( 'core/embed', $post ) || has_block( 'videopress/video', $post ) ) {
 			Sensei()->assets->enqueue_script( 'sensei-course-video-blocks-extension' );
 		}
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -86,6 +86,7 @@
 		<properties>
 			<property name="custom_capabilities" type="array">
 				<element value="manage_sensei"/>
+				<element value="edit_course"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7514
And part of https://github.com/Automattic/sensei-pro/pull/2578

## Proposed Changes

For context, VideoPress used the "Video" block previously. Now it has its own block (p7DVsv-gDF-p2) which the HTML is similar to the VideoPress embed block, so we leverage this integration.

* Besides being part of https://github.com/Automattic/sensei-pro/pull/2578, it also adds VideoPress block compatibility to Video integrations in courses.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This test instructions are for Video integrations for courses. The rest can be tested in https://github.com/Automattic/sensei-pro/pull/2578.

1. Bump the Sensei LMS plugin version to make sure it will use this build in WPCOM when you upload.
2. Build the plugin.
3. Install it in a WPCOM atomic site.
4. Create a new course and activate the video settings.
![Screenshot 2024-04-18 at 12 33 27](https://github.com/Automattic/sensei/assets/876340/136b70b4-a205-4c51-abe7-1639a885c86f)
6. In a lesson of the course, add a VideoPress video using the new VideoPress block.
![Screenshot 2024-04-18 at 12 34 29](https://github.com/Automattic/sensei/assets/876340/792504b3-f356-4234-8627-0585b3572492)
8. Access the course as a student, and make sure the video integrations are working properly.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
