### PR TITLE
Deprecate Student Courses Block

### DIFF
--- a/assets/blocks/learner-courses-block/block.json
+++ b/assets/blocks/learner-courses-block/block.json
@@ -14,7 +14,8 @@
     "student"
   ],
   "supports": {
-    "html": false
+    "html": false,
+    "inserter": false
   },
   "attributes": {
     "options": {

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -9,8 +9,9 @@ import { omitBy } from 'lodash';
  */
 import { useState } from '@wordpress/element';
 import { Icon, image } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { Warning } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -202,25 +203,24 @@ const LearnerCoursesEdit = ( {
 				} }
 			>
 				<div className="wp-block-sensei-lms-learner-courses__deprecation-notice">
-					<Notice
-						status="warning"
-						isDismissible={ false }
+					<Warning
 						actions={ [
-							{
-								label: __( 'Read more', 'sensei-lms' ),
-								onClick: () => {
-									window.open(
-										'https://senseilms.com/documentation/course-list-block/'
-									);
-								},
-							},
+							<Button
+								__next40pxDefaultSize
+								key="read-more-action"
+								variant="secondary"
+								href="https://senseilms.com/documentation/course-list-block/"
+								target="_blank"
+							>
+								{ __( 'Read more', 'sensei-lms' ) }
+							</Button>,
 						] }
 					>
 						{ __(
-							'This is a legacy block. We recommend using the Course List block for more customization and flexibility.',
+							'This is a legacy block. Use the Course List block for more customization and flexibility.',
 							'sensei-lms'
 						) }
-					</Notice>
+					</Warning>
 				</div>
 				<p className="wp-block-sensei-lms-learner-courses__filter">
 					{ filters.map( ( { label, value } ) => (

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -208,9 +208,11 @@ const LearnerCoursesEdit = ( {
 						actions={ [
 							{
 								label: __( 'Read more', 'sensei-lms' ),
-								url:
-									'https://senseilms.com/documentation/course-list-block/',
-								target: '_blank',
+								onClick: () => {
+									window.open(
+										'https://senseilms.com/documentation/course-list-block/'
+									);
+								},
 							},
 						] }
 					>

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -10,6 +10,7 @@ import { omitBy } from 'lodash';
 import { useState } from '@wordpress/element';
 import { Icon, image } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -200,6 +201,25 @@ const LearnerCoursesEdit = ( {
 					progressBarBorderRadius: `${ options.progressBarBorderRadius }px`,
 				} }
 			>
+				<div className="wp-block-sensei-lms-learner-courses__deprecation-notice">
+					<Notice
+						status="warning"
+						isDismissible={ false }
+						actions={ [
+							{
+								label: __( 'Read more', 'sensei-lms' ),
+								url:
+									'https://senseilms.com/documentation/course-list-block/',
+								target: '_blank',
+							},
+						] }
+					>
+						{ __(
+							'This is a legacy block. We recommend using the Course List block for more customization and flexibility.',
+							'sensei-lms'
+						) }
+					</Notice>
+				</div>
 				<p className="wp-block-sensei-lms-learner-courses__filter">
 					{ filters.map( ( { label, value } ) => (
 						<a

--- a/assets/blocks/learner-courses-block/learner-courses-editor.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-editor.scss
@@ -4,6 +4,20 @@
 $block: '.wp-block-sensei-lms-learner-courses';
 $courses-list: '#{$block}__courses-list';
 
+.editor-styles-wrapper #{$block} {
+	&__deprecation-notice {
+		margin-bottom: 2rem;
+
+		.components-notice__actions {
+			margin-top: 5px;
+
+			.components-button:first-child {
+				margin-left: 0;
+			}
+		}
+	}
+}
+
 .editor-styles-wrapper #{$courses-list} {
 	list-style: none;
 	padding: 0;

--- a/assets/blocks/learner-courses-block/learner-courses-editor.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-editor.scss
@@ -6,15 +6,7 @@ $courses-list: '#{$block}__courses-list';
 
 .editor-styles-wrapper #{$block} {
 	&__deprecation-notice {
-		margin-bottom: 2rem;
-
-		.components-notice__actions {
-			margin-top: 5px;
-
-			.components-button:first-child {
-				margin-left: 0;
-			}
-		}
+		margin-bottom: 1rem;
 	}
 }
 

--- a/changelog/change-deprecate-student-courses-block
+++ b/changelog/change-deprecate-student-courses-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: deprecated
+
+Deprecate Student Courses Block in favor of Course List block


### PR DESCRIPTION
See p6rkRX-7nh-p2

## Proposed Changes

Course Students block should not be used anymore in favor of the Course List block. But it should be around, at least for now, for backwards compatibility (users that have it added already). With this PR, we are implementing the simplest approach, but there are others that we could implement in the future, such as approaches related to block migration (see more in p6rkRX-7nh-p2).

With this PR, we are adding a deprecation warning to the top of the block on the editor. We are also removing it from the block inserter, so users who don't have it already won't add it accidentally.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On `trunk`, add the "Student Courses" block to a page.
2. Navigate to this branch.
3. Make sure the block now displays a warning that it's a legacy block.
4. Also check that you can't find the block in the inserter anymore.

## Screenshots

<img width="349" alt="Screenshot 2025-03-05 at 15 02 21" src="https://github.com/user-attachments/assets/b21a1ba8-a9dc-4bce-aa14-40d8d81b42c4" />

<img width="1233" alt="Screenshot 2025-03-06 at 10 32 42" src="https://github.com/user-attachments/assets/21496511-5f0b-4057-a199-3f82c40a59f9" />


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions