### PR TITLE
Fix early translation in the tracking class

### DIFF
--- a/changelog/fix-early-translations-in-tracking
+++ b/changelog/fix-early-translations-in-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix loading some translations too early

--- a/includes/block-patterns/class-sensei-block-patterns.php
+++ b/includes/block-patterns/class-sensei-block-patterns.php
@@ -67,7 +67,6 @@ class Sensei_Block_Patterns {
 	 * @access private
 	 */
 	public function register_course_list_block_patterns() {
-		require __DIR__ . '/course-list/class-sensei-course-list-block-patterns.php';
 		( new Sensei_Course_List_Block_Patterns() )->register_course_list_block_patterns();
 	}
 

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -150,6 +150,13 @@ abstract class Sensei_Usage_Tracking_Base {
 		// Init instance vars.
 		$this->job_name = $this->get_prefix() . '_usage_tracking_send_usage_data';
 
+		add_action( 'init', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Initialize.
+	 */
+	public function init() {
 		// Set up schedule and action needed for cron job.
 		add_filter( 'cron_schedules', array( $this, 'add_usage_tracking_two_week_schedule' ) );
 		add_action( $this->job_name, array( $this, 'send_usage_data' ) );
@@ -214,7 +221,6 @@ abstract class Sensei_Usage_Tracking_Base {
 		$properties['_ul'] = $user->user_login;
 
 		return $this->send_tracks_request( $event, $properties, $event_timestamp );
-
 	}
 
 
@@ -288,9 +294,14 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * and schedule the job, before the user opts into tracking.
 	 */
 	public function schedule_tracking_task() {
-		if ( ! wp_next_scheduled( $this->job_name ) ) {
-			wp_schedule_event( time(), $this->get_prefix() . '_usage_tracking_two_weeks', $this->job_name );
-		}
+		add_action(
+			'init',
+			function () {
+				if ( ! wp_next_scheduled( $this->job_name ) ) {
+					wp_schedule_event( time(), $this->get_prefix() . '_usage_tracking_two_weeks', $this->job_name );
+				}
+			}
+		);
 	}
 
 	/**

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -56,11 +56,13 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 		// Should successfully schedule the task
 		$this->assertFalse( wp_get_schedule( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' ), 'Not scheduled initial' );
 		$this->usage_tracking->schedule_tracking_task();
+		do_action( 'init' );
 		$this->assertNotFalse( wp_get_schedule( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' ), 'Schedules a job' );
 		$this->assertEquals( 1, $this->event_counts['schedule_event'], 'Schedules only one job' );
 
 		// Should not duplicate when called again
 		$this->usage_tracking->schedule_tracking_task();
+		do_action( 'init' );
 		$this->assertEquals( 1, $this->event_counts['schedule_event'], 'Does not schedule an additional job' );
 	}
 

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -39,6 +39,10 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 	 * Ensure cron job action is set up.
 	 */
 	public function testCronJobActionAdded() {
+		/* Arrange */
+		do_action( 'init' );
+
+		/* Assert */
 		$this->assertTrue( ! ! has_action( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data', array( $this->usage_tracking, 'send_usage_data' ) ) );
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/sensei/pull/7701 and https://github.com/Automattic/sensei/issues/7770

## Proposed Changes
* Fixes an "early translation" PHP notice when the `sensei_usage_tracking_send_usage_data` cron schedule is added. The error is also visible when activating Sensei Pro for the first time. The issue is solved by moving the cron schedule initialization to the `init` hook, which is a somewhat standard practice. As a side effect, this approach also forces the `wp_schedule_event` to be called on `init` as well.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On WordPress 6.8 the deprecation notice can be seen even when the language is English. For ease of testing, the testing instructions target this version.

1. Install the WordPress Beta Tester plugin.
2. In Tools > Beta Testing, select Bleeding Edge and Beta/RC Only.
3. Update to WordPress 6.8-beta3.
4. Install the WP Crontrol plugin.
5. Go to Tools -> Cron Events.
6. To re-create the job, find the `sensei_usage_tracking_send_usage_data` cron and delete it.
7. There should be no PHP notice generated, i.e. no `PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly`.
8. Refresh the page and make sure the `sensei_usage_tracking_send_usage_data` job is re-created.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] Code is tested on the minimum supported PHP and WordPress versions
