### PR TITLE
Course: Fix focus issue on lesson/module add to inner blocks

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline-appender.js
+++ b/assets/blocks/course-outline/outline-block/outline-appender.js
@@ -44,11 +44,10 @@ const OutlineAppender = ( { clientId, openModal } ) => {
 		{
 			title: __( 'Lesson', 'sensei-lms' ),
 			icon: LessonIcon,
-			onClick: () => {
+			onClick: () =>
 				insertAndSelectBlock( 'sensei-lms/course-outline-lesson', {
 					placeholder: __( 'Lesson name', 'sensei-lms' ),
-				} );
-			},
+				} ),
 		},
 		{
 			title: __( 'Existing Lesson(s)', 'sensei-lms' ),

--- a/assets/blocks/course-outline/outline-block/outline-appender.js
+++ b/assets/blocks/course-outline/outline-block/outline-appender.js
@@ -3,6 +3,7 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -20,25 +21,34 @@ import TextAppender from '../../../shared/components/text-appender';
  * @param {Function} props.openModal Open modal callback.
  */
 const OutlineAppender = ( { clientId, openModal } ) => {
-	const { insertBlock } = useDispatch( 'core/block-editor' );
+	const { insertBlock, selectBlock } = useDispatch( 'core/block-editor' );
 	const internalBlockCount = useSelect(
 		( select ) => select( 'core/block-editor' ).getBlockCount( clientId ),
 		[]
+	);
+
+	const insertAndSelectBlock = useCallback(
+		( blockName, attributes = {} ) => {
+			const newBlock = createBlock( blockName, attributes );
+			insertBlock(
+				newBlock,
+				internalBlockCount,
+				clientId,
+				true
+			).then( () => selectBlock( newBlock.clientId ) );
+		},
+		[ insertBlock, selectBlock, internalBlockCount, clientId ]
 	);
 
 	const controls = [
 		{
 			title: __( 'Lesson', 'sensei-lms' ),
 			icon: LessonIcon,
-			onClick: () =>
-				insertBlock(
-					createBlock( 'sensei-lms/course-outline-lesson', {
-						placeholder: __( 'Lesson name', 'sensei-lms' ),
-					} ),
-					internalBlockCount,
-					clientId,
-					true
-				),
+			onClick: () => {
+				insertAndSelectBlock( 'sensei-lms/course-outline-lesson', {
+					placeholder: __( 'Lesson name', 'sensei-lms' ),
+				} );
+			},
 		},
 		{
 			title: __( 'Existing Lesson(s)', 'sensei-lms' ),
@@ -49,12 +59,7 @@ const OutlineAppender = ( { clientId, openModal } ) => {
 			title: __( 'Module', 'sensei-lms' ),
 			icon: ModuleIcon,
 			onClick: () =>
-				insertBlock(
-					createBlock( 'sensei-lms/course-outline-module' ),
-					internalBlockCount,
-					clientId,
-					true
-				),
+				insertAndSelectBlock( 'sensei-lms/course-outline-module' ),
 		},
 	];
 

--- a/changelog/fix-focus-on-added-lesson
+++ b/changelog/fix-focus-on-added-lesson
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Course outline: Fix focus issue on lesson/module add to inner blocks


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7759

## Proposed Changes
* Fix focus issue on lesson/module add to inner blocks

## Testing Instructions

1. Go to the editor
2. Select "Course Outline" block
3. Click on "Add Module or Lesson" button
4. Select "Lesson" or "Module"
5. Check if the newly inserted block is in focus

![Screen Capture on 2025-03-24 at 19-43-54](https://github.com/user-attachments/assets/05f7027d-0f38-4220-8d77-5bad11b72e5a)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
