### PR TITLE
Fix plugin configure link pointing to a non-existing settings tab

### DIFF
--- a/changelog/fix-settings-link
+++ b/changelog/fix-settings-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix plugin configure link pointing to the wrong settings URL

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1765,7 +1765,7 @@ class Sensei_Main {
 	 * @return string plugin settings URL
 	 */
 	public function get_settings_url( $plugin_id = null ) {
-		return admin_url( 'admin.php?page=sensei-settings&tab=general' );
+		return admin_url( 'admin.php?page=sensei-settings' );
 	}
 
 	/**
@@ -1806,7 +1806,7 @@ class Sensei_Main {
 	 */
 	public function is_general_configuration_page() {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,
-		return isset( $_GET['page'] ) && 'sensei-settings' === trim( $_GET['page'] ) && ( ! isset( $_GET['tab'] ) || 'general' === trim( $_GET['tab'] ) );
+		return isset( $_GET['page'] ) && 'sensei-settings' === trim( $_GET['page'] ) && ( ! isset( $_GET['tab'] ) || 'default-settings' === trim( $_GET['tab'] ) );
 	}
 
 		/**
@@ -1815,7 +1815,7 @@ class Sensei_Main {
 		 * @return string admin configuration url for the admin general configuration page
 		 */
 	public function get_general_configuration_url() {
-		return admin_url( 'admin.php?page=sensei-settings&tab=general' );
+		return admin_url( 'admin.php?page=sensei-settings&tab=default-settings' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes
* Fixes the "Configure" link pointing to a non-existing settings tab.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the installed plugins list and find Sensei LMS.
2. Click the "Configure" link
3. You should be redirected to "/admin.php?page=sensei-settings" and see all the settings from the "General" tab.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] Code is tested on the minimum supported PHP and WordPress versions
