### PR TITLE
Fix PHP deprecation notice about passing null to parameter of type st…

### DIFF
--- a/changelog/fix-php-deprecations-and-warnings
+++ b/changelog/fix-php-deprecations-and-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP deprecation notice when opening site editor

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2917,8 +2917,9 @@ class Sensei_Utils {
 	public static function output_query_params_as_inputs( array $excluded = [], string $url = '', bool $echo = true ) {
 		// phpcs:ignore WordPress.Security.NonceVerification -- The nonce should be checked before calling this method.
 		$query_params = $_GET;
+
 		if ( $url ) {
-			parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_params );
+			parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_params );
 		}
 
 		$output = '';


### PR DESCRIPTION
## Proposed Changes
Fixes a deprecation notice:
```
PHP Deprecated:  parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/donnapep/Local Sites/senseitheme/app/public/wp-content/plugins/sensei/includes/class-sensei-utils.php on line 2921
```

## Testing Instructions
1. Ensure you're using PHP 8.1+.
2. Go to _Appearance_ > _Editor_.
3. Ensure the above deprecation notice is not logged.

Note that the following PHP warnings are still logged, but this PR does not attempt to fix those:
```
PHP Warning:  Undefined property: stdClass::$modified in /Users/donnapep/Local Sites/senseitheme/app/public/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php on line 766
PHP Warning:  DOMDocument::loadHTML(): Unexpected end tag : p in Entity, line: 1 in /Users/donnapep/Local Sites/senseitheme/app/public/wp-content/plugins/sensei/includes/blocks/class-sensei-blocks.php on line 225
```

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues