### PR TITLE
Fix errors and warnings in the course/lesson/question editor

### DIFF
--- a/assets/admin/course-pre-publish-panel/course-pre-publish-panel.js
+++ b/assets/admin/course-pre-publish-panel/course-pre-publish-panel.js
@@ -3,13 +3,18 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel as DeprecatedPluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import SenseiIcon from '../../icons/logo-tree.svg';
+
+if ( ! PluginPrePublishPanel ) {
+	PluginPrePublishPanel = DeprecatedPluginPrePublishPanel;
+}
 
 /**
  * Course pre-publish panel.

--- a/assets/admin/course-pre-publish-panel/course-pre-publish-panel.js
+++ b/assets/admin/course-pre-publish-panel/course-pre-publish-panel.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
 import { PluginPrePublishPanel as DeprecatedPluginPrePublishPanel } from '@wordpress/edit-post';
-import { PluginPrePublishPanel } from '@wordpress/editor';
+import { PluginPrePublishPanel as NewPluginPrePublishPanel } from '@wordpress/editor';
 import { ToggleControl } from '@wordpress/components';
 
 /**
@@ -12,9 +12,8 @@ import { ToggleControl } from '@wordpress/components';
  */
 import SenseiIcon from '../../icons/logo-tree.svg';
 
-if ( ! PluginPrePublishPanel ) {
-	PluginPrePublishPanel = DeprecatedPluginPrePublishPanel;
-}
+const PluginPrePublishPanel =
+	NewPluginPrePublishPanel || DeprecatedPluginPrePublishPanel;
 
 /**
  * Course pre-publish panel.

--- a/assets/admin/editor-wizard/patterns-list.js
+++ b/assets/admin/editor-wizard/patterns-list.js
@@ -137,7 +137,9 @@ const PatternsList = ( { onChoose } ) => {
 						>
 							<div className="sensei-patterns-list__item-preview">
 								<BlockPreview
-									__experimentalPadding={ 30 }
+									additionalStyles={ [
+										{ css: 'body { padding: 30px; }' },
+									] }
 									blocks={ blocks
 										.filter( withoutLessonActions )
 										.map( withBlockExample ) }

--- a/assets/admin/tour/course-tour/steps.js
+++ b/assets/admin/tour/course-tour/steps.js
@@ -48,7 +48,7 @@ function focusOnCourseOutlineBlock() {
 	if ( ! courseOutlineBlock ) {
 		return;
 	}
-	dispatch( editorStore ).selectBlock( courseOutlineBlock.clientId );
+	dispatch( blockEditorStore ).selectBlock( courseOutlineBlock.clientId );
 }
 
 async function ensureLessonBlocksIsInEditor() {

--- a/assets/admin/tour/data/store.js
+++ b/assets/admin/tour/data/store.js
@@ -1,15 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
-/**
- * Internal dependencies
- */
-import { createReducerFromActionMap } from '../../../shared/data/store-helpers';
 import { controls } from '@wordpress/data-controls';
 import apiFetch from '@wordpress/api-fetch';
 
-export const SENSEI_TOUR_STORE = 'sensei/tour';
+/**
+ * Internal dependencies
+ */
+import {
+	createReducerFromActionMap,
+	createStore,
+} from '../../../shared/data/store-helpers';
 
 export const DEFAULT_STATE = {
 	showTour: true,
@@ -80,11 +81,9 @@ export const reducers = {
 	DEFAULT: ( action, state ) => state,
 };
 
-export const store = createReduxStore( SENSEI_TOUR_STORE, {
+export const SENSEI_TOUR_STORE = createStore( 'sensei/tour', {
 	reducer: createReducerFromActionMap( reducers, DEFAULT_STATE ),
 	actions,
 	selectors,
 	controls,
 } );
-
-register( store );

--- a/assets/admin/tour/lesson-tour/steps.js
+++ b/assets/admin/tour/lesson-tour/steps.js
@@ -8,7 +8,6 @@ import { ExternalLink } from '@wordpress/components';
 import { select, dispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editPostStore } from '@wordpress/edit-post';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -59,7 +58,7 @@ export const focusOnQuizBlock = () => {
 	if ( ! quizBlock ) {
 		return;
 	}
-	dispatch( editorStore ).selectBlock( quizBlock.clientId );
+	dispatch( blockEditorStore ).selectBlock( quizBlock.clientId );
 };
 
 export const focusOnQuestionBlock = () => {
@@ -67,7 +66,7 @@ export const focusOnQuestionBlock = () => {
 	if ( ! questionBlock ) {
 		return;
 	}
-	dispatch( editorStore ).selectBlock( questionBlock.clientId );
+	dispatch( blockEditorStore ).selectBlock( questionBlock.clientId );
 };
 
 export const focusOnBooleanQuestionBlock = () => {
@@ -75,7 +74,7 @@ export const focusOnBooleanQuestionBlock = () => {
 	if ( ! questionBlock ) {
 		return;
 	}
-	dispatch( editorStore ).selectBlock( questionBlock.clientId );
+	dispatch( blockEditorStore ).selectBlock( questionBlock.clientId );
 };
 
 export const ensureBooleanQuestionIsInEditor = () => {

--- a/assets/blocks/course-actions-block/course-status-toolbar.js
+++ b/assets/blocks/course-actions-block/course-status-toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Toolbar } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -41,14 +41,14 @@ const CourseStatusToolbar = ( {
 		: setCourseStatus;
 
 	return (
-		<Toolbar>
+		<ToolbarGroup>
 			<ToolbarDropdown
 				options={ CourseStatusOptions }
 				optionsLabel="Course Status"
 				value={ courseStatusValue }
 				onChange={ setCourseStatusCallback }
 			/>
-		</Toolbar>
+		</ToolbarGroup>
 	);
 };
 

--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, Spinner, Toolbar, ToolbarItem } from '@wordpress/components';
+import {
+	Button,
+	Spinner,
+	ToolbarGroup,
+	ToolbarItem,
+} from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
@@ -75,7 +80,11 @@ const LessonEditToolbar = ( { lessonId, lessonTitle } ) => {
 		toolbarItem = savingPostIndicator;
 	}
 
-	return <Toolbar className="components-button">{ toolbarItem }</Toolbar>;
+	return (
+		<ToolbarGroup className="components-button">
+			{ toolbarItem }
+		</ToolbarGroup>
+	);
 };
 
 export default LessonEditToolbar;

--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -7,6 +7,7 @@ import {
 	ToolbarGroup,
 	ToolbarItem,
 } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
@@ -24,14 +25,19 @@ const getLessonURL = ( lessonId ) => `post.php?post=${ lessonId }&action=edit`;
  *
  * @param {Object} props          Component props.
  * @param {number} props.lessonId The lesson ID.
+ * @param {Object} forwardedRef   The forwarded ref.
  */
-export const EditLessonLink = ( { lessonId } ) => (
-	<a
-		href={ getLessonURL( lessonId ) }
-		className="wp-block-sensei-lms-course-outline-lesson__edit"
-	>
-		{ __( 'Edit lesson', 'sensei-lms' ) }
-	</a>
+export const EditLessonLink = forwardRef(
+	( { lessonId, ...props }, forwardedRef ) => (
+		<a
+			ref={ forwardedRef }
+			href={ getLessonURL( lessonId ) }
+			className="wp-block-sensei-lms-course-outline-lesson__edit"
+			{ ...props }
+		>
+			{ __( 'Edit lesson', 'sensei-lms' ) }
+		</a>
+	)
 );
 
 /**
@@ -75,7 +81,9 @@ const LessonEditToolbar = ( { lessonId, lessonTitle } ) => {
 
 	let toolbarItem = savePostLink;
 	if ( lessonId ) {
-		toolbarItem = <EditLessonLink lessonId={ lessonId } />;
+		toolbarItem = (
+			<ToolbarItem as={ EditLessonLink } lessonId={ lessonId } />
+		);
 	} else if ( isSavingPost || isSavingStructure || isSavingMetaBoxes ) {
 		toolbarItem = savingPostIndicator;
 	}

--- a/assets/blocks/course-outline/lesson-block/lesson-settings.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-settings.js
@@ -51,6 +51,7 @@ const LessonSettings = ( {
 				) }
 				<PanelBody title={ __( 'Typography', 'sensei-lms' ) }>
 					<FontSizePicker
+						__nextHasNoMarginBottom // Can be removed when we support WP 6.5+
 						fontSizes={ fontSizes }
 						value={ fontSize }
 						onChange={ ( value ) => {

--- a/assets/blocks/course-outline/status-preview/status-store.js
+++ b/assets/blocks/course-outline/status-preview/status-store.js
@@ -1,14 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { select as selectData, registerStore } from '@wordpress/data';
+import { select as selectData } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { Status } from './index';
 import { select, controls } from '@wordpress/data-controls';
-import { createReducerFromActionMap } from '../../../shared/data/store-helpers';
+import {
+	createStore,
+	createReducerFromActionMap,
+} from '../../../shared/data/store-helpers';
 
 const DEFAULT_STATE = {
 	completedLessons: [],
@@ -311,9 +314,7 @@ const reducers = {
 	DEFAULT: ( action, state ) => state,
 };
 
-export const COURSE_STATUS_STORE = 'sensei/course-status';
-
-registerStore( COURSE_STATUS_STORE, {
+export const COURSE_STATUS_STORE = createStore( 'sensei/course-status', {
 	reducer: createReducerFromActionMap( reducers, DEFAULT_STATE ),
 	actions,
 	selectors,

--- a/assets/blocks/course-progress-block/block.json
+++ b/assets/blocks/course-progress-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 2,
   "name": "sensei-lms/course-progress",
   "title": "Course Progress",
   "description": "Display the user's progress in the course. This block is only displayed if the user is enrolled.",

--- a/assets/blocks/editor-components/toolbar-dropdown/index.js
+++ b/assets/blocks/editor-components/toolbar-dropdown/index.js
@@ -7,11 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	Button,
-	Dropdown,
 	MenuGroup,
 	MenuItem,
-	NavigableMenu,
+	ToolbarDropdownMenu,
 } from '@wordpress/components';
 import { check } from '@wordpress/icons';
 
@@ -48,10 +46,10 @@ const ToolbarDropdown = ( {
 	const selectedOption = options.find( ( option ) => value === option.value );
 
 	return (
-		<Dropdown
+		<ToolbarDropdownMenu
 			className="sensei-toolbar-dropdown"
 			popoverProps={ {
-				isAlternate: true,
+				variant: 'toolbar',
 				position: 'bottom right left',
 				focusOnMount: true,
 				...popoverProps,
@@ -60,52 +58,45 @@ const ToolbarDropdown = ( {
 					'sensei-toolbar-dropdown__popover'
 				),
 			} }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					onClick={ onToggle }
-					icon={ icon }
-					aria-expanded={ isOpen }
-					aria-haspopup="true"
-					{ ...toggleProps }
-					children={
-						toggleProps?.children
-							? toggleProps.children( selectedOption )
-							: selectedOption?.label
-					}
-				/>
-			) }
-			renderContent={ ( { onClose } ) => (
-				<NavigableMenu role="menu" stopNavigationEvents>
-					<MenuGroup label={ optionsLabel }>
-						{ options.map( ( option ) => {
-							const isSelected =
-								option.value === selectedOption?.value;
-							const menuItemProps = getMenuItemProps?.( option );
-							return (
-								<MenuItem
-									key={ option.value }
-									role="menuitemradio"
-									isSelected={ isSelected }
-									icon={ isSelected ? check : null }
-									className={ classnames(
-										'sensei-toolbar-dropdown__option',
-										{ 'is-selected': isSelected },
-										menuItemProps?.className
-									) }
-									onClick={ () => {
-										onChange( option.value );
-										onClose();
-									} }
-									children={ option.label }
-									{ ...menuItemProps }
-								/>
-							);
-						} ) }
-					</MenuGroup>
-				</NavigableMenu>
-			) }
+			label={ optionsLabel }
+			icon={ icon ?? null }
+			text={
+				toggleProps?.children
+					? toggleProps.children( selectedOption )
+					: selectedOption?.label
+			}
 			{ ...props }
-		/>
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup label={ optionsLabel }>
+					{ options.map( ( option ) => {
+						const isSelected =
+							option.value === selectedOption?.value;
+						const menuItemProps = getMenuItemProps?.( option );
+
+						return (
+							<MenuItem
+								key={ option.value }
+								role="menuitemradio"
+								isSelected={ isSelected }
+								icon={ isSelected ? check : null }
+								className={ classnames(
+									'sensei-toolbar-dropdown__option',
+									{ 'is-selected': isSelected },
+									menuItemProps?.className
+								) }
+								onClick={ () => {
+									onChange( option.value );
+									onClose();
+								} }
+								children={ option.label }
+								{ ...menuItemProps }
+							/>
+						);
+					} ) }
+				</MenuGroup>
+			) }
+		</ToolbarDropdownMenu>
 	);
 };
 

--- a/assets/blocks/featured-video/block.json
+++ b/assets/blocks/featured-video/block.json
@@ -2,10 +2,10 @@
 	"name": "sensei-lms/featured-video",
 	"title": "Featured Video",
 	"description": "Add a featured video to your lesson to highlight the video and make use of our video templates.",
-    "icon": "format-video",
+	"icon": "format-video",
 	"category": "sensei-lms",
 	"textdomain": "sensei-lms",
 	"supports": {
-        "multiple": false
+		"multiple": false
 	}
 }

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -228,23 +228,21 @@ const QuestionEdit = ( props ) => {
 				getErrorMessages={ getQuestionBlockValidationErrorMessages }
 			/>
 			<BlockControls>
-				<>
-					<QuestionTypeToolbar
-						value={ type }
-						onSelect={ ( nextValue ) =>
-							setAttributes( { type: nextValue } )
-						}
-						options={ questionOptions }
-					/>
-					<QuestionGradeToolbar
-						value={ options.grade }
-						onChange={ ( nextGrade ) =>
-							setAttributes( {
-								options: { ...options, grade: nextGrade },
-							} )
-						}
-					/>
-				</>
+				<QuestionTypeToolbar
+					value={ type }
+					onSelect={ ( nextValue ) =>
+						setAttributes( { type: nextValue } )
+					}
+					options={ questionOptions }
+				/>
+				<QuestionGradeToolbar
+					value={ options.grade }
+					onChange={ ( nextGrade ) =>
+						setAttributes( {
+							options: { ...options, grade: nextGrade },
+						} )
+					}
+				/>
 			</BlockControls>
 			<QuestionSettings controls={ AnswerBlock?.settings } { ...props } />
 		</div>

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarGroup } from '@wordpress/components';
+import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -18,7 +18,11 @@ export const QuestionGradeToolbar = ( { value, onChange } ) => {
 	return (
 		<>
 			<ToolbarGroup className="sensei-lms-question-block__grade-toolbar">
-				<QuestionGradeControl value={ value } onChange={ onChange } />
+				<ToolbarItem
+					as={ QuestionGradeControl }
+					value={ value }
+					onChange={ onChange }
+				/>
 			</ToolbarGroup>
 		</>
 	);

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Toolbar } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
@@ -20,7 +20,7 @@ import ToolbarDropdown from '../../editor-components/toolbar-dropdown';
  */
 export const QuestionTypeToolbar = ( { value, onSelect, options } ) => {
 	return (
-		<Toolbar className="sensei-lms-question-block__type-selector__toolbar">
+		<ToolbarGroup className="sensei-lms-question-block__type-selector__toolbar">
 			<ToolbarDropdown
 				className="sensei-lms-question-block__type-selector"
 				label={ __( 'Question Type', 'sensei-lms' ) }
@@ -70,6 +70,6 @@ export const QuestionTypeToolbar = ( { value, onSelect, options } ) => {
 					return props;
 				} }
 			/>
-		</Toolbar>
+		</ToolbarGroup>
 	);
 };

--- a/assets/blocks/quiz/question-block/single-question.js
+++ b/assets/blocks/quiz/question-block/single-question.js
@@ -8,20 +8,20 @@ import {
 	PluginPostStatusInfo as DeprecatedPluginPostStatusInfo,
 	PluginPrePublishPanel as DeprecatedPluginPrePublishPanel,
 } from '@wordpress/edit-post';
-import { PluginPostStatusInfo, PluginPrePublishPanel } from '@wordpress/editor';
+import {
+	PluginPostStatusInfo as NewPluginPostStatusInfo,
+	PluginPrePublishPanel as NewPluginPrePublishPanel,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { Effect, usePostSavingEffect } from '../../../shared/helpers/blocks';
 
-if ( ! PluginPostStatusInfo ) {
-	PluginPostStatusInfo = DeprecatedPluginPostStatusInfo;
-}
-
-if ( ! PluginPrePublishPanel ) {
-	PluginPrePublishPanel = DeprecatedPluginPrePublishPanel;
-}
+const PluginPostStatusInfo =
+	NewPluginPostStatusInfo || DeprecatedPluginPostStatusInfo;
+const PluginPrePublishPanel =
+	NewPluginPrePublishPanel || DeprecatedPluginPrePublishPanel;
 
 /**
  * Additional controls for a question block in the single question editor.

--- a/assets/blocks/quiz/question-block/single-question.js
+++ b/assets/blocks/quiz/question-block/single-question.js
@@ -5,14 +5,23 @@ import { Notice } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
-	PluginPostStatusInfo,
-	PluginPrePublishPanel,
+	PluginPostStatusInfo as DeprecatedPluginPostStatusInfo,
+	PluginPrePublishPanel as DeprecatedPluginPrePublishPanel,
 } from '@wordpress/edit-post';
+import { PluginPostStatusInfo, PluginPrePublishPanel } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { Effect, usePostSavingEffect } from '../../../shared/helpers/blocks';
+
+if ( ! PluginPostStatusInfo ) {
+	PluginPostStatusInfo = DeprecatedPluginPostStatusInfo;
+}
+
+if ( ! PluginPrePublishPanel ) {
+	PluginPrePublishPanel = DeprecatedPluginPrePublishPanel;
+}
 
 /**
  * Additional controls for a question block in the single question editor.

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -6,7 +6,7 @@ import {
 	PanelRow,
 	ToggleControl,
 	SelectControl,
-	Toolbar,
+	ToolbarItem,
 	ToolbarGroup,
 } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
@@ -171,17 +171,18 @@ export const PaginationToolbarSettings = ( { settings, updatePagination } ) => {
 
 	return (
 		<>
-			<Toolbar>
+			<ToolbarGroup>
 				<ToolbarDropdown
 					options={ paginationOptions }
 					optionsLabel={ __( 'Quiz pagination', 'sensei-lms' ) }
 					value={ paginationNumber === null ? SINGLE : MULTI }
 					onChange={ onDropdownChange( updatePagination ) }
 				/>
-			</Toolbar>
+			</ToolbarGroup>
 			{ paginationNumber !== null && (
 				<ToolbarGroup className="sensei-lms-quiz-block__toolbar-group">
-					<QuestionsControl
+					<ToolbarItem
+						as={ QuestionsControl }
 						settings={ settings }
 						updatePagination={ updatePagination }
 					/>

--- a/assets/blocks/quiz/quiz-block/quiz-validation.js
+++ b/assets/blocks/quiz/quiz-block/quiz-validation.js
@@ -4,9 +4,10 @@
 import { Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
-	PluginPostStatusInfo,
-	PluginPrePublishPanel,
+	PluginPostStatusInfo as DeprecatedPluginPostStatusInfo,
+	PluginPrePublishPanel as DeprecatedPluginPrePublishPanel,
 } from '@wordpress/edit-post';
+import { PluginPostStatusInfo, PluginPrePublishPanel } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
@@ -15,6 +16,14 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import { BLOCK_META_STORE } from '../../../shared/blocks/block-metadata';
 import { Effect, usePostSavingEffect } from '../../../shared/helpers/blocks';
+
+if ( ! PluginPostStatusInfo ) {
+	PluginPostStatusInfo = DeprecatedPluginPostStatusInfo;
+}
+
+if ( ! PluginPrePublishPanel ) {
+	PluginPrePublishPanel = DeprecatedPluginPrePublishPanel;
+}
 
 /**
  * Notice about incomplete questions in the quiz.

--- a/assets/blocks/quiz/quiz-block/quiz-validation.js
+++ b/assets/blocks/quiz/quiz-block/quiz-validation.js
@@ -7,7 +7,10 @@ import {
 	PluginPostStatusInfo as DeprecatedPluginPostStatusInfo,
 	PluginPrePublishPanel as DeprecatedPluginPrePublishPanel,
 } from '@wordpress/edit-post';
-import { PluginPostStatusInfo, PluginPrePublishPanel } from '@wordpress/editor';
+import {
+	PluginPostStatusInfo as NewPluginPostStatusInfo,
+	PluginPrePublishPanel as NewPluginPrePublishPanel,
+} from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
@@ -17,13 +20,10 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { BLOCK_META_STORE } from '../../../shared/blocks/block-metadata';
 import { Effect, usePostSavingEffect } from '../../../shared/helpers/blocks';
 
-if ( ! PluginPostStatusInfo ) {
-	PluginPostStatusInfo = DeprecatedPluginPostStatusInfo;
-}
-
-if ( ! PluginPrePublishPanel ) {
-	PluginPrePublishPanel = DeprecatedPluginPrePublishPanel;
-}
+const PluginPostStatusInfo =
+	NewPluginPostStatusInfo || DeprecatedPluginPostStatusInfo;
+const PluginPrePublishPanel =
+	NewPluginPrePublishPanel || DeprecatedPluginPrePublishPanel;
 
 /**
  * Notice about incomplete questions in the quiz.

--- a/assets/course-theme/blocks/register-template-blocks.js
+++ b/assets/course-theme/blocks/register-template-blocks.js
@@ -36,8 +36,6 @@ export function registerTemplateBlocks( blocks ) {
 			return;
 		}
 
-		const isTemplate =
-			'lesson' === postType && editPost.isEditingTemplate();
-		toggleBlockRegistration( isTemplate );
+		toggleBlockRegistration( false );
 	} );
 }

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -6,20 +6,17 @@ import { keyBy, merge, isEqual } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	createReduxStore,
-	register,
-	select,
-	dispatch,
-	createRegistrySelector,
-} from '@wordpress/data';
+import { select, dispatch, createRegistrySelector } from '@wordpress/data';
 import { controls, apiFetch } from '@wordpress/data-controls';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { createReducerFromActionMap } from '../shared/data/store-helpers';
+import {
+	createStore,
+	createReducerFromActionMap,
+} from '../shared/data/store-helpers';
 import { logEvent } from '../shared/helpers/log-event';
 import '../shared/data/api-fetch-preloaded-once';
 
@@ -357,12 +354,10 @@ const reducer = {
 	DEFAULT: ( action, state ) => state,
 };
 
-export const EXTENSIONS_STORE = createReduxStore( 'sensei/extensions', {
+export const EXTENSIONS_STORE = createStore( 'sensei/extensions', {
 	reducer: createReducerFromActionMap( reducer, DEFAULT_STATE ),
 	actions,
 	selectors,
 	resolvers,
 	controls,
 } );
-
-register( EXTENSIONS_STORE );

--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -3,6 +3,9 @@
  */
 import { select, dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editPostStore } from '@wordpress/edit-post';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -39,9 +42,19 @@ const metaboxReplacements = {
 };
 
 // WordPress data.
-const blockEditorSelector = select( 'core/block-editor' );
-const editPostSelector = select( 'core/edit-post' );
-const editPostDispatcher = dispatch( 'core/edit-post' );
+const blockEditorSelector = select( blockEditorStore );
+const editorSelector = select( editorStore );
+const editorDispatcher = dispatch( editorStore );
+const editPostSelector = select( editPostStore );
+const editPostDispatcher = dispatch( editPostStore );
+
+const isEditorPanelEnabled = editorSelector.isEditorPanelEnabled
+	? editorSelector.isEditorPanelEnabled
+	: editPostSelector.isEditorPanelEnabled;
+
+const toggleEditorPanelEnabled = editorDispatcher.toggleEditorPanelEnabled
+	? editorDispatcher.toggleEditorPanelEnabled
+	: editPostDispatcher.toggleEditorPanelEnabled;
 
 /**
  * Start blocks toggling control.
@@ -86,11 +99,8 @@ export const startBlocksTogglingControl = ( postType ) => {
 		Object.entries( metaboxReplacements[ postType ] ).forEach(
 			( [ metaboxName, blockDeps ] ) => {
 				const enable = ! hasSomeBlocks( blockDeps );
-				if (
-					enable !==
-					editPostSelector.isEditorPanelEnabled( metaboxName )
-				) {
-					editPostDispatcher.toggleEditorPanelEnabled( metaboxName );
+				if ( enable !== isEditorPanelEnabled( metaboxName ) ) {
+					toggleEditorPanelEnabled( metaboxName );
 				}
 			}
 		);
@@ -99,7 +109,7 @@ export const startBlocksTogglingControl = ( postType ) => {
 		document
 			.querySelectorAll( '#module_course_mb input' )
 			.forEach( ( input ) => {
-				input.disabled = ! editPostSelector.isEditorPanelEnabled(
+				input.disabled = ! isEditorPanelEnabled(
 					'meta-box-module_course_mb'
 				);
 			} );
@@ -108,7 +118,7 @@ export const startBlocksTogglingControl = ( postType ) => {
 		document
 			.querySelectorAll( '#lesson-info input, #lesson-info select' )
 			.forEach( ( input ) => {
-				input.disabled = ! editPostSelector.isEditorPanelEnabled(
+				input.disabled = ! isEditorPanelEnabled(
 					'meta-box-lesson-info'
 				);
 			} );

--- a/assets/js/admin/course-settings-plugin-sidebar.js
+++ b/assets/js/admin/course-settings-plugin-sidebar.js
@@ -3,10 +3,17 @@
  */
 import { applyFilters } from '@wordpress/hooks';
 import {
+	store as editPostStore,
+	PluginDocumentSettingPanel as DeprecatedPluginDocumentSettingPanel,
+	PluginSidebar as DeprecatedPluginSidebar,
+	PluginSidebarMoreMenuItem as DeprecatedPluginSidebarMoreMenuItem,
+} from '@wordpress/edit-post';
+import {
+	store as editorStore,
 	PluginDocumentSettingPanel,
 	PluginSidebar,
 	PluginSidebarMoreMenuItem,
-} from '@wordpress/edit-post';
+} from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { dispatch, useSelect } from '@wordpress/data';
 import { Slot } from '@wordpress/components';
@@ -20,6 +27,18 @@ import CourseThemeSidebar from './course-theme/course-theme-sidebar';
 import CourseVideoSidebar from './course-video-sidebar';
 import CourseGeneralSidebar from './course-general-sidebar';
 import SenseiIcon from '../../icons/logo-tree.svg';
+
+if ( ! PluginDocumentSettingPanel ) {
+	PluginDocumentSettingPanel = DeprecatedPluginDocumentSettingPanel;
+}
+
+if ( ! PluginSidebar ) {
+	PluginSidebar = DeprecatedPluginSidebar;
+}
+
+if ( ! PluginSidebarMoreMenuItem ) {
+	PluginSidebarMoreMenuItem = DeprecatedPluginSidebarMoreMenuItem;
+}
 
 export const pluginSidebarHandle = 'sensei-lms-course-settings-sidebar';
 export const pluginDocumentHandle = 'sensei-lms-document-settings-sidebar';
@@ -73,17 +92,26 @@ export const CourseSidebar = () => {
 
 export const SenseiSettingsDocumentSidebar = () => {
 	const isSenseiEditorPanelOpen = useSelect( ( select ) => {
-		return select( 'core/edit-post' ).isEditorPanelOpened(
+		const isEditorPanelOpened = select( editorStore ).isEditorPanelOpened
+			? select( editorStore ).isEditorPanelOpened
+			: select( editPostStore ).isEditorPanelOpened;
+
+		return isEditorPanelOpened(
 			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
 		);
 	} );
 	if ( isSenseiEditorPanelOpen ) {
+		const toggleEditorPanelOpened = dispatch( editorStore )
+			.toggleEditorPanelOpened
+			? dispatch( editorStore ).toggleEditorPanelOpened
+			: dispatch( editPostStore ).toggleEditorPanelOpened;
+
 		// when 'Course Settings' is clicked, isSenseiEditorPanelOpen returns true, so we open the 'Course Settings'
 		// plugin sidebar and then close the 'Sensei Settings' panel which sets isSenseiEditorPanelOpen back to false.
-		dispatch( 'core/edit-post' ).openGeneralSidebar(
+		dispatch( editPostStore ).openGeneralSidebar(
 			`${ pluginSidebarHandle }/${ pluginSidebarHandle }`
 		);
-		dispatch( 'core/edit-post' ).toggleEditorPanelOpened(
+		toggleEditorPanelOpened(
 			`${ pluginDocumentHandle }/${ pluginDocumentHandle }`
 		);
 	}

--- a/assets/shared/blocks/block-metadata.js
+++ b/assets/shared/blocks/block-metadata.js
@@ -1,23 +1,21 @@
 /**
+ * External dependencies
+ */
+import { pick, mapValues } from 'lodash';
+import createSelector from 'rememo';
+
+/**
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import {
-	dispatch,
-	useDispatch,
-	useSelect,
-	createSelector,
-} from '@wordpress/data';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import {
 	createContext,
 	useCallback,
 	useContext,
 	useMemo,
 } from '@wordpress/element';
-/**
- * External dependencies
- */
-import { pick, mapValues } from 'lodash';
+
 /**
  * Internal dependencies
  */

--- a/assets/shared/blocks/block-metadata.js
+++ b/assets/shared/blocks/block-metadata.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { dispatch, useDispatch, useSelect } from '@wordpress/data';
+import {
+	dispatch,
+	useDispatch,
+	useSelect,
+	createSelector,
+} from '@wordpress/data';
 import {
 	createContext,
 	useCallback,
@@ -76,12 +81,15 @@ const store = {
 		 * @param {string}   [key]     Only return metadata for the given key.
 		 * @return {Object} Blocks metadata, indexed by block ID.
 		 */
-		getMultipleBlockMeta: ( state, clientIds = [], key = null ) => {
-			const blocks = clientIds?.length
-				? pick( state, clientIds )
-				: { ...state };
-			return key ? mapValues( blocks, key ) : blocks;
-		},
+		getMultipleBlockMeta: createSelector(
+			( state, clientIds = [], key = null ) => {
+				const blocks = clientIds?.length
+					? pick( state, clientIds )
+					: state;
+				return key ? mapValues( blocks, key ) : blocks;
+			},
+			( state ) => [ state ]
+		),
 	},
 };
 

--- a/assets/shared/data/store-helpers.js
+++ b/assets/shared/data/store-helpers.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, register, registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 
 /**
  * Compose an action creator with the given start, success and error actions.
@@ -59,11 +59,7 @@ export const createReducerFromActionMap = ( reducers, defaultState ) => {
  * @return {string|Object} Store key.
  */
 export const createStore = ( name, settings ) => {
-	if ( createReduxStore ) {
-		const store = createReduxStore( name, settings );
-		register( store );
-		return store;
-	}
-	registerStore( name, settings );
-	return name;
+	const store = createReduxStore( name, settings );
+	register( store );
+	return store;
 };

--- a/assets/shared/data/store-helpers.js
+++ b/assets/shared/data/store-helpers.js
@@ -3,6 +3,9 @@
  */
 import { createReduxStore, register } from '@wordpress/data';
 
+window.senseiStores = window.senseiStores || [];
+const { senseiStores } = window;
+
 /**
  * Compose an action creator with the given start, success and error actions.
  *
@@ -59,7 +62,12 @@ export const createReducerFromActionMap = ( reducers, defaultState ) => {
  * @return {string|Object} Store key.
  */
 export const createStore = ( name, settings ) => {
+	if ( senseiStores[ name ] ) {
+		return senseiStores[ name ];
+	}
+
 	const store = createReduxStore( name, settings );
 	register( store );
+	senseiStores[ name ] = store;
 	return store;
 };

--- a/assets/shared/data/store-helpers.js
+++ b/assets/shared/data/store-helpers.js
@@ -3,6 +3,8 @@
  */
 import { createReduxStore, register } from '@wordpress/data';
 
+// We register the store in the global scope to avoid registering it multiple times.
+// The reason to be in the global scope is that some times we have different built files using the same source.
 window.senseiStores = window.senseiStores || [];
 const { senseiStores } = window;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "memize": "1.1.0",
         "qrcode.react": "3.1.0",
         "react-animate-height": "2.0.23",
+        "rememo": "4.0.2",
         "terser-webpack-plugin": "5.3.1",
         "uuid": "7.0.3",
         "whatwg-fetch": "3.6.2"
@@ -1890,11 +1891,6 @@
         "@babel/runtime": "^7.0.0",
         "react-with-styles": "^3.0.0 || ^4.0.0"
       }
-    },
-    "node_modules/@automattic/tour-kit/node_modules/rememo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
-      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@automattic/tour-kit/node_modules/style-value-types": {
       "version": "5.0.0",
@@ -9820,9 +9816,9 @@
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/blocks/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
       "version": "19.12.0",
@@ -9975,9 +9971,9 @@
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/keyboard-shortcuts/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/primitives": {
       "version": "3.8.0",
@@ -10017,9 +10013,9 @@
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/rich-text/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/block-editor/node_modules/framer-motion": {
       "version": "6.3.11",
@@ -10117,6 +10113,11 @@
         "@babel/runtime": "^7.0.0",
         "react-with-styles": "^3.0.0 || ^4.0.0"
       }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
     },
     "node_modules/@wordpress/block-editor/node_modules/style-value-types": {
       "version": "5.0.0",
@@ -10338,6 +10339,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/block-library/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+    },
     "node_modules/@wordpress/block-library/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -10428,6 +10434,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/blocks/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+    },
     "node_modules/@wordpress/blocks/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -10507,6 +10518,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@wordpress/components/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
     },
     "node_modules/@wordpress/components/node_modules/uuid": {
       "version": "8.3.2",
@@ -10634,6 +10650,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@wordpress/core-data/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
     },
     "node_modules/@wordpress/core-data/node_modules/uuid": {
       "version": "8.3.2",
@@ -11112,6 +11133,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/edit-post/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+    },
     "node_modules/@wordpress/edit-post/node_modules/uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
@@ -11283,9 +11309,9 @@
       }
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/blocks/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/components": {
       "version": "19.12.0",
@@ -11421,9 +11447,9 @@
       }
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/core-data/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/data": {
       "version": "6.10.0",
@@ -11484,9 +11510,9 @@
       }
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/keyboard-shortcuts/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/media-utils": {
       "version": "3.6.0",
@@ -11646,9 +11672,9 @@
       }
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/reusable-blocks/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/rich-text": {
       "version": "5.8.0",
