### PR TITLE
Fix required quiz score texts

### DIFF
--- a/changelog/fix-required-quiz-score-text
+++ b/changelog/fix-required-quiz-score-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix required quiz score texts

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1176,7 +1176,7 @@ class Sensei_Utils {
 					$status    = 'failed';
 					$box_class = 'alert';
 
-					if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ) ) ) {
+					if ( sensei_has_translation_or_is_english( 'You must score at least %1$d%% to pass this course. Your grade is %2$s%%.' ) ) {
 						// translators: Placeholders are the required grade and the actual grade, respectively.
 						$message = sprintf( __( 'You must score at least %1$d%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ), $passmark, $user_grade );
 					} else {
@@ -1334,7 +1334,7 @@ class Sensei_Utils {
 						// translators: Placeholders are an opening and closing <a> tag linking to the quiz permalink.
 						$message = sprintf( __( 'You have completed this lesson\'s quiz and it will be graded soon. %1$sView the lesson quiz%2$s', 'sensei-lms' ), '<a href="' . esc_url( get_permalink( $quiz_id ) ) . '" title="' . esc_attr( get_the_title( $quiz_id ) ) . '">', '</a>' );
 					} else { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found -- Keep nested to be easier to remove later.
-						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You have completed this quiz and it will be graded soon. You must score at least %1$s%% to pass.', 'sensei-lms' ) ) ) {
+						if ( sensei_has_translation_or_is_english( 'You have completed this quiz and it will be graded soon. You must score at least %1$s%% to pass.' ) ) {
 							// translators: Placeholder is the quiz passmark.
 							$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You must score at least %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 						} else {
@@ -1348,7 +1348,7 @@ class Sensei_Utils {
 					$status    = 'failed';
 					$box_class = 'alert';
 					if ( $is_lesson ) {
-						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ) ) ) {
+						if ( sensei_has_translation_or_is_english( 'You must score at least %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%' ) ) {
 							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
 							$message = sprintf( __( 'You must score at least %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
 						} else {
@@ -1356,7 +1356,7 @@ class Sensei_Utils {
 							$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
 						}
 					} else { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found -- Keep nested to be easier to remove later.
-						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ) ) ) {
+						if ( sensei_has_translation_or_is_english( 'You must score at least %1$d%% to pass this quiz. Your grade is %2$s%%' ) ) {
 							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
 							$message = sprintf( __( 'You must score at least %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
 						} else {
@@ -1373,7 +1373,7 @@ class Sensei_Utils {
 					if ( ! Sensei_Lesson::is_prerequisite_complete( $lesson_id, get_current_user_id() ) ) {
 						$message = '';
 					} elseif ( $is_lesson ) {
-						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ) ) ) {
+						if ( sensei_has_translation_or_is_english( 'You must score at least %1$d%% to pass this lesson\'s quiz.' ) ) {
 							// translators: Placeholder is the quiz passmark.
 							$message = sprintf( __( 'You must score at least %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 						} else {
@@ -1381,7 +1381,7 @@ class Sensei_Utils {
 							$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 						}
 					} else { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found -- Keep nested to be easier to remove later.
-						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this quiz.', 'sensei-lms' ) ) ) {
+						if ( sensei_has_translation_or_is_english( 'You must score at least %1$d%% to pass this quiz.' ) ) {
 							// translators: Placeholder is the quiz passmark.
 							$message = sprintf( __( 'You must score at least %1$d%% to pass this quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 						} else {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1183,7 +1183,6 @@ class Sensei_Utils {
 						// translators: Placeholders are the required grade and the actual grade, respectively.
 						$message = sprintf( __( 'You require %1$d%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ), $passmark, $user_grade );
 					}
-
 				}
 			}
 		}
@@ -1334,7 +1333,7 @@ class Sensei_Utils {
 					if ( $is_lesson ) {
 						// translators: Placeholders are an opening and closing <a> tag linking to the quiz permalink.
 						$message = sprintf( __( 'You have completed this lesson\'s quiz and it will be graded soon. %1$sView the lesson quiz%2$s', 'sensei-lms' ), '<a href="' . esc_url( get_permalink( $quiz_id ) ) . '" title="' . esc_attr( get_the_title( $quiz_id ) ) . '">', '</a>' );
-					} else {
+					} else { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found -- Keep nested to be easier to remove later.
 						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You have completed this quiz and it will be graded soon. You must score at least %1$s%% to pass.', 'sensei-lms' ) ) ) {
 							// translators: Placeholder is the quiz passmark.
 							$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You must score at least %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
@@ -1356,7 +1355,7 @@ class Sensei_Utils {
 							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
 							$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
 						}
-					} else {
+					} else { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found -- Keep nested to be easier to remove later.
 						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ) ) ) {
 							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
 							$message = sprintf( __( 'You must score at least %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
@@ -1381,7 +1380,7 @@ class Sensei_Utils {
 							// translators: Placeholder is the quiz passmark.
 							$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 						}
-					} else {
+					} else { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found -- Keep nested to be easier to remove later.
 						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this quiz.', 'sensei-lms' ) ) ) {
 							// translators: Placeholder is the quiz passmark.
 							$message = sprintf( __( 'You must score at least %1$d%% to pass this quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1175,8 +1175,15 @@ class Sensei_Utils {
 				} else {
 					$status    = 'failed';
 					$box_class = 'alert';
-					// translators: Placeholders are the required grade and the actual grade, respectively.
-					$message = sprintf( __( 'You require %1$d%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ), $passmark, $user_grade );
+
+					if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ) ) ) {
+						// translators: Placeholders are the required grade and the actual grade, respectively.
+						$message = sprintf( __( 'You must score at least %1$d%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ), $passmark, $user_grade );
+					} else {
+						// translators: Placeholders are the required grade and the actual grade, respectively.
+						$message = sprintf( __( 'You require %1$d%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ), $passmark, $user_grade );
+					}
+
 				}
 			}
 		}
@@ -1328,8 +1335,13 @@ class Sensei_Utils {
 						// translators: Placeholders are an opening and closing <a> tag linking to the quiz permalink.
 						$message = sprintf( __( 'You have completed this lesson\'s quiz and it will be graded soon. %1$sView the lesson quiz%2$s', 'sensei-lms' ), '<a href="' . esc_url( get_permalink( $quiz_id ) ) . '" title="' . esc_attr( get_the_title( $quiz_id ) ) . '">', '</a>' );
 					} else {
-						// translators: Placeholder is the quiz passmark.
-						$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You require %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You have completed this quiz and it will be graded soon. You must score at least %1$s%% to pass.', 'sensei-lms' ) ) ) {
+							// translators: Placeholder is the quiz passmark.
+							$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You must score at least %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						} else {
+							// translators: Placeholder is the quiz passmark.
+							$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You require %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						}
 					}
 
 					// Lesson status must be "failed".
@@ -1337,11 +1349,21 @@ class Sensei_Utils {
 					$status    = 'failed';
 					$box_class = 'alert';
 					if ( $is_lesson ) {
-						// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
-						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
+						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ) ) ) {
+							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
+							$message = sprintf( __( 'You must score at least %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
+						} else {
+							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
+							$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
+						}
 					} else {
-						// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
-						$message = sprintf( __( 'You require %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
+						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ) ) ) {
+							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
+							$message = sprintf( __( 'You must score at least %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
+						} else {
+							// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
+							$message = sprintf( __( 'You require %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
+						}
 					}
 
 					// Lesson/Quiz requires a pass.
@@ -1352,11 +1374,21 @@ class Sensei_Utils {
 					if ( ! Sensei_Lesson::is_prerequisite_complete( $lesson_id, get_current_user_id() ) ) {
 						$message = '';
 					} elseif ( $is_lesson ) {
-						// translators: Placeholder is the quiz passmark.
-						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ) ) ) {
+							// translators: Placeholder is the quiz passmark.
+							$message = sprintf( __( 'You must score at least %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						} else {
+							// translators: Placeholder is the quiz passmark.
+							$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						}
 					} else {
-						// translators: Placeholder is the quiz passmark.
-						$message = sprintf( __( 'You require %1$d%% to pass this quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$d%% to pass this quiz.', 'sensei-lms' ) ) ) {
+							// translators: Placeholder is the quiz passmark.
+							$message = sprintf( __( 'You must score at least %1$d%% to pass this quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						} else {
+							// translators: Placeholder is the quiz passmark.
+							$message = sprintf( __( 'You require %1$d%% to pass this quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
+						}
 					}
 				}
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1238,7 +1238,7 @@ class Sensei_Utils {
 
 			// Quiz grade.
 			$submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
-			$quiz_grade = $submission ? $submission->get_final_grade() : 0;
+			$quiz_grade = ( $submission ? $submission->get_final_grade() : 0 ) ?? 0;
 
 			// Quiz passmark.
 			$quiz_passmark = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ) );

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -123,7 +123,7 @@ class Sensei_Course_Theme_Lesson {
 		if ( 'ungraded' === $quiz_progress->get_status() ) {
 			$text = __( 'Awaiting grade', 'sensei-lms' );
 		} elseif ( 'failed' === $quiz_progress->get_status() ) {
-			if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ) ) ) {
+			if ( sensei_has_translation_or_is_english( 'You must score at least %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.' ) ) {
 				// translators: Placeholders are the required grade and the actual grade, respectively.
 				$text = sprintf( __( 'You must score at least %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $passmark_rounded . '</strong>', '<strong>' . $grade_rounded . '</strong>' );
 			} else {
@@ -166,7 +166,7 @@ class Sensei_Course_Theme_Lesson {
 		$first_unanswered_question = null;
 		$filtered_user_answers     = array_filter(
 			$user_answers,
-			function( $answer ) use ( &$answers_index, &$first_unanswered_question ) {
+			function ( $answer ) use ( &$answers_index, &$first_unanswered_question ) {
 				if ( '' === $answer && null === $first_unanswered_question ) {
 					$first_unanswered_question = $answers_index;
 				}

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -123,8 +123,13 @@ class Sensei_Course_Theme_Lesson {
 		if ( 'ungraded' === $quiz_progress->get_status() ) {
 			$text = __( 'Awaiting grade', 'sensei-lms' );
 		} elseif ( 'failed' === $quiz_progress->get_status() ) {
-			// translators: Placeholders are the required grade and the actual grade, respectively.
-			$text = sprintf( __( 'You require %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $passmark_rounded . '</strong>', '<strong>' . $grade_rounded . '</strong>' );
+			if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ) ) ) {
+				// translators: Placeholders are the required grade and the actual grade, respectively.
+				$text = sprintf( __( 'You must score at least %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $passmark_rounded . '</strong>', '<strong>' . $grade_rounded . '</strong>' );
+			} else {
+				// translators: Placeholders are the required grade and the actual grade, respectively.
+				$text = sprintf( __( 'You require %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $passmark_rounded . '</strong>', '<strong>' . $grade_rounded . '</strong>' );
+			}
 		} else {
 			// translators: Placeholder is the quiz grade.
 			$text = sprintf( __( 'Your Grade: %s%%', 'sensei-lms' ), '<strong class="sensei-course-theme-lesson-quiz-notice__grade">' . $grade_rounded . '</strong>' );

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -137,7 +137,6 @@ class Sensei_Course_Theme_Quiz {
 				);
 			}
 
-
 			// Display Contact Teacher button.
 			if ( ! $reset_allowed ) {
 				$block     = new Sensei_Block_Contact_Teacher();

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -121,7 +121,7 @@ class Sensei_Course_Theme_Quiz {
 			$passmark         = get_post_meta( $quiz_id, '_quiz_passmark', true );
 			$passmark_rounded = Sensei_Utils::round( $passmark, 2 );
 
-			if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ) ) ) {
+			if ( sensei_has_translation_or_is_english( 'You must score at least %1$s%% to pass this quiz. Your grade is %2$s%%.' ) ) {
 				$text = sprintf(
 					// translators: The first placeholder is the minimum grade required, and the second placeholder is the actual grade.
 					__( 'You must score at least %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ),

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -120,12 +120,23 @@ class Sensei_Course_Theme_Quiz {
 		} elseif ( 'failed' === $quiz_progress->get_status() ) {
 			$passmark         = get_post_meta( $quiz_id, '_quiz_passmark', true );
 			$passmark_rounded = Sensei_Utils::round( $passmark, 2 );
-			$text             = sprintf(
-				// translators: The first placeholder is the minimum grade required, and the second placeholder is the actual grade.
-				__( 'You require %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ),
-				$passmark_rounded,
-				$grade_rounded
-			);
+
+			if ( get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( 'You must score at least %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ) ) ) {
+				$text = sprintf(
+					// translators: The first placeholder is the minimum grade required, and the second placeholder is the actual grade.
+					__( 'You must score at least %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ),
+					$passmark_rounded,
+					$grade_rounded
+				);
+			} else {
+				$text = sprintf(
+					// translators: The first placeholder is the minimum grade required, and the second placeholder is the actual grade.
+					__( 'You require %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ),
+					$passmark_rounded,
+					$grade_rounded
+				);
+			}
+
 
 			// Display Contact Teacher button.
 			if ( ! $reset_allowed ) {

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -536,3 +536,15 @@ function sensei_log_jetpack_event( $event_name, $properties = [] ) {
 		$tracking->record_user_event( $event_name, $properties );
 	}
 }
+
+/**
+ * Check if the text has a translation or is in English.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $text The text to check.
+ * @return bool True if the text has a translation or is in English, false otherwise.
+ */
+function sensei_has_translation_or_is_english( $text ) {
+	return get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( $text, 'sensei-lms' ) );
+}

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -119,7 +119,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertStringContainsString( 'You require <strong>80</strong>% to pass this lesson\'s quiz. Your grade is <strong>0</strong>%.', $html, 'Should return quiz failed notice' );
+		$this->assertStringContainsString( 'You must score at least <strong>80</strong>% to pass this lesson\'s quiz. Your grade is <strong>0</strong>%.', $html, 'Should return quiz failed notice' );
 	}
 
 	/**

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -147,6 +147,72 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 		$this->assertTrue( $has_checks );
 	}
 
+	public function testHasTranslationOrIsEnglish_WhenEnglishLocale_ReturnsTrue() {
+		/* Arrange. */
+		add_filter(
+			'locale',
+			function () {
+				return 'en_US';
+			}
+		);
+
+		/* Act. */
+		$result = sensei_has_translation_or_is_english( 'Some text' );
+
+		/* Assert. */
+		$this->assertTrue( $result, 'Should return true when locale is en_US' );
+	}
+
+	/**
+	 * Test that translated text in non-English locale returns true.
+	 */
+	public function testHasTranslationOrIsEnglish_WhenHasTranslation_ReturnsTrue() {
+		// Skip if has_translation doesn't exist.
+		if ( ! function_exists( 'has_translation' ) ) {
+			$this->markTestSkipped( 'has_translation function not available' );
+		}
+
+		/* Arrange. */
+		add_filter(
+			'locale',
+			function () {
+				return 'pt_BR';
+			}
+		);
+		// Load the translation file from core tests.
+		load_textdomain( 'sensei-lms', DIR_TESTDATA . '/pomo/simple.mo' );
+
+		/* Act. */
+		$result = sensei_has_translation_or_is_english( 'baba' );
+
+		/* Assert. */
+		$this->assertTrue( $result, 'Should return true when text has translation' );
+	}
+
+	/**
+	 * Test that untranslated text in non-English locale returns false.
+	 */
+	public function testHasTranslationOrIsEnglish_WhenUntranslatedTextInNonEnglishLocale_ReturnsFalse() {
+		// Skip if has_translation doesn't exist.
+		if ( ! function_exists( 'has_translation' ) ) {
+			$this->markTestSkipped( 'has_translation function not available' );
+		}
+
+		/* Arrange. */
+		add_filter(
+			'locale',
+			function () {
+				return 'pt_BR';
+			}
+		);
+
+		/* Act. */
+		$result = sensei_has_translation_or_is_english( 'Test untranslated text' );
+
+		/* Assert. */
+		$this->assertFalse( $result, 'Should return false when text has no translation' );
+	}
+
 	/**
 	 * Filter for setting theme to Twenty Sixteen.
 	 *


### PR DESCRIPTION
Resolves #7788

## Proposed Changes

* Fix required quiz score texts.
* The used approach will keep the old text for translations until it's translated. I created an issue to remove the conditionals in the future here: https://github.com/Automattic/sensei/issues/7794
  * Notice that I used the new `has_translation` function (introduced in WP 6.7). The strings won't be translated in older versions until we remove the conditionals.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course with a lesson and a quiz with pass required.
2. Answer the quiz and grade it.
3. Visit the lesson and quiz pages with and without Learning Mode.
4. Check that the new text is applied to your English site.
5. Change the site language (I tested it with "Português do Brasil", but you can use any language that contains the translations), and make sure it continues getting the existing translations.
6. Test that it's not broken on WordPress 6.5.

## Screenshots

![Screenshot 2025-03-27 at 17 37 55](https://github.com/user-attachments/assets/dde0347f-e0d6-4395-99df-7887f3f2d532)
![Screenshot 2025-03-27 at 17 38 32](https://github.com/user-attachments/assets/1f25e183-9c0d-461f-9386-2e0b92647c4f)
![Screenshot 2025-03-27 at 18 03 39](https://github.com/user-attachments/assets/9332b346-51d6-4fc6-9e79-43095b384e0a)
![Screenshot 2025-03-27 at 18 05 04](https://github.com/user-attachments/assets/d4d34ae1-8c30-4684-96d1-0d35fec23334)
![Screenshot 2025-03-27 at 18 05 11](https://github.com/user-attachments/assets/18b8ee91-1af7-4e7c-8f87-f8260063e460)


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] Code is tested on the minimum supported PHP and WordPress versions
