### PR TITLE
Fix incorrect URLs for edited emails

### DIFF
--- a/changelog/fix-email-url-issue
+++ b/changelog/fix-email-url-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix incorrect URL for edited emails

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -236,7 +236,8 @@ class Email_Sender {
 	 */
 	private function replace_placeholders( string $content, array $placeholders ): string {
 		foreach ( $placeholders as $placeholder => $value ) {
-			$content = str_replace( '[' . $placeholder . ']', $value, $content );
+			// Strip out URL protocol if necessary. Temp workaround for https://github.com/Automattic/sensei/issues/7621.
+			$content = preg_replace( '~(https?://)?\[' . $placeholder . '\]~', $value, $content );
 		}
 
 		return $content;

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -236,7 +236,7 @@ class Email_Sender {
 	 */
 	private function replace_placeholders( string $content, array $placeholders ): string {
 		foreach ( $placeholders as $placeholder => $value ) {
-			// Strip out URL protocol if necessary. Temp workaround for https://github.com/Automattic/sensei/issues/7621.
+			// Strip out URL protocol if necessary. Partial solution for https://github.com/Automattic/sensei/issues/7621.
 			$content = preg_replace( '~(https?://)?\[' . $placeholder . '\]~', $value, $content );
 		}
 


### PR DESCRIPTION
Resolves #7621.

## Proposed Changes
Strips out the URL protocol if necessary when replacing URL placeholders in the email content (e.g. `href="http://[completed:url]"` or `href="https://[completed:url]"`). The placeholder value already contains the protocol and it was being duplicated, resulting in the issue.

Note:
- I haven't included any test coverage in order to ship this change quickly in today's release.
- The proper solution would be to not prepend the protocol on save, but that solution is more involved so I opted for a faster one.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the Student Course Completed email.
2. Select the _View Results_ button and click the pencil icon to edit it. The URL should be `[completed:url]`.
3. Click _Open in a new tab_.
4. Save the change and the email.
5. Edit the button again and see that the URL is now `http://[completed:url]`. (This PR does not address this issue.)
6. As a student, complete a course.
7. Click the _View Results_ button and ensure the link is correct.
8. Click _Recreate Emails_ in Sensei > Tools.
9. Double check that the URL for the button has been reset to `[completed:url]`. Don't make any changes or save the email.
10. As a student, complete a course.
11. Click the _View Results_ button and ensure the link is correct.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
