### PR TITLE
Fix horizontal scroll on Course page when using Course theme

### DIFF
--- a/changelog/fix-course-horizontal-scroll-with-course-theme
+++ b/changelog/fix-course-horizontal-scroll-with-course-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix horizontal scroll on Course page when using Course theme

--- a/includes/3rd-party/themes/astra.php
+++ b/includes/3rd-party/themes/astra.php
@@ -12,7 +12,7 @@ function sensei_load_learning_mode_styles_for_astra_theme() {
 	$course_id       = Sensei_Utils::get_current_course();
 	$is_target_theme = 'astra' === strtolower( wp_get_theme()->get_template() );
 
-	if ( empty( $course_id ) || ! $is_target_theme ) {
+	if ( empty( $course_id ) || ! $is_target_theme || 'course' === get_post_type() ) {
 		return false;
 	}
 

--- a/includes/3rd-party/themes/course.php
+++ b/includes/3rd-party/themes/course.php
@@ -12,7 +12,7 @@ function sensei_load_learning_mode_style_for_course_theme() {
 	$course_id       = Sensei_Utils::get_current_course();
 	$is_course_theme = 'course' === wp_get_theme()->get_template();
 
-	if ( empty( $course_id ) || ! $is_course_theme ) {
+	if ( empty( $course_id ) || ! $is_course_theme || 'course' === get_post_type() ) {
 		return false;
 	}
 

--- a/includes/3rd-party/themes/divi.php
+++ b/includes/3rd-party/themes/divi.php
@@ -97,7 +97,7 @@ function sensei_load_learning_mode_style_for_divi_theme() {
 	$course_id       = Sensei_Utils::get_current_course();
 	$is_target_theme = 'divi' === strtolower( wp_get_theme()->get_template() );
 
-	if ( empty( $course_id ) || ! $is_target_theme ) {
+	if ( empty( $course_id ) || ! $is_target_theme || 'course' === get_post_type() ) {
 		return false;
 	}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/themes/issues/8334

## Proposed Changes

* It fixes a horizontal scroll in the course theme when using the Course theme. I was done by not loading the 3rd-party `learning-mode.css` in the course page. Since the course is a normal page like the others, we don't want the learning mode styles there. Unless I'm missing something here. ⚠️
* The same logic was replicated to the astra and divi compatibility files.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install and activate the Course theme.
2. Create a course with Learning Mode.
3. Navigate to the course page.
4. Check that it doesn't have a horizontal scroll anymore.
5. Navigate to the lessons, and make sure it continues working properly, and it loads the `learning-mode.css` from the `3rd-party` folder (you can search for `course-learning-mode-css` in the source or add some styles to debug if it's applied or not).

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Acceptance criteria is met
- [x] Decisions are publicly documented
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] New UIs match the designs
- [ ] Different user privileges (admin, teacher, subscriber) are tested as appropriate
- [ ] Legacy courses (course without blocks) are tested
- [ ] Code is tested on the minimum supported PHP and WordPress versions
- [ ] User interface changes have been tested on the latest versions of Chrome, Firefox and Safari
- [ ] "Needs Documentation" label is added if this change requires updates to documentation
- [ ] Known issues are created as new GitHub issues
