### PR TITLE
Fix template blocks inconsistency (sometimes not available)

### DIFF
--- a/assets/course-theme/blocks/register-template-blocks.js
+++ b/assets/course-theme/blocks/register-template-blocks.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
-import { select, subscribe } from '@wordpress/data';
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Makes sure the template blocks are only registered when in the site or widget editor, or editing the template from
@@ -11,31 +10,8 @@ import { select, subscribe } from '@wordpress/data';
  * @param {Array} blocks
  */
 export function registerTemplateBlocks( blocks ) {
-	let themeBlocksEnabled = false;
-
-	const toggleBlockRegistration = ( enable ) => {
-		if ( enable === themeBlocksEnabled ) {
-			return;
-		}
-		themeBlocksEnabled = enable;
-		const method = enable ? registerBlockType : unregisterBlockType;
-		blocks.forEach( ( block ) => {
-			const { name, ...settings } = block;
-			method( name, settings );
-		} );
-	};
-
-	toggleBlockRegistration( true );
-
-	// TODO Only subscribe when in the post editor.
-	subscribe( () => {
-		const postType = select( 'core/editor' )?.getCurrentPostType();
-		const editPost = select( 'core/edit-post' );
-
-		if ( ! postType || ! editPost || 'wp_template' === postType ) {
-			return;
-		}
-
-		toggleBlockRegistration( false );
+	blocks.forEach( ( block ) => {
+		const { name, ...settings } = block;
+		registerBlockType( name, settings );
 	} );
 }

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -33,7 +33,6 @@ class Sensei_Course_Theme_Editor {
 	 * Sensei_Course_Theme constructor. Prevents other instances from being created outside of `self::instance()`.
 	 */
 	private function __construct() {
-
 	}
 
 	/**
@@ -59,7 +58,6 @@ class Sensei_Course_Theme_Editor {
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_site_editor_assets' ] );
 
 		add_action( 'admin_menu', [ $this, 'add_admin_menu_site_editor_item' ], 20 );
-
 	}
 
 	/**
@@ -79,7 +77,6 @@ class Sensei_Course_Theme_Editor {
 			'edit_theme_options',
 			'site-editor.php?postType=wp_template'
 		);
-
 	}
 
 	/**
@@ -104,7 +101,6 @@ class Sensei_Course_Theme_Editor {
 				Sensei_Course_Theme::instance()->override_theme();
 			}
 		}
-
 	}
 
 	/**
@@ -210,7 +206,7 @@ class Sensei_Course_Theme_Editor {
 	 */
 	public function enqueue_site_editor_assets() {
 
-		if ( $this->lesson_has_learning_mode() || $this->is_site_editor() ) {
+		if ( $this->is_site_editor() ) {
 			Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-blocks', 'course-theme/blocks/index.js', [ 'sensei-shared-blocks' ] );
 			Sensei()->assets->enqueue_style( 'sensei-shared-blocks-editor-style' );
 			Sensei()->assets->enqueue_style( 'sensei-learning-mode-editor' );
@@ -219,7 +215,6 @@ class Sensei_Course_Theme_Editor {
 			Sensei_Course_Theme::instance()->enqueue_fonts();
 
 			Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-editor', 'course-theme/course-theme.editor.js' );
-
 		}
 	}
 
@@ -266,5 +261,4 @@ class Sensei_Course_Theme_Editor {
 
 		return ! empty( $screen ) && in_array( $screen->id, [ 'widgets', 'site-editor', 'customize', 'appearance_page_gutenberg-edit-site' ], true );
 	}
-
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/7785

## Proposed Changes

This PR is reverting https://github.com/Automattic/sensei/pull/5723, and registering the template blocks only when the user is in the site editor.

The reason is that the unregistration causes some inconsistencies, like this one: p1742918898801929-slack-C07418EJ0. I remember seeing other reports in the past related to template blocks being broken on the site editor, but I couldn't find it now.

And the current solution wasn't working in the latest versions of WordPress (6.5+ that we support currently) anyway. See https://github.com/Automattic/sensei/issues/7792.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to WP Admin > Appearance > Editor.
2. Edit the Learning Mode templates.
3. Make sure they are working properly.
4. Now edit a lesson, and make sure the template blocks are not available (Example: Course Navigation).

Notice that the inconsistency issue that it fixes is complex to reproduce, and I couldn't reproduce it in my environment.

### Known issue

https://github.com/Automattic/sensei/issues/7792

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] Code is tested on the minimum supported PHP and WordPress versions