### PR TITLE
Fix nock race condition on trunk workflow tests

### DIFF
--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -172,7 +172,6 @@ export const StudentModal = ( {
 			);
 			onClose( true );
 		} catch ( e ) {
-			console.log( 'error!!!!!!!!!!!!!!!!!', e );
 			if ( ! getSignal().aborted ) {
 				setError( true );
 				setIsSending( false );


### PR DESCRIPTION
It seems the try from https://github.com/Automattic/sensei/pull/7803 worked. So we won't need to revert it. I'm just removing the `console.log`.

The problem we were having is that the test was failing because a race condition with `nock`.

https://github.com/Automattic/sensei/actions/runs/14197282200/job/39775343698