### PR TITLE
Fix teacher email's label to say student's grade

### DIFF
--- a/changelog/fix-teacher-student-complete-email-label
+++ b/changelog/fix-teacher-student-complete-email-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Label on course complete email received by the teacher

--- a/includes/internal/emails/patterns/student-completes-course.php
+++ b/includes/internal/emails/patterns/student-completes-course.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"margin":{"top":"24px","bottom":"0px"}},"color":{"text":"#101517"}}} -->
-		<p class="has-text-color" style="color:#101517;margin-top:24px;margin-bottom:0px;font-size:16px"><strong><?php echo esc_html__( 'Your Grade', 'sensei-lms' ); ?></strong></p>
+		<p class="has-text-color" style="color:#101517;margin-top:24px;margin-bottom:0px;font-size:16px"><strong><?php echo esc_html__( "Student's Grade", 'sensei-lms' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"40px"}},"color":{"text":"#101517"}}} -->

--- a/includes/internal/emails/patterns/student-completes-course.php
+++ b/includes/internal/emails/patterns/student-completes-course.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"margin":{"top":"24px","bottom":"0px"}},"color":{"text":"#101517"}}} -->
-		<p class="has-text-color" style="color:#101517;margin-top:24px;margin-bottom:0px;font-size:16px"><strong><?php echo esc_html__( "Student's Grade", 'sensei-lms' ); ?></strong></p>
+		<p class="has-text-color" style="color:#101517;margin-top:24px;margin-bottom:0px;font-size:16px"><strong><?php echo esc_html__( 'Grade', 'sensei-lms' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"40px"}},"color":{"text":"#101517"}}} -->


### PR DESCRIPTION
## Proposed Changes
* When a student completes a course, we send an email to the teacher. Now it says "Your grade" in it. I should be "Student's grade"

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to Sensei LMS -> Tools -> Click on "Run Action" of the "Recreate Emails" tool
- Go to Sensei LMS -> Settings -> Emails (tab) -> Teacher Emails (tab)
- Open the "Course Completed" Email and make sure the grade label is "Student's Grade"
- Now take a course as a student and complete it
- Teacher's received email should have the new label

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