@@ -11675,9 +11701,9 @@
       }
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/rich-text/node_modules/rememo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-      "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/server-side-render": {
       "version": "3.8.0",
@@ -11813,6 +11839,11 @@
         "@babel/runtime": "^7.0.0",
         "react-with-styles": "^3.0.0 || ^4.0.0"
       }
+    },
+    "node_modules/@wordpress/editor/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
     },
     "node_modules/@wordpress/editor/node_modules/style-value-types": {
       "version": "5.0.0",
@@ -12753,6 +12784,11 @@
         "redux": "^4.1.0"
       }
     },
+    "node_modules/@wordpress/keyboard-shortcuts/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+    },
     "node_modules/@wordpress/keycodes": {
       "version": "3.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.51.0.tgz",
@@ -13206,6 +13242,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/reusable-blocks/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+    },
     "node_modules/@wordpress/reusable-blocks/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -13261,6 +13302,11 @@
       "peerDependencies": {
         "redux": "^4.1.0"
       }
+    },
+    "node_modules/@wordpress/rich-text/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
     },
     "node_modules/@wordpress/scripts": {
       "version": "22.4.2",
@@ -15771,6 +15817,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
     },
     "node_modules/@wordpress/server-side-render/node_modules/uuid": {
       "version": "8.3.2",
@@ -36668,8 +36719,9 @@
       }
     },
     "node_modules/rememo": {
-      "version": "3.0.0",
-      "license": "MIT"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "node_modules/remove-accents": {
       "version": "0.4.4",
@@ -42983,11 +43035,6 @@
             "global-cache": "^1.2.1"
           }
         },
