### PR TITLE
Sensei activation: Update the activation logic to always enable the setup wizard on the first installation

### DIFF
--- a/changelog/update-sensei-activation-hook
+++ b/changelog/update-sensei-activation-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated the activation logic to always enable the setup wizard on first installation

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1166,20 +1166,10 @@ class Sensei_Main {
 	 * @return void
 	 */
 	public function activate_sensei() {
-
 		if ( false === get_option( 'sensei_installed', false ) ) {
-
-			// Do not enable the wizard for sites that are created with the onboarding flow.
-			if ( 'sensei' !== get_option( 'site_intent' ) ) {
-
-				update_option( 'sensei_activation_redirect', 1 );
-				update_option( Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
-
-			} else {
-				Sensei_Setup_Wizard::instance()->finish_setup_wizard();
-			}
-		} else {
-			return;
+			// Enable the wizard on first installation
+			update_option( 'sensei_activation_redirect', 1 );
+			update_option( Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 		}
 
 		update_option( 'sensei_installed', 1 );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1170,9 +1170,8 @@ class Sensei_Main {
 			// Enable the wizard on first installation.
 			update_option( 'sensei_activation_redirect', 1 );
 			update_option( Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
+			update_option( 'sensei_installed', 1 );
 		}
-
-		update_option( 'sensei_installed', 1 );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1167,7 +1167,7 @@ class Sensei_Main {
 	 */
 	public function activate_sensei() {
 		if ( false === get_option( 'sensei_installed', false ) ) {
-			// Enable the wizard on first installation
+			// Enable the wizard on first installation.
 			update_option( 'sensei_activation_redirect', 1 );
 			update_option( Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 		}


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7774

## Proposed Changes
* Update the activation logic to always enable the setup wizard on the first installation

## Testing Instructions

1. Checkout this branch locally
2. Run `npm run build`
3. Open a `/wp-admin/plugins.php` page of your WPCOM business site
4. Upload a plugin `sensei-lms.zip` file from the root of this repo (the file is created in step 2)
5. Activate it and check if there is Sensei onboarding

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
