### PR TITLE
"Unexpected end tag : p in Entity" warning in the site editor

### DIFF
--- a/changelog/fix-php-warning-course-completed-actions
+++ b/changelog/fix-php-warning-course-completed-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix "Unexpected end tag : p in Entity" warning in the site editor

--- a/includes/blocks/class-sensei-course-completed-actions-block.php
+++ b/includes/blocks/class-sensei-course-completed-actions-block.php
@@ -33,7 +33,10 @@ class Sensei_Course_Completed_Actions_Block {
 	 * @return string Block HTML.
 	 */
 	public function update_more_courses_button_url( $block_content, $block ): string {
-		if ( 'core/button' !== $block['blockName'] ) {
+		if (
+			! isset( $block['blockName'] )
+			|| 'core/button' !== $block['blockName']
+		) {
 			return $block_content;
 		}
 

--- a/includes/blocks/class-sensei-course-completed-actions-block.php
+++ b/includes/blocks/class-sensei-course-completed-actions-block.php
@@ -33,6 +33,10 @@ class Sensei_Course_Completed_Actions_Block {
 	 * @return string Block HTML.
 	 */
 	public function update_more_courses_button_url( $block_content, $block ): string {
+		if ( 'core/button' !== $block['blockName'] ) {
+			return $block_content;
+		}
+
 		return Sensei_Blocks::update_button_block_url(
 			$block_content,
 			$block,


### PR DESCRIPTION
Fixes the following error in the site editor:
```
PHP Warning:  DOMDocument::loadHTML(): Unexpected end tag : p in Entity, line: 1 in /Users/donnapep/Local Sites/senseitheme/app/public/wp-content/plugins/sensei/includes/blocks/class-sensei-blocks.php on line 225
```

## Proposed Changes
Check if the block is a `core/button` immediately in the `render_callback` for the Course Completed Actions block.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate a block theme.
2. Open the site editor
3. Ensure the PHP warning above is not logged.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
