### PR TITLE
Fix contact teacher form not displaying correctly in Learning Mode

### DIFF
--- a/assets/blocks/contact-teacher-block/contact-teacher.scss
+++ b/assets/blocks/contact-teacher-block/contact-teacher.scss
@@ -1,3 +1,5 @@
+@import '../../css/sensei-modal.scss';
+
 .sensei-contact-teacher-form {
 	position: relative;
 	&, * {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -1259,7 +1259,4 @@ body.tax-module #main .lesson-content .lesson-meta {
  */
 @import 'grid';
 @import 'notices';
-
 @import '../blocks/quiz/question-block/question';
-
-@import './sensei-modal.scss';

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -10,6 +10,7 @@
 .sensei-course-theme__link,
 .sensei-course-theme .wp-block-button.is-style-outline > .wp-block-button__link {
 	align-items: center;
+	display: inline-block;
 	height: 100%;
 	justify-content: center;
 	white-space: nowrap;

--- a/assets/css/sensei-course-theme/fixed-sidebar.scss
+++ b/assets/css/sensei-course-theme/fixed-sidebar.scss
@@ -23,6 +23,7 @@ $min_desktop_width: 783px;
 			display: flex;
 			flex-direction: column;
 			padding: 32px 24px 40px 24px;
+			row-gap: 40px;
 		}
 
 		&__header ~ &__columns &__sidebar {


### PR DESCRIPTION
Resolves #7605. This was a regression introduced by #7587.

## Proposed Changes
- Moves modal CSS from `frontend.scss` to the `contact-teacher.scss` to avoid loading CSS when it's not needed. The Contact Teacher block appears to be the only place that uses it.
- Fixes an issue with the Contact Teacher block overlapping lessons in the sidebar.

Note: There's no change log entry for this PR as I accidentally committed it to `trunk`. 🙄 

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. In the site editor, add a Contact Teacher block to the lesson sidebar and another one to the content. Also add one to the quiz template.
2. Open a lesson in the editor and add another Contact Teacher block.
3. With Learning Mode enabled, check that the Contact Teacher block works in the sidebar, lesson content and quiz content.
4. Disable Learning Mode.
5. Check that the Contact Teacher button works for a lesson.
6. Test on different themes.
7. Bonus: Check other places that use a modal like the exit survey and editor modals, though they don't appear to use `sensei-modal.scss` at all.

## Screenshots

### Before
![Screenshot 2024-06-03 at 10 13 12 AM](https://github.com/Automattic/sensei/assets/1190420/5fb01c44-1e89-4902-9106-4aa2c964f238)

### After
![Screenshot 2024-06-03 at 10 14 09 AM](https://github.com/Automattic/sensei/assets/1190420/2154f8fb-fe11-420a-800e-9bc204a9a9a5)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [x] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
