### PR TITLE
Fix global button styles for colors and borders

### DIFF
--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -142,6 +142,16 @@ $breakpoint: 782px;
 .editor-styles-wrapper .sensei-course-theme__main-content .wp-block-button,
 .sensei-course-theme .wp-block-button,
 .sensei-course-theme__button {
+	cursor: pointer;
+	font-family: var(--wp--preset--font-family--body-font);
+	font-size: 1.125rem;
+	font-weight: 400;
+	letter-spacing: normal;
+	margin: 0;
+	text-align: center;
+	text-decoration: none !important;
+	text-transform: unset;
+
 	.wp-block-button__link {
 		background-color: var(--sensei-secondary-color);
 		border: solid 1px var(--sensei-secondary-color);
@@ -157,16 +167,6 @@ $breakpoint: 782px;
 			text-decoration: none !important;
 		}
 	}
-
-	cursor: pointer;
-	font-family: var(--wp--preset--font-family--body-font);
-	font-size: 1.125rem;
-	font-weight: 400;
-	letter-spacing: normal;
-	margin: 0;
-	text-align: center;
-	text-decoration: none !important;
-	text-transform: unset;
 
 	&.is-primary,
 	&.is-secondary,

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -143,12 +143,12 @@ $breakpoint: 782px;
 .sensei-course-theme .wp-block-button,
 .sensei-course-theme__button {
 	.wp-block-button__link {
-		border: none;
+		background-color: var(--sensei-secondary-color);
+		border: solid 1px var(--sensei-secondary-color);
+		color: var(--sensei-button-text-color);
 		font-family: inherit;
-		font-weight: inherit;
 		font-size: inherit;
-		background-color: inherit;
-		color: inherit;
+		font-weight: inherit;
 		text-transform: unset;
 
 		&:hover {
@@ -158,8 +158,6 @@ $breakpoint: 782px;
 		}
 	}
 
-	border: none;
-	border-radius: 2px;
 	cursor: pointer;
 	font-family: var(--wp--preset--font-family--body-font);
 	font-size: 1.125rem;
@@ -191,8 +189,6 @@ $breakpoint: 782px;
 	&.is-primary,
 	&.is-secondary,
 	&.wp-block-button {
-		border: solid 1px var(--sensei-secondary-color);
-
 		&.wp-block-button__link {
 			border: none;
 		}
@@ -204,9 +200,6 @@ $breakpoint: 782px;
 
 	&.is-primary,
 	&.wp-block-button:not(.is-style-outline, .is-style-link) {
-		background-color: var(--sensei-secondary-color);
-		color: var(--sensei-button-text-color);
-
 		&:not(.sensei-course-theme-quiz-graded-notice__pending-grade):hover {
 			color: var(--sensei-button-fill-hover-color);
 			background-color: var(--sensei-primary-color);

--- a/assets/css/learning-mode-compat.scss
+++ b/assets/css/learning-mode-compat.scss
@@ -139,9 +139,10 @@ $breakpoint: 782px;
 	}
 }
 
-.editor-styles-wrapper .sensei-course-theme__main-content .wp-block-button,
-.sensei-course-theme .wp-block-button,
-.sensei-course-theme__button {
+.editor-styles-wrapper .sensei-course-theme__main-content .wp-block-button, // Editor styles don't work?
+.sensei-course-theme .wp-block-button {
+// Is .sensei-course-theme__button needed? Seems to only be set on invisibile lesson action buttons?
+// .sensei-course-theme__button {
 	cursor: pointer;
 	font-family: var(--wp--preset--font-family--body-font);
 	font-size: 1.125rem;
@@ -149,9 +150,12 @@ $breakpoint: 782px;
 	letter-spacing: normal;
 	margin: 0;
 	text-align: center;
-	text-decoration: none !important;
+	text-decoration: none;
 	text-transform: unset;
 
+	// Fill button style
+	// Done: Next Lesson + Take Quiz + non-Sensei fill style (default + hover)
+	// TODO: Quiz buttons + Global styles
 	.wp-block-button__link {
 		background-color: var(--sensei-secondary-color);
 		border: solid 1px var(--sensei-secondary-color);
@@ -162,12 +166,30 @@ $breakpoint: 782px;
 		text-transform: unset;
 
 		&:hover {
-			background-color: inherit !important;
-			color: inherit !important;
-			text-decoration: none !important;
+			background-color: var(--sensei-primary-color); // Should be #155E65
+			border-color: var(--sensei-primary-color);	// Should be #155E65
+			color: var(--sensei-button-fill-hover-color);
+			text-decoration: none;
 		}
 	}
 
+	// Outline button style.
+	// Done: All LM buttons(Contact Teacher, Complete Lesson, Reset Lesson, Completed) +
+	// non-Sensei outline style (default + hover)
+	// TODO: Quiz buttons + Global styles
+	&.is-style-outline .wp-block-button__link {
+		background-color: transparent;
+		border: solid 1px var(--sensei-secondary-color);
+
+		&:hover {
+			background-color: var(--sensei-button-outline-hover-color);
+			border: solid 1px var(--sensei-secondary-color);
+			color: var(--sensei-primary-color);
+			text-decoration: none;
+		}
+	}
+
+	// TODO: Figure out what to do about all this crap.
 	&.is-primary,
 	&.is-secondary,
 	&.is-link,
@@ -201,9 +223,9 @@ $breakpoint: 782px;
 	&.is-primary,
 	&.wp-block-button:not(.is-style-outline, .is-style-link) {
 		&:not(.sensei-course-theme-quiz-graded-notice__pending-grade):hover {
-			color: var(--sensei-button-fill-hover-color);
-			background-color: var(--sensei-primary-color);
-			border-color: var(--sensei-primary-color);
+			// color: var(--sensei-button-fill-hover-color);
+			// background-color: var(--sensei-primary-color);
+			// border-color: var(--sensei-primary-color);
 		}
 
 		&:focus {
@@ -215,15 +237,17 @@ $breakpoint: 782px;
 	&.is-secondary,
 	&.wp-block-button.is-style-outline {
 		--wp--custom--button--border--color: var(--sensei-primary-color);
-		color: var(--sensei-primary-color);
+		// color: var(--sensei-primary-color);
 		flex-shrink: 0;
 
 		&:hover {
-			background-color: var(--sensei-button-outline-hover-color);
-			color: var(--sensei-primary-color);
+			// Removed as hover style is now on .wp-block-button__link element.
+			// background-color: var(--sensei-button-outline-hover-color);
+			// color: var(--sensei-primary-color);
 
 			.wp-block-button__link {
-				border-color: var(--sensei-primary-color);
+				// Breaks border of outline button on hover.
+				// border-color: var(--sensei-primary-color);
 			}
 		}
 
@@ -287,29 +311,29 @@ $breakpoint: 782px;
 	}
 }
 
-.sensei-course-theme,
-.editor-styles-wrapper {
-	.wp-block-sensei-lms-lesson-actions {
-		.wp-block-sensei-button.wp-block-button {
-			&.is-style-outline,
-			&.is-style-default {
-				border: none;
+// .sensei-course-theme,
+// .editor-styles-wrapper {
+// 	.wp-block-sensei-lms-lesson-actions {
+// 		.wp-block-sensei-button.wp-block-button {
+// 			// &.is-style-outline, // Not needed for outline style (i.e. Complete Lesson button).
+// 			&.is-style-default {
+// 				border: none;
 
-				.wp-block-button__link {
-					border: solid 1px var(--sensei-secondary-color);
-				}
-			}
-		}
+// 				.wp-block-button__link {
+// 					border: solid 1px var(--sensei-secondary-color);
+// 				}
+// 			}
+// 		}
 
-		.wp-block-sensei-button.wp-block-button.is-style-default {
-			background-color: unset;
+// 		.wp-block-sensei-button.wp-block-button.is-style-default {
+// 			background-color: unset;
 
-			.wp-block-button__link {
-				background-color: var(--sensei-secondary-color);
-			}
-		}
-	}
-}
+// 			.wp-block-button__link {
+// 				background-color: var(--sensei-secondary-color);
+// 			}
+// 		}
+// 	}
+// }
 
 /* Comments */
 .sensei-course-theme .wp-block-comments {


### PR DESCRIPTION
Resolves #

## Proposed Changes
Previously, we were applying colours to the `.wp-block-button` element, which caused issues with colours not working when set through Global Styles. To address this, colour styles have been moved to `.wp-block-button__link` to match what core does for the Buttons block.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate any theme besides Course (`learning-mode-compat.scss` isn't loaded for Course theme).
2. 
3.

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

*

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
