### PR TITLE
Remove obsolete code from Students area

### DIFF
--- a/changelog/remove-obsolete-learner-management-code
+++ b/changelog/remove-obsolete-learner-management-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove obsolete code from Students area

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -187,9 +187,6 @@
     <InvalidArgument occurrences="1">
       <code>'course-category'</code>
     </InvalidArgument>
-    <PossibleRawObjectIteration occurrences="1">
-      <code>$cats</code>
-    </PossibleRawObjectIteration>
     <PossiblyFalseArgument occurrences="6">
       <code>$name</code>
       <code>$post_id</code>
@@ -201,9 +198,6 @@
     <PossiblyFalseReference occurrences="1">
       <code>is_enrolled</code>
     </PossiblyFalseReference>
-    <PossiblyInvalidIterator occurrences="1">
-      <code>$cats</code>
-    </PossiblyInvalidIterator>
     <PossiblyInvalidMethodCall occurrences="1">
       <code>get_provider_results</code>
     </PossiblyInvalidMethodCall>

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -36,7 +36,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	private $lesson_id;
 
 	/**
-	 * The current view of learner management. Possible values are 'lessons', 'courses' and 'learners'.
+	 * The current view of learner management. Possible values are 'lessons' and 'learners'.
 	 *
 	 * @var string
 	 */
@@ -96,10 +96,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			wp_die( esc_html__( 'Invalid lesson', 'sensei-lms' ), 404 );
 		}
 
-		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'courses', 'lessons', 'learners' ), true ) ) {
+		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'lessons', 'learners' ), true ) ) {
 			$this->view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
 		} else {
-			$this->view = 'courses';
+			$this->view = '';
 		}
 
 		$this->enrolment_status = 'all';
@@ -180,16 +180,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					'updated'      => __( 'Last Updated', 'sensei-lms' ),
 				);
 				break;
-
-			case 'courses':
-			default:
-				$columns = array(
-					'title'        => __( 'Course', 'sensei-lms' ),
-					'num_learners' => __( '# Students', 'sensei-lms' ),
-					'updated'      => __( 'Last Updated', 'sensei-lms' ),
-				);
-				break;
 		}
+
 		$columns['actions'] = '';
 
 		// Backwards compatible.
@@ -240,6 +232,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				);
 				break;
 		}
+
 		// Backwards compatible.
 		if ( 'learners' === $this->view ) {
 			$columns = apply_filters_deprecated(
@@ -333,14 +326,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					$orderby = 'post_modified';
 				}
 				$this->items = $this->get_lessons( compact( 'per_page', 'offset', 'orderby', 'order', 'search' ) );
-
-				break;
-
-			default:
-				if ( empty( $orderby ) ) {
-					$orderby = 'post_modified';
-				}
-				$this->items = $this->get_courses( compact( 'per_page', 'offset', 'orderby', 'order', 'category', 'search' ) );
 
 				break;
 		}
@@ -683,61 +668,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$escaped_column_data = Sensei_Wp_Kses::wp_kses_array( $column_data );
 
 				break;
-			case 'courses':
-			default:
-				$course_learners = Sensei_Utils::sensei_check_for_activity(
-					apply_filters(
-						'sensei_learners_course_learners',
-						array(
-							'post_id' => $item->ID,
-							'type'    => 'sensei_course_status',
-							'status'  => 'any',
-						)
-					)
-				);
-				$title           = get_the_title( $item );
-				// translators: Placeholder is the item title/name.
-				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), $title );
-
-				$grading_action = ' <a class="button" href="' . esc_url(
-					add_query_arg(
-						array(
-							'page'      => 'sensei_grading',
-							'course_id' => $item->ID,
-						),
-						admin_url( 'admin.php' )
-					)
-				) . '">' . esc_html__( 'Grading', 'sensei-lms' ) . '</a>';
-
-				$column_data = apply_filters(
-					'sensei_learners_main_column_data',
-					array(
-						'title'        =>
-							'<strong>' .
-								'<a class="row-title" href="' . esc_url(
-									add_query_arg(
-										array(
-											'page'      => 'sensei_learners',
-											'course_id' => $item->ID,
-											'view'      => 'learners',
-										),
-										admin_url( 'admin.php' )
-									)
-								) . '" title="' . esc_attr( $a_title ) . '">' .
-									esc_html( $title ) .
-								'</a>' .
-							'</strong>',
-						'num_learners' => esc_html( $course_learners ),
-						'updated'      => esc_html( $item->post_modified ),
-						'actions'      =>
-							'<div class="student-action-menu" data-course-id="' . esc_attr( $item->ID ) . '"></div>',
-					),
-					$item
-				);
-
-				$escaped_column_data = Sensei_Wp_Kses::wp_kses_array( $column_data );
-
-				break;
 		}
 
 		return $escaped_column_data;