-        "rememo": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
-          "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
-        },
         "style-value-types": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
@@ -48736,9 +48783,9 @@
           },
           "dependencies": {
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -48864,9 +48911,9 @@
           },
           "dependencies": {
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -48899,9 +48946,9 @@
           },
           "dependencies": {
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -48979,6 +49026,11 @@
             "array.prototype.flat": "^1.2.1",
             "global-cache": "^1.2.1"
           }
+        },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
         },
         "style-value-types": {
           "version": "5.0.0",
@@ -49180,6 +49232,11 @@
             "@wordpress/primitives": "^2.2.0"
           }
         },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -49254,6 +49311,11 @@
             "@wordpress/primitives": "^2.2.0"
           }
         },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -49320,6 +49382,11 @@
             "@wordpress/element": "wp-5.9",
             "@wordpress/primitives": "^2.2.0"
           }
+        },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -49428,6 +49495,11 @@
             "@wordpress/element": "wp-5.9",
             "@wordpress/primitives": "^2.2.0"
           }
+        },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -49830,6 +49902,11 @@
             "@wordpress/primitives": "^2.2.0"
           }
         },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+        },
         "uuid": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
@@ -49980,9 +50057,9 @@
           },
           "dependencies": {
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -50097,9 +50174,9 @@
               }
             },
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -50147,9 +50224,9 @@
           },
           "dependencies": {
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -50281,9 +50358,9 @@
               }
             },
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -50306,9 +50383,9 @@
           },
           "dependencies": {
             "rememo": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
-              "integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+              "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
             }
           }
         },
