### PR TITLE
Register blocks to make translations available in the editor

### DIFF
--- a/includes/blocks/class-sensei-block-quiz-question.php
+++ b/includes/blocks/class-sensei-block-quiz-question.php
@@ -22,21 +22,21 @@ class Sensei_Block_Quiz_Question {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/quiz-question',
 			[
-				'render_callback' => [ $this, '__return_empty_string' ],
+				'render_callback' => '__return_empty_string',
 			],
 			Sensei()->assets->src_path( 'blocks/quiz/question-block' )
 		);
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/question-description',
 			[
-				'render_callback' => [ $this, '__return_empty_string' ],
+				'render_callback' => '__return_empty_string',
 			],
 			Sensei()->assets->src_path( 'blocks/quiz/question-description-block' )
 		);
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/question-answers',
 			[
-				'render_callback' => [ $this, '__return_empty_string' ],
+				'render_callback' => '__return_empty_string',
 			],
 			Sensei()->assets->src_path( 'blocks/quiz/question-answers-block' )
 		);

--- a/includes/blocks/class-sensei-block-quiz-question.php
+++ b/includes/blocks/class-sensei-block-quiz-question.php
@@ -22,21 +22,21 @@ class Sensei_Block_Quiz_Question {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/quiz-question',
 			[
-				'render_callback' => [ $this, 'render_empty_string' ],
+				'render_callback' => [ $this, '__return_empty_string' ],
 			],
 			Sensei()->assets->src_path( 'blocks/quiz/question-block' )
 		);
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/question-description',
 			[
-				'render_callback' => [ $this, 'render_empty_string' ],
+				'render_callback' => [ $this, '__return_empty_string' ],
 			],
 			Sensei()->assets->src_path( 'blocks/quiz/question-description-block' )
 		);
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/question-answers',
 			[
-				'render_callback' => [ $this, 'render_empty_string' ],
+				'render_callback' => [ $this, '__return_empty_string' ],
 			],
 			Sensei()->assets->src_path( 'blocks/quiz/question-answers-block' )
 		);
@@ -53,22 +53,8 @@ class Sensei_Block_Quiz_Question {
 	 * @return string The block HTML.
 	 */
 	public function render_quiz_question( array $attributes, string $content ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Block_Quiz_Question::render_empty_string' );
+		_deprecated_function( __METHOD__, '$$next-version$$', '__return_empty_string' );
 
-		return '';
-	}
-
-	/**
-	 * Renders the block as an empty string.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param array  $attributes The block attributes.
-	 * @param string $content    The block content.
-	 *
-	 * @return string The block HTML.
-	 */
-	public function render_empty_string( array $attributes, string $content ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		return '';
 	}
 }

