### PR TITLE
Prevent early translation loading

### DIFF
--- a/changelog/fix-early-translations
+++ b/changelog/fix-early-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix loading some translations too early which generates a warning on WP 6.7

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -1789,9 +1789,8 @@
       <code>$user_id</code>
       <code>$which</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="2">
       <code>$file</code>
-      <code>$name</code>
       <code>$page_slug</code>
     </MissingPropertyType>
     <PossiblyFalseArgument occurrences="1">
@@ -2422,18 +2421,6 @@
       <code>get_queried_object()-&gt;ID</code>
       <code>get_queried_object()-&gt;post_type</code>
     </PossiblyNullPropertyFetch>
-    <PropertyNotSetInConstructor occurrences="10">
-      <code>$course</code>
-      <code>$lesson</code>
-      <code>$messages</code>
-      <code>$question</code>
-      <code>$quiz</code>
-      <code>WooThemes_Sensei_PostTypes</code>
-      <code>WooThemes_Sensei_PostTypes</code>
-      <code>WooThemes_Sensei_PostTypes</code>
-      <code>WooThemes_Sensei_PostTypes</code>
-      <code>WooThemes_Sensei_PostTypes</code>
-    </PropertyNotSetInConstructor>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$post instanceof WP_Post</code>
     </RedundantConditionGivenDocblockType>
@@ -4181,11 +4168,9 @@
     <InvalidGlobal occurrences="1">
       <code>global $sensei_email_data;</code>
     </InvalidGlobal>
-    <MissingPropertyType occurrences="6">
-      <code>$heading</code>
+    <MissingPropertyType occurrences="4">
       <code>$learner</code>
       <code>$recipient</code>
-      <code>$subject</code>
       <code>$teacher</code>
       <code>$template</code>
     </MissingPropertyType>
@@ -4432,8 +4417,7 @@
       <code>$post</code>
       <code>$post</code>
     </ParamNameMismatch>
-    <PossiblyNullArgument occurrences="2">
-      <code>get_edit_post_link( $post )</code>
+    <PossiblyNullArgument occurrences="1">
       <code>get_edit_post_link( $post-&gt;ID )</code>
     </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="4">
@@ -4970,13 +4954,6 @@
     </TypeDoesNotContainType>
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-course-progress-controller.php">
-    <InvalidClass occurrences="1">
-      <code>WP_HTTP</code>
-    </InvalidClass>
-    <PossiblyInvalidArrayAssignment occurrences="2">
-      <code>$result[ $student_id ][ $course_id ]</code>
-      <code>$result[ $student_id ][ $course_id ]</code>
-    </PossiblyInvalidArrayAssignment>
     <PossiblyNullArgument occurrences="1">
       <code>$edit_course_cap</code>
     </PossiblyNullArgument>
@@ -5013,8 +4990,7 @@
       <code>WP_HTTP</code>
       <code>WP_HTTP</code>
     </InvalidClass>
-    <PossiblyInvalidArrayAssignment occurrences="2">
-      <code>$result[ $user_id ][ $course_id ]</code>
+    <PossiblyInvalidArrayAssignment occurrences="1">
       <code>$result[ $user_id ][ $course_id ]</code>
     </PossiblyInvalidArrayAssignment>
     <PossiblyNullArgument occurrences="1">
@@ -5249,12 +5225,6 @@
     </UndefinedPropertyFetch>
   </file>
   <file src="includes/rest-api/class-sensei-rest-api-question-helpers-trait.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$post_args</code>
-    </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
-      <code>$post_args</code>
-    </InvalidArgument>
     <PossibleRawObjectIteration occurrences="1">
       <code>$question_categories</code>
     </PossibleRawObjectIteration>

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -25,29 +25,26 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Learner_Management {
 	/**
-	 * Name of the menu/page.
-	 *
-	 * @var string $name
-	 */
-	public $name;
-	/**
 	 * Main plugin file name.
 	 *
 	 * @var string $file
 	 */
 	public $file;
+
 	/**
 	 * Menu slug name.
 	 *
 	 * @var string $page_slug
 	 */
 	public $page_slug;
+
 	/**
 	 * Reference to the class responsible for Bulk Learner Actions.
 	 *
 	 * @var Sensei_Learners_Admin_Bulk_Actions_Controller $bulk_actions_controller
 	 */
 	public $bulk_actions_controller;
+
 	/**
 	 * Per page screen option ID.
 	 *
@@ -63,7 +60,6 @@ class Sensei_Learner_Management {
 	 * @param string $file Main plugin file name.
 	 */
 	public function __construct( $file ) {
-		$this->name      = __( 'Students', 'sensei-lms' );
 		$this->file      = $file;
 		$this->page_slug = 'sensei_learners';
 
@@ -99,6 +95,22 @@ class Sensei_Learner_Management {
 		}
 	}
 
+	/**
+	 * Graceful fallback for deprecated properties.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key The key to get.
+	 *
+	 * @return mixed
+	 */
+	public function __get( $key ) {
+		if ( 'name' === $key ) {
+			_doing_it_wrong( __CLASS__ . '->name', 'The "name" property is deprecated. Use get_name() instead.', '$$next-version$$' );
+
+			return $this->get_name();
+		}
+	}
 
 	/**
 	 * Add custom navigation to the admin pages.
@@ -148,8 +160,8 @@ class Sensei_Learner_Management {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			$learners_page = add_submenu_page(
 				'sensei',
-				$this->name,
-				$this->name,
+				$this->get_name(),
+				$this->get_name(),
 				'manage_sensei_grades',
 				$this->page_slug,
 				array( $this, 'learners_page' )
@@ -274,7 +286,6 @@ class Sensei_Learner_Management {
 		foreach ( $classes_to_load as $class_file ) {
 			Sensei()->load_class( $class_file );
 		}
-
 	}
 
 	/**
@@ -320,7 +331,6 @@ class Sensei_Learner_Management {
 		} else {
 			require __DIR__ . '/views/html-admin-page-students-main.php';
 		}
-
 	}
 
 	/**
@@ -340,7 +350,6 @@ class Sensei_Learner_Management {
 		 * @hook sensei_learners_after_headers
 		 */
 		do_action( 'sensei_learners_after_headers' );
-
 	}
 
 	/**
@@ -944,9 +953,8 @@ class Sensei_Learner_Management {
 	 * @return string Name of the menu/page.
 	 */
 	public function get_name() {
-		return $this->name;
+		return __( 'Students', 'sensei-lms' );
 	}
-
 }
 
 /**

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -21,13 +21,6 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	const REMOVE_PROGRESS                         = 'remove_progress';
 
 	/**
-	 * The available bulk actions.
-	 *
-	 * @var array|null
-	 */
-	private $known_bulk_actions;
-
-	/**
 	 * The page slug.
 	 *
 	 * @var string
@@ -56,19 +49,12 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	private $learner;
 
 	/**
-	 * The name of the page
-	 *
-	 * @var string
-	 */
-	private $name;
-
-	/**
 	 * Get the name of the page.
 	 *
 	 * @return string|void
 	 */
 	public function get_name() {
-		return $this->name;
+		return __( 'Bulk Student Actions', 'sensei-lms' );
 	}
 
 	/**
@@ -117,15 +103,8 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	public function __construct( $management, $learner ) {
 		$this->learner_management = $management;
 		$this->learner            = $learner;
-		$this->name               = __( 'Bulk Student Actions', 'sensei-lms' );
 		$this->page_slug          = $management->page_slug;
 		$this->view               = 'sensei_learner_admin';
-
-		$this->known_bulk_actions = [
-			self::ENROL_RESTORE_ENROLMENT => __( 'Add to Course', 'sensei-lms' ),
-			self::REMOVE_ENROLMENT        => __( 'Remove from Course', 'sensei-lms' ),
-			self::REMOVE_PROGRESS         => __( 'Reset Progress', 'sensei-lms' ),
-		];
 
 		if ( is_admin() ) {
 			$this->register_hooks();
@@ -190,7 +169,11 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	 * @return array
 	 */
 	public function get_known_bulk_actions() {
-		$known_bulk_actions = $this->known_bulk_actions;
+		$known_bulk_actions = [
+			self::ENROL_RESTORE_ENROLMENT => __( 'Add to Course', 'sensei-lms' ),
+			self::REMOVE_ENROLMENT        => __( 'Remove from Course', 'sensei-lms' ),
+			self::REMOVE_PROGRESS         => __( 'Reset Progress', 'sensei-lms' ),
+		];
 
 		/**
 		 * Filter the known bulk actions.

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -11,18 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class Sensei_Analysis {
-
 	/**
 	 * The reports' page slug.
 	 */
 	const PAGE_SLUG = 'sensei_reports';
-
-	/**
-	 * The reports' page name (title).
-	 *
-	 * @var string
-	 */
-	public $name;
 
 	/**
 	 * Reference to the main plugin file name.
@@ -38,7 +30,6 @@ class Sensei_Analysis {
 	 * @param string $file
 	 */
 	public function __construct( $file ) {
-		$this->name = __( 'Reports', 'sensei-lms' );
 		$this->file = $file;
 
 		// Admin functions.
@@ -67,14 +58,31 @@ class Sensei_Analysis {
 	 *
 	 * @param string $key The key to get.
 	 *
-	 * @return string|void
+	 * @return mixed
 	 */
 	public function __get( $key ) {
 		if ( 'page_slug' === $key ) {
-			_doing_it_wrong( 'Sensei_Analysis->page_slug', 'The "page_slug" property is deprecated. Use the Sensei_Analysis::PAGE_SLUG constant instead.', '4.2.0' );
+			_doing_it_wrong( __CLASS__ . '->page_slug', 'The "page_slug" property is deprecated. Use the Sensei_Analysis::PAGE_SLUG constant instead.', '4.2.0' );
 
 			return self::PAGE_SLUG;
 		}
+
+		if ( 'name' === $key ) {
+			_doing_it_wrong( __CLASS__ . '->name', 'The "name" property is deprecated. Use get_name() instead.', '$$next-version$$' );
+
+			return $this->get_name();
+		}
+	}
+
+	/**
+	 * Get the screen name.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Reports', 'sensei-lms' );
 	}
 
 	/**
@@ -144,7 +152,7 @@ class Sensei_Analysis {
 		 * @param {string} $title The page title.
 		 * @return {string} Returns filtered page title.
 		 */
-		$data = apply_filters( 'sensei_analysis_nav_title', $this->name );
+		$data = apply_filters( 'sensei_analysis_nav_title', $this->get_name() );
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
 			<div class="sensei-custom-navigation__heading">
@@ -175,8 +183,8 @@ class Sensei_Analysis {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			add_submenu_page(
 				'sensei',
-				$this->name,
-				$this->name,
+				$this->get_name(),
+				$this->get_name(),
 				'manage_sensei_grades',
 				self::PAGE_SLUG,
 				array( $this, 'analysis_page' )
@@ -581,7 +589,7 @@ class Sensei_Analysis {
 	 */
 	public function analysis_default_nav() {
 		_deprecated_function( __METHOD__, '4.2.0' );
-		$title = $this->name;
+		$title = $this->get_name();
 		?>
 			<h1>
 				<?php
@@ -610,7 +618,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'admin.php' ) ) ), esc_html( $this->name ) );
+		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'admin.php' ) ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
 			$user_id   = intval( $_GET['user_id'] );
 			$url       = esc_url(
@@ -656,7 +664,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'admin.php' ) ) ), esc_html( $this->name ) );
+		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'admin.php' ) ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
 			$user_id   = intval( $_GET['user_id'] );
 			$user_data = get_userdata( $user_id );
