### PR TITLE
Update markup and styles for the lesson title and status in the editor

### DIFF
--- a/assets/blocks/course-outline/course-outline-editor.scss
+++ b/assets/blocks/course-outline/course-outline-editor.scss
@@ -24,10 +24,20 @@ body .editor-styles-wrapper,
 	}
 
 	.wp-block-sensei-lms-course-outline-lesson .wp-block-sensei-lms-course-outline-lesson {
+		&__input-container {
+			margin: 12px 16px;
+			display: flex;
+			flex-direction: column;
+			flex-grow: 1;
+		}
+
+		&__no-status {
+			margin: 20px 16px;
+		}
 
 		&__input {
-			margin: 20px 16px;
 			background: none;
+			margin: 0;
 
 			@at-root {
 				.block-editor-block-preview__content-iframe & {
@@ -37,14 +47,13 @@ body .editor-styles-wrapper,
 		}
 
 		&__post-status {
-			position: absolute;
-			bottom: 4px;
-			left: 56px;
 			font-size: 12px;
 			font-weight: 600;
 			color: inherit;
 			opacity: 0.5;
 			border-radius: 6px;
+			margin: 0;
+			line-height: normal;
 		}
 	}
 

--- a/assets/blocks/course-outline/lesson-block/lesson-edit.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit.js
@@ -78,6 +78,13 @@ export const LessonEdit = ( props ) => {
 		},
 	};
 
+	const inputContainerClasses = classnames(
+		'wp-block-sensei-lms-course-outline-lesson__input-container',
+		{
+			'wp-block-sensei-lms-course-outline-lesson__no-status': ! postStatus,
+		}
+	);
+
 	return (
 		<>
 			<LessonSettings { ...props } { ...lessonStatus } />
@@ -86,16 +93,24 @@ export const LessonEdit = ( props ) => {
 					icon={ check }
 					className="wp-block-sensei-lms-course-outline-lesson__status"
 				/>
-				<SingleLineInput
-					className="wp-block-sensei-lms-course-outline-lesson__input"
-					placeholder={
-						placeholder || __( 'Add Lesson', 'sensei-lms' )
-					}
-					value={ title }
-					onChange={ updateTitle }
-					onKeyDown={ onKeyDown }
-					style={ { fontSize } }
-				/>
+				<div className={ inputContainerClasses }>
+					<SingleLineInput
+						className="wp-block-sensei-lms-course-outline-lesson__input"
+						placeholder={
+							placeholder || __( 'Add Lesson', 'sensei-lms' )
+						}
+						value={ title }
+						onChange={ updateTitle }
+						onKeyDown={ onKeyDown }
+						style={ { fontSize } }
+					/>
+
+					{ postStatus && (
+						<div className="wp-block-sensei-lms-course-outline-lesson__post-status">
+							{ postStatus }
+						</div>
+					) }
+				</div>
 
 				{ preview && (
 					<span className="wp-block-sensei-lms-course-outline-lesson__badge">
@@ -103,11 +118,6 @@ export const LessonEdit = ( props ) => {
 					</span>
 				) }
 
-				{ postStatus && (
-					<div className="wp-block-sensei-lms-course-outline-lesson__post-status">
-						{ postStatus }
-					</div>
-				) }
 				<Icon
 					icon={ chevronRight }
 					className="wp-block-sensei-lms-course-outline-lesson__chevron"


### PR DESCRIPTION
Resolves https://github.com/Automattic/themes/issues/7616

For solving this issue I also have another PR: https://github.com/Automattic/sensei/pull/7742

In this PR, I'm trying to find a better (more reliable and predictable) way to position the status text.

First, I want to explain that the row that contains the tick icon, lesson title, lesson status, preview and chevron is a flex container with a row direction. So, it is expected that all of them are in a row, not one under another. But then we want to place the lesson status under the lesson title, and we use `position: absolute` for that.
![CleanShot 2025-01-23 at 22 30 43@2x](https://github.com/user-attachments/assets/afe1b30d-513b-4022-9e9f-11b30d00739a)

That results in a unpredictable visual effects when, for example, the line height changes.

In this PR, I propose to put the lesson title and the lesson status in a separate flex container. Then there is no magic involved, their behavior becomes predictable and not vulnurable for accidental undesired visual effects.

![CleanShot 2025-01-23 at 22 27 45@2x](https://github.com/user-attachments/assets/e6a023ba-a122-4473-98b2-ffe213f7c860)

But with this approach now we need to offset the size of the status text. You can see it in different vertical margin depending on whether we have status or no.

## Screenshots

### Before with status
![before blue](https://github.com/user-attachments/assets/9efebf47-dd46-4aeb-92d7-39be73174605)
![before dark](https://github.com/user-attachments/assets/4b649b6a-8f9e-4ac5-9a59-d47c96b6777d)
![before default](https://github.com/user-attachments/assets/68602575-be8d-4797-a88b-75f85a5a5a54)
![before gold](https://github.com/user-attachments/assets/85fdc4c5-8741-487f-8a24-dd428e7fa0dc)

### After with status
![after blue](https://github.com/user-attachments/assets/7bb4cd11-c495-479d-a2c8-d5396a447d3c)
![after dark](https://github.com/user-attachments/assets/512b337b-9bd4-44fb-909f-0197b504ff20)
![after default](https://github.com/user-attachments/assets/35091457-0eb3-4669-baa6-b11930e57fa8)
![after gold](https://github.com/user-attachments/assets/91d63b30-b6ac-4a50-8189-f20ac5383e11)

### Before without status
![before blue - no status](https://github.com/user-attachments/assets/db01ef37-5dce-4797-8e90-31d56c7b5ad8)
![before dark - no status](https://github.com/user-attachments/assets/9883af91-a6d3-4877-8f89-7f3a83650982)
![before default - no status](https://github.com/user-attachments/assets/632e128e-253d-446e-821a-9f6df7e5f65b)
![before gold - no status](https://github.com/user-attachments/assets/3f856226-0d06-4932-bf8c-9e2e397b739b)

### After without status
![after blue - no status](https://github.com/user-attachments/assets/118d2db0-5520-4fd1-9fbe-45ccf08e287a)
![after dark - no status](https://github.com/user-attachments/assets/f3be4a18-4d3a-4a33-9301-cc43a5fd655b)
![after default - no status](https://github.com/user-attachments/assets/960bf77b-5785-461f-9d5e-16e1ef842b65)
![after gold - no status](https://github.com/user-attachments/assets/6fa0a567-41b4-4d2c-ae5c-2dc8a2ddafed)

## Proposed Changes
* Change the markup for lesson in the course outline in the editor.

## Testing Instructions

1. Install and activate Course theme.
2. Go to Site Editor and choose, Blue or Dark variation. In these two the issue is more noticeable.
3. Stay on trunk.
4. Go to Sensei LMS → Courses and create a course with a few lessons. Don't publish it. In this case, you have either Unsaved or Draft status for the lessons. If you publish the course, make sure you disabled publishing of the lessons.
5. Check the position of the status in the Course Outline in the editor.
6. Switch to this branch fix-course-outline-lesson-status-position.
7. Refresh the editor.
8. Make sure there is more space between the lesson title and the status.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
