### PR TITLE
Fix deprecation notice when passing NULL to `wp_kses_post` on the reports screen

### DIFF
--- a/changelog/fix-deprecation-notice-on-reports-screen
+++ b/changelog/fix-deprecation-notice-on-reports-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deprecation notice on the reports screen when using PHP 8.1

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -285,7 +285,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$escaped_column_data = array();
 
 		foreach ( $column_data as $key => $data ) {
-			$escaped_column_data[ $key ] = wp_kses_post( $data );
+			$escaped_column_data[ $key ] = $data ? wp_kses_post( $data ) : $data;
 		}
 
 		return $escaped_column_data;


### PR DESCRIPTION
Part  of https://github.com/Automattic/sensei/issues/7634

## Proposed Changes
* Fix passing NULL to `wp_kses_post` on the reports screen, generating a deprecation notice on PHP 8.1.

![image](https://github.com/user-attachments/assets/e75e56d0-ea42-48cb-aaf9-208da12aed27)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use PHP 8.1.
2. Add `define( 'WP_DEBUG_DISPLAY', true );` in wp-config.php.
3. Go to Sensei LMS -> Reports. 
4. Select a student that is enrolled in a course.
5. Select a course.
6. There should be no deprecation notice.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