@@ -711,7 +719,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->name ) );
+		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
@@ -753,7 +761,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->name ) );
+		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
@@ -795,7 +803,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->name ) );
+		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['lesson_id'] ) ) {
 			$lesson_id = intval( $_GET['lesson_id'] );
 			$course_id = intval( get_post_meta( $lesson_id, '_lesson_course', true ) );

--- a/includes/class-sensei-customizer.php
+++ b/includes/class-sensei-customizer.php
@@ -10,19 +10,22 @@
  * Add customizer settings.
  */
 class Sensei_Customizer {
-
-	/**
-	 * Configurable colors.
-	 *
-	 * @var array[]
-	 */
-	private $colors;
-
 	/**
 	 * Sensei_Customizer constructor.
 	 */
 	public function __construct() {
-		$this->colors = [
+		add_action( 'customize_register', [ $this, 'add_customizer_settings' ] );
+		add_action( 'customize_preview_init', [ $this, 'enqueue_customizer_helper' ] );
+		add_action( 'wp_head', [ $this, 'output_custom_settings' ] );
+	}
+
+	/**
+	 * Get the configurable colors.
+	 *
+	 * @return array[]
+	 */
+	private function get_colors() {
+		return [
 			'sensei-course-theme-primary-color'    => [
 				'label'   => __( 'Primary Color', 'sensei-lms' ),
 				'default' => '#1e1e1e',
@@ -36,16 +39,12 @@ class Sensei_Customizer {
 				'default' => '#1e1e1e',
 			],
 		];
-
-		add_action( 'customize_register', [ $this, 'add_customizer_settings' ] );
-		add_action( 'customize_preview_init', [ $this, 'enqueue_customizer_helper' ] );
-		add_action( 'wp_head', [ $this, 'output_custom_settings' ] );
 	}
 
 	/**
 	 * Add Sensei section and settings to Customizer.
 	 *
-	 * @param WP_Customize_Manager $wp_customize
+	 * @param WP_Customize_Manager $wp_customize The WP_Customize_Manager instance.
 	 */
 	public function add_customizer_settings( WP_Customize_Manager $wp_customize ) {
 
@@ -59,7 +58,7 @@ class Sensei_Customizer {
 			]
 		);
 
-		foreach ( $this->colors as $variable => $settings ) {
+		foreach ( $this->get_colors() as $variable => $settings ) {
 
 			$wp_customize->add_setting(
 				$variable,
@@ -84,7 +83,6 @@ class Sensei_Customizer {
 				)
 			);
 		}
-
 	}
 
 	/**
@@ -103,7 +101,7 @@ class Sensei_Customizer {
 
 		$css = '';
 
-		foreach ( $this->colors as $variable => $settings ) {
+		foreach ( $this->get_colors() as $variable => $settings ) {
 			$value = get_option( $variable );
 			if ( $value && $value !== $settings['default'] ) {
 				$css .= sprintf( "--%s: %s;\n", $variable, ( $value ) );
@@ -127,7 +125,7 @@ class Sensei_Customizer {
 		?>
 		<script type="text/javascript">
 			<?php
-			foreach ( $this->colors as $variable => $settings ) {
+			foreach ( $this->get_colors() as $variable => $settings ) {
 				?>
 			wp.customize( '<?php echo esc_js( $variable ); ?>', ( setting ) => {
 				setting.bind( ( value ) => {

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -15,7 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Grading {
 
-	public $name;
 	public $file;
 	public $page_slug;
 
@@ -27,7 +26,6 @@ class Sensei_Grading {
 	 * @param $file
 	 */
 	public function __construct( $file ) {
-		$this->name      = __( 'Grading', 'sensei-lms' );
 		$this->file      = $file;
 		$this->page_slug = 'sensei_grading';
 
@@ -49,6 +47,32 @@ class Sensei_Grading {
 			add_action( 'wp_ajax_get_lessons_dropdown', array( $this, 'get_lessons_dropdown' ) );
 			add_action( 'wp_ajax_get_redirect_url', array( $this, 'get_redirect_url' ) );
 		}
+	}
+
+	/**
+	 * Graceful fallback for deprecated properties.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key The key to get.
+	 *
+	 * @return mixed
+	 */
+	public function __get( $key ) {
+		if ( 'name' === $key ) {
+			_doing_it_wrong( __CLASS__ . '->name', 'The "name" property is deprecated. Use get_name() instead.', '$$next-version$$' );
+
+			return $this->get_name();
+		}
+	}
+
+	/**
+	 * Get the name of the screen.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Grading', 'sensei-lms' );
 	}
 
 	/**
@@ -392,7 +416,7 @@ class Sensei_Grading {
 	 * @return void
 	 */
 	public function grading_default_nav() {
-		$title = esc_html( $this->name );
+		$title = esc_html( $this->get_name() );
 
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
@@ -432,7 +456,7 @@ class Sensei_Grading {
 	 * @return void
 	 */
 	public function grading_user_quiz_nav() {
-		$title = esc_html( $this->name );
+		$title = esc_html( $this->get_name() );
 
 		if ( isset( $_GET['quiz_id'] ) ) {
 			$quiz_id   = intval( $_GET['quiz_id'] );

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -13,20 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Learner_Profiles {
 	/**
-	 * @var string
-	 */
-	private $profile_url_base;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since  1.4.0
 	 */
 	public function __construct() {
-
-		// Setup learner profile URL base
-		$this->profile_url_base = apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'sensei-lms' ) );
-
 		// Setup permalink structure for learner profiles
 		add_action( 'init', array( $this, 'setup_permastruct' ) );
 		add_filter( 'wp_title', array( $this, 'page_title' ), 10, 2 );
@@ -39,6 +30,15 @@ class Sensei_Learner_Profiles {
 
 		// Add class to body tag
 		add_filter( 'body_class', array( $this, 'learner_profile_body_class' ), 10, 1 );
+	}
+
+	/**
+	 * Get the profile URL base.
+	 *
+	 * @return string
+	 */
+	private function get_profile_url_base() {
+		return (string) apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'sensei-lms' ) );
 	}
 
 	/**
@@ -68,7 +68,7 @@ class Sensei_Learner_Profiles {
 		if ( isset( Sensei()->settings->settings['learner_profile_enable'] )
 			&& Sensei()->settings->settings['learner_profile_enable'] ) {
 
-			add_rewrite_rule( '^' . $this->profile_url_base . '/([^/]*)/?', 'index.php?learner_profile=$matches[1]', 'top' );
+			add_rewrite_rule( '^' . $this->get_profile_url_base() . '/([^/]*)/?', 'index.php?learner_profile=$matches[1]', 'top' );
 			add_rewrite_tag( '%learner_profile%', '([^&]+)' );
 
 		}
@@ -130,7 +130,7 @@ class Sensei_Learner_Profiles {
 
 		if ( $user ) {
 			if ( get_option( 'permalink_structure' ) ) {
-				$permalink = trailingslashit( get_home_url() ) . $this->profile_url_base . '/' . $user->user_nicename;
+				$permalink = trailingslashit( get_home_url() ) . $this->get_profile_url_base() . '/' . $user->user_nicename;
 			} else {
 				$permalink = trailingslashit( get_home_url() ) . '?learner_profile=' . $user->user_nicename;
 			}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -82,18 +82,6 @@ class Sensei_Lesson {
 
 		$this->allowed_html = Sensei_Wp_Kses::get_default_wp_kses_allowed_html();
 
-		$this->legacy_quiz_message = '<p><em>' .
-			sprintf(
-				// translators: %1$s is a link to the quiz documentation, %2$s is a link to a support article about the WordPress editor.
-				__(
-					'*Note that this functionality has been moved to the <a href="%1$s">quiz block</a> and will not be supported going forward. Please consider switching to the <a href="%2$s">block editor</a>.</em>',
-					'sensei-lms'
-				),
-				'https://senseilms.com/lesson/quizzes/',
-				'https://wordpress.org/support/article/wordpress-editor/'
-			) .
-		'</em></p>';
-
 		// Admin actions.
 		if ( is_admin() ) {
 
@@ -1256,9 +1244,28 @@ class Sensei_Lesson {
 		);
 	}
 
+	/**
+	 * Get the legazy quiz message.
+	 *
+	 * @return string
+	 */
+	private function get_legacy_quiz_message() {
+		return '<p><em>' .
+			sprintf(
+				// translators: %1$s is a link to the quiz documentation, %2$s is a link to a support article about the WordPress editor.
+				__(
+					'*Note that this functionality has been moved to the <a href="%1$s">quiz block</a> and will not be supported going forward. Please consider switching to the <a href="%2$s">block editor</a>.</em>',
+					'sensei-lms'
+				),
+				'https://senseilms.com/lesson/quizzes/',
+				'https://wordpress.org/support/article/wordpress-editor/'
+			) .
+		'</em></p>';
+	}
+
 	public function quiz_panel( $quiz_id = 0 ) {
 		$html  = wp_nonce_field( 'sensei-save-post-meta', 'woo_' . $this->token . '_nonce', true, false );
-		$html .= $this->legacy_quiz_message;
+		$html .= $this->get_legacy_quiz_message();
 		$html .= '<div id="add-quiz-main">';
 		if ( 0 == $quiz_id ) {
 			$html .= '<p>';
@@ -2462,7 +2469,7 @@ class Sensei_Lesson {
 	public function lesson_quiz_settings_meta_box_content() {
 		global $post;
 
-		$html = $this->legacy_quiz_message;
+		$html = $this->get_legacy_quiz_message();
 
 		// Get quiz panel
 		$quiz_id   = 0;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -58,15 +58,6 @@ class Sensei_Lesson {
 	private $lesson_id_updating;
 
 	/**
-	 * Message to display on the legacy quiz meta boxes.
-	 *
-	 * @since 3.9.1
-	 *
-	 * @var string
-	 */
-	private $legacy_quiz_message;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since  1.0.0
@@ -1245,7 +1236,7 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Get the legazy quiz message.
+	 * Get the message to display on the legacy quiz meta boxes.
 	 *
 	 * @return string
 	 */

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -910,11 +910,11 @@ class Sensei_PostTypes {
 	/**
 	 * Get the singular, plural and menu label names for the post types.
 	 *
-	 * @param string $post_type The post type.
+	 * @param string|null $post_type The post type.
 	 *
-	 * @return string[]
+	 * @return array
 	 */
-	private function get_main_post_type_labels( $post_type ) {
+	private function get_main_post_type_labels( $post_type = null ) {
 		$labels = array(
 			'course'            => array(
 				'singular' => __( 'Course', 'sensei-lms' ),
@@ -948,7 +948,7 @@ class Sensei_PostTypes {
 			),
 		);
 
-		return $labels[ $post_type ];
+		return $post_type ? $labels[ $post_type ] : $labels;
 	}
 
 	/**

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -57,13 +57,6 @@ class Sensei_PostTypes {
 	public $messages;
 
 	/**
-	 * Labels for post types.
-	 *
-	 * @var array
-	 */
-	public $labels;
-
-	/**
 	 * Array of post ID's for which to fire an "initial publish" action.
 	 *
 	 * @var array
@@ -78,10 +71,7 @@ class Sensei_PostTypes {
 	public function __construct() {
 
 		// Setup Post Types
-		$this->labels = array();
-		$this->token  = 'woothemes-sensei-posttypes';
-
-		$this->setup_post_type_labels_base();
+		$this->token = 'woothemes-sensei-posttypes';
 
 		add_action( 'init', array( $this, 'setup_course_post_type' ), 10 );
 		add_action( 'template_redirect', array( $this, 'redirect_course_archive_page' ) );
@@ -133,7 +123,23 @@ class Sensei_PostTypes {
 		add_action( 'admin_menu', array( $this, 'add_submenus' ) );
 
 		$this->setup_initial_publish_action();
+	}
 
+	/**
+	 * Graceful fallback for deprecated properties.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key The key to get.
+	 *
+	 * @return mixed
+	 */
+	public function __get( $key ) {
+		if ( 'labels' === $key ) {
+			_doing_it_wrong( __CLASS__ . '->labels', 'The "labels" property is deprecated.', '$$next-version$$' );
+
+			return $this->get_main_post_type_labels();
+		}
 	}
 
 	/**
@@ -154,7 +160,6 @@ class Sensei_PostTypes {
 			$this->$posttype_token->token = $posttype_token;
 
 		}
-
 	}
 
 	/**
@@ -233,7 +238,7 @@ class Sensei_PostTypes {
 		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
-			'labels'                => $this->create_post_type_labels( $this->labels['course']['singular'], $this->labels['course']['plural'], $this->labels['course']['menu'] ),
+			'labels'                => $this->get_all_post_type_labels( 'course' ),
 			'public'                => true,
 			'publicly_queryable'    => true,
 			'show_ui'               => true,
@@ -276,7 +281,6 @@ class Sensei_PostTypes {
 		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'course', apply_filters( 'sensei_register_post_type_course', $args ) );
-
 	}
 
 	/**
@@ -329,14 +333,13 @@ class Sensei_PostTypes {
 		// as the page URI
 		if ( is_a( $settings_course_page, 'WP_Post' ) && ! $this->has_old_shortcodes( $settings_course_page->post_content ) ) {
 
-			 return get_page_uri( $settings_course_page->ID );
+			return get_page_uri( $settings_course_page->ID );
 
 		} else {
 
 			return 'courses';
 
 		}
-
 	}
 
 	/**
@@ -355,7 +358,6 @@ class Sensei_PostTypes {
 		|| has_shortcode( $content, 'featuredcourses' )
 		|| has_shortcode( $content, 'freecourses' )
 		|| has_shortcode( $content, 'paidcourses' ) );
-
 	}
 
 	/**
@@ -380,7 +382,7 @@ class Sensei_PostTypes {
 		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
-			'labels'                => $this->create_post_type_labels( $this->labels['lesson']['singular'], $this->labels['lesson']['plural'], $this->labels['lesson']['menu'] ),
+			'labels'                => $this->get_all_post_type_labels( 'lesson' ),
 			'public'                => true,
 			'publicly_queryable'    => true,
 			'show_ui'               => true,
@@ -423,7 +425,6 @@ class Sensei_PostTypes {
 		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'lesson', apply_filters( 'sensei_register_post_type_lesson', $args ) );
-
 	}
 
 	/**
@@ -438,11 +439,7 @@ class Sensei_PostTypes {
 		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
-			'labels'              => $this->create_post_type_labels(
-				$this->labels['quiz']['singular'],
-				$this->labels['quiz']['plural'],
-				$this->labels['quiz']['menu']
-			),
+			'labels'              => $this->get_all_post_type_labels( 'quiz' ),
 			'public'              => true,
 			'publicly_queryable'  => true,
 			'show_ui'             => true,
@@ -487,7 +484,6 @@ class Sensei_PostTypes {
 		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'quiz', apply_filters( 'sensei_register_post_type_quiz', $args ) );
-
 	}
 
 	/**
@@ -501,7 +497,7 @@ class Sensei_PostTypes {
 		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
-			'labels'                => $this->create_post_type_labels( $this->labels['question']['singular'], $this->labels['question']['plural'], $this->labels['question']['menu'] ),
+			'labels'                => $this->get_all_post_type_labels( 'question' ),
 			'public'                => false,
 			'publicly_queryable'    => false,
 			'show_ui'               => true,
@@ -533,7 +529,6 @@ class Sensei_PostTypes {
 		 * @return {array} The filtered arguments.
 		 */
 		register_post_type( 'question', apply_filters( 'sensei_register_post_type_question', $args ) );
-
 	}
 
 	/**
@@ -545,7 +540,7 @@ class Sensei_PostTypes {
 	public function setup_multiple_question_post_type() {
 
 		$args = array(
-			'labels'              => $this->create_post_type_labels( $this->labels['multiple_question']['singular'], $this->labels['multiple_question']['plural'], $this->labels['multiple_question']['menu'] ),
+			'labels'              => $this->get_all_post_type_labels( 'multiple_question' ),
 			'public'              => false,
 			'publicly_queryable'  => false,
 			'show_ui'             => false,
@@ -589,7 +584,7 @@ class Sensei_PostTypes {
 		if ( ! isset( Sensei()->settings->settings['messages_disable'] ) || ! Sensei()->settings->settings['messages_disable'] ) {
 
 			$args = array(
-				'labels'                => $this->create_post_type_labels( $this->labels['sensei_message']['singular'], $this->labels['sensei_message']['plural'], $this->labels['sensei_message']['menu'] ),
+				'labels'                => $this->get_all_post_type_labels( 'sensei_message' ),
 				'public'                => true,
 				'publicly_queryable'    => true,
 				'show_ui'               => true,
@@ -706,7 +701,6 @@ class Sensei_PostTypes {
 		);
 
 		register_taxonomy( 'course-category', array( 'course' ), $args );
-
 	}
 
 	/**
@@ -914,65 +908,64 @@ class Sensei_PostTypes {
 	}
 
 	/**
-	 * Setup the singular, plural and menu label names for the post types.
+	 * Get the singular, plural and menu label names for the post types.
 	 *
-	 * @since  1.0.0
+	 * @param string $post_type The post type.
+	 *
+	 * @return string[]
 	 */
-	private function setup_post_type_labels_base() {
-		$this->labels = array(
-			'course'   => array(),
-			'lesson'   => array(),
-			'quiz'     => array(),
-			'question' => array(),
+	private function get_main_post_type_labels( $post_type ) {
+		$labels = array(
+			'course'            => array(
+				'singular' => __( 'Course', 'sensei-lms' ),
+				'plural'   => __( 'Courses', 'sensei-lms' ),
+				'menu'     => __( 'Courses', 'sensei-lms' ),
+			),
+			'lesson'            => array(
+				'singular' => __( 'Lesson', 'sensei-lms' ),
+				'plural'   => __( 'Lessons', 'sensei-lms' ),
+				'menu'     => __( 'Lessons', 'sensei-lms' ),
+			),
+			'quiz'              => array(
+				'singular' => __( 'Quiz', 'sensei-lms' ),
+				'plural'   => __( 'Quizzes', 'sensei-lms' ),
+				'menu'     => __( 'Quizzes', 'sensei-lms' ),
+			),
+			'question'          => array(
+				'singular' => __( 'Question', 'sensei-lms' ),
+				'plural'   => __( 'Questions', 'sensei-lms' ),
+				'menu'     => __( 'Questions', 'sensei-lms' ),
+			),
+			'multiple_question' => array(
+				'singular' => __( 'Multiple Question', 'sensei-lms' ),
+				'plural'   => __( 'Multiple Questions', 'sensei-lms' ),
+				'menu'     => __( 'Multiple Questions', 'sensei-lms' ),
+			),
+			'sensei_message'    => array(
+				'singular' => __( 'Message', 'sensei-lms' ),
+				'plural'   => __( 'Messages', 'sensei-lms' ),
+				'menu'     => __( 'Messages', 'sensei-lms' ),
+			),
 		);
 
-		$this->labels['course']            = array(
-			'singular' => __( 'Course', 'sensei-lms' ),
-			'plural'   => __( 'Courses', 'sensei-lms' ),
-			'menu'     => __( 'Courses', 'sensei-lms' ),
-		);
-		$this->labels['lesson']            = array(
-			'singular' => __( 'Lesson', 'sensei-lms' ),
-			'plural'   => __( 'Lessons', 'sensei-lms' ),
-			'menu'     => __( 'Lessons', 'sensei-lms' ),
-		);
-		$this->labels['quiz']              = array(
-			'singular' => __( 'Quiz', 'sensei-lms' ),
-			'plural'   => __( 'Quizzes', 'sensei-lms' ),
-			'menu'     => __( 'Quizzes', 'sensei-lms' ),
-		);
-		$this->labels['question']          = array(
-			'singular' => __( 'Question', 'sensei-lms' ),
-			'plural'   => __( 'Questions', 'sensei-lms' ),
-			'menu'     => __( 'Questions', 'sensei-lms' ),
-		);
-		$this->labels['multiple_question'] = array(
-			'singular' => __( 'Multiple Question', 'sensei-lms' ),
-			'plural'   => __( 'Multiple Questions', 'sensei-lms' ),
-			'menu'     => __( 'Multiple Questions', 'sensei-lms' ),
-		);
-		$this->labels['sensei_message']    = array(
-			'singular' => __( 'Message', 'sensei-lms' ),
-			'plural'   => __( 'Messages', 'sensei-lms' ),
-			'menu'     => __( 'Messages', 'sensei-lms' ),
-		);
-
+		return $labels[ $post_type ];
 	}
 
 	/**
 	 * Create the labels for a specified post type.
 	 *
-	 * @since  1.0.0
-	 * @param  string $singular The label for a singular instance of the post type
-	 * @param  string $plural   The label for a plural instance of the post type
-	 * @param  string $menu     The menu item label
-	 * @return array            An array of the labels to be used
+	 * @param  string $post_type The post type.
+	 * @return array             An array of the labels to be used
 	 */
-	private function create_post_type_labels( $singular, $plural, $menu ) {
+	private function get_all_post_type_labels( $post_type ) {
+		$labels   = $this->get_main_post_type_labels( $post_type );
+		$singular = $labels['singular'];
+		$plural   = $labels['plural'];
+		$menu     = $labels['menu'];
 
 		$lower_case_plural = function_exists( 'mb_strtolower' ) ? mb_strtolower( $plural, 'UTF-8' ) : strtolower( $plural );
 
-		$labels = array(
+		return array(
 			'name'               => $plural,
 			'singular_name'      => $singular,
 			'add_new'            => __( 'Add New', 'sensei-lms' ),
@@ -995,8 +988,6 @@ class Sensei_PostTypes {
 			'parent_item_colon'  => '',
 			'menu_name'          => $menu,
 		);
-
-		return $labels;
 	}
 
 	/**
@@ -1026,36 +1017,35 @@ class Sensei_PostTypes {
 	private function create_post_type_messages( $post_type ) {
 		global $post, $post_ID;
 
-		if ( ! isset( $this->labels[ $post_type ] ) ) {
-			return array(); }
+		$labels = $this->get_main_post_type_labels( $post_type );
 
 		$messages = array(
 			0  => '',
 			// translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
-			1  => sprintf( __( '%1$s updated. %2$sView %1$s%3$s.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'], '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
+			1  => sprintf( __( '%1$s updated. %2$sView %1$s%3$s.', 'sensei-lms' ), $labels['singular'], '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
 			2  => __( 'Custom field updated.', 'sensei-lms' ),
 			3  => __( 'Custom field deleted.', 'sensei-lms' ),
 			// translators: Placeholder is the singular label for the post type.
-			4  => sprintf( __( '%1$s updated.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'] ),
+			4  => sprintf( __( '%1$s updated.', 'sensei-lms' ), $labels['singular'] ),
 			// translators: Placeholders are the singular label for the post type and the post's revision, respectively.
-			5  => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'], wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			5  => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s.', 'sensei-lms' ), $labels['singular'], wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
 			// translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
-			6  => sprintf( __( '%1$s published. %2$sView %1$s%3$s.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'], '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
+			6  => sprintf( __( '%1$s published. %2$sView %1$s%3$s.', 'sensei-lms' ), $labels['singular'], '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
 			// translators: Placeholder is the singular label for the post type.
-			7  => sprintf( __( '%1$s saved.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'] ),
+			7  => sprintf( __( '%1$s saved.', 'sensei-lms' ), $labels['singular'] ),
 			// translators: Placeholders are the singular label for the post type and the post's preview link, respectively.
-			8  => sprintf( __( '%1$s submitted. %2$sPreview %1$s%3$s.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'], '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', '</a>' ),
+			8  => sprintf( __( '%1$s submitted. %2$sPreview %1$s%3$s.', 'sensei-lms' ), $labels['singular'], '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', '</a>' ),
 			/*
-			  * translators: Placeholders are as follows (in order):
-			  *
-			  * - The singular label for the post type.
-			  * - The formatted post date.
-			  * - The opening tag for the post's permalink.
-			  * - The closing tag for the post's permalink.
-			  */
-			9  => sprintf( __( '%1$s scheduled for: %2$s. %3$sPreview %4$s%5$s.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'], '<strong>' . date_i18n( __( 'M j, Y @ G:i', 'sensei-lms' ), strtotime( $post->post_date ) ) . '</strong>', '<a target="_blank" href="' . esc_url( get_permalink( $post_ID ) ) . '">', $this->labels[ $post_type ]['singular'], '</a>' ),
+			 * translators: Placeholders are as follows (in order):
+			 *
+			 * - The singular label for the post type.
+			 * - The formatted post date.
+			 * - The opening tag for the post's permalink.
+			 * - The closing tag for the post's permalink.
+			 */
+			9  => sprintf( __( '%1$s scheduled for: %2$s. %3$sPreview %4$s%5$s.', 'sensei-lms' ), $labels['singular'], '<strong>' . date_i18n( __( 'M j, Y @ G:i', 'sensei-lms' ), strtotime( $post->post_date ) ) . '</strong>', '<a target="_blank" href="' . esc_url( get_permalink( $post_ID ) ) . '">', $labels['singular'], '</a>' ),
 			// translators: Placeholders are the singular label for the post type and the post's preview link, respectively.
-			10 => sprintf( __( '%1$s draft updated. %2$sPreview %3$s%4$s.', 'sensei-lms' ), $this->labels[ $post_type ]['singular'], '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', $this->labels[ $post_type ]['singular'], '</a>' ),
+			10 => sprintf( __( '%1$s draft updated. %2$sPreview %3$s%4$s.', 'sensei-lms' ), $labels['singular'], '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', $labels['singular'], '</a>' ),
 		);
 
 		return $messages;
@@ -1153,7 +1143,6 @@ class Sensei_PostTypes {
 
 			);
 		}
-
 	}
 
 	/**
@@ -1451,7 +1440,6 @@ class Sensei_PostTypes {
 	private function check_post_already_published( $post_id ) {
 		return get_post_meta( $post_id, '_sensei_already_published', true );
 	}
-
 }
 
 /**

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -35,20 +35,6 @@ class Sensei_Settings_API {
 	public $page_slug;
 
 	/**
-	 * Page name.
-	 *
-	 * @var string
-	 */
-	public $name;
-
-	/**
-	 * Menu label.
-	 *
-	 * @var string
-	 */
-	public $menu_label;
-
-	/**
 	 * Settings.
 	 *
 	 * @var array
@@ -132,7 +118,6 @@ class Sensei_Settings_API {
 	 * @since  1.0.0
 	 */
 	public function __construct() {
-
 		$this->token        = 'sensei-settings';
 		$this->token_legacy = 'woothemes-sensei-settings';
 		$this->page_slug    = 'sensei-settings-api';
@@ -149,9 +134,48 @@ class Sensei_Settings_API {
 		$this->settings_version  = '';
 
 		// Set default empty values for properties.
-		$this->name       = '';
-		$this->menu_label = '';
-		$this->settings   = array();
+		$this->settings = array();
+	}
+
+	/**
+	 * Graceful fallback for deprecated properties.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key The key to get.
+	 *
+	 * @return mixed
+	 */
+	public function __get( $key ) {
+		if ( 'name' === $key ) {
+			_doing_it_wrong( __CLASS__ . '->name', 'The "name" property is deprecated.', '$$next-version$$' );
+
+			return $this->get_name();
+		}
+
+		if ( 'menu_label' === $key ) {
+			_doing_it_wrong( __CLASS__ . '->menu_label', 'The "menu_label" property is deprecated.', '$$next-version$$' );
+
+			return $this->get_menu_label();
+		}
+	}
+
+	/**
+	 * Get the name of the screen.
+	 *
+	 * @return string
+	 */
+	protected function get_name() {
+		return ''; // Should be overwritten by extension.
+	}
+
+	/**
+	 * Get the menu label.
+	 *
+	 * @return string
+	 */
+	protected function get_menu_label() {
+		return ''; // Should be overwritten by extension.
 	}
 
 	/**
@@ -498,7 +522,7 @@ class Sensei_Settings_API {
 	public function register_settings_screen() {
 
 		if ( current_user_can( 'manage_sensei' ) ) {
-			$hook = add_submenu_page( 'sensei', $this->name, $this->menu_label, 'manage_sensei', $this->page_slug, array( $this, 'settings_screen' ) );
+			$hook = add_submenu_page( 'sensei', $this->get_name(), $this->get_menu_label(), 'manage_sensei', $this->page_slug, array( $this, 'settings_screen' ) );
 
 			$this->hook = $hook;
 		}
@@ -527,7 +551,7 @@ class Sensei_Settings_API {
 					<div class="sensei-custom-navigation__title">
 						<h1>
 							<?php
-							echo esc_html( $this->name );
+							echo esc_html( $this->get_name() );
 
 							if ( '' != $this->settings_version ) {
 								echo ' <span class="version">' . esc_html( $this->settings_version ) . '</span>';
@@ -1240,7 +1264,7 @@ class Sensei_Settings_API {
 			}
 		} else {
 			// translators: Placeholder is the name of the settings page.
-			$message = sprintf( __( '%s updated', 'sensei-lms' ), $this->name );
+			$message = sprintf( __( '%s updated', 'sensei-lms' ), $this->get_name() );
 			add_settings_error( $this->token . '-errors', $this->token, $message, 'updated' );
 		}
 	}

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -33,12 +33,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Setup Admin Settings data
 		if ( is_admin() ) {
-
-			$this->has_tabs   = true;
-			$this->name       = __( 'Sensei LMS Settings', 'sensei-lms' );
-			$this->menu_label = __( 'Settings', 'sensei-lms' );
-			$this->page_slug  = 'sensei-settings';
-
+			$this->has_tabs  = true;
+			$this->page_slug = 'sensei-settings';
 		}
 
 		$this->register_hook_listener();
@@ -74,6 +70,24 @@ class Sensei_Settings extends Sensei_Settings_API {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get the name of the screen.
+	 *
+	 * @return string
+	 */
+	protected function get_name() {
+		return __( 'Sensei LMS Settings', 'sensei-lms' );
+	}
+
+	/**
+	 * Get the menu label.
+	 *
+	 * @return string
+	 */
+	protected function get_menu_label() {
+		return __( 'Settings', 'sensei-lms' );
 	}
 
 	/**
@@ -127,8 +141,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$this->settings_version = Sensei()->version; // Use the global plugin version on this settings screen.
 		$this->hook             = add_submenu_page(
 			'sensei',
-			$this->name,
-			$this->menu_label,
+			$this->get_name(),
+			$this->get_menu_label(),
 			'manage_sensei',
 			$this->page_slug,
 			array( $this, 'settings_screen' )
@@ -174,7 +188,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 					<div class="sensei-custom-navigation__title">
 						<h1>
 							<?php
-							echo esc_html( $this->name );
+							echo esc_html( $this->get_name() );
 
 							if ( '' !== $this->settings_version ) {
 								echo ' <span class="version">' . esc_html( $this->settings_version ) . '</span>';

--- a/includes/emails/class-sensei-email-teacher-completed-lesson.php
+++ b/includes/emails/class-sensei-email-teacher-completed-lesson.php
@@ -31,25 +31,6 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson', false ) ) :
 		}
 
 		/**
-		 * Get the subject.
-		 *
-		 * @return string
-		 */
-		function get_subject() {
-			// translators: Placeholder is the blog name.
-			return apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a lesson', 'sensei-lms' ), get_bloginfo( 'name' ) ), $this->template );
-		}
-
-		/**
-		 * Get the heading.
-		 *
-		 * @return string
-		 */
-		function get_heading() {
-			return apply_filters( 'sensei_email_heading', __( 'Your student has completed a lesson', 'sensei-lms' ), $this->template );
-		}
-
-		/**
 		 * trigger function.
 		 *
 		 * @param int $learner_id
@@ -91,6 +72,25 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson', false ) ) :
 
 			// Send mail
 			Sensei()->emails->send( $this->recipient, $this->get_subject(), Sensei()->emails->get_content( $this->template ) );
+		}
+
+		/**
+		 * Get the subject.
+		 *
+		 * @return string
+		 */
+		private function get_subject() {
+			// translators: Placeholder is the blog name.
+			return (string) apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a lesson', 'sensei-lms' ), get_bloginfo( 'name' ) ), $this->template );
+		}
+
+		/**
+		 * Get the heading.
+		 *
+		 * @return string
+		 */
+		private function get_heading() {
+			return (string) apply_filters( 'sensei_email_heading', __( 'Your student has completed a lesson', 'sensei-lms' ), $this->template );
 		}
 	}
 

--- a/includes/emails/class-sensei-email-teacher-completed-lesson.php
+++ b/includes/emails/class-sensei-email-teacher-completed-lesson.php
@@ -19,8 +19,6 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson', false ) ) :
 	class Sensei_Email_Teacher_Completed_Lesson {
 
 		var $template;
-		var $subject;
-		var $heading;
 		var $recipient;
 		var $learner;
 		var $teacher;
@@ -30,9 +28,25 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson', false ) ) :
 		 */
 		function __construct() {
 			$this->template = 'teacher-completed-lesson';
+		}
+
+		/**
+		 * Get the subject.
+		 *
+		 * @return string
+		 */
+		function get_subject() {
 			// translators: Placeholder is the blog name.
-			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a lesson', 'sensei-lms' ), get_bloginfo( 'name' ) ), $this->template );
-			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has completed a lesson', 'sensei-lms' ), $this->template );
+			return apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a lesson', 'sensei-lms' ), get_bloginfo( 'name' ) ), $this->template );
+		}
+
+		/**
+		 * Get the heading.
+		 *
+		 * @return string
+		 */
+		function get_heading() {
+			return apply_filters( 'sensei_email_heading', __( 'Your student has completed a lesson', 'sensei-lms' ), $this->template );
 		}
 
 		/**
@@ -63,7 +77,7 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson', false ) ) :
 				'sensei_email_data',
 				array(
 					'template'     => $this->template,
-					'heading'      => $this->heading,
+					'heading'      => $this->get_heading(),
 					'teacher_id'   => $teacher_id,
 					'learner_id'   => $learner_id,
 					'learner_name' => $this->learner->display_name,
@@ -76,7 +90,7 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson', false ) ) :
 			$this->recipient = stripslashes( $this->teacher->user_email );
 
 			// Send mail
-			Sensei()->emails->send( $this->recipient, $this->subject, Sensei()->emails->get_content( $this->template ) );
+			Sensei()->emails->send( $this->recipient, $this->get_subject(), Sensei()->emails->get_content( $this->template ) );
 		}
 	}
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,11 @@
 				<referencedProperty name="Sensei_Main::$lesson_progress_repository_factory" />
 				<referencedProperty name="Sensei_Main::$quiz_progress_repository_factory" />
 				<referencedProperty name="Sensei_REST_API_Lesson_Actions_Controller::$schema" />
+				<referencedProperty name="Sensei_PostTypes::$course" />
+				<referencedProperty name="Sensei_PostTypes::$lesson" />
+				<referencedProperty name="Sensei_PostTypes::$question" />
+				<referencedProperty name="Sensei_PostTypes::$quiz" />
+				<referencedProperty name="Sensei_PostTypes::$messages" />
 			</errorLevel>
 		</PropertyNotSetInConstructor>
 		<UndefinedClass>


### PR DESCRIPTION
Resolves #7696

## Proposed Changes

There is a new change in WordPress 6.7 that prevents plugins from loading translations too early, without waiting for more parts of WordPress to be loaded.

This PR fixes all translations that are loaded early while preserving the code logic.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use WordPress 6.7.
2. Set site language to something other than en_US.
3. Ensure all translations are installed.
4. Make sure there are no PHP translation warnings similar to this: `PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly`
5. Test the plugin and make sure everything works as before.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
