### PR TITLE
Always allow access to a lesson if the lesson preview is enabled

### DIFF
--- a/changelog/fix-enforce-lesson-preview
+++ b/changelog/fix-enforce-lesson-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Always allow access to a lesson if the lesson preview is enabled

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -158,8 +158,7 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 
 	$can_user_view_lesson = ! sensei_is_login_required()
 							|| sensei_all_access( $user_id )
-							|| ( $user_can_view_course_content && $pre_requisite_complete )
-							|| $is_preview_lesson;
+							|| ( $user_can_view_course_content && $pre_requisite_complete );
 
 	/**
 	 * Filter if the user can view lesson and quiz content.
@@ -173,7 +172,9 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 	 * @param {int}  $user_id              User ID.
 	 * @return {bool} Filtered access.
 	 */
-	return apply_filters( 'sensei_can_user_view_lesson', $can_user_view_lesson, $lesson_id, $user_id );
+	$can_user_view_lesson = apply_filters( 'sensei_can_user_view_lesson', $can_user_view_lesson, $lesson_id, $user_id );
+
+	return $can_user_view_lesson || $is_preview_lesson;
 }
 
 if ( ! function_exists( 'sensei_light_or_dark' ) ) {


### PR DESCRIPTION
Resolves #7630

In the original issue, the Preview setting didn't work if the user's access expired.

Here, we prioritize the Preview setting so that it will have higher priority over other settings.

## Proposed Changes

* Always allow access to a lesson if the lesson preview is enabled

## Testing Instructions

1. Install Sensei Pro.
2. Create a course with a few lessons.
3. Set access period for the course.
4. For one lesson, make sure you added some content and enable the Preview setting (Allow this lesson to be viewed without login).
5. Create a student.
6. As a student, take the course.
7. Then go to Students. In the row with the student from step 6, click on the course in the Enrolled Courses column.
8. Set Access Expiration date in the past so that the access was expired for the student.
9. As a student, open the lesson with the enabled Preview setting.
10. Make sure you see the content you added in step 4.

![CleanShot 2024-08-01 at 23 46 29@2x](https://github.com/user-attachments/assets/78dae62c-31d4-4ac7-be08-720c21fb934a)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
