### PR TITLE
Replace `date` with `gmdate`

### DIFF
--- a/changelog/update-replace-date-with-gmdate
+++ b/changelog/update-replace-date-with-gmdate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace `date` with `gmdate`

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -526,7 +526,7 @@ class Sensei_Learner_Management {
 		}
 
 		$formatted_date = gmdate( 'Y-m-d H:i:s', $date->getTimestamp() );
-		$updated    = (bool) update_comment_meta( $comment_id, 'start', $formatted_date, $date_started );
+		$updated        = (bool) update_comment_meta( $comment_id, 'start', $formatted_date, $date_started );
 
 		/**
 		 * Filter sensei_learners_learner_updated

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -524,7 +524,9 @@ class Sensei_Learner_Management {
 		if ( false === $date ) {
 			exit( '' );
 		}
-		$mysql_date = date( 'Y-m-d H:i:s', $date->getTimestamp() );
+
+		$mysql_date = gmdate( 'Y-m-d H:i:s', $date->getTimestamp() );
+
 		if ( false === $mysql_date ) {
 			exit( '' );
 		}

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -525,8 +525,8 @@ class Sensei_Learner_Management {
 			exit( '' );
 		}
 
-		$mysql_date = gmdate( 'Y-m-d H:i:s', $date->getTimestamp() );
-		$updated    = (bool) update_comment_meta( $comment_id, 'start', $mysql_date, $date_started );
+		$formatted_date = gmdate( 'Y-m-d H:i:s', $date->getTimestamp() );
+		$updated    = (bool) update_comment_meta( $comment_id, 'start', $formatted_date, $date_started );
 
 		/**
 		 * Filter sensei_learners_learner_updated
@@ -546,7 +546,7 @@ class Sensei_Learner_Management {
 			exit( '' );
 		}
 
-		exit( esc_html( $mysql_date ) );
+		exit( esc_html( $formatted_date ) );
 	}
 
 	/**

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -526,12 +526,7 @@ class Sensei_Learner_Management {
 		}
 
 		$mysql_date = gmdate( 'Y-m-d H:i:s', $date->getTimestamp() );
-
-		if ( false === $mysql_date ) {
-			exit( '' );
-		}
-
-		$updated = (bool) update_comment_meta( $comment_id, 'start', $mysql_date, $date_started );
+		$updated    = (bool) update_comment_meta( $comment_id, 'start', $mysql_date, $date_started );
 
 		/**
 		 * Filter sensei_learners_learner_updated


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-security/issues/22.

## Proposed Changes
Switch to using `gmdate` instead of `date`.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Browse to _Sensei LMS_ > _Students_.
2. Select a course in the _Enrolled Courses_ column.
3. Select a new date for _Date Started_.
4. Click the _Update Student_ button and ensure the date is updated correctly.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions