### PR TITLE
Add lesson status icon for "complete" status

### DIFF
--- a/changelog/fix-missing-lesson-status-icon
+++ b/changelog/fix-missing-lesson-status-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix missing lesson status icon for "complete" status

--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -24,6 +24,7 @@ class Course_Navigation {
 		'not-started' => 'circle',
 		'in-progress' => 'half-filled-circle',
 		'ungraded'    => 'half-filled-circle',
+		'complete'    => 'check-filled-circle',
 		'completed'   => 'check-filled-circle',
 		'failed'      => 'half-filled-circle',
 		'locked'      => 'lock',
@@ -95,7 +96,7 @@ class Course_Navigation {
 		$modules_html = implode(
 			'',
 			array_map(
-				function( $item ) {
+				function ( $item ) {
 					if ( 'module' === $item['type'] ) {
 						return $this->render_module( $item );
 					}
@@ -108,7 +109,7 @@ class Course_Navigation {
 		$lessons_html = implode(
 			'',
 			array_map(
-				function( $item ) {
+				function ( $item ) {
 					if ( 'lesson' === $item['type'] ) {
 						return $this->render_lesson( $item );
 					}
@@ -164,7 +165,7 @@ class Course_Navigation {
 		$lessons_html = implode(
 			'',
 			array_map(
-				function( $lesson ) {
+				function ( $lesson ) {
 					return $this->render_lesson( $lesson );
 				},
 				$lessons
@@ -175,7 +176,7 @@ class Course_Navigation {
 		$has_current_lesson = count(
 			array_filter(
 				$lessons,
-				function( $lesson ) use ( $current_lesson_id ) {
+				function ( $lesson ) use ( $current_lesson_id ) {
 					return $current_lesson_id === $lesson['id'];
 				}
 			)
@@ -186,7 +187,7 @@ class Course_Navigation {
 		$quiz_count   = count(
 			array_filter(
 				$lessons,
-				function( $lesson ) {
+				function ( $lesson ) {
 					return \Sensei_Lesson::lesson_quiz_has_questions( $lesson['id'] );
 				}
 			)


### PR DESCRIPTION
Resolves #7594.

## Proposed Changes
Adds an icon for when the lesson status is `complete`. I'm not sure how a lesson can arrive in this state as per [this comment](https://github.com/Automattic/sensei/issues/7594#issuecomment-2292355356), but I suspect it has something to do with HPPS since we updated statuses as part of that project.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It's unclear how to test this without manipulating the database, but the lesson status icons in the sidebar of Learning Mode should all display correctly.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues