### PR TITLE
Lesson details: Focus the title input on the form render

### DIFF
--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -58,6 +58,7 @@ const LessonDetailsStep = ( { wizardData, setWizardData } ) => {
 						value={ lessonTitle }
 						onChange={ updateLessonTitle }
 						maxLength={ 40 }
+						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 					/>
 				</div>
 			</div>

--- a/changelog/update-lesson-details-form
+++ b/changelog/update-lesson-details-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Autofocus the title input on the form render


### PR DESCRIPTION
## Proposed Changes

* Autofocus the title input on the lesson details component render; matches behavior as the Course details screen.

## Testing Instructions
1. Go to the Sensei LMS plugin
2. Click on `Lessons -> New Lesson`
3. Check if the Title input is in focus

<img width="907" alt="Screenshot 2025-04-01 at 12 52 20" src="https://github.com/user-attachments/assets/04459806-1a13-4d86-a145-c19471c66334" />


## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
