### PR TITLE
Ignore phpcs file system errors

### DIFF
--- a/includes/admin/class-sensei-status.php
+++ b/includes/admin/class-sensei-status.php
@@ -236,9 +236,9 @@ class Sensei_Status {
 		}
 
 		// Read the first 8kb of the file.
-		$fp        = fopen( $file, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- Read only open.
-		$file_data = fread( $fp, 8192 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread
-		fclose( $fp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+		$fp        = fopen( $file, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Read only open.
+		$file_data = fread( $fp, 8192 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
+		fclose( $fp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 
 		// Make sure we catch CR-only line endings.
 		$file_data = str_replace( "\r", "\n", $file_data );

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -1022,7 +1022,7 @@ class Sensei_Analysis {
 		foreach ( $report_data as $row ) {
 			fputcsv( $fp, $row );
 		}
-		fclose( $fp );
+		fclose( $fp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-security/issues/23

Plugin Check is suggesting to use `WP_Filesystem` instead of the system calls. I'm ignoring it because the class doesn't provide the needed functionality.

## Proposed Changes
* Ignore the phpcs system calls errors.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install the Plugin Check plugin.
2. Go to _Tools_ > _Plugin Check_.
3. Select Sensei LMS from the dropdown and ensure _Plugin Repo_ is selected.
4. Click _Check it!_ button.
5. Make sure there are no `WP_Filesystem` errors.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
