### PR TITLE
Workflow: Update PR milestone validation supporting task re-run

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,7 +9,15 @@ jobs:
     name: Check Milestone
     runs-on: ubuntu-latest
     steps:
-      - if: github.event.pull_request.milestone == null
+      - name: Check PR milestone
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "This PR is missing a milestone."
-          exit 1
+          PR_DATA=$(gh api /repos/$REPO/pulls/$PR_NUMBER)
+          MILESTONE=$(echo $PR_DATA | jq -r '.milestone')
+          if [ "$MILESTONE" = "null" ]; then
+            echo "This PR is missing a milestone."
+            exit 1
+          fi

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,9 +2,7 @@ name: Pull Request Validation
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
-  pull_request_target:
-    types: [milestoned, demilestoned]
+    types: [opened, reopened, synchronize, edited]
 
 jobs:
   check-milestone:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,6 +3,8 @@ name: Pull Request Validation
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [milestoned, demilestoned]
 
 jobs:
   check-milestone:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,7 @@ name: Pull Request Validation
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize, milestoned, demilestoned]
 
 jobs:
   check-milestone:

--- a/changelog/update-pr-milestone-validation
+++ b/changelog/update-pr-milestone-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Workflow: Update PR milestone validation supporting task re-run


### PR DESCRIPTION
## Proposed Changes

* Workflow: Update PR milestone validation supporting task re-run

## Testing Instructions

Recently, I was working on the PR and didn't select the PR milestone. The workflow task failed, which is OK, but after the re-run, it didn't pass, and the only solution for me was to close and then open the PR. This PR fixes this case.

- Clear the milestone field
- Check if the "Check milestone" is re-run and failed
- Set the milestone
- Check if the "Check milestone" is re-run and passed

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
