### PR TITLE
Pass checks argument to sensei_can_user_view_lesson filter

### DIFF
--- a/changelog/update-sensei-can-user-view-lesson-args
+++ b/changelog/update-sensei-can-user-view-lesson-args
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Pass checks argument to sensei_can_user_view_lesson filter.

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -161,19 +161,29 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 							|| ( $user_can_view_course_content && $pre_requisite_complete )
 							|| $is_preview_lesson;
 
+	$checks = array(
+		'login_not_required'           => ! sensei_is_login_required(),
+		'user_has_all_access'          => sensei_all_access( $user_id ),
+		'user_can_view_course_content' => $user_can_view_course_content,
+		'pre_requisite_complete'       => $pre_requisite_complete,
+		'is_preview_lesson'            => $is_preview_lesson,
+	);
+
 	/**
 	 * Filter if the user can view lesson and quiz content.
 	 *
 	 * @since 1.9.0
+	 * @since $$next-version$$ Added $checks parameter.
 	 *
 	 * @hook sensei_can_user_view_lesson
 	 *
-	 * @param {bool} $can_user_view_lesson True if they can view lesson/quiz content.
-	 * @param {int}  $lesson_id            Lesson post ID.
-	 * @param {int}  $user_id              User ID.
+	 * @param {bool}  $can_user_view_lesson True if they can view lesson/quiz content.
+	 * @param {int}   $lesson_id            Lesson post ID.
+	 * @param {int}   $user_id              User ID.
+	 * $param {array} $checks               Array of checks that were made to determine access.
 	 * @return {bool} Filtered access.
 	 */
-	return apply_filters( 'sensei_can_user_view_lesson', $can_user_view_lesson, $lesson_id, $user_id );
+	return apply_filters( 'sensei_can_user_view_lesson', $can_user_view_lesson, $lesson_id, $user_id, $checks );
 }
 
 if ( ! function_exists( 'sensei_light_or_dark' ) ) {

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -156,14 +156,17 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 		$pre_requisite_complete = true;
 	};
 
-	$can_user_view_lesson = ! sensei_is_login_required()
-							|| sensei_all_access( $user_id )
+	$login_not_required  = ! sensei_is_login_required();
+	$user_has_all_access = sensei_all_access( $user_id );
+
+	$can_user_view_lesson = $login_not_required
+							|| $user_has_all_access
 							|| ( $user_can_view_course_content && $pre_requisite_complete )
 							|| $is_preview_lesson;
 
 	$checks = array(
-		'login_not_required'           => ! sensei_is_login_required(),
-		'user_has_all_access'          => sensei_all_access( $user_id ),
+		'login_not_required'           => $login_not_required,
+		'user_has_all_access'          => $user_has_all_access,
 		'user_can_view_course_content' => $user_can_view_course_content,
 		'pre_requisite_complete'       => $pre_requisite_complete,
 		'is_preview_lesson'            => $is_preview_lesson,

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -131,11 +131,11 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 		$has_checks = false;
 		$filter     = function ( $can_view_lesson, $lesson_id, $user_id, $checks ) use ( &$has_checks ) {
 			$has_checks = is_array( $checks ) && isset(
-				$checks[ 'login_not_required' ],
-				$checks[ 'user_has_all_access' ],
-				$checks[ 'user_can_view_course_content' ],
-				$checks[ 'pre_requisite_complete' ],
-				$checks[ 'is_preview_lesson' ]
+				$checks['login_not_required'],
+				$checks['user_has_all_access'],
+				$checks['user_can_view_course_content'],
+				$checks['pre_requisite_complete'],
+				$checks['is_preview_lesson']
 			);
 		};
 		add_filter( 'sensei_can_user_view_lesson', $filter, 10, 4 );

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -2,11 +2,26 @@
 
 class Sensei_Functions_Test extends WP_UnitTestCase {
 
+	/**
+	 * Sensei factory.
+	 *
+	 * @var \Sensei_Factory
+	 */
+	protected $factory;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new \Sensei_Factory();
+	}
+
 	public function tearDown(): void {
 		// Ensure explicit theme support is removed.
 		remove_theme_support( 'sensei' );
 
 		parent::tearDown();
+
+		$this->factory->tearDown();
 	}
 
 	/**
@@ -106,6 +121,30 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 			sensei_user_registration_url(),
 			'Should return NULL when filter is set to use wp registration link'
 		);
+	}
+
+	public function testSenseiCanUserViewLesson_WhenCalled_FiresFilterWithChecksArgument() {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create();
+		$user_id   = $this->factory->user->create();
+
+		$has_checks = false;
+		$filter     = function ( $can_view_lesson, $lesson_id, $user_id, $checks ) use ( &$has_checks ) {
+			$has_checks = is_array( $checks ) && isset(
+				$checks[ 'login_not_required' ],
+				$checks[ 'user_has_all_access' ],
+				$checks[ 'user_can_view_course_content' ],
+				$checks[ 'pre_requisite_complete' ],
+				$checks[ 'is_preview_lesson' ]
+			);
+		};
+		add_filter( 'sensei_can_user_view_lesson', $filter, 10, 4 );
+
+		/* Act. */
+		sensei_can_user_view_lesson( $lesson_id, $user_id );
+
+		/* Assert. */
+		$this->assertTrue( $has_checks );
 	}
 
 	/**


### PR DESCRIPTION
Resolves #7630

In the original issue, the Preview setting didn't work if the user's access expired.

Here, we pass our initial checks to the filter to allow making a final decision inside hooks.

Based on the discussion: https://github.com/Automattic/sensei/pull/7655#discussion_r1702244354

## Proposed Changes
* Pass checks argument to sensei_can_user_view_lesson filter.

## Testing Instructions

1. Check the tests pass.
2. Check Sensei Pro PR: https://github.com/Automattic/sensei-pro/pull/2597

## New/Updated Hooks

* `sensei_can_user_view_lesson` - `$checks` param added.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
