### PR TITLE
Learning Mode: Make the logo look in the Site Editor the same way it looks on the frontend

### DIFF
--- a/assets/css/sensei-course-theme/editor.scss
+++ b/assets/css/sensei-course-theme/editor.scss
@@ -7,6 +7,20 @@
 		left: unset;
 		right: unset;
 		bottom: unset;
+
+		.wp-block-site-logo {
+			.components-resizable-box__container {
+				max-height: 24px !important;
+				width: auto !important;
+				max-width: none !important;
+
+				img {
+					max-height: 24px !important;
+					width: auto !important;
+					max-width: none !important;
+				}
+			}
+		}
 	}
 
 	&__columns {

--- a/changelog/fix-learning-mode-logo
+++ b/changelog/fix-learning-mode-logo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: There is no functional changes
+
+


### PR DESCRIPTION
Resolves https://github.com/Automattic/themes/issues/7663

I tried several approaches to solve the issue.
First, I wanted to make the markup more "flexible", but it could lead to issues on the users' websites.
Then, I tried to find options to adjust the block for the template. However, it impossible. I suppose, partially, because it is not a stand-alone theme.
Eventually, I decided to make the appearance the same in the Site Editor and on the frontend. Unfortunately, we can't remove the controls here, but at least using them the user can't break design.

## Proposed Changes
* Add styles to make the site logo look the same as it looks on the frontend

## Testing Instructions

1. Go to Appearance -> Editor
2. Go to Templates -> Sensei LMS -> Learning Mode
3. Upload a logo (try images of different shapes: square, horizontal, vertical).
4. Make sure the logo doesn't break markup and looks the same way it looks in the Learning Mode on the frontend.

## Screenshots
![CleanShot 2025-03-06 at 17 40 00@2x](https://github.com/user-attachments/assets/8fbf1286-00bc-45a2-b358-2eed80ce661b)
![CleanShot 2025-03-06 at 17 40 11@2x](https://github.com/user-attachments/assets/e9164f9b-fc2c-4b8a-b8df-1675f851e116)
![CleanShot 2025-03-06 at 17 40 27@2x](https://github.com/user-attachments/assets/e80a9bc5-b655-4828-807c-b100178c5b93)
![CleanShot 2025-03-06 at 17 40 38@2x](https://github.com/user-attachments/assets/1ac2beca-c376-47e0-a3d1-3b45893640a0)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
