### PR TITLE
Fix empty string check in quiz question answers

### DIFF
--- a/changelog/fix-quiz-questions-with-falsy-answers
+++ b/changelog/fix-quiz-questions-with-falsy-answers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Support "0" or other falsy values as an answer for a quiz question

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -353,7 +353,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$meta['_answer_order']           = [];
 
 			foreach ( $question['answer']['answers'] ?? [] as $option ) {
-				if ( empty( $option['label'] ) ) {
+				if ( ! isset( $option['label'] ) || '' === $option['label'] ) {
 					continue;
 				}
 
@@ -437,7 +437,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 *
 	 * @return array
 	 */
-	private function get_category_question( WP_Post $question ) : array {
+	private function get_category_question( WP_Post $question ): array {
 		$category = (int) get_post_meta( $question->ID, 'category', true );
 		$number   = (int) get_post_meta( $question->ID, 'number', true );
 
@@ -494,7 +494,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 *
 	 * @return array Media info. It includes the type, id, url and title.
 	 */
-	private function get_question_media( int $question_media_id, int $question_id ) : array {
+	private function get_question_media( int $question_media_id, int $question_id ): array {
 		$question_media = [];
 		$mimetype       = get_post_mime_type( $question_media_id );
 		$attachment     = get_post( $question_media_id );

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -71,7 +71,6 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 
 		$controller = new Sensei_REST_API_Lesson_Quiz_Controller( '' );
 		$this->assertMeetsSchema( $controller->get_item_schema(), $response->get_data() );
-
 	}
 
 	/**
@@ -687,7 +686,8 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	/**
 	 * Tests posting multiple choice question with answer "0" (falsy value).
 	 */
-	public function testPostMultipleChoiceQuestion_WhenAnswersContainsFalsyValue_AnswerIsNotRemoved() {
+	public function testSaveQuiz_WhenAnswersContainsFalsyValue_AnswerIsNotRemoved() {
+		// Arrange.
 		$this->login_as_teacher();
 
 		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
@@ -718,17 +718,19 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 			],
 		];
 
+		// Act.
 		$this->send_post_request( $lesson_id, $body );
-
 		$questions = Sensei()->quiz->get_questions( Sensei()->lesson->lesson_quizzes( $lesson_id ) );
 
+		// Assert.
 		$this->assertContains( '0', get_post_meta( $questions[0]->ID, '_question_wrong_answers', true ) );
 	}
 
 	/**
 	 * Tests posting multiple choice question with empty string as an answer.
 	 */
-	public function testPostMultipleChoiceQuestion_WhenAnswersContainsEmptyString_AnswerIsRemoved() {
+	public function testSaveQuiz_WhenAnswersContainsEmptyString_AnswerIsRemoved() {
+		// Arrange.
 		$this->login_as_teacher();
 
 		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
@@ -759,10 +761,11 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 			],
 		];
 
+		// Act.
 		$this->send_post_request( $lesson_id, $body );
-
 		$questions = Sensei()->quiz->get_questions( Sensei()->lesson->lesson_quizzes( $lesson_id ) );
 
+		// Assert.
 		$this->assertCount( 1, get_post_meta( $questions[0]->ID, '_question_wrong_answers', true ) );
 	}
 

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -685,6 +685,88 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	}
 
 	/**
+	 * Tests posting multiple choice question with answer "0" (falsy value).
+	 */
+	public function testPostMultipleChoiceQuestion_WhenAnswersContainsFalsyValue_AnswerIsNotRemoved() {
+		$this->login_as_teacher();
+
+		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
+
+		$body = [
+			'options'   => [],
+			'questions' => [
+				[
+					'title'  => 'Question',
+					'type'   => 'multiple-choice',
+					'answer' => [
+						'answers' => [
+							[
+								'label'   => 'Right',
+								'correct' => true,
+							],
+							[
+								'label'   => 'Wrong',
+								'correct' => false,
+							],
+							[
+								'label'   => '0',
+								'correct' => false,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->send_post_request( $lesson_id, $body );
+
+		$questions = Sensei()->quiz->get_questions( Sensei()->lesson->lesson_quizzes( $lesson_id ) );
+
+		$this->assertContains( '0', get_post_meta( $questions[0]->ID, '_question_wrong_answers', true ) );
+	}
+
+	/**
+	 * Tests posting multiple choice question with empty string as an answer.
+	 */
+	public function testPostMultipleChoiceQuestion_WhenAnswersContainsEmptyString_AnswerIsRemoved() {
+		$this->login_as_teacher();
+
+		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
+
+		$body = [
+			'options'   => [],
+			'questions' => [
+				[
+					'title'  => 'Question',
+					'type'   => 'multiple-choice',
+					'answer' => [
+						'answers' => [
+							[
+								'label'   => 'Right',
+								'correct' => true,
+							],
+							[
+								'label'   => 'Wrong',
+								'correct' => false,
+							],
+							[
+								'label'   => '',
+								'correct' => false,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->send_post_request( $lesson_id, $body );
+
+		$questions = Sensei()->quiz->get_questions( Sensei()->lesson->lesson_quizzes( $lesson_id ) );
+
+		$this->assertCount( 1, get_post_meta( $questions[0]->ID, '_question_wrong_answers', true ) );
+	}
+
+	/**
 	 * Tests editing true/false question properties.
 	 */
 	public function testPostBooleanQuestion() {


### PR DESCRIPTION
Resolves #7606

## Proposed Changes

* Fix empty string check in quiz question answers.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Course with a lesson and a quiz.
2. Add a multiple choice question.
3. Add an answer with the text _0_.
4. Save the lesson and make sure the answer wasn't removed.
5. Access the quiz as a student, and make sure it works properly.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
