### PR TITLE
Replace `unlink` with `wp_delete_file`

### DIFF
--- a/changelog/update-replace-unlink-with-wp_delete_file
+++ b/changelog/update-replace-unlink-with-wp_delete_file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace `unlink` with `wp_delete_file`

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -212,7 +212,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	public function get_logs() {
 		usort(
 			$this->logs,
-			function( $first_log, $second_log ) {
+			function ( $first_log, $second_log ) {
 
 				// Get the type ordering and compare the two logs based on that.
 				$log_order                = $this->get_log_type_order();
@@ -514,7 +514,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		$move_new_file = @copy( $tmp_file, $file_save_path );
 
 		if ( 0 === strpos( $tmp_file, sys_get_temp_dir() ) ) {
-			unlink( $tmp_file );
+			wp_delete_file( $tmp_file );
 		}
 
 		if ( ! $move_new_file || ! file_exists( $file_save_path ) ) {

--- a/includes/data-port/export-tasks/class-sensei-export-task.php
+++ b/includes/data-port/export-tasks/class-sensei-export-task.php
@@ -258,10 +258,11 @@ abstract class Sensei_Export_Task
 		$type     = $this->get_content_type();
 		$date     = gmdate( 'Y-m-d' );
 		$filename = sanitize_file_name( get_bloginfo( 'name' ) . '-' . ucwords( $type ) . 's-' . $date . '.csv' );
+
 		$this->get_job()->save_file( $type, $tmp_file, $filename );
+
 		if ( file_exists( $tmp_file ) ) {
-			unlink( $tmp_file );
+			wp_delete_file( $tmp_file );
 		}
 	}
-
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-security/issues/25.

## Proposed Changes
Switch to using `wp_delete_file` instead of `unlink`.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Browse to _Sensei LMS_ > _Tools_.
2. Visit the _Export Content_ tool.
3. Export courses.
4. In your `/var/tmp` folder, ensure there are no files starting with `sensei-lms-export` with today's date.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions