### PR TITLE
Wrap question number in `<span>` tag to facilitate translating with TranslatePress

### DIFF
--- a/changelog/update-wrap-question-title-in-span
+++ b/changelog/update-wrap-question-title-in-span
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Wrap question numbers in `<span>` tags

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -687,7 +687,7 @@ class Sensei_Question {
 		$title_html = '<div class="sensei-lms-question-block__header"><h2 class="question question-title">';
 
 		// translators: %d is the question number.
-		$title_html .= sprintf( esc_html__( '%d. ', 'sensei-lms' ), sensei_get_the_question_number() );
+		$title_html .= '<span>' . sprintf( esc_html__( '%d. ', 'sensei-lms' ), sensei_get_the_question_number() ) . '</span>';
 		$title_html .= esc_html( $title );
 		$title_html .= '</h2>';
 


### PR DESCRIPTION
Resolves #7622.

## Proposed Changes
Wraps the question numbers in `<span>` tags to facilitate translating with TranslatePress.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a question to a lesson.
2. View it on the frontend.
3. Check the page source and ensure the question number is wrapped in a `<span>` tag.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
