### PR TITLE
Initialize Sensei blocks for new posts

### DIFF
--- a/changelog/fix-no-sensei-blocks-for-posts
+++ b/changelog/fix-no-sensei-blocks-for-posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Initialize Sensei blocks for posts

--- a/includes/blocks/class-sensei-blocks-initializer.php
+++ b/includes/blocks/class-sensei-blocks-initializer.php
@@ -132,8 +132,12 @@ abstract class Sensei_Blocks_Initializer {
 			return $post_type ? $post_type : null;
 		}
 
-		if ( 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && post_type_exists( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput -- Only reading the post type.
-			return $_GET['post_type']; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput -- Already validated.
+		if ( 'post-new.php' === $pagenow ) {
+			if ( isset( $_GET['post_type'] ) && post_type_exists( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput -- Only reading the post type.
+				return $_GET['post_type']; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput -- Already validated.
+			} else {
+				return 'post';
+			}
 		}
 
 		return null;

--- a/tests/unit-tests/blocks/test-class-sensei-blocks-initializer.php
+++ b/tests/unit-tests/blocks/test-class-sensei-blocks-initializer.php
@@ -105,7 +105,24 @@ class Sensei_Blocks_Initializer_Test extends WP_UnitTestCase {
 		$initializer_mock->maybe_initialize_blocks();
 	}
 
-	public function testMaybeInitializeBlocks_WhenInAdminOnNewPostScreenAndHasCorrectPostType_InitializesBlocks() {
+	public function testMaybeInitializeBlocks_WhenInAdminOnNewPostScreen_InitializesBlocks() {
+		/* Arrange */
+		$initializer_mock = $this->getMockForAbstractClass( Sensei_Blocks_Initializer::class );
+
+		set_current_screen( 'post' );
+
+		global $pagenow;
+		$pagenow = 'post-new.php';
+
+		/* Assert */
+		$initializer_mock->expects( $this->once() )
+			->method( 'initialize_blocks' );
+
+		/* Act */
+		$initializer_mock->maybe_initialize_blocks();
+	}
+
+	public function testMaybeInitializeBlocks_WhenInAdminOnNewCourseScreenAndHasCorrectPostType_InitializesBlocks() {
 		/* Arrange */
 		$initializer_mock = $this->getMockForAbstractClass( Sensei_Blocks_Initializer::class, [ [ 'course' ] ] );
 


### PR DESCRIPTION
Resolves #7734.
Rregression from https://github.com/Automattic/sensei/pull/6823.

## Proposed Changes
The [conditional check](https://github.com/Automattic/sensei/compare/fix/no-sensei-blocks-for-posts?expand=1#diff-036ada2becf9d97f72c69f4ba373ba214db8bd090ff6e8f2f0d6f269f2a84251L135) assumed that all new posts would have the `post_type` query parameter, but that is not true for posts. This PR handles that use case.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new post.
2. Open the inserter and check that Sensei blocks are there, including Course List.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
