### PR TITLE
Fix Course list block listing other patterns that are not related to Courses

### DIFF
--- a/changelog/fix-other-patterns-in-course-list-picker
+++ b/changelog/fix-other-patterns-in-course-list-picker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Non course-list patterns showing up in the Course List block's pattern picker

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -54,7 +54,7 @@ class Sensei_Course_List_Block_Patterns {
 			[
 				'title'       => __( 'Courses displayed in a list', 'sensei-lms' ),
 				'categories'  => array( 'query' ),
-				'blockTypes'  => array( 'core/query' ),
+				'blockTypes'  => array( 'core/query/sensei-lms/course-list' ),
 				'description' => 'course-list-element',
 				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":6},"displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
 					<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view">
@@ -121,7 +121,7 @@ class Sensei_Course_List_Block_Patterns {
 				[
 					'title'       => __( 'Courses displayed in a grid', 'sensei-lms' ),
 					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
+					'blockTypes'  => array( 'core/query/sensei-lms/course-list' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-grid-view alignwide">
@@ -183,6 +183,7 @@ class Sensei_Course_List_Block_Patterns {
 				[
 					'title'      => __( 'Course List', 'sensei-lms' ),
 					'categories' => array( 'sensei-lms' ),
+					'blockTypes' => array( 'core/query/sensei-lms/course-list' ),
 					'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","right":"20px","left":"20px","bottom":"100px"},"blockGap":"0px"},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","className":"sensei-course-theme-course-list-pattern","layout":{"type":"constrained","contentSize":"1000px"}} -->
 						<div class="wp-block-group alignfull sensei-course-theme-course-list-pattern has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:80px;padding-right:20px;padding-bottom:100px;padding-left:20px"><!-- wp:group {"style":{"border":{"left":{"width":"1px","style":"solid"},"top":{},"right":{},"bottom":{}},"spacing":{"padding":{"left":"20px"},"margin":{"bottom":"40px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 						<div class="wp-block-group" style="border-left-style:solid;border-left-width:1px;margin-bottom:40px;padding-left:20px"><!-- wp:heading {"style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"700"},"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"fontSize":"medium"} -->


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7757

## Proposed Changes
* Connected the patterns only to the Course List block

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to a Page in site editor
2. Go to inserter and insert the Course List block
3. Click on the pattern picker button
4. Make sure you see only the Course list related patterns

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
