### PR TITLE
Fix CI failing

### DIFF
--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -494,7 +494,7 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		global $wp_version;
 
 		// Account for the string change introduced in https://core.trac.wordpress.org/ticket/61535
-		$minutes_text = version_compare( $wp_version, '6.6.1', '<=' ) ? 'mins' : 'minutes';
+		$minutes_text = version_compare( $wp_version, '6.6.2', '<=' ) ? 'mins' : 'minutes';
 
 		return [
 			'days'    => [ ( 5 * 24 * 60 * 60 ), '5 days ago' ],


### PR DESCRIPTION
Fix CI failing because https://core.trac.wordpress.org/ticket/61535 didn't make it into WP 6.6.2

## Proposed Changes
* Update the check to return 'mins' instead of 'minutes' for WP version 6.6.2

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. The CI should pass

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
