### PR TITLE
Avoid creating new translation when it exists

### DIFF
--- a/changelog/fix-wpml-slug-translation
+++ b/changelog/fix-wpml-slug-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Register Sensei LMS custom post types without delay

--- a/changelog/fix-wpml-translate-updated-content
+++ b/changelog/fix-wpml-translate-updated-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid creating a new translation if it exists already

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -4455,7 +4455,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/emails/class-email-list-table.php">
-    <ArgumentTypeCoercion occurrences="1"/>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$post</code>
     </MoreSpecificImplementedParamType>
@@ -4512,9 +4511,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/internal/emails/class-email-preview.php">
-    <PossiblyFalseArgument occurrences="1">
-      <code>get_the_ID()</code>
-    </PossiblyFalseArgument>
     <PossiblyNullArgument occurrences="2">
       <code>$this-&gt;get_email_post_for_preview()</code>
       <code>$this-&gt;get_email_post_for_preview()</code>
@@ -5351,9 +5347,10 @@
       <code>true|WP_Error</code>
     </InvalidReturnType>
     <MissingClosureParamType occurrences="1">
-      <code>$object</code>
+      <code>$question</code>
     </MissingClosureParamType>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$post</code>
       <code>$post</code>
       <code>$question_id</code>
     </PossiblyInvalidArgument>
@@ -5377,10 +5374,12 @@
       <code>$current_user</code>
       <code>$current_user</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedPropertyAssignment occurrences="1">
+    <UndefinedPropertyAssignment occurrences="2">
+      <code>$response-&gt;data</code>
       <code>$response-&gt;data</code>
     </UndefinedPropertyAssignment>
-    <UndefinedPropertyFetch occurrences="1">
+    <UndefinedPropertyFetch occurrences="2">
+      <code>$response-&gt;data</code>
       <code>$response-&gt;data</code>
     </UndefinedPropertyFetch>
   </file>
@@ -5824,21 +5823,16 @@
     </DocblockTypeContradiction>
   </file>
   <file src="includes/wpml/trait-quiz-translation-helper.php">
-    <InvalidArgument occurrences="1">
-      <code>$args</code>
-    </InvalidArgument>
-    <PossiblyInvalidPropertyFetch occurrences="1">
-      <code>$question-&gt;ID</code>
-    </PossiblyInvalidPropertyFetch>
     <InvalidArgument occurrences="2">
       <code>$args</code>
       <code>$args</code>
     </InvalidArgument>
-    <PossiblyInvalidPropertyFetch occurrences="4">
+    <PossiblyInvalidPropertyFetch occurrences="5">
       <code>$existing_term-&gt;description</code>
       <code>$existing_term-&gt;name</code>
       <code>$existing_term-&gt;slug</code>
       <code>$question-&gt;ID</code>
