### PR TITLE
Remove usage of deprecated parameters in WordPress Core functions

### DIFF
--- a/changelog/fix-wordpress-core-deprecations
+++ b/changelog/fix-wordpress-core-deprecations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove usage of deprecated parameters in WordPress Core functions

--- a/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-categories-filter.php
@@ -31,7 +31,7 @@ class Sensei_Course_List_Categories_Filter extends Sensei_Course_List_Filter_Abs
 	 *
 	 * @param WP_Block $block The block instance.
 	 */
-	public function get_content( WP_Block $block ) : string {
+	public function get_content( WP_Block $block ): string {
 		$attributes       = $block->attributes;
 		$query_id         = $block->context['queryId'];
 		$is_inherited     = $block->context['query']['inherit'] ?? false;
@@ -78,7 +78,12 @@ class Sensei_Course_List_Categories_Filter extends Sensei_Course_List_Filter_Abs
 		// phpcs:ignore WordPress.Security.NonceVerification
 		$category_id = intval( $_GET[ $filter_param_key ] );
 
-		$course_categories = get_terms( 'course-category', [ 'fields' => 'ids' ] );
+		$course_categories = get_terms(
+			array(
+				'fields'   => 'ids',
+				'taxonomy' => 'course-category',
+			)
+		);
 
 		if ( ! is_array( $course_categories ) || ! in_array( $category_id, $course_categories, true ) ) {
 			return [];

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1697,12 +1697,14 @@ class Sensei_Lesson {
 	}
 
 	public function quiz_panel_add( $context = 'quiz' ) {
-
-		$html = '<div id="add-new-question">';
-
-			$question_types = Sensei()->question->question_types();
-
-			$question_cats = get_terms( 'question-category', array( 'hide_empty' => false ) );
+		$question_types = Sensei()->question->question_types();
+		$question_cats  = get_terms(
+			array(
+				'hide_empty' => false,
+				'taxonomy'   => 'question-category',
+			)
+		);
+		$html           = '<div id="add-new-question">';
 
 		if ( 'quiz' == $context ) {
 			$html     .= '<h2 class="nav-tab-wrapper add-question-tabs">';

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2289,11 +2289,13 @@ class Sensei_Core_Modules {
 	 * Will return the admin user author could not be determined.
 	 *
 	 * @since 1.8.0
+	 * @deprecated $$next-version$$
 	 *
 	 * @param string $term_name
 	 * @return array $owners { type WP_User }. Empty array if none if found.
 	 */
 	public static function get_term_authors( $term_name ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
 
 		$terms = get_terms(
 			array( 'module' ),

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2298,18 +2298,17 @@ class Sensei_Core_Modules {
 		_deprecated_function( __METHOD__, '$$next-version$$' );
 
 		$terms = get_terms(
-			array( 'module' ),
 			array(
-				'name__like' => $term_name,
 				'hide_empty' => false,
+				'name__like' => $term_name,
+				'taxonomy'   => 'module',
 			)
 		);
 
 		$owners = array();
+
 		if ( empty( $terms ) ) {
-
 			return $owners;
-
 		}
 
 		// setup the admin user

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -474,8 +474,14 @@ class Sensei_Question {
 			$output .= $type_options;
 			$output .= '</select>';
 
-			// Question category
-			$cats = get_terms( 'question-category', array( 'hide_empty' => false ) );
+			// Question category.
+			$cats = get_terms(
+				array(
+					'hide_empty' => false,
+					'taxonomy'   => 'question-category',
+				)
+			);
+
 			if ( ! empty( $cats ) && ! is_wp_error( $cats ) ) {
 				$selected    = isset( $_GET['question_cat'] ) ? $_GET['question_cat'] : '';
 				$cat_options = '<option value="">' . esc_html__( 'All categories', 'sensei-lms' ) . '</option>';

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -793,9 +793,9 @@ class Sensei_Usage_Tracking_Data {
 		foreach ( $courses as $course ) {
 			// Get modules for this course.
 			$module_count = wp_count_terms(
-				'module',
 				array(
 					'object_ids' => $course,
+					'taxonomy'   => 'module',
 				)
 			);
 
@@ -830,9 +830,9 @@ class Sensei_Usage_Tracking_Data {
 		for ( $i = 0; $i < $total_courses; $i++ ) {
 			// Get modules for this course.
 			$module_count = wp_count_terms(
-				'module',
 				array(
 					'object_ids' => $courses[ $i ],
+					'taxonomy'   => 'module',
 				)
 			);
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -794,7 +794,7 @@ class Sensei_Usage_Tracking_Data {
 			// Get modules for this course.
 			$module_count = wp_count_terms(
 				array(
-					'object_ids' => $course,
+					'object_ids' => (int) $course,
 					'taxonomy'   => 'module',
 				)
 			);
@@ -831,7 +831,7 @@ class Sensei_Usage_Tracking_Data {
 			// Get modules for this course.
 			$module_count = wp_count_terms(
 				array(
-					'object_ids' => $courses[ $i ],
+					'object_ids' => (int) $courses[ $i ],
 					'taxonomy'   => 'module',
 				)
 			);

--- a/includes/shortcodes/class-sensei-shortcode-course-categories.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-categories.php
@@ -134,9 +134,7 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 		if ( is_wp_error( $terms ) ) {
 			$this->sensei_course_taxonomy_terms = array();
 		} else {
-			$terms = (array) $terms;
-
-			$this->sensei_course_taxonomy_terms = $terms;
+			$this->sensei_course_taxonomy_terms = (array) $terms;
 		}
 	}
 

--- a/includes/shortcodes/class-sensei-shortcode-course-categories.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-categories.php
@@ -118,7 +118,6 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 	 * @return mixed
 	 */
 	public function setup_course_categories() {
-
 		$args = array(
 			'orderby'    => $this->orderby,
 			'order'      => $this->order,
@@ -128,10 +127,10 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 			'parent'     => $this->parent,
 			'hide_empty' => $this->hide_empty,
 			'fields'     => 'all',
+			'taxonomy'   => 'course-category',
 		);
 
-		$this->sensei_course_taxonomy_terms = get_terms( 'course-category', $args );
-
+		$this->sensei_course_taxonomy_terms = get_terms( $args );
 	}
 
 	/**

--- a/includes/shortcodes/class-sensei-shortcode-course-categories.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-categories.php
@@ -59,14 +59,14 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 	/**
 	 * Include categories.
 	 *
-	 * @var array
+	 * @var int[]
 	 */
 	public $include;
 
 	/**
 	 * Exclude categories.
 	 *
-	 * @var array
+	 * @var int[]
 	 */
 	public $exclude;
 
@@ -79,7 +79,7 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 
 
 	/**
-	 * @var array list of taxonomy terms.
+	 * @var WP_Term[] List of taxonomy terms.
 	 */
 	protected $sensei_course_taxonomy_terms;
 
@@ -113,9 +113,8 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 	}
 
 	/**
-	 * create the messages query .
+	 * Create the messages query .
 	 *
-	 * @return mixed
 	 */
 	public function setup_course_categories() {
 		$args = array(
@@ -130,7 +129,15 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 			'taxonomy'   => 'course-category',
 		);
 
-		$this->sensei_course_taxonomy_terms = get_terms( $args );
+		$terms = get_terms( $args );
+
+		if ( is_wp_error( $terms ) ) {
+			$this->sensei_course_taxonomy_terms = array();
+		} else {
+			$terms = (array) $terms;
+
+			$this->sensei_course_taxonomy_terms = $terms;
+		}
 	}
 
 	/**
@@ -139,27 +146,23 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 	 * @return string $content
 	 */
 	public function render() {
-
 		if ( empty( $this->sensei_course_taxonomy_terms ) ) {
-
 			return __( 'No course categories found.', 'sensei-lms' );
-
 		}
 
 		$terms_html = '';
 
-		// set the wp_query to the current messages query
+		// Set the wp_query to the current messages query.
 		$terms_html .= '<ul class="sensei course-categories">';
-		foreach ( $this->sensei_course_taxonomy_terms as $category ) {
 
+		foreach ( $this->sensei_course_taxonomy_terms as $category ) {
 			$category_link = '<a href="' . get_term_link( $category ) . '">' . $category->name . '</a>';
 			$terms_html   .= '<li class="sensei course-category" >' . $category_link . '</li>';
-
 		}
+
 		$terms_html .= '</ul>';
 
 		return $terms_html;
-
 	}
 
 	/**
@@ -168,41 +171,31 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 	 * @since 1.9.0
 	 *
 	 * @param array $category_ids
-	 * @return array
+	 * @return int[]
 	 */
 	public function generate_term_ids( $categories = array() ) {
-
 		$cat_ids = array();
 
 		if ( is_array( $categories ) ) {
 			foreach ( $categories as $cat ) {
-
 				if ( ! is_numeric( $cat ) ) {
-
 					// try the slug
 					$term = get_term_by( 'slug', $cat, 'course-category' );
 
 					// if the slug didn't work try the name
 					if ( ! $term ) {
-
 						$term = get_term_by( 'name', $cat, 'course-category' );
-
 					}
 
 					if ( $term ) {
 						$cat_ids[] = $term->term_id;
 					}
 				} else {
-
-					$cat_ids[] = $cat;
-
+					$cat_ids[] = (int) $cat;
 				}
 			}
 		}
 
 		return $cat_ids;
-
 	}
-
 }
-

--- a/includes/shortcodes/class-sensei-shortcode-course-categories.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-categories.php
@@ -114,7 +114,6 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 
 	/**
 	 * Create the messages query .
-	 *
 	 */
 	public function setup_course_categories() {
 		$args = array(

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -88,62 +88,6 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$this->assertFalse( Sensei()->modules->do_link_to_module( $test_module, false ) );
 	}
 
-	/**
-	 * Testing Sensei_Core_Modules::get_term_author
-	 */
-	public function testGetTermAuthor() {
-
-		// setup assertions
-		$test_user_id = wp_create_user( 'teacherGetTermAuthor', 'teacherGetTermAuthor', 'teacherGetTermAuthor@test.com' );
-
-		// insert a general term
-		wp_insert_term( 'Get Started', 'module' );
-		// insert a term as if from the user
-		wp_insert_term(
-			'Get Started Today',
-			'module',
-			array(
-				'description' => 'A yummy apple.',
-				'slug'        => $test_user_id . '-get-started-today',
-			)
-		);
-
-		// does the function exist?
-		$this->assertTrue( method_exists( 'Sensei_Core_Modules', 'get_term_authors' ), 'The function Sensei_Core_Modules::get_term_author does not exist ' );
-
-		// does the taxonomy exist
-		$module_taxonomy = get_taxonomy( 'module' );
-		$this->assertTrue( $module_taxonomy->public, 'The module taxonomy is not loaded' );
-
-		// does it return empty array id for bogus term nam?
-		$term_authors = Sensei_Core_Modules::get_term_authors( 'bogusnonexistan' );
-		$this->assertTrue( empty( $term_authors ), 'The function should return false for an invalid term' );
-
-		// does it return the admin user for a valid term ?
-		$admin        = get_user_by( 'email', get_bloginfo( 'admin_email' ) );
-		$term_authors = Sensei_Core_Modules::get_term_authors( 'Get Started' );
-		$this->assertTrue( $admin == $term_authors[0], 'The function should return admin user for normal module term.' );
-
-		// does it return the expected new user for the given term registered with that id in front of the slug?
-		$term_authors = Sensei_Core_Modules::get_term_authors( 'Get Started Today' );
-		$this->assertTrue( get_userdata( $test_user_id ) == $term_authors[0], 'The function should admin user for normal module term.' );
-
-		// what about terms with the same name but different slug?
-		// It should return 2 authors as we've created 2 with the same name
-		// insert a term that is the same as the first one
-		wp_insert_term(
-			'Get Started',
-			'module',
-			array(
-				'description' => 'A yummy apple.',
-				'slug'        => $test_user_id . '-get-started',
-			)
-		);
-		$term_authors = Sensei_Core_Modules::get_term_authors( 'Get Started' );
-		$this->assertTrue( 2 == count( $term_authors ), 'The function should admin user for normal module term.' );
-
-	}
-
 	public function testGetTermAuthor_WhenNoAuthorAndSiteAdminEmailDoesNotMatchAnyUser_AddsTheFirstAdminUserInFallback() {
 		/* Arrange */
 		wp_insert_term( 'Get Started', 'module' );


### PR DESCRIPTION
Partial fix for https://github.com/Automattic/sensei-security/issues/19.

## Proposed Changes
- Deprecates the `get_term_authors` function as I was unable to find any calls to it either in Sensei or any of its extensions. It was first added [here](https://github.com/Automattic/sensei/commit/18676be4cd222d5ca353d3ca3d849c16040a3915), which didn't call the function either. 😕 
- Fixes instances of the `wp_count_terms` function to pass a single parameter.
- Fixes instances of the `get_terms` function to pass a single parameter.

There is one more deprecation fix needed in the `class-sensei-learners-main.php` file. The problem line is part of what appears to be obsolete code, so I'm planning to remove it in a separate PR.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On `trunk`, enable usage tracking.
2. Using the WP Crontrol plugin, run the `sensei_usage_tracking_send_usage_data` job.
3. Find the `sensei_stats_log` event in Tracks and note the value of `modules_max` and `modules_min`.
4. Switch to this branch.
5. Re-run the `sensei_usage_tracking_send_usage_data` job and ensure the values noted in step 3 are the same.
6. On the front-end, browse to a page containing the Course List block.
7. Filter the list on a particular category and ensure only courses with that category are displayed.
8. Add the `[sensei_course_categories exclude="123,xxx"]` shortcode to a page, where `123` is a course category ID and `xxx` is a course category slug to exclude.
9. Ensure that all course categories, save the excluded ones, are displayed on the frontend.
10. Go to Sensei LMS > Questions.
11. Ensure that all question categories appear in the categories dropdown.
12. Activate the Classic Editor plugin.
13. Open an existing lesson.
14. In the Quiz Questions panel, select the Category Questions tab.
15. Ensure that all question categories appear in the dropdown.

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

* `Sensei_Core_Modules::get_term_authors`

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
