### PR TITLE
Add a button to replace the legacy Student Courses block with the new Course List block

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -13,24 +13,24 @@ import './hooks';
 import icon from '../../icons/course-list.svg';
 import FeaturedLabel from './featured-label';
 
-export const registerCourseListBlock = () => {
-	const DEFAULT_ATTRIBUTES = {
-		className: 'wp-block-sensei-lms-course-list',
-		query: {
-			perPage: 3,
-			pages: 0,
-			offset: 0,
-			postType: 'course',
-			order: 'desc',
-			orderBy: 'date',
-			author: '',
-			search: '',
-			exclude: [],
-			sticky: '',
-			inherit: false,
-		},
-	};
+export const DEFAULT_ATTRIBUTES = {
+	className: 'wp-block-sensei-lms-course-list',
+	query: {
+		perPage: 3,
+		pages: 0,
+		offset: 0,
+		postType: 'course',
+		order: 'desc',
+		orderBy: 'date',
+		author: '',
+		search: '',
+		exclude: [],
+		sticky: '',
+		inherit: false,
+	},
+};
 
+export const registerCourseListBlock = () => {
 	registerBlockVariation( 'core/query', {
 		name: 'sensei-lms/course-list',
 		title: __( 'Course List', 'sensei-lms' ),

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -31,6 +31,15 @@ import { DEFAULT_ATTRIBUTES as COURSE_LIST_DEFAULT_ATTRIBUTES } from '../course-
 const DeprecationNotice = ( { clientId } ) => {
 	const { replaceBlock } = useDispatch( blockEditorStore );
 
+	const onReplaceClick = () => {
+		const newBlock = createBlock(
+			'core/query',
+			COURSE_LIST_DEFAULT_ATTRIBUTES
+		);
+
+		replaceBlock( clientId, newBlock );
+	};
+
 	return (
 		<div className="wp-block-sensei-lms-learner-courses__deprecation-notice">
 			<Warning
@@ -39,14 +48,7 @@ const DeprecationNotice = ( { clientId } ) => {
 						__next40pxDefaultSize
 						key="replace-block-action"
 						variant="primary"
-						onClick={ () => {
-							const newBlock = createBlock(
-								'core/query',
-								COURSE_LIST_DEFAULT_ATTRIBUTES
-							);
-
-							replaceBlock( clientId, newBlock );
-						} }
+						onClick={ onReplaceClick }
 					>
 						{ __( 'Replace', 'sensei-lms' ) }
 					</Button>,

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -7,10 +7,12 @@ import { omitBy } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { useDispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { Icon, image } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { Warning } from '@wordpress/block-editor';
+import { store as blockEditorStore, Warning } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -18,6 +20,55 @@ import { __ } from '@wordpress/i18n';
  */
 import ProgressBar from '../../shared/blocks/progress-bar';
 import LearnerCoursesSettings from './learner-courses-settings';
+import { DEFAULT_ATTRIBUTES as COURSE_LIST_DEFAULT_ATTRIBUTES } from '../course-list-block';
+
+/**
+ * Deprecation notice component.
+ *
+ * @param {Object} props
+ * @param {Object} props.clientId Block client ID.
+ */
+const DeprecationNotice = ( { clientId } ) => {
+	const { replaceBlock } = useDispatch( blockEditorStore );
+
+	return (
+		<div className="wp-block-sensei-lms-learner-courses__deprecation-notice">
+			<Warning
+				actions={ [
+					<Button
+						__next40pxDefaultSize
+						key="replace-block-action"
+						variant="primary"
+						onClick={ () => {
+							const newBlock = createBlock(
+								'core/query',
+								COURSE_LIST_DEFAULT_ATTRIBUTES
+							);
+
+							replaceBlock( clientId, newBlock );
+						} }
+					>
+						{ __( 'Replace', 'sensei-lms' ) }
+					</Button>,
+					<Button
+						__next40pxDefaultSize
+						key="read-more-action"
+						variant="secondary"
+						href="https://senseilms.com/documentation/course-list-block/"
+						target="_blank"
+					>
+						{ __( 'Read more', 'sensei-lms' ) }
+					</Button>,
+				] }
+			>
+				{ __(
+					'This is a legacy block. Use the Course List block for more customization and flexibility.',
+					'sensei-lms'
+				) }
+			</Warning>
+		</div>
+	);
+};
 
 /**
  * Featured image placeholder element.
@@ -78,12 +129,14 @@ const StylesWrapper = ( {
  * Learner Settings component.
  *
  * @param {Object}   props
+ * @param {Object}   props.clientId           Block client ID.
  * @param {Object}   props.className          Block className.
  * @param {Object}   props.attributes         Block attributes.
  * @param {Object}   props.attributes.options Block options attribute.
  * @param {Function} props.setAttributes      Block set attributes function.
  */
 const LearnerCoursesEdit = ( {
+	clientId,
 	className,
 	attributes: { options },
 	setAttributes,
@@ -202,26 +255,8 @@ const LearnerCoursesEdit = ( {
 					progressBarBorderRadius: `${ options.progressBarBorderRadius }px`,
 				} }
 			>
-				<div className="wp-block-sensei-lms-learner-courses__deprecation-notice">
-					<Warning
-						actions={ [
-							<Button
-								__next40pxDefaultSize
-								key="read-more-action"
-								variant="secondary"
-								href="https://senseilms.com/documentation/course-list-block/"
-								target="_blank"
-							>
-								{ __( 'Read more', 'sensei-lms' ) }
-							</Button>,
-						] }
-					>
-						{ __(
-							'This is a legacy block. Use the Course List block for more customization and flexibility.',
-							'sensei-lms'
-						) }
-					</Warning>
-				</div>
+				<DeprecationNotice clientId={ clientId } />
+
 				<p className="wp-block-sensei-lms-learner-courses__filter">
 					{ filters.map( ( { label, value } ) => (
 						<a


### PR DESCRIPTION
Based off of #7764

## Proposed Changes

* This PR introduces a new button to replace the legacy block in the warning introduced in https://github.com/Automattic/sensei/pull/7764. I decided to create a separate and optional PR to avoid confusion in the discussion of the original PR.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On `trunk`, add the "Student Courses" block to a page.
2. Navigate to this branch.
3. Make sure you see the new "Replace" button in the legacy notice.
4. Click on the button, and check that it replaces the block properly.

## Known issues

- https://github.com/Automattic/sensei/issues/7757

## Recording

https://github.com/user-attachments/assets/784478ee-8b18-4067-9c6f-7014049b0878

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
