### PR TITLE
Avoid unauthenticated flushing rewrite rules

### DIFF
--- a/changelog/fix-unauthenticated-flush-rewrite-rules
+++ b/changelog/fix-unauthenticated-flush-rewrite-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent unauthenticated flushing of rewrite rules

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -31,8 +31,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 	public function __construct() {
 		parent::__construct(); // Required in extended classes.
 
-		add_action( 'init', array( __CLASS__, 'flush_rewrite_rules' ) );
-
 		// Setup Admin Settings data
 		if ( is_admin() ) {
 
@@ -45,6 +43,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$this->register_hook_listener();
 		$this->get_settings();
+
+		// Flush rewrite rules on settings update.
+		add_action( 'init', array( $this, 'flush_rewrite_rules_on_update' ), 10, 0 );
 
 		// Log when settings are updated by the user.
 		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
@@ -1011,21 +1012,40 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * This is to ensure that the proper permalinks are set up for archive pages.
 	 *
 	 * @since 1.9.0
+	 *
+	 * @deprecated $$next-version$$ Use flush_rewrite_rules_on_update instance method instead.
 	 */
 	public static function flush_rewrite_rules() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Use flush_rewrite_rules_on_update instance method instead' );
 
-		/*
-		 * Skipping nonce check because it is already done by WordPress for the Settings page.
-		 * phpcs:disable WordPress.Security.NonceVerification
-		 */
-		if ( isset( $_POST['option_page'] ) && 'sensei-settings' === $_POST['option_page']
-			&& isset( $_POST['action'] ) && 'update' === $_POST['action'] ) {
-			// phpcs:enable WordPress.Security.NonceVerification
+		$settings = new self();
+		$settings->flush_rewrite_rules_on_update();
+	}
 
-			Sensei()->initiate_rewrite_rules_flush();
-
+	/**
+	 * Flush the rewrite rules after the settings have been updated.
+	 * This is to ensure that the proper permalinks are set up for archive pages.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 */
+	public function flush_rewrite_rules_on_update() {
+		$nonce_action = $this->token . '-options';
+		$nonce_value  = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ?? '' ) );
+		if ( ! wp_verify_nonce( $nonce_value, $nonce_action ) ) {
+			return;
 		}
 
+		if ( ! is_admin() || ! current_user_can( 'manage_sensei' ) ) {
+			return;
+		}
+
+		if ( isset( $_POST['option_page'] ) && 'sensei-settings' === $_POST['option_page']
+			&& isset( $_POST['action'] ) && 'update' === $_POST['action'] ) {
+
+			Sensei()->initiate_rewrite_rules_flush();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://hackerone.com/reports/2472962 and https://hackerone.com/reports/2472961.

## Proposed Changes
* Check if user has 'manage_sensei' capability before flushing rewrite rules.

## Testing Instructions

1. Enable debug log.
2. Go to `includes/class-sensei-settings.php` in the editor and put `error_log( 'Flushing!' );` on line 1030.
3. Execute in terminal: `curl 'http://localhost/wp-admin/admin-ajax.php?action=heartbeat' -d 'action=update&option_page=sensei-settings'` (Replace `http://localhost` with your host and protocol.)
4. Check debug.log. Make sure you don't see "Flushing!" there.

## Deprecated

- `Sensei_Settings::flush_rewrite_rules` – replaced with an instance method `flush_rewrite_rules_on_update`.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
