### PR TITLE
Fix deprecation notices on PHP 8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 8.1]
+                php: [7.4, 8.2]
         steps:
             - name: Download Build Artifact
               uses: actions/download-artifact@v3

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -59,7 +59,7 @@ jobs:
             matrix:
                 wp: ['latest']
                 wpmu: [0]
-                php: ['7.4', '8.0']
+                php: ['7.4', '8.2']
                 include:
                     - php: 7.4
                       wp: '6.1'

--- a/changelog/fix-deprecation-notice-on-question-edit-screen
+++ b/changelog/fix-deprecation-notice-on-question-edit-screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Deprecation notice on the question edit screen on PHP 8.1

--- a/changelog/fix-deprecation-notice-on-reports-screen
+++ b/changelog/fix-deprecation-notice-on-reports-screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Deprecation notice on the reports screen when using PHP 8.1

--- a/changelog/fix-deprecation-notices
+++ b/changelog/fix-deprecation-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deprecation notices on PHP 8.2

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -490,7 +490,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		$more_button   = '';
 
 		foreach ( $courses as $course ) {
-			$html_items[] = '<a href="' . esc_url( $this->controller->get_learner_management_course_url( $course->ID ) ) .
+			$html_items[] = '<a href="' . esc_url( (string) $this->controller->get_learner_management_course_url( $course->ID ) ) .
 				'" class="sensei-students__enrolled-course" data-course-id="' . esc_attr( $course->ID ) . '">' .
 					esc_html( $course->post_title ) .
 				'</a>';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4804,7 +4804,7 @@ class Sensei_Lesson {
 		 * @return {bool} Whether to show the course sign up notice.
 		 */
 		if ( apply_filters( 'sensei_lesson_show_course_signup_notice', $show_course_signup_notice, $course_id ) ) {
-			$course_link  = '<a href="' . esc_url( Sensei()->lesson->get_take_course_url( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'sensei-lms' ) . '">';
+			$course_link  = '<a href="' . esc_url( (string) Sensei()->lesson->get_take_course_url( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'sensei-lms' ) . '">';
 			$course_link .= esc_html__( 'course', 'sensei-lms' );
 			$course_link .= '</a>';
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1,7 +1,6 @@
 <?php
 
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
-use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -1335,7 +1334,7 @@ class Sensei_Quiz {
 
 		foreach ( $encoded_feedback as $question_id => $feedback ) {
 
-			$answers_feedback[ $question_id ] = base64_decode( $feedback );
+			$answers_feedback[ $question_id ] = base64_decode( (string) $feedback );
 
 		}
 

--- a/includes/course-theme/class-sensei-course-theme-styles.php
+++ b/includes/course-theme/class-sensei-course-theme-styles.php
@@ -203,7 +203,7 @@ class Sensei_Course_Theme_Styles {
 			);
 			$value          = "var(--wp--$unwrapped_name)";
 		} elseif ( preg_match( '/^[a-z0-9-]+$/i', $value ) ) {
-			$value = "var(--wp--preset--color--${value})";
+			$value = "var(--wp--preset--color--{$value})";
 		}
 
 		return $value;

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -402,7 +402,7 @@ class Sensei_Data_Port_Utilities {
 	 *
 	 * @return array|string[]
 	 */
-	public static function split_list_safely( $str_list, $remove_quotes = false ) {
+	public static function split_list_safely( string $str_list, bool $remove_quotes = false ) {
 		if ( empty( trim( $str_list ) ) ) {
 			return [];
 		}

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -352,7 +352,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 
 		$taxonomy_terms[ Sensei_Data_Port_Question_Schema::TAXONOMY_QUESTION_CATEGORY ] = [];
 
-		$category_list = Sensei_Data_Port_Utilities::split_list_safely( $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_CATEGORIES ), true );
+		$category_list = Sensei_Data_Port_Utilities::split_list_safely( (string) $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_CATEGORIES ), true );
 		if ( ! empty( $category_list ) ) {
 			foreach ( $category_list as $category ) {
 				$category_term = Sensei_Data_Port_Utilities::get_term( $category, Sensei_Data_Port_Question_Schema::TAXONOMY_QUESTION_CATEGORY );

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -8,8 +8,6 @@
 namespace Sensei\Internal\Emails;
 
 use Sensei_List_Table;
-use WP_Post;
-use WP_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -130,7 +128,7 @@ class Email_List_Table extends Sensei_List_Table {
 		$description = $is_available ?
 			sprintf(
 				'<strong><a href="%1$s" class="row-title">%2$s</a></strong>%3$s',
-				esc_url( get_edit_post_link( $post ) ),
+				esc_url( (string) get_edit_post_link( $post ) ),
 				get_post_meta( $post->ID, '_sensei_email_description', true ),
 				$this->row_actions( $actions )
 			) : sprintf(

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -263,7 +263,7 @@ abstract class Sensei_Usage_Tracking_Base {
 		$p                 = array();
 
 		foreach ( $properties as $key => $value ) {
-			$p[] = rawurlencode( $key ) . '=' . rawurlencode( $value );
+			$p[] = rawurlencode( $key ) . '=' . rawurlencode( (string) $value );
 		}
 
 		$pixel .= '?' . implode( '&', $p ) . '&_=_'; // EOF marker.

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -21,6 +21,13 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 	private $event_counts       = array();
 	private $track_http_request = array();
 
+	/**
+	 * Usage tracking test subclass instance.
+	 *
+	 * @var Usage_Tracking_Test_Subclass
+	 */
+	private $usage_tracking;
+
 	public function setUp(): void {
 		parent::setUp();
 		// Update the class name here to match the Usage Tracking class.

--- a/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
@@ -35,7 +35,7 @@ class Sensei_REST_API_Course_Progress_Controller extends \WP_REST_Controller {
 	 *
 	 * @param string $namespace Routes namespace.
 	 */
-	public function __construct( $namespace ) {
+	public function __construct( $namespace ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.namespaceFound -- The variable name if defined in the WP_REST_Controller class.
 		$this->namespace = $namespace;
 	}
 
@@ -74,7 +74,7 @@ class Sensei_REST_API_Course_Progress_Controller extends \WP_REST_Controller {
 			$student               = new WP_User( $student_id );
 			$result[ $student_id ] = false;
 			if ( $student->exists() ) {
-				$result[ $student_id ] = [];
+				$result[ $student_id ] = array();
 				foreach ( $course_ids as $course_id ) {
 					$result[ $student_id ][ $course_id ] = false;
 					if ( Sensei_Utils::has_started_course( $course_id, $student_id ) ) {
@@ -84,7 +84,7 @@ class Sensei_REST_API_Course_Progress_Controller extends \WP_REST_Controller {
 			}
 		}
 
-		return new WP_REST_Response( $result, WP_HTTP::OK );
+		return new WP_REST_Response( $result, WP_Http::OK );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
@@ -74,6 +74,7 @@ class Sensei_REST_API_Course_Progress_Controller extends \WP_REST_Controller {
 			$student               = new WP_User( $student_id );
 			$result[ $student_id ] = false;
 			if ( $student->exists() ) {
+				$result[ $student_id ] = [];
 				foreach ( $course_ids as $course_id ) {
 					$result[ $student_id ][ $course_id ] = false;
 					if ( Sensei_Utils::has_started_course( $course_id, $student_id ) ) {

--- a/includes/rest-api/class-sensei-rest-api-course-students-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-students-controller.php
@@ -80,7 +80,7 @@ class Sensei_REST_API_Course_Students_Controller extends \WP_REST_Controller {
 			$user               = new WP_User( $user_id );
 			$result[ $user_id ] = false;
 			if ( $user->exists() ) {
-				$result[ $user_id ] = [];
+				$result[ $user_id ] = array();
 				foreach ( $course_ids as $course_id ) {
 					$course_enrolment                 = Sensei_Course_Enrolment::get_course_instance( $course_id );
 					$result[ $user_id ][ $course_id ] = $course_enrolment->enrol( $user_id );

--- a/includes/rest-api/class-sensei-rest-api-course-students-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-students-controller.php
@@ -80,6 +80,7 @@ class Sensei_REST_API_Course_Students_Controller extends \WP_REST_Controller {
 			$user               = new WP_User( $user_id );
 			$result[ $user_id ] = false;
 			if ( $user->exists() ) {
+				$result[ $user_id ] = [];
 				foreach ( $course_ids as $course_id ) {
 					$course_enrolment                 = Sensei_Course_Enrolment::get_course_instance( $course_id );
 					$result[ $user_id ][ $course_id ] = $course_enrolment->enrol( $user_id );

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
+        convertDeprecationsToExceptions="true"
         verbose="true"
 >
     <php>

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -45,41 +45,64 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 	protected $basic_test_question_ids;
 
 	/**
+	 * Course factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Course
 	 */
 	public $course;
 
 	/**
+	 * Lesson factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Lesson
 	 */
 	public $lesson;
 
 	/**
+	 * Quiz factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Quiz
 	 */
 	public $quiz;
 
 	/**
+	 * Question factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Question
 	 */
 	public $question;
 
 	/**
+	 * Multiple question factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Multiple_Question
 	 */
 	public $multiple_question;
 
 	/**
+	 * Module factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Module
 	 */
 	public $module;
 
 	/**
+	 * Question category factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Question_Category
 	 */
 	public $question_category;
 
 	/**
+	 * Course category factory.
+	 *
+	 * @var Sensei_UnitTest_Factory_For_Course_Category
+	 */
+	public $course_category;
+
+	/**
+	 * Message factory.
+	 *
 	 * @var WP_UnitTest_Factory_For_Message
 	 */
 	public $message;

--- a/tests/framework/trait-sensei-hpps-helpers.php
+++ b/tests/framework/trait-sensei-hpps-helpers.php
@@ -25,6 +25,48 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.20.0
  */
 trait Sensei_HPPS_Helpers {
+	/**
+	 * Course progress repository.
+	 *
+	 * @var \Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface
+	 */
+	private $_course_progress_repository;
+
+	/**
+	 * Lesson progress repository.
+	 *
+	 * @var \Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Interface
+	 */
+	private $_lesson_progress_repository;
+
+	/**
+	 * Quiz repository.
+	 *
+	 * @var \Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface
+	 */
+	private $_quiz_progress_repository;
+
+	/**
+	 * Submission repository.
+	 *
+	 * @var \Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface
+	 */
+	private $_quiz_submission_repository;
+
+	/**
+	 * Answer repository.
+	 *
+	 * @var \Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface
+	 */
+	private $_quiz_answer_repository;
+
+	/**
+	 * Grade repository.
+	 *
+	 * @var \Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interface
+	 */
+	private $_quiz_grade_repository;
+
 	private function enable_hpps_tables_repository() {
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::TABLES_STORAGE;
 

--- a/tests/framework/trait-sensei-hpps-helpers.php
+++ b/tests/framework/trait-sensei-hpps-helpers.php
@@ -6,6 +6,7 @@
  */
 
 // phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+// phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
 
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory;

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -15,6 +15,13 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	use Sensei_Test_Redirect_Helpers;
 
 	/**
+	 * The original screen.
+	 *
+	 * @var WP_Screen
+	 */
+	private $original_screen;
+
+	/**
 	 * Set up before the class.
 	 */
 	public static function setUpBeforeClass(): void {

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -346,7 +346,9 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		update_option( 'sensei_activation_redirect', 1 );
 
 		// Act.
+		ob_start();
 		Sensei()->setup_wizard->render_wizard_page();
+		ob_end_clean();
 
 		// Assert.
 		$this->assertFalse( get_option( 'sensei_activation_redirect', false ) );

--- a/tests/unit-tests/blocks/test-class-sensei-block-course-progress.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-course-progress.php
@@ -15,6 +15,13 @@ class Sensei_Course_Progress_Block_Test extends WP_UnitTestCase {
 	private $block;
 
 	/**
+	 * The course post.
+	 *
+	 * @var WP_Post
+	 */
+	private $course;
+
+	/**
 	 * Factory for setting up testing data.
 	 *
 	 * @var Sensei_Factory

--- a/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
@@ -18,6 +18,20 @@ class Sensei_Block_Learner_Courses_Test extends WP_UnitTestCase {
 	private $block;
 
 	/**
+	 * The course post.
+	 *
+	 * @var WP_Post
+	 */
+	private $course;
+
+	/**
+	 * Factory for setting up testing data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
 	 * Set up the test.
 	 */
 	public function setUp(): void {

--- a/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
@@ -18,6 +18,20 @@ class Sensei_Block_View_Results_Test extends WP_UnitTestCase {
 	private $block;
 
 	/**
+	 * The course post.
+	 *
+	 * @var WP_Post
+	 */
+	private $course;
+
+	/**
+	 * Factory for setting up testing data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
 	 * Block content.
 	 */
 	const CONTENT = '<!-- wp:sensei-lms/button-view-results -->

--- a/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
@@ -18,6 +18,20 @@ class Sensei_Continue_Course_Block_Test extends WP_UnitTestCase {
 	private $block;
 
 	/**
+	 * The course post.
+	 *
+	 * @var WP_Post
+	 */
+	private $course;
+
+	/**
+	 * Factory for setting up testing data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
 	 * Block content.
 	 */
 	const CONTENT = '<!-- wp:sensei-lms/button-continue-course -->

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -60,6 +60,14 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 <!-- wp:post-title {"level":1,"isLink":true,"fontSize":"large"} /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->';
+
+	/**
+	 * Course archive
+	 *
+	 * @var Sensei_Unsupported_Theme_Handler_Course_Archive
+	 */
+	private $handler;
+
 	/**
 	 * Set up the test.
 	 */

--- a/tests/unit-tests/blocks/test-class-sensei-global-blocks.php
+++ b/tests/unit-tests/blocks/test-class-sensei-global-blocks.php
@@ -64,6 +64,10 @@ class Sensei_Global_Blocks_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertTrue( wp_script_is( 'sensei-course-list-filter' ) );
 		$this->assertTrue( wp_style_is( 'sensei-global-blocks-style' ) );
+
+		/* Reset */
+		wp_dequeue_script( 'sensei-course-list-filter' );
+		wp_dequeue_style( 'sensei-global-blocks-style' );
 	}
 
 	/**
@@ -71,8 +75,6 @@ class Sensei_Global_Blocks_Test extends WP_UnitTestCase {
 	 */
 	public function testEnqueueBlockAssets_WhenCalledOnAdmin_NotEnqueueCourseListFilter() {
 		/* Arrange */
-
-		$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
 		set_current_screen( 'edit-post' );
 
 		/* Act */
@@ -80,6 +82,9 @@ class Sensei_Global_Blocks_Test extends WP_UnitTestCase {
 
 		/* Assert */
 		$this->assertFalse( wp_script_is( 'sensei-course-list-filter' ) );
+
+		/* Reset */
+		wp_dequeue_style( 'sensei-global-blocks-style' );
 	}
 
 

--- a/tests/unit-tests/internal/emails/test-class-email-preview.php
+++ b/tests/unit-tests/internal/emails/test-class-email-preview.php
@@ -18,6 +18,27 @@ use WPDieException;
 class Email_Preview_Test extends \WP_UnitTestCase {
 	use Sensei_Test_Login_Helpers;
 
+	/**
+	 * Factory instance.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Email_Sender mock.
+	 *
+	 * @var \PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected $email_sender;
+
+	/**
+	 * Sensei_Assets mock.
+	 *
+	 * @var \PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected $assets;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->factory      = new Sensei_Factory();

--- a/tests/unit-tests/internal/emails/test-class-email-user-profile-settings.php
+++ b/tests/unit-tests/internal/emails/test-class-email-user-profile-settings.php
@@ -39,6 +39,13 @@ class Email_User_Profile_Settings_Test extends \WP_UnitTestCase {
 	 */
 	protected $list_table;
 
+	/**
+	 * Email subscription instance.
+	 *
+	 * @var \Sensei\Internal\Emails\Email_Subscription
+	 */
+	protected $subscription;
+
 	public function setUp(): void {
 		parent::setUp();
 

--- a/tests/unit-tests/test-class-sensei-guest-user.php
+++ b/tests/unit-tests/test-class-sensei-guest-user.php
@@ -21,6 +21,13 @@ class Sensei_Guest_User_Test extends WP_UnitTestCase {
 	protected $factory;
 
 	/**
+	 * Guest user instance.
+	 *
+	 * @var Sensei_Guest_User
+	 */
+	protected $guest_user;
+
+	/**
 	 * Set up the test.
 	 */
 	public function setUp(): void {

--- a/tests/unit-tests/test-class-sensei-preview-user.php
+++ b/tests/unit-tests/test-class-sensei-preview-user.php
@@ -21,6 +21,13 @@ class Sensei_Preview_User_Test extends WP_UnitTestCase {
 	protected $factory;
 
 	/**
+	 * Preview user instance.
+	 *
+	 * @var Sensei_Preview_User
+	 */
+	protected $preview_user;
+
+	/**
 	 * Set up the test.
 	 */
 	public function setUp(): void {


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7633, https://github.com/Automattic/sensei/issues/7634, https://github.com/Automattic/sensei/issues/7635

## Proposed Changes
* Fix deprecation notices in the UI and when running unit tests on PHP 8.2.
* Fix unit tests.
* Bump the CI unit tests PHP version to 8.2.
* Code cleanup.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use PHP 8.2.
2. Add `define( 'WP_DEBUG_DISPLAY', true );` and `define( 'WP_DEBUG_LOG', true );` in wp-config.php.
3. Test the main flow of the plugin:
    1. Create a course with lessons, modules, and a quiz.
    2. Complete the course as a student.
    3. Grade the quiz.
    4. Check the reports screen.
4. Because I wasn't able to test all features, consider going through plugin features outside of the main flow.
5. Check your `debug.log` file and make sure there are no errors related to sensei-pro. Note that there could be some related to Sensei core which will be addressed in another PR.
6. Run the unit tests and make sure there are no deprecation messages related to sensei-lms.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
