### PR TITLE
Fix Courses page throwing 404 in Hello Elementor theme

### DIFF
--- a/changelog/fix-archive-404-issue-in-hello-elementor
+++ b/changelog/fix-archive-404-issue-in-hello-elementor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hello elementor theme throwing 404 when rendering the Courses archive page

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -94,13 +94,13 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		// Prevent comments form from appearing.
-		$wp_query->post_count        = 1;
-		$wp_query->is_404            = false;
-		$wp_query->is_page           = true;
-		$wp_query->is_single         = true;
-		$wp_query->is_singular       = true;
-		$wp_query->is_archive        = false;
-		$wp_query->max_num_pages     = 0;
+		$wp_query->post_count    = 1;
+		$wp_query->is_404        = false;
+		$wp_query->is_page       = true;
+		$wp_query->is_single     = true;
+		$wp_query->is_singular   = true;
+		$wp_query->is_archive    = false;
+		$wp_query->max_num_pages = 0;
 
 		Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -88,8 +88,8 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		// On taxonomy pages the queried_object must remain a WP_Term object.
 		if ( ! is_tax() ) {
 			$wp_query->queried_object    = $post;
-			$wp_query->queried_object_id = $post->ID;
 		}
+
 		$wp_the_query = $wp_query;
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
@@ -99,7 +99,6 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		$wp_query->is_page           = true;
 		$wp_query->is_single         = true;
 		$wp_query->is_singular       = true;
-		$wp_query->queried_object_id = null;
 		$wp_query->is_archive        = false;
 		$wp_query->max_num_pages     = 0;
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -87,7 +87,7 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		$wp_query->posts = array( $post );
 		// On taxonomy pages the queried_object must remain a WP_Term object.
 		if ( ! is_tax() ) {
-			$wp_query->queried_object    = $post;
+			$wp_query->queried_object = $post;
 		}
 
 		$wp_the_query = $wp_query;

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -94,12 +94,14 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		// Prevent comments form from appearing.
-		$wp_query->post_count    = 1;
-		$wp_query->is_404        = false;
-		$wp_query->is_page       = true;
-		$wp_query->is_single     = true;
-		$wp_query->is_archive    = false;
-		$wp_query->max_num_pages = 0;
+		$wp_query->post_count        = 1;
+		$wp_query->is_404            = false;
+		$wp_query->is_page           = true;
+		$wp_query->is_single         = true;
+		$wp_query->is_singular       = true;
+		$wp_query->queried_object_id = null;
+		$wp_query->is_archive        = false;
+		$wp_query->max_num_pages     = 0;
 
 		Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
 

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-course-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-course-archive.php
@@ -137,6 +137,18 @@ class Sensei_Unsupported_Theme_Handler_Course_Archive_Test extends WP_UnitTestCa
 		$this->assertStringContainsString( 'wp-block-sensei-lms-course-list', $post->post_content );
 	}
 
+	public function testHandleRequest_WhenCalled_SetsGlobalWpQueryWithCorrectIsSingularAndQueryObjectId() {
+		/* ARRANGE */
+		Sensei_Setup_Wizard::instance()->pages->create_pages();
+
+		/* ACT */
+		$this->handler->handle_request();
+
+		/* ASSERT */
+		$this->assertTrue( is_singular() );
+		$this->assertEquals( 0, get_queried_object_id() );
+	}
+
 	/**
 	 * Helper to set up the current request to be a course archive page. This request
 	 * will be handled by the unsupported theme handler if the theme is not


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7678

## Proposed Changes

When using the Hello Elementor Theme, our Courses page (/courses-overview) threw a 404.

To explain the reason, we should know that Sensei handles the Courses archive page very differently than usual.

When a request comes to render the Course archive page, we override the usual flow of the request, and handle it using [this class](https://github.com/Automattic/sensei/blob/trunk/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php). From an archive request, we change it to a single post request, so every plugin or theme after that point considers and handles the request as a single page request. And, as the global single post to be rendered, we set a dummy post, the content of which is whatever we want to render, In this case, a custom content we generate by [rendering the blocks from the page](https://github.com/Automattic/sensei/blob/ac2ab6be7d8e89c741b1c6164d02a418366ffb6b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php#L51-L57) from "Settings -> General -> Course Archive Page" setting.

The issue here is not because of the content, but rather, because of the properties of the global wp_query [to go with the single post we set](https://github.com/Automattic/sensei/blob/ac2ab6be7d8e89c741b1c6164d02a418366ffb6b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php#L84-L102). Notice that we set up all the properties to imitate that of a single page, `is_singular` and `is_page` is set to true and `is_archive` is set to false.

Now [check out](https://github.com/elementor/hello-theme/blob/d5c0d0f95b03851dd01af5e423e83a8ecd68f8f4/index.php#L19-L23) this code in Hello Elementor. This is where it decides which template to choose. Notice that, to render the `single` template, it requires the `is_singular` check to be true. But even though we set `is_single`, we don't set `is_singular` to true. Which causes the `is_singular` check to fail. Thus, it falls back to the 404 template. So, setting `is_singular` to true fixes the archive rendering issue, and Hello Elementor starts using the single template as we want.

Notice that we've also removed `queried_object_id`. It's because once we set "is_singular" to true, this [WP Core check](https://github.com/WordPress/wordpress-develop/blob/13e0e5095040900226b316ac5d5081e9b8b53b34/src/wp-includes/link-template.php#L4154-L4156) also starts passing. So it tries to fetch the dummy post again from the database using `get_post()` using the id from the `queried_object_id`, where it doesn't exist. So it gets a null object, and subsequently throws an error. So I've removed the `queried_object_id` to prevent it from happening.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install the "Hello Elementor" theme.
2. Go to the Courses archive page
3. Make sure it renders without any issue
4. Add a couple of courses to a category
5. Check the category Course list from frontend to make sure it doesn't throw any error when the archive is rendered under taxonomy (One way to render courses under category is to click on the category tag that's shown on each course in the course list)
6. Now create a copy of the **Courses** page, give it a different name and permalink. Set this new pages as the course archive page from "Settings -> General -> Course Archive Page"
7. Try to access the new page and make sure it doesn't throw a 404
8. Test the above steps in all top themes to make sure no regression has happened.
9. Try to think about any scenario where it can cause a regression.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [x] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
