### PR TITLE
Fix CI failing because of Ubuntu update

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,6 +7,9 @@ jobs:
     hookdocs:
         runs-on: ubuntu-latest
         steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18
             - uses: actions/checkout@v4
             - name: npm install, and build docs
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ jobs:
         name: Plugin Build
         runs-on: ubuntu-latest
         steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18
             - uses: actions/checkout@v4
             - name: Get npm cache directory
               id: npm-cache

--- a/.github/workflows/dependencies-report.yml
+++ b/.github/workflows/dependencies-report.yml
@@ -8,6 +8,9 @@ jobs:
         runs-on: ubuntu-latest
         name: Build trunk for Dependencies Report
         steps:
+            -   uses: actions/setup-node@v4
+                with:
+                    node-version: 18
             -   uses: actions/checkout@v4
                 with:
                     ref: trunk
@@ -53,6 +56,9 @@ jobs:
         name: WordPress Dependencies Report
         runs-on: ubuntu-latest
         steps:
+            -   uses: actions/setup-node@v4
+                with:
+                    node-version: 18
             -   uses: actions/checkout@v4
             -   name: Get npm cache directory
                 id: npm-cache

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,10 @@ jobs:
         timeout-minutes: 15
         runs-on: ubuntu-latest
         steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18
+
             - name: Checkout code
               uses: actions/checkout@v4
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -9,6 +9,9 @@ jobs:
         name: JS Linting
         runs-on: ubuntu-latest
         steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18
             - uses: actions/checkout@v4
             - uses: actions/cache@v4
               with:
@@ -29,6 +32,9 @@ jobs:
         name: TypeScript Checking
         runs-on: ubuntu-latest
         steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18
             - uses: actions/checkout@v4
             - uses: actions/cache@v4
               with:
@@ -47,6 +53,9 @@ jobs:
         name: JS Testing
         runs-on: ubuntu-latest
         steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18
             # clone the repository
             - uses: actions/checkout@v4
             - uses: actions/cache@v4

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -83,6 +83,10 @@ jobs:
                     - 3306:3306
                 options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
         steps:
+            - name: Install SVN
+              run: |
+                  sudo apt update
+                  sudo apt -y install subversion
             - name: Checkout code
               uses: actions/checkout@v4
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -86,7 +86,7 @@ jobs:
             - name: Install SVN
               run: |
                   sudo apt update
-                  sudo apt -y install subversion
+                  sudo apt install subversion
             - name: Checkout code
               uses: actions/checkout@v4
 

--- a/tests/e2e-playwright/pages/admin/courses/index.ts
+++ b/tests/e2e-playwright/pages/admin/courses/index.ts
@@ -92,7 +92,8 @@ export default class CoursesPage extends PostType {
 		this.wizardModal = new WizardModal( wizardLocator );
 
 		this.createCourseButton = page.locator(
-			'a.page-title-action[href$="post-new.php?post_type=course"]:has-text("New Course"):visible'
+			'a.page-title-action[href$="post-new.php?post_type=course"]',
+			{ hasText: /^New Course$/ }
 		);
 
 		this.courseOutlineBlock = new CourseOutline( page );


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7719

The CI started failing because of a recent Github Actions Ubuntu update - https://github.com/actions/runner-images/issues/10636.

## Proposed Changes

* Install the subversion package which is missing in Ubuntu 24.04.
* Switch back to Node 18. The default is Node 20 in the new Ubuntu version.
* Fix E2E tests strict mode violation causing flakiness.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The CI should be passing.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
