### PR TITLE
Check lesson status return

### DIFF
--- a/changelog/fix-quiz-submission-error
+++ b/changelog/fix-quiz-submission-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Occasional error when submitting a quiz

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1897,7 +1897,6 @@ class Sensei_Utils {
 		}
 
 		if ( $lesson_id > 0 && $user_id > 0 ) {
-
 			$user_lesson_status = self::sensei_check_for_activity(
 				array(
 					'post_id' => $lesson_id,
@@ -1908,11 +1907,9 @@ class Sensei_Utils {
 			);
 
 			// Check if there is a valid status for the user yet.
-			if ( empty( $user_lesson_status ) ) {
-				return false;
+			if ( $user_lesson_status instanceof WP_Comment ) {
+				return $user_lesson_status;
 			}
-
-			return $user_lesson_status;
 		}
 
 		return false;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1907,6 +1907,11 @@ class Sensei_Utils {
 				true
 			);
 
+			// Check if there is a valid status for the user yet.
+			if ( empty( $user_lesson_status ) ) {
+				return false;
+			}
+
 			return $user_lesson_status;
 		}
 


### PR DESCRIPTION
Since the underlying `get_comments` function can return an empty array, check it before returning the value.

Fixes #7754.

Resolves #7754
