### PR TITLE
Fix lesson loading error issue in learning mode for themes that are using referenced styles

### DIFF
--- a/changelog/fix-passing-array-to-strncmp
+++ b/changelog/fix-passing-array-to-strncmp
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Edge case of an error message in learning mode in strncmp function
+Prevent lesson loading error in learning mode for themes that are using referenced styles

--- a/changelog/fix-passing-array-to-strncmp
+++ b/changelog/fix-passing-array-to-strncmp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Edge case of an error message in learning mode in strncmp function

--- a/includes/course-theme/class-sensei-course-theme-styles.php
+++ b/includes/course-theme/class-sensei-course-theme-styles.php
@@ -48,7 +48,6 @@ class Sensei_Course_Theme_Styles {
 
 		$style = esc_attr( implode( ' ', $colors ) );
 		return self::set_style_attribute( $block_content, $style );
-
 	}
 
 	/**
@@ -78,11 +77,9 @@ class Sensei_Course_Theme_Styles {
 	 * @return array Name-value pairs of CSS variables
 	 */
 	private static function get_colors_as_css_variables( $styles ) {
-
 		if ( empty( $styles ) ) {
 			return [];
 		}
-
 	}
 
 	/**
@@ -139,7 +136,6 @@ class Sensei_Course_Theme_Styles {
 		$colors = self::get_colors( $styles );
 
 		return self::format_css_variables( $colors );
-
 	}
 
 	/**
@@ -190,6 +186,9 @@ class Sensei_Course_Theme_Styles {
 	 * @return string Style property value.
 	 */
 	private static function get_property_value( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
 
 		$prefix     = 'var:';
 		$prefix_len = strlen( $prefix );

--- a/includes/course-theme/class-sensei-course-theme-styles.php
+++ b/includes/course-theme/class-sensei-course-theme-styles.php
@@ -151,7 +151,10 @@ class Sensei_Course_Theme_Styles {
 			if ( $postfix ) {
 				$variable = $variable . $postfix;
 			}
-			if ( $value ) {
+			if (
+				$value &&
+				is_string( $value )
+			) {
 				$css[] = sprintf( '%s: %s;', $variable, self::get_property_value( $value ) );
 			}
 		}
@@ -186,10 +189,6 @@ class Sensei_Course_Theme_Styles {
 	 * @return string Style property value.
 	 */
 	private static function get_property_value( $value ) {
-		if ( ! is_string( $value ) ) {
-			return '';
-		}
-
 		$prefix     = 'var:';
 		$prefix_len = strlen( $prefix );
 		$token_in   = '|';


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7659

8551277-zd-a8c

## Proposed Changes
* In theme.json [version 3](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/), it's possible to use a reference of a color from another json file instead of explicitly using the name of hexcode of a color. We can use a object with a ref property now. But this [function here](https://github.com/Automattic/sensei/blob/71b1a9db49b87e72aaec14ec88afc4bfddcfe654/includes/course-theme/class-sensei-course-theme-styles.php#L192-L210) can only extract the style from a string property, not from a reference object.

So to prevent the error, we've added a check to attempt extracting style only when the value is a string. For proper extraction we've created an issue here https://github.com/Automattic/sensei/issues/7660 .

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure you are on PHP 8.1 or above
2. Create a course with lessons
3. Ensure learning mode is enabled for that course
4. Download and enable the theme https://wordpress.com/theme/assembler
5. Access the lesson as a student
6. It should render without any issue
7. Now try to do the same from trunk
8. It should throw an error

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [x] Known issues are created as new GitHub issues