### PR TITLE
Fix PHP deprecation notice in View Results block

### DIFF
--- a/changelog/fix-view-results-block-deprecated-notice
+++ b/changelog/fix-view-results-block-deprecated-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP deprecation notice in View Results block

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -73,7 +73,8 @@ class Sensei_Block_View_Results {
 		}
 
 		$results_link = Sensei_Course::get_view_results_link( $course_id );
-		parse_str( wp_parse_url( $results_link, PHP_URL_QUERY ), $results_link_query_params );
+
+		parse_str( (string) wp_parse_url( $results_link, PHP_URL_QUERY ), $results_link_query_params );
 
 		$form_inputs = '';
 		foreach ( $results_link_query_params as $name => $value ) {


### PR DESCRIPTION
## Proposed Changes
Fixes a deprecation notice in the View Results block:
```
PHP Deprecated:  parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/donnapep/Local Sites/senseitheme/app/public/wp-content/plugins/sensei/includes/blocks/class-sensei-block-view-results.php on line 78
```

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure you're using PHP 8.1+.
2. Complete a course as a student.
3. Visit the Courses page.
4. Ensure the above deprecation notice is not logged.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