@@ -1013,12 +943,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			case 'lessons':
 				$text = __( 'No lessons found.', 'sensei-lms' );
 				break;
-
-			case 'courses':
-			case 'default':
-			default:
-				$text = __( 'No courses found.', 'sensei-lms' );
-				break;
 		}
 		/**
 		 * Filter the text displayed when no items are found.
@@ -1048,30 +972,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		 */
 		do_action( 'sensei_learners_before_dropdown_filters' );
 
-		// Display Course Categories only on default view.
-		if ( 'courses' === $this->view ) {
-
-			$selected_cat = 0;
-			// phpcs:disable WordPress.Security.NonceVerification -- No data are modified.
-			if ( isset( $_GET['course_cat'] ) && '' !== sanitize_text_field( wp_unslash( $_GET['course_cat'] ) ) ) {
-				$selected_cat = (int) $_GET['course_cat'];
-			}
-			// phpcs:enable
-
-			$cats = get_terms( 'course-category', array( 'hide_empty' => false ) );
-
-			echo '<div class="select-box">' . "\n";
-			echo '<select id="course-category-options" data-placeholder="' . esc_attr__( 'Course Category', 'sensei-lms' ) . '" name="learners_course_cat" class="chosen_select widefat">' . "\n";
-			echo '<option value="0">' . esc_html__( 'All Course Categories', 'sensei-lms' ) . '</option>' . "\n";
-
-			foreach ( $cats as $cat ) {
-				echo '<option value="' . esc_attr( $cat->term_id ) . '"' . selected( $cat->term_id, $selected_cat, false ) . '>' . esc_html( $cat->name ) . '</option>' . "\n";
-			}
-
-			echo '</select>' . "\n";
-
-			echo '</div>' . "\n";
-		}
 		echo '</div><!-- /.learners-selects -->';
 	}
 
@@ -1315,10 +1215,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 			case 'lessons':
 				$text = __( 'Search Lessons', 'sensei-lms' );
-				break;
-
-			default:
-				$text = __( 'Search Courses', 'sensei-lms' );
 				break;
 		}
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -161,6 +161,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return array $columns, the array of columns to use with the table
 	 */
 	public function get_columns() {
+		$columns = array();
 
 		switch ( $this->view ) {
 			case 'learners':
@@ -935,6 +936,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function no_items() {
+		$text = '';
+
 		switch ( $this->view ) {
 			case 'learners':
 				$text = __( 'No students found.', 'sensei-lms' );
@@ -1207,6 +1210,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return string $text
 	 */
 	public function search_button() {
+		$text = '';
 
 		switch ( $this->view ) {
 			case 'learners':


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-security/issues/19.

## Proposed Changes
While working on https://github.com/Automattic/sensei/pull/7724, I noticed that code that used to run in the Students area when the URL had the `view=courses` query parameter, [or when the URL had no `view` parameter](https://github.com/Automattic/sensei/pull/7726/files#diff-deb2afc1bc5a974347791cea75a09ea2fa56bc00ba830fdbca102ef3a72a632cL102), appears to be obsolete. I clicked through all of the Students screens and was unable to find an instance where there was no `view` parameter or where `view` was set to `courses.`

I then reverted Sensei to version 4.3, which is the release prior to the one in which we [overhauled Learner Management](https://github.com/Automattic/sensei/milestone/109). In that version, the default screen that displayed when clicking _Student Management_ did indeed set the `view` property to `courses` and execute this code. So I think we just missed removing this obsolete code back then, and I'm going ahead and ripping the bandaid off now. 😬 

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Try to click through all of the _Students_ area to see if anything breaks, including Bulk Actions.
2. Click through other areas of Sensei just in case.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