@@ -50416,6 +50493,11 @@
             "array.prototype.flat": "^1.2.1",
             "global-cache": "^1.2.1"
           }
+        },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
         },
         "style-value-types": {
           "version": "5.0.0",
@@ -51134,6 +51216,11 @@
             "turbo-combine-reducers": "^1.0.2",
             "use-memo-one": "^1.1.1"
           }
+        },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
         }
       }
     },
@@ -51503,6 +51590,11 @@
             "@wordpress/primitives": "^2.2.0"
           }
         },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -51548,6 +51640,11 @@
             "turbo-combine-reducers": "^1.0.2",
             "use-memo-one": "^1.1.1"
           }
+        },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
         }
       }
     },
@@ -53311,6 +53408,11 @@
             "@wordpress/element": "wp-5.9",
             "@wordpress/primitives": "^2.2.0"
           }
+        },
+        "rememo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+          "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -68316,7 +68418,9 @@
       }
     },
     "rememo": {
-      "version": "3.0.0"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="
     },
     "remove-accents": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "memize": "1.1.0",
     "qrcode.react": "3.1.0",
     "react-animate-height": "2.0.23",
+    "rememo": "4.0.2",
     "terser-webpack-plugin": "5.3.1",
     "uuid": "7.0.3",
     "whatwg-fetch": "3.6.2"


