### PR TITLE
Avoid caching when getting course structure

### DIFF
--- a/changelog/fix-module-lesson-order
+++ b/changelog/fix-module-lesson-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid caching when getting course structure

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -105,7 +105,6 @@ class Sensei_Course_Outline_Block {
 			],
 			Sensei()->assets->src_path( 'blocks/course-outline/lesson-block' )
 		);
-
 	}
 
 	/**
@@ -174,7 +173,7 @@ class Sensei_Course_Outline_Block {
 			$context = 'edit';
 		}
 
-		$structure = Sensei_Course_Structure::instance( $post->ID )->get( $context );
+		$structure = Sensei_Course_Structure::instance( $post->ID )->get( $context, wp_using_ext_object_cache() );
 
 		$this->add_block_attributes( $structure );
 
@@ -183,7 +182,6 @@ class Sensei_Course_Outline_Block {
 			'attributes' => $attributes,
 			'blocks'     => $structure,
 		];
-
 	}
 
 	/**
@@ -233,7 +231,6 @@ class Sensei_Course_Outline_Block {
 
 		$this->block_content = $this->course->render_course_outline_block( $outline );
 		return $this->block_content;
-
 	}
 
 	/**
@@ -251,7 +248,7 @@ class Sensei_Course_Outline_Block {
 		}
 
 		$course_id       = $post->ID;
-		$structure       = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
+		$structure       = Sensei_Course_Structure::instance( $course_id )->get( 'view', wp_using_ext_object_cache() );
 		$has_draft       = $this->has_draft( $structure );
 		$can_edit_course = Sensei_Course::can_current_user_edit_course( $course_id );
 
@@ -333,5 +330,4 @@ class Sensei_Course_Outline_Block {
 			Sensei()->notices->add_notice( $message, 'info', 'sensei-course-outline-drafts' );
 		}
 	}
-
 }


### PR DESCRIPTION
Resolves #7146

## Proposed Changes
* Avoid caching when getting course structure

## Testing Instructions

1. Go to Sensei LMS > Courses, create a course with modules and lessons in them.
2. Go to Sensei LMS > Modules, change the order of the modules for the course. Save it.
3. Go to Sensei LMS > Lessons, change the order of the lessons in modules and outside the modules. Save it.
4. Open the course on the frontend and check the order is the same you set on previous steps.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
