### PR TITLE
Fix deprecation notice on the question edit screen on PHP 8.1

### DIFF
--- a/changelog/fix-deprecation-notice-on-question-edit-screen
+++ b/changelog/fix-deprecation-notice-on-question-edit-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deprecation notice on the question edit screen on PHP 8.1

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -2237,14 +2237,13 @@
       <code>WP_Query</code>
       <code>integer</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="7">
+    <InvalidScalarArgument occurrences="6">
       <code>$course_id</code>
       <code>$course_id</code>
       <code>$possible_user_id</code>
       <code>$post_after-&gt;post_author</code>
       <code>$term</code>
       <code>$term</code>
-      <code>esc_attr( $_POST['course_id'] )</code>
     </InvalidScalarArgument>
     <MissingParamType occurrences="21">
       <code>$args</code>
@@ -2550,16 +2549,15 @@
       <code>$attachment_src[1]</code>
       <code>$attachment_src[2]</code>
     </PossiblyInvalidArrayAccess>
-    <PossiblyInvalidArrayAssignment occurrences="2">
-      <code>$lessons[ $lesson_id ]</code>
-      <code>$lessons[ $lesson_id ]</code>
-    </PossiblyInvalidArrayAssignment>
     <PossiblyInvalidIterator occurrences="1">
       <code>$cats</code>
     </PossiblyInvalidIterator>
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$user_lesson_status-&gt;comment_approved</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$lesson['link']</code>
+    </PossiblyUndefinedArrayOffset>
     <TypeDoesNotContainType occurrences="1">
       <code>$is_quiz_graded</code>
     </TypeDoesNotContainType>
@@ -3071,12 +3069,11 @@
       <code>require_once ABSPATH . 'wp-admin/includes/image.php'</code>
       <code>require_once ABSPATH . 'wp-admin/includes/plugin-install.php'</code>
     </MissingFile>
-    <MissingParamType occurrences="15">
+    <MissingParamType occurrences="14">
       <code>$attributes</code>
       <code>$course_id</code>
       <code>$data_key</code>
       <code>$file</code>
-      <code>$from_course</code>
       <code>$key</code>
       <code>$options</code>
       <code>$plugin_class_to_look_for</code>
@@ -3561,9 +3558,6 @@
       <code>null === $first</code>
       <code>null === $second</code>
     </DocblockTypeContradiction>
-    <InvalidAttribute occurrences="1">
-      <code>\ReturnTypeWillChange</code>
-    </InvalidAttribute>
     <InvalidReturnStatement occurrences="1">
       <code>wp_delete_attachment( $file_id, true )</code>
     </InvalidReturnStatement>
@@ -3622,9 +3616,6 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
-    <InvalidAttribute occurrences="1">
-      <code>\ReturnTypeWillChange</code>
-    </InvalidAttribute>
     <InvalidReturnStatement occurrences="2">
       <code>$this-&gt;create_job( $user_id, Sensei_Export_Job::class )</code>
       <code>$this-&gt;create_job( $user_id, Sensei_Import_Job::class )</code>
@@ -4200,10 +4191,6 @@
     </MissingPropertyType>
   </file>
   <file src="includes/emails/class-sensei-email-teacher-new-course-assignment.php">
-    <MissingParamType occurrences="2">
-      <code>$course_id</code>
-      <code>$teacher_id</code>
-    </MissingParamType>
     <MissingPropertyType occurrences="6">
       <code>$heading</code>
       <code>$learner</code>
@@ -4299,9 +4286,6 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="includes/enrolment/class-sensei-course-enrolment-provider-results.php">
-    <InvalidAttribute occurrences="1">
-      <code>\ReturnTypeWillChange</code>
-    </InvalidAttribute>
     <InvalidScalarArgument occurrences="1">
       <code>$version</code>
     </InvalidScalarArgument>
@@ -4410,17 +4394,9 @@
     <InvalidArgument occurrences="1">
       <code>$provider_states</code>
     </InvalidArgument>
-    <InvalidAttribute occurrences="1">
-      <code>\ReturnTypeWillChange</code>
-    </InvalidAttribute>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$provider_states</code>
     </InvalidPropertyAssignmentValue>
-  </file>
-  <file src="includes/enrolment/class-sensei-enrolment-provider-state.php">
-    <InvalidAttribute occurrences="1">
-      <code>\ReturnTypeWillChange</code>
-    </InvalidAttribute>
   </file>
   <file src="includes/hooks/template.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -387,7 +387,7 @@ class Sensei_Question {
 			return;
 		}
 
-		$lessons = false;
+		$lessons = [];
 
 		foreach ( $quizzes as $quiz ) {
 


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/7634

## Proposed Changes
* Fix the deprecation notice on the question edit screen on PHP 8.1.

![image](https://github.com/user-attachments/assets/de7983bb-20ee-4927-8e5e-c2c6c47fb9e4)


## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use PHP 8.1.
2. Add `define( 'WP_DEBUG_DISPLAY', true );` in wp-config.php.
3. Go to Sensei LMS -> Questions and select any question.
4. There should be no deprecation notice.
5. The "Quizzes" section should be working as before.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
