### PR TITLE
Register custom post types without delay

### DIFF
--- a/changelog/fix-wpml-slug-translation
+++ b/changelog/fix-wpml-slug-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Register Sensei LMS custom post types without delay

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -83,21 +83,21 @@ class Sensei_PostTypes {
 
 		$this->setup_post_type_labels_base();
 
-		add_action( 'init', array( $this, 'setup_course_post_type' ), 100 );
+		add_action( 'init', array( $this, 'setup_course_post_type' ), 10 );
 		add_action( 'template_redirect', array( $this, 'redirect_course_archive_page' ) );
-		add_action( 'init', array( $this, 'setup_lesson_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_quiz_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_question_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_multiple_question_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_sensei_message_post_type' ), 100 );
+		add_action( 'init', array( $this, 'setup_lesson_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_quiz_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_question_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_multiple_question_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_sensei_message_post_type' ), 10 );
 
 		// Setup Taxonomies
-		add_action( 'init', array( $this, 'setup_learner_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_course_category_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_quiz_type_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_question_type_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_question_category_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_lesson_tag_taxonomy' ), 100 );
+		add_action( 'init', array( $this, 'setup_learner_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_course_category_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_quiz_type_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_question_type_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_question_category_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_lesson_tag_taxonomy' ), 10 );
 
 		// Load Post Type Objects
 		$default_post_types = array(


### PR DESCRIPTION
While working on Sensei LMS and WPML compatibility, we found we can't save translated slugs for Sensei CPTs.

It appeared, that at the moment of saving those strings, the CPTs were still unknown for WP. And the sensei_email CPT was registered.

It appeared we register our main CPTs with a "delay", which means we set priority "100" to those actions.

It also makes our setting in Sensei LMS -> Settings -> WPML less useful.
When the translations for the slugs are set we don't get 404 issue.
(Though the 404 error happens until the users sets those translations.)

## Proposed Changes
* Register custom post types without delay

## Testing Instructions

1. Install Sensei LMS and WPML.
    - Install WPML Multilingual CMS and String Translation as part of WPML setup. 
2. Either during WPML setup or in WPML -> Languages add one or more additional languages, use Spanish as one of those languages as it helps us to test slugs.
3. Go to Dashboard -> Updates and update translations (click "Update Translations" almost in the bottom of the page).
4. Create a course with three lessons (the one is created by default with empty lessons is totally fine — we just want to test slugs).
5. Go to Sensei LMS -> Courses and translate the course to Spanish (click on the plus icon for Spanish).
6. Open the translated course on the frontend: you get 404 error. (Just want to remind we do this experiment with Spanish language, because it has the "default" translation "curso" which won't work here.)
7. Go to WPML -> Settings -> Post Types Translation.
8. Find "Courses (course)" and click on "Set different slugs in different languages for Courses."
9. Fill translations for the slug.
10. Click "Save" below the "Post Types Translation" table.
11. Make sure the translated slugs were saved. (You can see them in the same form.)
12. Open the translated course on the frontend.
13. Make sure it is found now and you can see the course.
14. If you want to test it with lessons, make sure you set slug translations for "Lessons (lesson)" on the settings page (WPML -> Settings -> Post Types Translation).

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
