### PR TITLE
Fix some reports not exporting all rows

### DIFF
--- a/changelog/fix-report-not-exporting
+++ b/changelog/fix-report-not-exporting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Some reports not exporting all rows

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -328,7 +328,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$args = array(
-			'number'  => -1,
+			'number'  => '',
 			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -328,7 +328,6 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$args = array(
-			'number'  => '',
 			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,
@@ -347,12 +346,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 
 		switch ( $this->view ) {
 			case 'user':
+				$args['number'] = '';
 				$this->items = $this->get_course_statuses( $args );
-				break;
 
+				break;
 			case 'lesson':
 			default:
+				$args['number'] = -1;
 				$this->items = $this->get_lessons( $args );
+
 				break;
 		}
 

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -347,13 +347,13 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		switch ( $this->view ) {
 			case 'user':
 				$args['number'] = '';
-				$this->items = $this->get_course_statuses( $args );
+				$this->items    = $this->get_course_statuses( $args );
 
 				break;
 			case 'lesson':
 			default:
 				$args['number'] = -1;
-				$this->items = $this->get_lessons( $args );
+				$this->items    = $this->get_lessons( $args );
 
 				break;
 		}

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -192,7 +192,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$args = array(
-			'number'  => -1,
+			'number'  => '',
 			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -112,6 +112,51 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_items( $table->items ) );
 	}
 
+	public function testGenerateReport_LessonView_ReturnsCorrectNumberOfRows() {
+		/* Arrange. */
+		$course_id   = $this->factory->course->create();
+		$lesson_args = [
+			'meta_input' => [
+				'_lesson_course' => $course_id,
+			],
+		];
+
+		$lesson1_id = $this->factory->lesson->create( $lesson_args );
+		$lesson2_id = $this->factory->lesson->create( $lesson_args );
+		$lesson3_id = $this->factory->lesson->create( $lesson_args );
+
+		$_GET['view'] = 'lesson';
+
+		/* Act. */
+		$table       = new Sensei_Analysis_Course_List_Table( $course_id );
+		$export_data = $table->generate_report( 'course-name-lessons-overview' );
+
+		/* Assert. */
+		self::assertSame( 4, count( $export_data ) ); // Header row + 3 lessons.
+	}
+
+	public function testGenerateReport_UserView_ReturnsCorrectNumberOfRows() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+
+		$user1_id = $this->factory->user->create();
+		$user2_id = $this->factory->user->create();
+		$user3_id = $this->factory->user->create();
+
+		$activity1_id = Sensei_Utils::start_user_on_course( $user1_id, $course_id );
+		$activity2_id = Sensei_Utils::start_user_on_course( $user2_id, $course_id );
+		$activity3_id = Sensei_Utils::start_user_on_course( $user3_id, $course_id );
+
+		$_GET['view'] = 'user';
+
+		/* Act. */
+		$table       = new Sensei_Analysis_Course_List_Table( $course_id );
+		$export_data = $table->generate_report( 'course-name-users-overview' );
+
+		/* Assert. */
+		self::assertSame( 4, count( $export_data ) ); // Header row + 3 students.
+	}
+
 	public function testTableFooter_WhenCalledWithNoData_NotDisplayTheExportButton() {
 		/* Arrange. */
 		$list_table = new Sensei_Analysis_Course_List_Table();

--- a/tests/unit-tests/test-class-sensei-analysis-lesson-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-lesson-list-table.php
@@ -25,11 +25,13 @@ class Sensei_Analysis_Lesson_List_Table_Test extends WP_UnitTestCase {
 	public function testGenerateReport_StudentsByLesson_ReturnsCorrectNumberOfRows() {
 		/* Arrange. */
 		$course_id = $this->factory->course->create();
-		$lesson_id = $this->factory->lesson->create( [
-			'meta_input' => [
-				'_lesson_course' => $course_id,
-			],
-		] );
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
 
 		$user1_id = $this->factory->user->create();
 		$user2_id = $this->factory->user->create();

--- a/tests/unit-tests/test-class-sensei-analysis-lesson-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-lesson-list-table.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Sensei Analysis Lesson List Table Unit Test.
+ *
+ * @covers Sensei_Analysis_Lesson_List_Table
+ */
+class Sensei_Analysis_Lesson_List_Table_Test extends WP_UnitTestCase {
+	/**
+	 * Factory object.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function testGenerateReport_StudentsByLesson_ReturnsCorrectNumberOfRows() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create( [
+			'meta_input' => [
+				'_lesson_course' => $course_id,
+			],
+		] );
+
+		$user1_id = $this->factory->user->create();
+		$user2_id = $this->factory->user->create();
+		$user3_id = $this->factory->user->create();
+
+		Sensei_Utils::start_user_on_course( $user1_id, $course_id );
+		Sensei_Utils::start_user_on_course( $user2_id, $course_id );
+		Sensei_Utils::start_user_on_course( $user3_id, $course_id );
+
+		Sensei_Utils::user_start_lesson( $user1_id, $lesson_id );
+		Sensei_Utils::user_start_lesson( $user2_id, $lesson_id );
+		Sensei_Utils::user_start_lesson( $user3_id, $lesson_id );
+
+		/* Act. */
+		$table       = new Sensei_Analysis_Lesson_List_Table( $lesson_id );
+		$export_data = $table->generate_report( 'lesson-name-learners-overview' );
+
+		/* Assert. */
+		self::assertSame( 4, count( $export_data ) ); // Header row + 3 students.
+	}
+}


### PR DESCRIPTION
Resolves #7666.

## Proposed Changes
* Reverts #7647.
* Conditionally sets the `number` arg based on which report is being exported:
  * Sets it to an empty string for the students report, as that ultimately ends up getting passed to the `get_comments` function inside `sensei_check_for_activity`. As per [this doc](https://developer.wordpress.org/reference/classes/wp_comment_query/__construct/#parameters), an empty string should be used to return all rows.
  * Sets it to `-1` for the lessons report, as that is ultimately used to set `posts_per_page` for `WP_Query`. As per [this doc](https://developer.wordpress.org/reference/classes/wp_query/#pagination-parameters), `-1` should be used to show all posts.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to _Reports_ > _Courses_ and select a course.
2. Export the rows (ensure there are multiple) and check that they were all exported.
3. Click on _Students taking this Course_.
4. Export the rows (ensure there are multiple) and check that they were all exported.
5. Go to _Reports_ > _Lessons_ and select a course.
6. Export the rows (ensure there are multiple) and check that they were all exported.

Note that I tested exporting all other reports and they work.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
