### PR TITLE
Fix courses ordering on WPCOM

### DIFF
--- a/changelog/fix-course-ordering
+++ b/changelog/fix-course-ordering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix course ordering on wordpress.com

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1212,22 +1212,18 @@ class Sensei_Admin {
 	}
 
 	public function save_course_order( $order_string = '' ) {
-		global $wpdb;
 		$order = array();
 
 		$i = 1;
 		foreach ( explode( ',', $order_string ) as $course_id ) {
 			if ( $course_id ) {
-				$order[] = $course_id;
-
-				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-				$wpdb->query(
-					$wpdb->prepare(
-						"UPDATE $wpdb->posts SET menu_order = %d WHERE ID = %d",
-						$i,
-						absint( $course_id )
-					)
+				$order[]     = $course_id;
+				$update_args = array(
+					'ID'         => absint( $course_id ),
+					'menu_order' => $i,
 				);
+
+				wp_update_post( $update_args );
 
 				++$i;
 			}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1223,6 +1223,7 @@ class Sensei_Admin {
 					'menu_order' => $i,
 				);
 
+				// If you face performance issues on Simple Sites, see https://github.com/Automattic/sensei/pull/7799.
 				wp_update_post( $update_args );
 
 				++$i;


### PR DESCRIPTION
This reverts commit 19a00b2da25da651483887343c35081905d8cc44.

See issue reported p1743440666861309-slack-C07418EJ0

## Proposed Changes

At some point, we made a change to [improve a performance issue noticed on Learnomattic](https://github.com/Automattic/sensei/pull/4422#discussion_r750342649).

Now it's causing an issue in atomic sites on WPCOM, not ordering the courses at all. Given that currently Learnomattic doesn't have a page to list all the courses, it should not be a problem anymore, and we should prioritize user sites.

If we face this performance issue again for a specific type of environment, we need to find a different solution. Or if the reverted solution still works in this environment, we could try a conditional with the 2 approaches depending on the environment.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply this change on atomic.
2. Create some courses.
3. Navigate to WP Admin > Sensei LMS > Courses.
4. Click on "Order Courses".
5. Reorder your courses.
6. Visit your courses list on your site frontend.
7. Check that the reordering worked properly.
8. Repeat the reorder, and make sure it still works (I noticed that sometimes it was working the first time).

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions