### PR TITLE
Prevent storing enrolment data in memory on Students screen

### DIFF
--- a/changelog/fix-out-of-memory-on-students-screen
+++ b/changelog/fix-out-of-memory-on-students-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent storing enrolment data in memory on Students screen

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -924,8 +924,13 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	private function is_manually_enrolled( $user_id ) {
 		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
 		$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
+		$is_enrolled               = $manual_enrolment_provider->is_enrolled( $user_id, $this->course_id );
 
-		return $manual_enrolment_provider->is_enrolled( $user_id, $this->course_id );
+		// Reset the enrolment state store to avoid out of memory issues.
+		// TODO: This can be removed once the state store no longer holds all the data in memory.
+		Sensei_Enrolment_Provider_State_Store::reset();
+
+		return $is_enrolled;
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-provider-state-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-store.php
@@ -73,6 +73,15 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	}
 
 	/**
+	 * Reset to initial state.
+	 *
+	 * @return void
+	 */
+	public static function reset() {
+		self::$instances = [];
+	}
+
+	/**
 	 * Restore a provider state store from a serialized JSON string.
 	 *
 	 * @param string $json_string JSON representation of enrolment state.

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -53,9 +53,7 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	 * Resets the state stores.
 	 */
 	private static function resetEnrolmentStateStores() {
-		$state_store_instances = new ReflectionProperty( Sensei_Enrolment_Provider_State_Store::class, 'instances' );
-		$state_store_instances->setAccessible( true );
-		$state_store_instances->setValue( [] );
+		Sensei_Enrolment_Provider_State_Store::reset();
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
@@ -193,4 +193,16 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_persisted_set, $persisted_set, 'The state stores should NOT have been persisted without a change' );
 	}
 
+	public function testReset_WhenHasInstances_ResetsInstances() {
+		/* Arrange */
+		$state_store_instances = new ReflectionProperty( Sensei_Enrolment_Provider_State_Store::class, 'instances' );
+		$state_store_instances->setAccessible( true );
+		$state_store_instances->setValue( [ 'something' ] );
+
+		/* Act */
+		Sensei_Enrolment_Provider_State_Store::reset();
+
+		/* Assert */
+		$this->assertEmpty( $state_store_instances->getValue() );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2640

## Proposed Changes
* Reset the enrolment provider state store to avoid storing too much data in memory when rendering one of the Students screens.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have Sensei Pro enabled.
2. Have a course with multiple enrolments.
3. In code, add a breakpoint in the `Sensei_Enrolment_Provider_State_Store::persist_all` method to inspect the `$instances` property. Note that this method is called on the `shutdown` action so just adding a `var_dump(self::$instances)` should work as well.
4. Go to Students -> Click on a course that has multiple enrolled users -> Click Manually Enrolled Students (the URL should be similar to `/wp-admin/admin.php?page=sensei_learners&course_id=578669&view=learners&enrolment_status=manual`)
5. Make sure the `$instances` property is empty.
6. Make sure the screen works as before.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] Code is tested on the minimum supported PHP and WordPress versions
