### PR TITLE
Change subject of student_starts_course email to be correct regardless of the student's access date

### DIFF
--- a/changelog/fix-student-started-course-email-subject
+++ b/changelog/fix-student-started-course-email-subject
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed subject of student_starts_course from 'started' to 'enrolled in' to make it correct regardless of access date

--- a/includes/internal/emails/class-email-seeder-data.php
+++ b/includes/internal/emails/class-email-seeder-data.php
@@ -69,7 +69,7 @@ class Email_Seeder_Data {
 			],
 			'student_starts_course'       => [
 				'types'       => [ 'teacher' ],
-				'subject'     => __( '[student:displayname] started [course:name]', 'sensei-lms' ),
+				'subject'     => __( '[student:displayname] enrolled in [course:name]', 'sensei-lms' ),
 				'description' => __( 'Course Started', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/student-starts-course"} /-->',
 			],

--- a/includes/internal/emails/class-email-seeder-data.php
+++ b/includes/internal/emails/class-email-seeder-data.php
@@ -70,7 +70,7 @@ class Email_Seeder_Data {
 			'student_starts_course'       => [
 				'types'       => [ 'teacher' ],
 				'subject'     => __( '[student:displayname] enrolled in [course:name]', 'sensei-lms' ),
-				'description' => __( 'Course Started', 'sensei-lms' ),
+				'description' => __( 'Course Enrolled', 'sensei-lms' ),
 				'content'     => '<!-- wp:pattern {"slug":"sensei-lms/student-starts-course"} /-->',
 			],
 			'student_completes_course'    => [


### PR DESCRIPTION
## Proposed Changes
* When a student enrolls in a Course, we send an email to the teacher. The subject of that email was "X started Y". It bears the correct meaning when the student's access starts immediately. But the student's access is supposed to begin at a future date (Either by using Course Access date or by Group Cohort functionality), sending an Email to the teacher by saying "started" is not correct, because even though the student was "enrolled" in that course, they'll only be able to "start" the course later. So to make the title accurate in both present and future, we're changing it to "X enrolled in Y" here.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei LMS -> Tools -> Click on "Run Action" of the "Recreate Emails" tool
2. Go to Sensei LMS -> Settings -> Emails (tab) -> Teacher Emails (tab)
3. Make sure the **Course Started** email has the subject `[student:displayname] enrolled in [course:name]`
4. Now take a course as a student
5. As a teacher, make sure you received the enrol email with the updated subject

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