### PR DESCRIPTION
Part of #7624

## Proposed Changes

* Fix JS errors and warnings displayed in the browser console.
* Since it's just fixing deprecated code, and users won't see any change, I'm not adding any changelog.

## Known issues

- When navigating to the course editor, and navigating back (browser history), it gives the error `Blocked attempt to show a 'beforeunload' confirmation panel for a frame that never had a user gesture since its load.`. I could isolate it noticing that the warning is not displayed anymore when we remove the `TextControl` from the modal.
  - I didn't invest much time into that because it's external and not too critical.
- https://github.com/Automattic/wp-calypso/issues/93167 - When using the tour, there is a warning about a deprecated prop (`isElevated`), which comes from [Calypso](https://github.com/Automattic/wp-calypso/blob/e5b49b40406c4a8adc844e3fbab8c57d13e9e462/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx#L32).

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Prepare 2 development environments and repeat the test for WordPress 6.4 and WordPress 6.6.
2. For WordPress 6.6, activate Gutenberg with the version from `trunk` or:
  2.1. Install the WordPress Beta Tester plugin.
  2.2. Switch to the bleeding edge nightly.
3. Open the browser console and monitor for warnings and errors.
4. While performing the following tests, play with the blocks settings and toolbar.
5. Create a course with lessons.
6. In a lesson, create a quiz with questions.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