--- a/includes/blocks/class-sensei-block-quiz-question.php
+++ b/includes/blocks/class-sensei-block-quiz-question.php
@@ -22,21 +22,53 @@ class Sensei_Block_Quiz_Question {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/quiz-question',
 			[
-				'render_callback' => [ $this, 'render_quiz_question' ],
+				'render_callback' => [ $this, 'render_empty_string' ],
 			],
 			Sensei()->assets->src_path( 'blocks/quiz/question-block' )
+		);
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/question-description',
+			[
+				'render_callback' => [ $this, 'render_empty_string' ],
+			],
+			Sensei()->assets->src_path( 'blocks/quiz/question-description-block' )
+		);
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/question-answers',
+			[
+				'render_callback' => [ $this, 'render_empty_string' ],
+			],
+			Sensei()->assets->src_path( 'blocks/quiz/question-answers-block' )
 		);
 	}
 
 	/**
 	 * Renders the block as an empty string.
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param array  $attributes The block attributes.
 	 * @param string $content    The block content.
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render_quiz_question( array $attributes, string $content ) : string {
+	public function render_quiz_question( array $attributes, string $content ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Sensei_Block_Quiz_Question::render_empty_string' );
+
+		return '';
+	}
+
+	/**
+	 * Renders the block as an empty string.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content    The block content.
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render_empty_string( array $attributes, string $content ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		return '';
 	}
 }

--- a/includes/blocks/class-sensei-block-quiz.php
+++ b/includes/blocks/class-sensei-block-quiz.php
@@ -24,7 +24,7 @@ class Sensei_Block_Quiz {
 			[
 				'render_callback' => [ $this, 'render_quiz' ],
 			],
-			Sensei()->assets->src_path( 'blocks/quiz' )
+			Sensei()->assets->src_path( 'blocks/quiz/quiz-block' )
 		);
 	}
 

--- a/includes/blocks/class-sensei-course-actions-block.php
+++ b/includes/blocks/class-sensei-course-actions-block.php
@@ -19,22 +19,8 @@ class Sensei_Course_Actions_Block {
 	public function __construct() {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/course-actions',
-			[
-				'render_callback' => [ $this, 'render_course_actions' ],
-			],
+			array(),
 			Sensei()->assets->src_path( 'blocks/course-actions-block/course-actions' )
 		);
-	}
-
-	/**
-	 * Renders the block as an empty string.
-	 *
-	 * @param array  $attributes The block attributes.
-	 * @param string $content    The block content.
-	 *
-	 * @return string The block HTML.
-	 */
-	public function render_course_actions( array $attributes, string $content ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		return '';
 	}
 }

--- a/includes/blocks/class-sensei-course-actions-block.php
+++ b/includes/blocks/class-sensei-course-actions-block.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * File containing the class Sensei_Course_Actions_Block.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Actions_Block
+ */
+class Sensei_Course_Actions_Block {
+	/**
+	 * Sensei_Course_Actions_Block constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-actions',
+			[
+				'render_callback' => [ $this, 'render_course_actions' ],
+			],
+			Sensei()->assets->src_path( 'blocks/course-actions-block/course-actions' )
+		);
+	}
+
+	/**
+	 * Renders the block as an empty string.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content    The block content.
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render_course_actions( array $attributes, string $content ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return '';
+	}
+}

--- a/includes/blocks/class-sensei-global-blocks.php
+++ b/includes/blocks/class-sensei-global-blocks.php
@@ -32,6 +32,7 @@ class Sensei_Global_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_Course_Progress_Block();
 		new Sensei_Course_Overview_Block();
 		new Sensei_Course_List_Block();
+		new Sensei_Course_Actions_Block();
 	}
 
 	/**


### PR DESCRIPTION
Part of #6351

Some blocks appeared to be untranslated in the editor. Eventually, [the investigation](https://github.com/Automattic/sensei/pull/6994#issuecomment-1936618063) gave us an answer: we need to register these blocks in the admin on the backend. We need to be specificn and register even those blocks that don't make much sense on the backend (as they are nested blocks).

## Proposed Changes
* Register blocks to make their translations available in the editor.

## Testing Instructions

1. Switch the website language from English to another one.
2. Update translations (Dashboard → Updates).
3. Create a course, open it in the editor.
4. Open the block inserter and make sure all Sensei LMS blocks (shipped with Sensei LMS plugin!) are translated.
5. Open Document Overview and check all Sensei blocks are translated (including nested blocks).
6. Create a lesson and open it in the editor.
7. Repeat step 4: Open the block inserter and make sure all Sensei LMS blocks (shipped with Sensei LMS plugin!) are translated.
8. Add a quiz.
9. Add a question with description, answers, feedback.
10. Open Document Overview and check all Sensei blocks are translated (including nested blocks).
11. Publish the course with the lesson.
12. Go to the course and check all inserted blocks that are supposed to be visible are visible.
13. Go to the lesson and check all inserted blocks that are supposed to be visible are visible.

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

* `Sensei_Block_Quiz_Question::render_quiz_question`—replaced with `Sensei_Block_Quiz_Question::render_empty_string`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
