### PR TITLE
Fix undefined property notice in WP 6.8

### DIFF
--- a/changelog/fix-undefined-property-error
+++ b/changelog/fix-undefined-property-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix undefined property notice on WP 6.8

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -191,6 +191,7 @@ class Sensei_Course_Theme_Templates {
 			'origin'         => 'theme',
 			'is_custom'      => false,
 			'has_theme_file' => true,
+			'modified'       => null,
 			'status'         => 'publish',
 		];
 


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/7770

## Proposed Changes
This resolves the following error generated when creating a new post:

```
PHP Notice:  Undefined property: stdClass::$modified in /Users/m1r0/Sites/sensei/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php on line 778
```

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable the following in your `wp-config.php`:
```php
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', true );
```
2. Switch to the latest WP 6.8 beta using the WordPress Beta Tester plugin.
2. Go to the admin panel -> Posts -> Add post
3. Check the `wp-content/debug.log` file and make sure there's no PHP notice.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
