### PR TITLE
Allow editing title on Course Archive page

### DIFF
--- a/changelog/fix-show-template-title-on-course-archive
+++ b/changelog/fix-show-template-title-on-course-archive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow editing course archive page title from the block editor

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3486,16 +3486,16 @@ class Sensei_Course {
 			global $wp_query;
 			$taxonomy = $wp_query->get_queried_object();
 			$tax_obj  = get_taxonomy( $taxonomy->taxonomy );
-			
+
 			// translators: Placeholders are the taxonomy name and the term name, respectively.
-			$title = sprintf( 
-				__( '%1$s Archives: %2$s', 'sensei-lms' ), 
-				$tax_obj->labels->name, 
-				$taxonomy->name 
+			$title = sprintf(
+				__( '%1$s Archives: %2$s', 'sensei-lms' ),
+				$tax_obj->labels->name,
+				$taxonomy->name
 			);
-			
-			echo wp_kses_post( 
-				apply_filters( 'course_category_archive_title', $before_html . $title . $after_html ) 
+
+			echo wp_kses_post(
+				apply_filters( 'course_category_archive_title', $before_html . $title . $after_html )
 			);
 			return;
 		}
@@ -3511,13 +3511,13 @@ class Sensei_Course {
 
 		if ( Sensei()->course->course_archive_page_has_query_block() ) {
 			$archive_page_title = get_post( Sensei()->settings->get( 'course_page' ) )->post_title;
-			$default_title = 'Courses' === $archive_page_title ? $default_title : $archive_page_title;
+			$default_title      = 'Courses' === $archive_page_title ? $default_title : $archive_page_title;
 		}
 
 		$title = $titles[ $query_type ] ?? $default_title;
-		
-		echo wp_kses_post( 
-			apply_filters( 'course_archive_title', $before_html . $title . $after_html ) 
+
+		echo wp_kses_post(
+			apply_filters( 'course_archive_title', $before_html . $title . $after_html )
 		);
 	}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3473,60 +3473,53 @@ class Sensei_Course {
 	 * @return void
 	 */
 	public static function archive_header( $query_type = '', $before_html = '', $after_html = '' ) {
-
 		if ( ! is_post_type_archive( 'course' ) ) {
 			return;
 		}
 
-		$html = '';
+		// Set default HTML wrappers if not provided.
+		$before_html = empty( $before_html ) ? '<header class="archive-header"><h1>' : $before_html;
+		$after_html  = empty( $after_html ) ? '</h1></header>' : $after_html;
 
-		if ( empty( $before_html ) ) {
-
-			$before_html = '<header class="archive-header"><h1>';
-
-		}
-
-		if ( empty( $after_html ) ) {
-
-			$after_html = '</h1></header>';
-
-		}
-
+		// Handle course category archives.
 		if ( is_tax( 'course-category' ) ) {
-
 			global $wp_query;
-
-			$taxonomy_obj        = $wp_query->get_queried_object();
-			$taxonomy_short_name = $taxonomy_obj->taxonomy;
-			$taxonomy_raw_obj    = get_taxonomy( $taxonomy_short_name );
+			$taxonomy = $wp_query->get_queried_object();
+			$tax_obj  = get_taxonomy( $taxonomy->taxonomy );
+			
 			// translators: Placeholders are the taxonomy name and the term name, respectively.
-			$title = sprintf( __( '%1$s Archives: %2$s', 'sensei-lms' ), $taxonomy_raw_obj->labels->name, $taxonomy_obj->name );
-			echo wp_kses_post( apply_filters( 'course_category_archive_title', $before_html . $title . $after_html ) );
+			$title = sprintf( 
+				__( '%1$s Archives: %2$s', 'sensei-lms' ), 
+				$tax_obj->labels->name, 
+				$taxonomy->name 
+			);
+			
+			echo wp_kses_post( 
+				apply_filters( 'course_category_archive_title', $before_html . $title . $after_html ) 
+			);
 			return;
-
 		}
 
-		switch ( $query_type ) {
-			case 'newcourses':
-				$html .= $before_html . __( 'New Courses', 'sensei-lms' ) . $after_html;
-				break;
-			case 'featuredcourses':
-				$html .= $before_html . __( 'Featured Courses', 'sensei-lms' ) . $after_html;
-				break;
-			case 'freecourses':
-				$html .= $before_html . __( 'Free Courses', 'sensei-lms' ) . $after_html;
-				break;
-			case 'paidcourses':
-				$html .= $before_html . __( 'Paid Courses', 'sensei-lms' ) . $after_html;
-				break;
-			default:
-				$html .= $before_html . __( 'Courses', 'sensei-lms' ) . $after_html;
-				break;
+		$titles = [
+			'newcourses'      => __( 'New Courses', 'sensei-lms' ),
+			'featuredcourses' => __( 'Featured Courses', 'sensei-lms' ),
+			'freecourses'     => __( 'Free Courses', 'sensei-lms' ),
+			'paidcourses'     => __( 'Paid Courses', 'sensei-lms' ),
+		];
+
+		$default_title = __( 'Courses', 'sensei-lms' );
+
+		if ( Sensei()->course->course_archive_page_has_query_block() ) {
+			$archive_page_title = get_post( Sensei()->settings->get( 'course_page' ) )->post_title;
+			$default_title = 'Courses' === $archive_page_title ? $default_title : $archive_page_title;
 		}
 
-		echo wp_kses_post( apply_filters( 'course_archive_title', $html ) );
+		$title = $titles[ $query_type ] ?? $default_title;
+		
+		echo wp_kses_post( 
+			apply_filters( 'course_archive_title', $before_html . $title . $after_html ) 
+		);
 	}
-
 
 	/**
 	 * Filter the single course content taking into account if the user has access.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3487,11 +3487,12 @@ class Sensei_Course {
 			$taxonomy = $wp_query->get_queried_object();
 			$tax_obj  = get_taxonomy( $taxonomy->taxonomy );
 
-			$title = sprintf(
-				__( '%1$s Archives: %2$s', 'sensei-lms' ), // translators: Placeholders are the taxonomy name and the term name, respectively.
+			$title = $tax_obj ? sprintf(
+				// translators: Placeholders are the taxonomy name and the term name, respectively.
+				__( '%1$s Archives: %2$s', 'sensei-lms' ),
 				$tax_obj->labels->name,
 				$taxonomy->name
-			);
+			) : '';
 
 			echo wp_kses_post(
 				apply_filters( 'course_category_archive_title', $before_html . $title . $after_html )

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3487,9 +3487,8 @@ class Sensei_Course {
 			$taxonomy = $wp_query->get_queried_object();
 			$tax_obj  = get_taxonomy( $taxonomy->taxonomy );
 
-			// translators: Placeholders are the taxonomy name and the term name, respectively.
 			$title = sprintf(
-				__( '%1$s Archives: %2$s', 'sensei-lms' ),
+				__( '%1$s Archives: %2$s', 'sensei-lms' ), // translators: Placeholders are the taxonomy name and the term name, respectively.
 				$tax_obj->labels->name,
 				$taxonomy->name
 			);

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -54,7 +54,6 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( isset( Sensei()->course ), 'Sensei Course class is not loaded' );
-
 	}
 
 	/**
@@ -80,7 +79,6 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			count( WooThemes_Sensei_Course::get_all_courses() ),
 			'The number of course returned is not equal to what is actually available'
 		);
-
 	}
 
 	/**
@@ -132,7 +130,6 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		// does it return all lessons
 		$this->assertEquals( count( $test_lessons ), count( Sensei()->course->get_completed_lesson_ids( $test_course_id, $test_user_id ) ), 'Course completed lesson count not accurate' );
-
 	}
 
 	/**
@@ -182,7 +179,6 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		}
 		// all lessons should no be completed
 		$this->assertEquals( 100, Sensei()->course->get_completion_percentage( $test_course_id, $test_user_id ), 'Course completed percentage is not accurate' );
-
 	}
 
 	/**
@@ -822,12 +818,12 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	public function testArchiveHeader_WhenNotCourseArchive_DoesNotOutput() {
 		// Arrange.
 		$this->go_to( '/' ); // Go to home page.
-		
+
 		// Act.
 		ob_start();
 		Sensei_Course::archive_header();
 		$output = ob_get_clean();
-		
+
 		// Assert.
 		$this->assertEmpty( $output );
 	}
@@ -840,16 +836,16 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	public function testArchiveHeader_OnCourseArchive_OutputsDefaultHeader() {
 		// Arrange.
 		$this->go_to( '/?post_type=course' );
-		
+
 		// Mock is_post_type_archive to return true.
 		global $wp_query;
 		$wp_query->is_post_type_archive = true;
-		
+
 		// Act.
 		ob_start();
 		Sensei_Course::archive_header();
 		$output = ob_get_clean();
-		
+
 		// Assert.
 		$this->assertStringContainsString( '<header class="archive-header"><h1>', $output );
 		$this->assertStringContainsString( '</h1></header>', $output );
@@ -863,16 +859,16 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	public function testArchiveHeader_WithCustomWrappers_OutputsCustomHeader() {
 		// Arrange.
 		$this->go_to( '/?post_type=course' );
-		
+
 		// Mock is_post_type_archive to return true.
 		global $wp_query;
 		$wp_query->is_post_type_archive = true;
-		
+
 		// Act.
 		ob_start();
 		Sensei_Course::archive_header( '', '<div class="custom">', '</div>' );
 		$output = ob_get_clean();
-		
+
 		// Assert.
 		$this->assertStringContainsString( '<div class="custom">', $output );
 		$this->assertStringContainsString( '</div>', $output );
@@ -886,12 +882,16 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	public function testArchiveHeader_OnCourseCategoryArchive_OutputsCategoryHeader() {
 		// Arrange.
 		// Register the taxonomy with proper labels.
-		register_taxonomy( 'course-category', 'course', array(
-			'labels' => array(
-				'name' => 'Course Categories'
+		register_taxonomy(
+			'course-category',
+			'course',
+			array(
+				'labels' => array(
+					'name' => 'Course Categories',
+				),
 			)
-		));
-		
+		);
+
 		// Create a test category.
 		$term = wp_insert_term( 'Test Category', 'course-category' );
 		if ( is_wp_error( $term ) ) {
@@ -899,25 +899,30 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		}
 
 		$term_obj = get_term( $term['term_id'], 'course-category' );
-		
+
 		// Set up the WordPress query environment.
 		global $wp_query;
-		$wp_query = new WP_Query();
-		$wp_query->is_tax = true;
-		$wp_query->is_archive = true;
+		$wp_query                       = new WP_Query();
+		$wp_query->is_tax               = true;
+		$wp_query->is_archive           = true;
 		$wp_query->is_post_type_archive = true;
-		$wp_query->set('post_type', 'course');
-		$wp_query->queried_object = $term_obj;
+		$wp_query->set( 'post_type', 'course' );
+		$wp_query->queried_object    = $term_obj;
 		$wp_query->queried_object_id = $term_obj->term_id;
-		
+
 		// Mock is_tax() to return true for course-category.
-		add_filter( 'is_tax', function( $is_tax, $taxonomy = '' ) {
-			if ( $taxonomy === 'course-category' ) {
-				return true;
-			}
-			return $is_tax;
-		}, 10, 2 );
-		
+		add_filter(
+			'is_tax',
+			function ( $is_tax, $taxonomy = '' ) {
+				if ( $taxonomy === 'course-category' ) {
+					return true;
+				}
+				return $is_tax;
+			},
+			10,
+			2
+		);
+
 		// Act.
 		ob_start();
 		Sensei_Course::archive_header();
@@ -925,7 +930,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		// Assert.
 		$this->assertStringContainsString( 'Course Categories Archives: Test Category', $output );
-		
+
 		// Cleanup.
 		remove_all_filters( 'is_tax' );
 	}

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -914,7 +914,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		add_filter(
 			'is_tax',
 			function ( $is_tax, $taxonomy = '' ) {
-				if ( $taxonomy === 'course-category' ) {
+				if ( 'course-category' === $taxonomy ) {
 					return true;
 				}
 				return $is_tax;

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -813,4 +813,120 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			->method( 'add_notice' );
 		Sensei_Course::self_enrollment_not_allowed_message();
 	}
+
+	/**
+	 * Test archive header is not output when not on course archive.
+	 *
+	 * @covers Sensei_Course::archive_header
+	 */
+	public function testArchiveHeader_WhenNotCourseArchive_DoesNotOutput() {
+		// Arrange.
+		$this->go_to( '/' ); // Go to home page.
+		
+		// Act.
+		ob_start();
+		Sensei_Course::archive_header();
+		$output = ob_get_clean();
+		
+		// Assert.
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test archive header with default wrappers.
+	 *
+	 * @covers Sensei_Course::archive_header
+	 */
+	public function testArchiveHeader_OnCourseArchive_OutputsDefaultHeader() {
+		// Arrange.
+		$this->go_to( '/?post_type=course' );
+		
+		// Mock is_post_type_archive to return true.
+		global $wp_query;
+		$wp_query->is_post_type_archive = true;
+		
+		// Act.
+		ob_start();
+		Sensei_Course::archive_header();
+		$output = ob_get_clean();
+		
+		// Assert.
+		$this->assertStringContainsString( '<header class="archive-header"><h1>', $output );
+		$this->assertStringContainsString( '</h1></header>', $output );
+	}
+
+	/**
+	 * Test archive header with custom wrappers.
+	 *
+	 * @covers Sensei_Course::archive_header
+	 */
+	public function testArchiveHeader_WithCustomWrappers_OutputsCustomHeader() {
+		// Arrange.
+		$this->go_to( '/?post_type=course' );
+		
+		// Mock is_post_type_archive to return true.
+		global $wp_query;
+		$wp_query->is_post_type_archive = true;
+		
+		// Act.
+		ob_start();
+		Sensei_Course::archive_header( '', '<div class="custom">', '</div>' );
+		$output = ob_get_clean();
+		
+		// Assert.
+		$this->assertStringContainsString( '<div class="custom">', $output );
+		$this->assertStringContainsString( '</div>', $output );
+	}
+
+	/**
+	 * Test archive header for course category.
+	 *
+	 * @covers Sensei_Course::archive_header
+	 */
+	public function testArchiveHeader_OnCourseCategoryArchive_OutputsCategoryHeader() {
+		// Arrange.
+		// Register the taxonomy with proper labels.
+		register_taxonomy( 'course-category', 'course', array(
+			'labels' => array(
+				'name' => 'Course Categories'
+			)
+		));
+		
+		// Create a test category.
+		$term = wp_insert_term( 'Test Category', 'course-category' );
+		if ( is_wp_error( $term ) ) {
+			$this->fail( 'Failed to create test category: ' . $term->get_error_message() );
+		}
+
+		$term_obj = get_term( $term['term_id'], 'course-category' );
+		
+		// Set up the WordPress query environment.
+		global $wp_query;
+		$wp_query = new WP_Query();
+		$wp_query->is_tax = true;
+		$wp_query->is_archive = true;
+		$wp_query->is_post_type_archive = true;
+		$wp_query->set('post_type', 'course');
+		$wp_query->queried_object = $term_obj;
+		$wp_query->queried_object_id = $term_obj->term_id;
+		
+		// Mock is_tax() to return true for course-category.
+		add_filter( 'is_tax', function( $is_tax, $taxonomy = '' ) {
+			if ( $taxonomy === 'course-category' ) {
+				return true;
+			}
+			return $is_tax;
+		}, 10, 2 );
+		
+		// Act.
+		ob_start();
+		Sensei_Course::archive_header();
+		$output = ob_get_clean();
+
+		// Assert.
+		$this->assertStringContainsString( 'Course Categories Archives: Test Category', $output );
+		
+		// Cleanup.
+		remove_all_filters( 'is_tax' );
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7682

## Proposed Changes
* Show the title from the archive page instead of showing a hardcoded title

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei LMS -> Settings (General) and check which page is selected as the Courses archive page
2. Open that page and make sure there is Course List block in that page
3. Edit the title
4. Now open your course archive pages (siteurl.local/courses-overview)
5. Make sure you see the edited title
6. Try the filters and make sure you still see the same edited title
7. Now remove the Course List block from the archive page. We are doing it so that the forced archive page template takes over
8. Now open the archive page from the frontend again
9. Make sure the title is the hardcoded one this time
10. Try the filters and make sure you see the different hardcoded filters there for different filters instead of the edited one.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
