### PR TITLE
Handle empty module titles on saving  the course from the tour

### DIFF
--- a/assets/admin/tour/course-tour/steps.js
+++ b/assets/admin/tour/course-tour/steps.js
@@ -13,6 +13,7 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import { TourStep } from '../types';
+import { setBlockMeta } from '../../../shared/blocks/block-metadata';
 import { getFirstBlockByName } from '../../../blocks/course-outline/data';
 import {
 	highlightElementsWithBorders,
@@ -84,6 +85,40 @@ async function ensureLessonBlocksIsInEditor() {
 	}
 
 	insertLessonBlock( 'Lesson 1' );
+}
+
+/**
+ * Check all modules have titles, if not, assign a default title.
+ */
+function ensureModulesHaveTitles() {
+	const blocks = getCourseOutlineBlock().innerBlocks;
+	const modules = blocks.filter(
+		( block ) => block.name === 'sensei-lms/course-outline-module'
+	);
+	const moduleTitles = modules
+		.map( ( block ) => {
+			if ( block.name !== 'sensei-lms/course-outline-module' ) {
+				return null;
+			}
+			const title = block.attributes?.title?.trim();
+			return title || null;
+		} )
+		.filter( ( value ) => !! value );
+
+	if ( modules.length > 0 ) {
+		let i = 0;
+		modules.forEach( ( module ) => {
+			let title = module.attributes?.title?.trim();
+			if ( title !== '' ) {
+				return;
+			}
+			do {
+				title = __( 'Module', 'sensei-lms' ) + ' ' + ++i;
+			} while ( moduleTitles.includes( title ) );
+			module.attributes.title = title;
+			setBlockMeta( module.clientId, module.attributes );
+		} );
+	}
 }
 
 /**
@@ -209,7 +244,7 @@ function getTourSteps() {
 				heading: __( 'Adding a module', 'sensei-lms' ),
 				descriptions: {
 					desktop: __(
-						'A module is a container for a group of related lessons in a course. Click + to open the inserter. Then click the Module option.',
+						'A module is a container for a group of related lessons in a course. Click + to open the inserter. Then click the Module option and give it a name.',
 						'sensei-lms'
 					),
 					mobile: null,
@@ -512,6 +547,7 @@ function getTourSteps() {
 				);
 
 				if ( ! savedLesson ) {
+					ensureModulesHaveTitles();
 					const { savePost } = dispatch( editorStore );
 					savePost();
 					await waitForElement( savedlessonSelector, 15 );

--- a/changelog/fix-handle-empty-module-on-save-frontend
+++ b/changelog/fix-handle-empty-module-on-save-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set default names for modules without titles when save course in the course tour


### PR DESCRIPTION
Resolves #7625

The problem described in the issue happens when, while following the tour, the user doesn't set the module title.

The course structure can't be saved in this case, and it causes the issue that the expected “Edit Lesson” link doesn't appear in the toolbar.

## Proposed Changes
* Set default names for modules without titles when we initiate saving the course from the tour.
* Adjust the text in the tour to instruct the user to set a title for the module.

## Testing Instructions

1. On a new website, create a course, and follow the next steps before saving/publishing the course.
2. Take the tour and on the third step (“Adding a module”) make sure we mention the need to add the title for the module: “Then click the Module option and give it a name.”
3. Add a few modules without setting titles for them.
4. Follow the tour to the end.
5. Make sure each module without a name got a title like “Module N” where N is an ordinal number towards the end of the tour.
6. Make sure you see "Edit Lesson" in the toolbar for lessons when the tour says we should see it there.

https://github.com/user-attachments/assets/406e996c-2005-4a13-8d97-0f6333801f1d

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