+      <code>$question-&gt;post_type</code>
     </PossiblyInvalidPropertyFetch>
     <UndefinedMethod occurrences="1">
       <code>$new_term</code>

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -83,21 +83,21 @@ class Sensei_PostTypes {
 
 		$this->setup_post_type_labels_base();
 
-		add_action( 'init', array( $this, 'setup_course_post_type' ), 100 );
+		add_action( 'init', array( $this, 'setup_course_post_type' ), 10 );
 		add_action( 'template_redirect', array( $this, 'redirect_course_archive_page' ) );
-		add_action( 'init', array( $this, 'setup_lesson_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_quiz_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_question_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_multiple_question_post_type' ), 100 );
-		add_action( 'init', array( $this, 'setup_sensei_message_post_type' ), 100 );
+		add_action( 'init', array( $this, 'setup_lesson_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_quiz_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_question_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_multiple_question_post_type' ), 10 );
+		add_action( 'init', array( $this, 'setup_sensei_message_post_type' ), 10 );
 
 		// Setup Taxonomies
-		add_action( 'init', array( $this, 'setup_learner_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_course_category_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_quiz_type_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_question_type_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_question_category_taxonomy' ), 100 );
-		add_action( 'init', array( $this, 'setup_lesson_tag_taxonomy' ), 100 );
+		add_action( 'init', array( $this, 'setup_learner_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_course_category_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_quiz_type_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_question_type_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_question_category_taxonomy' ), 10 );
+		add_action( 'init', array( $this, 'setup_lesson_tag_taxonomy' ), 10 );
 
 		// Load Post Type Objects
 		$default_post_types = array(

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -36,8 +36,8 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 			'question',
 			'question-type-slug',
 			[
-				'get_callback' => function( $object ) {
-					return Sensei()->question->get_question_type( $object['id'] );
+				'get_callback' => function ( $question ) {
+					return Sensei()->question->get_question_type( $question['id'] );
 				},
 				'context'      => [ 'view' ],
 				'schema'       => [
@@ -147,9 +147,15 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 		}
 
 		// Return the updated question.
-		$response = $this->prepare_item_for_response( get_post( $question_id ), $request );
-		return rest_ensure_response( $response );
+		$post = $this->get_post( $question_id );
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
 
+		$block = $this->serialize_question_as_block( $post );
+
+		$response->data['content']['raw'] = $block;
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -71,7 +71,7 @@ class Course_Translation {
 			// Create translatons if they don't exist.
 			$is_translated = $this->has_translation_in_language( $lesson_id, 'post_lesson', $details['language_code'] );
 			if ( ! $is_translated ) {
-				$this->admin_make_post_duplicates( $lesson_id );
+				$this->copy_post_to_language( $lesson_id, $details['language_code'], true );
 			}
 
 			$translations = $this->get_post_duplicates( $lesson_id );
@@ -80,7 +80,7 @@ class Course_Translation {
 				$this->update_translated_lesson_properties( (int) $translated_lesson_id, $lesson_id );
 			}
 
-			$this->update_quiz_translations( $lesson_id );
+			$this->update_quiz_translations( $lesson_id, $details['language_code'] );
 
 			// Sync lesson course field across translations.
 			$this->sync_custom_field( $lesson_id, '_lesson_course' );

--- a/includes/wpml/class-language-details.php
+++ b/includes/wpml/class-language-details.php
@@ -53,10 +53,12 @@ class Language_Details {
 			$language_code = $this->get_current_language();
 		}
 
+		$trix = $this->get_element_trid( $lesson_id, 'post_lesson' );
+
 		$args = array(
 			'element_id'    => $lesson_id,
 			'element_type'  => 'post_lesson',
-			'trid'          => false,
+			'trid'          => $trix,
 			'language_code' => $language_code,
 		);
 		$this->set_element_language_details( $args );
@@ -80,10 +82,12 @@ class Language_Details {
 			$language_code = $this->get_current_language();
 		}
 
+		$trix = $this->get_element_trid( $quiz_id, 'post_quiz' );
+
 		$args = array(
 			'element_id'    => $quiz_id,
 			'element_type'  => 'post_quiz',
-			'trid'          => false,
+			'trid'          => $trix,
 			'language_code' => $language_code,
 		);
 		$this->set_element_language_details( $args );
@@ -106,10 +110,12 @@ class Language_Details {
 		$question_id   = (int) $question_id;
 		$language_code = $this->get_current_language();
 
+		$trix = $this->get_element_trid( $question_id, 'post_question' );
+
 		$args = array(
 			'element_id'    => $question_id,
 			'element_type'  => 'post_question',
-			'trid'          => false,
+			'trid'          => $trix,
 			'language_code' => $language_code,
 		);
 		$this->set_element_language_details( $args );
@@ -134,10 +140,12 @@ class Language_Details {
 		$question_id   = (int) $question_id;
 		$language_code = $this->get_current_language();
 
+		$trix = $this->get_element_trid( $question_id, 'post_multiple_question' );
+
 		$args = array(
 			'element_id'    => $question_id,
 			'element_type'  => 'post_multiple_question',
-			'trid'          => false,
+			'trid'          => $trix,
 			'language_code' => $language_code,
 		);
 		$this->set_element_language_details( $args );

--- a/includes/wpml/class-lesson-translation.php
+++ b/includes/wpml/class-lesson-translation.php
@@ -63,7 +63,7 @@ class Lesson_Translation {
 		}
 
 		$this->update_translated_lesson_properties( $new_lesson_id, $master_lesson_id );
-		$this->update_quiz_translations( $master_lesson_id );
+		$this->update_quiz_translations( $master_lesson_id, $details['language_code'] );
 		$this->update_question_translations_from_lesson( $new_lesson_id );
 	}
 }

--- a/includes/wpml/trait-wpml-api.php
+++ b/includes/wpml/trait-wpml-api.php
@@ -200,6 +200,21 @@ trait WPML_API {
 	}
 
 	/**
+	 * Copy post to language.
+	 *
+	 * @see https://wpml.org/wpml-hook/wpml_copy_post_to_language/
+	 *
+	 * @param int    $post_id           Post ID.
+	 * @param string $target_language   Target language.
+	 * @param bool   $mark_as_duplicate Mark as duplicate.
+	 * @return int   Translated post ID.
+	 */
+	public function copy_post_to_language( $post_id, $target_language, $mark_as_duplicate ) {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		return (int) apply_filters( 'wpml_copy_post_to_language', $post_id, $target_language, $mark_as_duplicate );
+	}
+
+	/**
 	 * Sync custom field.
 	 *
 	 * @see https://wpml.org/wpml-hook/wpml_sync_custom_field/

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -74,17 +74,12 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_object_id', $object_id_fitler, 10, 2 );
 
-		$element_has_translations_filter = function () {
-			return false;
+		$created_duplicates           = array();
+		$copy_post_to_language_filter = function ( $id ) use ( &$created_duplicates ) {
+			$created_duplicates[] = $id;
+			return 1;
 		};
-		add_filter( 'wpml_element_has_translations', $element_has_translations_filter, 10, 0 );
-
-		$created_duplicates               = 0;
-		$admin_make_post_duplicates_acton = function () use ( &$created_duplicates ) {
-			++$created_duplicates;
-		};
-
-		add_action( 'wpml_admin_make_post_duplicates', $admin_make_post_duplicates_acton, 10, 0 );
+		add_filter( 'wpml_copy_post_to_language', $copy_post_to_language_filter );
 
 		$post_duplicates_filter = function ( $post_id ) use ( $new_lesson_id, $course_with_lessons ) {
 			if ( $post_id === $course_with_lessons['lesson_ids'][0] ) {
@@ -104,11 +99,11 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		/* Clean up & Assert. */
 		remove_filter( 'wpml_element_language_details', $element_language_details_filter );
 		remove_filter( 'wpml_object_id', $object_id_fitler );
-		remove_filter( 'wpml_element_has_translations', $element_has_translations_filter );
-		remove_action( 'wpml_admin_make_post_duplicates', $admin_make_post_duplicates_acton );
+		remove_action( 'wpml_copy_post_to_language', $copy_post_to_language_filter );
 		remove_filter( 'wpml_post_duplicates', $post_duplicates_filter );
 
 		// 1 lesson, 3 questions, 1 multiple question, 3 questions inside the multiple question.
-		$this->assertSame( 8, $created_duplicates );
+		$actual = count( array_unique( $created_duplicates ) );
+		$this->assertSame( 8, $actual );
 	}
 }


### PR DESCRIPTION
Resolves #7608 

This PR addresses two issues:
1. When a translated lesson with a quiz and questions was updated and questions in the quez were _not changed_, the question in the translated version is replaced with an original content.
2. When a translated lesson with a quiz and questions was updated and one question was _changed_, we see duplication of questions in the translated lesson.

Both issues related to the same problem: every time the quiz was saved, new translations for questions were created.

This PR also addresses another issue with questions: if we have an existing question, go to Sensei LMS -> Questions, open it in the editor and click Update, the question is updated, but we see errors in the question's blocks.

## Proposed Changes

* Translate posts (lessons, quizzes, questions) only in the needed direction. (No fan out.)
* Check existing trid (translation id) for an element and provide it when we set translation details (for existing translation not passing it creates a new translation).
* Prepare the response of the `update_item` method of the question REST controller the same way we prepare it for `get_item`.

## Testing Instructions

1. Start by installing and activating the WPML plugin:
  - Please ensure you follow the setup steps and activate your license.
  - We assume that you’ve installed the following WPML plugins:
    - [WPML Multilingual CMS](https://wpml.org/)
    - [WPML String Translation](https://wpml.org/documentation/getting-started-guide/string-translation/)
  - Go to Dashboard -> Updates and update translations (click "Update Translations" almost in the bottom of the page).
2. Setup slugs' translations it WPML
  - Go to WPML -> Settings -> Post Types Translation.
  - Find "Courses (course)" and click on "Set different slugs in different languages for Courses." Fill translations for the slug.
  - Find "Lessons (lesson)" and click on "Set different slugs in different languages for Lessons." Fill translations for the slug.
  - Find "Quizzes (quiz)" and click on "Set different slugs in different languages for Quizzes." Fill translations for the slug.
  - Click "Save" below the "Post Types Translation" table.
3. Create a course as you normally would:
  - Add a Course Outline block with at least two lessons.
  - Add content to those lessons.
  - Add quizzes with questions to the lesson.
    - Add a quiz with one question to the first lesson.
    - Add a quiz with two questions to the second lesson.
4. Publish the course.
5. Translate the course:
  - Go to Sensei LMS -> Courses and find the course you would like to translate.
  - Click on the plus icon in the translation column for the language you want to translate into.
  - Translate the strings using the WPML translation editor.
  - When you return from the WPML editor, you will see a circle arrow icon appear in place of the plus icon. It means the translation process is in progress.
  - When the pencil icon appears, the translation process has finished and the following actions were taken:
    - It created a translated version of the course post.
    - It also created post duplicates for lessons, quizzes and questions. The content of these posts remain in the original language and ready for translation.
    - Even though you set translations for lesson titles, in the course outline of the translated course they remain in the original language, as it is using real data from the lessons and they remain untranslated at the moment.
  - Now go to Sensei LMS -> Lessons. Use the WPML translation editor to translate the lesson:
    - Find the original lesson and click on the pencil icon for the language you want to translate into.
    - If you had a quiz in the lesson, questions remain untranslated even if you translated strings for them. Make sure you translate the questions in the next step.
  - Go to Sensei LMS -> Questions and translate the questions.
    - Find the original question and click on the pencil icon for the target translation language.
    - Use the WPML editor to translate all strings.
6. Open the translated lessons with quizzes on the frontend and make sure they were translated correctly:
  - Go to Sensei LMS -> Lessons, switch to the language of translation in the filter.
  - Find needed lessons and open them in new tabs by clicking "View" with the right mouse click and choosing "Open Link in New Tab". _We don't open it in the editor, we open it on the frontend._
  - Open the lesson's quiz for each lesson and make sure you see the translated version of each of them.
7. Go to Sensei LMS -> Lessons and switch back to the original language.
8. Open the original first lesson (with one question in the quiz), make changes in the lesson content and update it.
  - Open the lesson in the editor.
  - Don't modify the question.
  - Update the lesson.
9. Translate the lesson (in fact, we update the translation this time):
  - Go to Sensei LMS -> Lessons. Use the WPML translation editor to translate the lesson:
    - Find the original lesson and click on the icon (it might by a cog or two arrows) for the language you want to translate into.
    - Set new values in the WPML editor and complete the translation.
    - Wait when translation is completed on your website: after changes of the icon for the target translation, it becomes a pencil again.
10. Open the _translated_ lesson with one question in the quiz on the frontend.
  - Open the quiz.
  - Make sure there are no changes in the question and you still see the translated version.
11. Open the second lesson with two questions in the quiz and change one of the questions:
  - Don't delete the question, change its title and/or answers.
  - Update the lesson.
12. Translate the lesson. Follow the instructions from the step 9.
13. Open the translated lesson on the frontend, open the quiz.
14. Make sure you see only two questions.
15. Make sure you see the previous version of the questions (not the latest translation).
16. Go to Sensei LMS -> Questions and translate the changed questions from the second lesson.
  - Open the original question in the editor first and click Update.
  - Make sure there were no errors in the editor.
  - By doing that we inform WPML that the question content was updated. Otherwise we won't see changes in the WPML editor.
  - Find the original question and click on the icon (it might by a cog or two arrows) for the language you want to translate into.
  - Update translations for the changed strings and complete the translation.
  - Wait when translation is completed on your website: after changes of the icon for the target translation, it becomes a pencil again.
17. Open the quiz on the frontend again and make sure the questions are now translated.

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
