### PR TITLE
Switch to using `wp_json_encode` instead of `json_encode` in Modules admin

### DIFF
--- a/changelog/update-json_encode-to-wp_json_encode
+++ b/changelog/update-json_encode-to-wp_json_encode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch to using `wp_json_encode` instead of `json_encode` on Modules page

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -731,8 +731,8 @@ class Sensei_Core_Modules {
 			}
 		}
 
-		// Encode and return results for processing & selection
-		echo json_encode( $found_courses );
+		// Encode and return results for processing & selection.
+		echo wp_json_encode( $found_courses );
 		die();
 	}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-security/issues/21.

## Proposed Changes
Switch to using `wp_json_encode` instead of `json_encode` when searching courses on the Module admin page.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Browse to _Sensei LMS_ > _Modules_.
2. Search for a course in the _Course(s)_ dropdown and ensure it works.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
