### PR TITLE
Allow additional users to manage students

### DIFF
--- a/changelog/add-filter-student-management-teacher-ids
+++ b/changelog/add-filter-student-management-teacher-ids
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow additional users to manage students

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -485,7 +485,7 @@ class Sensei_Learner_Management {
 		$post_type = get_post_type( $post_id );
 
 		if ( 'lesson' === $post_type ) {
-			$can_edit_date = $this->can_user_manage_students( Sensei()->lesson->get_course_id( $post_id ), intval( $post->post_author ) );
+			$can_edit_date = $this->can_user_manage_students( (int) Sensei()->lesson->get_course_id( $post_id ), intval( $post->post_author ) );
 		} else {
 			$can_edit_date = $this->can_user_manage_students( $post_id, intval( $post->post_author ) );
 		}
@@ -567,7 +567,7 @@ class Sensei_Learner_Management {
 		$post_type       = $action_data['post_type'] ? sanitize_text_field( $action_data['post_type'] ) : '';
 
 		if ( 'lesson' === $post_type ) {
-			$can_remove_user = $this->can_user_manage_students( Sensei()->lesson->get_course_id( $post_id ), intval( $post->post_author ) );
+			$can_remove_user = $this->can_user_manage_students( (int) Sensei()->lesson->get_course_id( $post_id ), intval( $post->post_author ) );
 		} else {
 			$can_remove_user = $this->can_user_manage_students( $post_id, intval( $post->post_author ) );
 		}

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -482,7 +482,7 @@ class Sensei_Learner_Management {
 			exit( '' );
 		}
 
-		$post_type     = get_post_type( $post );
+		$post_type     = (string) get_post_type( $post );
 		$can_edit_date = $this->can_user_manage_students( $post_id, $post_type, intval( $post->post_author ) );
 
 		if ( ! $can_edit_date ) {
@@ -646,7 +646,7 @@ class Sensei_Learner_Management {
 			exit;
 		}
 
-		$post_type            = get_post_type( $post );
+		$post_type            = (string) get_post_type( $post );
 		$can_manage_enrolment = $this->can_user_manage_students( $course_id, $post_type, intval( $post->post_author ) );
 
 		if ( ! $can_manage_enrolment ) {
@@ -815,7 +815,7 @@ class Sensei_Learner_Management {
 		$post_type = $_POST['add_post_type'];
 		$user_ids  = array_map( 'intval', $_POST['add_user_id'] );
 		$course_id = intval( $_POST['add_course_id'] );
-		$lesson_id = isset( $_POST['add_lesson_id'] ) ? intval( $_POST['add_lesson_id'] ) : '';
+		$lesson_id = intval( $_POST['add_lesson_id'] );
 		$post_id   = 'course' === $post_type ? $course_id : $lesson_id;
 		$course    = get_post( $course_id );
 		$results   = [];

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -703,32 +703,32 @@ class Sensei_Learner_Management {
 
 		if ( 'course' === $post_type ) {
 			/**
-			 * Filter the teacher IDs that have permission to manage students in a given course.
+			 * Filter the user IDs that have permission to manage students in a given course.
 			 *
 			 * @since $$next-version$$
 			 *
-			 * @hook sensei_learners_allowed_teacher_ids_for_course
+			 * @hook sensei_learners_allowed_user_ids_for_course
 			 *
-			 * @param {int[]} $teacher_ids  Teacher IDs that have permission to manage students in a given course.
-			 *                              Defaults to post author.
-			 * @param {int}   $post_id      Course ID.
-			 * @return {int[]} Filtered teacher IDs that have permission to manage students in a given course.
+			 * @param {int[]} $user_ids User IDs that have permission to manage students in a given course.
+			 *                          Defaults to post author.
+			 * @param {int}   $post_id  Course ID.
+			 * @return {int[]} Filtered user IDs that have permission to manage students in a given course.
 			 */
-			$allowed_ids = apply_filters( 'sensei_learners_allowed_teacher_ids_for_course', [ $post_author ], $post_id );
+			$allowed_ids = apply_filters( 'sensei_learners_allowed_user_ids_for_course', [ $post_author ], $post_id );
 		} else if ( 'lesson' === $post_type ) {
 			/**
-			 * Filter the teacher IDs that have permission to manage students in a given lesson.
+			 * Filter the user IDs that have permission to manage students in a given lesson.
 			 *
 			 * @since $$next-version$$
 			 *
-			 * @hook sensei_learners_allowed_teacher_ids_for_lesson
+			 * @hook sensei_learners_allowed_user_ids_for_lesson
 			 *
-			 * @param {int[]} $teacher_ids  Teacher IDs that have permission to manage students in a given lesson.
-			 *                              Defaults to post author.
-			 * @param {int}   $post_id      Lesson ID.
-			 * @return {int[]} Filtered teacher IDs that have permission to manage students in a given lesson.
+			 * @param {int[]} $user_ids Users IDs that have permission to manage students in a given lesson.
+			 *                          Defaults to post author.
+			 * @param {int}   $post_id  Lesson ID.
+			 * @return {int[]} Filtered user IDs that have permission to manage students in a given lesson.
 			 */
-			$allowed_ids = apply_filters( 'sensei_learners_allowed_teacher_ids_for_lesson', [ $post_author ], $post_id );
+			$allowed_ids = apply_filters( 'sensei_learners_allowed_user_ids_for_lesson', [ $post_author ], $post_id );
 		}
 
 		if ( current_user_can( 'manage_sensei' ) || in_array( get_current_user_id(), $allowed_ids, true ) ) {

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -697,7 +697,7 @@ class Sensei_Learner_Management {
 	 *
 	 * @return bool true if the current user can manage a student's course or lesson.
 	 */
-	private function can_user_manage_students( int $post_id, string $post_type, int $post_author ) : bool {
+	private function can_user_manage_students( int $post_id, string $post_type, int $post_author ): bool {
 		$can_manage_student = false;
 		$allowed_ids        = [];
 
@@ -715,7 +715,7 @@ class Sensei_Learner_Management {
 			 * @return {int[]} Filtered user IDs that have permission to manage students in a given course.
 			 */
 			$allowed_ids = apply_filters( 'sensei_learners_allowed_user_ids_for_course', [ $post_author ], $post_id );
-		} else if ( 'lesson' === $post_type ) {
+		} elseif ( 'lesson' === $post_type ) {
 			/**
 			 * Filter the user IDs that have permission to manage students in a given lesson.
 			 *

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -715,7 +715,7 @@ class Sensei_Learner_Management {
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @hook sensei_learners_allowed_user_ids_for_course
+		 * @hook sensei_learners_allowed_user_ids
 		 *
 		 * @param {int[]} $user_ids  User IDs that have permission to manage students in a given course.
 		 *                           Defaults to post author.

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -697,7 +697,7 @@ class Sensei_Learner_Management {
 	 *
 	 * @return bool true if the current user can manage a student's course or lesson.
 	 */
-	private function can_user_manage_students( int $post_id, string $post_type, int $post_author ) : boolean {
+	private function can_user_manage_students( int $post_id, string $post_type, int $post_author ) : bool {
 		$can_manage_student = false;
 		$allowed_ids        = [];
 

--- a/tests/unit-tests/admin/test-class-sensei-learner-management.php
+++ b/tests/unit-tests/admin/test-class-sensei-learner-management.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Tests student management functionality (formerly known as Learner Management).
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Learner_Management class.
+ */
+class Sensei_Learner_Management_Test extends WP_UnitTestCase {
+	/**
+	 * Sensei_Factory instance.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Sensei_Learner_Management instance.
+	 *
+	 * @var Sensei_Learner_Management
+	 */
+	protected $learner_management;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory            = new Sensei_Factory();
+		$this->learner_management = new Sensei_Learner_Management( '' );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$this->factory->tearDown();
+	}
+
+	/**
+	 * Tests that students cannot be added to a course if current user is not the teacher.
+	 *
+	 * @covers Sensei_Learner_Management::add_new_learners
+	 */
+	public function testAddNewLearners_ToCourseWhenCurrentUserIsNotTeacher_ReturnsFalse() {
+		/* Arrange. */
+		$teacher_id      = $this->factory->user->create();
+		$student_id      = $this->factory->user->create();
+		$current_user_id = $this->factory->user->create();
+
+		wp_set_current_user( $current_user_id );
+
+		$_POST['add_learner_submit'] = 'some_value';
+		$_POST['add_learner_nonce']  = wp_create_nonce( 'add_learner_to_sensei' );
+		$_POST['add_post_type']      = 'course';
+		$_POST['add_user_id']        = [ $student_id ];
+		$_POST['add_course_id']      = $this->factory->course->create( [ 'post_author' => $teacher_id ] );
+		$_POST['add_lesson_id']      = 0;
+
+		/* Act. */
+		$result = $this->learner_management->add_new_learners();
+
+		/* Assert. */
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that students cannot be added to a lesson if current user is not the teacher.
+	 *
+	 * @covers Sensei_Learner_Management::add_new_learners
+	 */
+	public function testAddNewLearners_ToLessonWhenCurrentUserIsNotTeacher_ReturnsFalse() {
+		/* Arrange. */
+		$teacher_id      = $this->factory->user->create();
+		$student_id      = $this->factory->user->create();
+		$current_user_id = $this->factory->user->create();
+		$course_id       = $this->factory->course->create( [ 'post_author' => $teacher_id ] );
+		$lesson_id       = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+
+		wp_set_current_user( $current_user_id );
+
+		$_POST['add_learner_submit'] = 'some_value';
+		$_POST['add_learner_nonce']  = wp_create_nonce( 'add_learner_to_sensei' );
+		$_POST['add_post_type']      = 'lesson';
+		$_POST['add_user_id']        = [ $student_id ];
+		$_POST['add_course_id']      = $course_id;
+		$_POST['add_lesson_id']      = $lesson_id;
+
+		/* Act. */
+		$result = $this->learner_management->add_new_learners();
+
+		/* Assert. */
+		$this->assertFalse( $result );
+	}
+}


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei-pro/issues/2618.

## Proposed Changes
Add a filter to allow additional users to manage students (admins and teacher are the default).

Instead of using a hook, I debated changing the `manage_sensei` check to `manage_sensei_grades`, but this cap feels like it should be restricted to the _Grading_ menu based on its naming. Perhaps we could consider adding a new one for student management in the future?

I was only able to add a couple of test cases, as most of the functions that were changed call `exit`, so I tested the use cases where `return` is called before an `exit`.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See https://github.com/Automattic/sensei-pro/pull/2619.

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* `sensei_learners_allowed_user_ids` - Filter the user IDs that have permission to manage students.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
