### PR TITLE
Let the tooltip for buttons be visible: fix z-index for tour container

### DIFF
--- a/assets/admin/tour/style.scss
+++ b/assets/admin/tour/style.scss
@@ -7,7 +7,7 @@
 	box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.25);
 
 	&:hover {
-		z-index: 9999999999;
+		z-index: 9999;
 	}
 }
 


### PR DESCRIPTION
Resolves #7628 

Problem:
![image](https://github.com/user-attachments/assets/6f18ddb1-4ff8-4cbc-9c88-74cda779f329)

Tooltips appear below the container.

## Proposed Changes
* Fix z-index for the tour container.

## Testing Instructions

1. On a fresh website, create a course.
2. Make sure you see the course tour in the editor.
3. Make sure tooltips (“Minimize tour”, “Close tour”) appear above the tour container and are visible.
4. Please check in different browsers.


https://github.com/user-attachments/assets/4ed8dd80-0743-4126-982b-5394cfd84e2b


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] “Needs Documentation” label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
