### PR TITLE
Handle empty module on the course structure saving

### DIFF
--- a/assets/admin/tour/course-tour/steps.js
+++ b/assets/admin/tour/course-tour/steps.js
@@ -209,7 +209,7 @@ function getTourSteps() {
 				heading: __( 'Adding a module', 'sensei-lms' ),
 				descriptions: {
 					desktop: __(
-						'A module is a container for a group of related lessons in a course. Click + to open the inserter. Then click the Module option.',
+						'A module is a container for a group of related lessons in a course. Click + to open the inserter. Then click the Module option and give it a name.',
 						'sensei-lms'
 					),
 					mobile: null,

--- a/changelog/fix-handle-empty-module-on-save
+++ b/changelog/fix-handle-empty-module-on-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set default names for modules without titles

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -1297,6 +1297,9 @@
     <InvalidScalarArgument occurrences="1">
       <code>$course_name</code>
     </InvalidScalarArgument>
+    <MissingClosureReturnType occurrences="1">
+      <code>function ( $item ) use ( &amp;$existing_module_names, &amp;$i ) {</code>
+    </MissingClosureReturnType>
     <NullableReturnStatement occurrences="1">
       <code>$term-&gt;term_id</code>
     </NullableReturnStatement>
@@ -3558,6 +3561,9 @@
       <code>null === $first</code>
       <code>null === $second</code>
     </DocblockTypeContradiction>
+    <InvalidAttribute occurrences="1">
+      <code>\ReturnTypeWillChange</code>
+    </InvalidAttribute>
     <InvalidReturnStatement occurrences="1">
       <code>wp_delete_attachment( $file_id, true )</code>
     </InvalidReturnStatement>
@@ -3616,6 +3622,9 @@
       <code>! self::$instance</code>
       <code>self::$instance</code>
     </DocblockTypeContradiction>
+    <InvalidAttribute occurrences="1">
+      <code>\ReturnTypeWillChange</code>
+    </InvalidAttribute>
     <InvalidReturnStatement occurrences="2">
       <code>$this-&gt;create_job( $user_id, Sensei_Export_Job::class )</code>
       <code>$this-&gt;create_job( $user_id, Sensei_Import_Job::class )</code>
@@ -4286,6 +4295,9 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="includes/enrolment/class-sensei-course-enrolment-provider-results.php">
+    <InvalidAttribute occurrences="1">
+      <code>\ReturnTypeWillChange</code>
+    </InvalidAttribute>
     <InvalidScalarArgument occurrences="1">
       <code>$version</code>
     </InvalidScalarArgument>
@@ -4394,9 +4406,17 @@
     <InvalidArgument occurrences="1">
       <code>$provider_states</code>
     </InvalidArgument>
+    <InvalidAttribute occurrences="1">
+      <code>\ReturnTypeWillChange</code>
+    </InvalidAttribute>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$provider_states</code>
     </InvalidPropertyAssignmentValue>
+  </file>
+  <file src="includes/enrolment/class-sensei-enrolment-provider-state.php">
+    <InvalidAttribute occurrences="1">
+      <code>\ReturnTypeWillChange</code>
+    </InvalidAttribute>
   </file>
   <file src="includes/hooks/template.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -5255,12 +5275,6 @@
     </UndefinedPropertyFetch>
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-question-helpers-trait.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$post_args</code>
-    </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
-      <code>$post_args</code>
-    </InvalidArgument>
     <PossibleRawObjectIteration occurrences="1">
       <code>$question_categories</code>
     </PossibleRawObjectIteration>


### PR DESCRIPTION
Resolves #7625

The problem described in the issue happens when, while following the tour, the user doesn't set the module title.

The course structure can't be saved in this case, and it causes the issue that the expected “Edit Lesson” link doesn't appear in the toolbar.

## Proposed Changes
* Adjust the text in the tour to instruct the user to set a title for the module.
* Set default titles for modules on saving.

## Testing Instructions

1. On a new website, create a course, and follow the next steps before saving/publishing the course.
2. Take the tour and on the third step (“Adding a module”) make sure we mention the need to add the title for the module: “Then click the Module option and give it a name.”
3. Add a few modules without setting titles for them.
4. Save the draft.
5. Make sure each module without a name got a title like “Module N” where N is an ordinal number.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] “Needs Documentation” label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
