### PR TITLE
Show disabled indicator test beside email title in email list

### DIFF
--- a/changelog/fix-email-status-display
+++ b/changelog/fix-email-status-display
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Clear text indiacator to indicate disabled status of Emails

--- a/includes/internal/emails/class-email-list-table.php
+++ b/includes/internal/emails/class-email-list-table.php
@@ -112,8 +112,9 @@ class Email_List_Table extends Sensei_List_Table {
 	 * @return array
 	 */
 	protected function get_row_data( $post ) {
-		$title   = _draft_or_post_title( $post );
-		$actions = $this->get_row_actions( $post );
+		$title    = _draft_or_post_title( $post );
+		$actions  = $this->get_row_actions( $post );
+		$is_draft = 'draft' === get_post_status( $post );
 
 		$is_available = $this->is_email_available( $post );
 
@@ -127,9 +128,10 @@ class Email_List_Table extends Sensei_List_Table {
 
 		$description = $is_available ?
 			sprintf(
-				'<strong><a href="%1$s" class="row-title">%2$s</a></strong>%3$s',
+				'<strong><a href="%1$s" class="row-title">%2$s</a>%3$s</strong>%4$s',
 				esc_url( (string) get_edit_post_link( $post ) ),
 				get_post_meta( $post->ID, '_sensei_email_description', true ),
+				$is_draft ? ( ' &ndash; ' . __( 'Disabled', 'sensei-lms' ) ) : '',
 				$this->row_actions( $actions )
 			) : sprintf(
 				'<strong class="sensei-email-unavailable">%1$s</strong><span class="awaiting-mod sensei-upsell-pro-badge">%2$s</span>%3$s',


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7681

## Proposed Changes
* Adds a "Disabled" indicator text following "Draft" is shown on Posts and Pages list of WordPress

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei LMS -> Settings -> Emails
2. Disable one or more email
3. Make sure you see a "- Disabled" string at the end of the email titles
4. Make sure you don't see it when the emails are enabled

I'm having some issues with tests, so will add that separately.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
