### PR TITLE
Filter course IDs associated with a given teacher

### DIFF
--- a/changelog/fix-co-teachers-get-students
+++ b/changelog/fix-co-teachers-get-students
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Filter course IDs associated with a given teacher

--- a/changelog/fix-co-teachers-get-students
+++ b/changelog/fix-co-teachers-get-students
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: development
 Type: added
 
 Filter course IDs associated with a given teacher

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -838,7 +838,19 @@ class Sensei_Teacher {
 			return $learners_sql;
 		}
 
-		$teacher_course_ids = $this->get_teacher_courses( get_current_user_id(), true );
+		/**
+		 * Filter the course IDs associated with a given teacher.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @hook sensei_teacher_course_ids
+		 *
+		 * @param {int[]} $course_ids Course IDs for which the current user is the teacher.
+		 * @param {int}   $teacher_id Teacher ID.
+		 * @return {int[]} Filtered course IDs associated with a given teacher.
+		 */
+		$teacher_course_ids = apply_filters( 'sensei_teacher_course_ids', $this->get_teacher_courses( get_current_user_id(), true ), get_current_user_id() );
+
 		if ( ! $teacher_course_ids ) {
 			$teacher_course_ids = [ 0 ]; // Show no learners.
 		}

--- a/tests/unit-tests/test-class-teacher.php
+++ b/tests/unit-tests/test-class-teacher.php
@@ -502,7 +502,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 		$this->assertPostAuthor( $new_teacher_id, $course['lesson_ids'], 'All lessons must be from teacher B now' );
 	}
 
-	public function testFilterLearnersQuery_WhenUserIsNoATeacher_ReturnsSameInput() {
+	public function testFilterLearnersQuery_WhenUserIsNotATeacher_ReturnsSameInput() {
 		// Arrange.
 		set_current_screen( 'sensei-lms_page_sensei_learners' ); // Pretend we're on the students admin screen.
 


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei-pro/issues/2617.

## Proposed Changes
Add a filter for the course IDs associated with a given teacher.

## Testing Instructions
See https://github.com/Automattic/sensei-pro/pull/2621.

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

- `sensei_teacher_course_ids` - Filter the course IDs associated with a given teacher.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Acceptance criteria is met
- [ ] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [x] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
