### PR TITLE
Add timeout to avoid test flakyness

### DIFF
--- a/assets/admin/students/student-modal/index.test.js
+++ b/assets/admin/students/student-modal/index.test.js
@@ -215,9 +215,17 @@ describe( '<StudentModal />', () => {
 
 			fireEvent.click( await buttonByLabel( 'Remove from Course' ) );
 
-			await waitFor( () => {
-				expect( mockRequest.isDone() ).toBe( true );
-			} );
+			await waitFor(
+				() => {
+					expect(
+						screen.queryByText(
+							'Unable to remove students. Please try again.'
+						)
+					).not.toBeInTheDocument();
+					expect( mockRequest.isDone() ).toBe( true );
+				},
+				{ timeout: 500 } // Give it more time to complete to avoid flakiness.
+			);
 
 			await waitFor( () => {
 				expect( onClose ).toHaveBeenCalledWith( true );


### PR DESCRIPTION
## Proposed Changes

It seems the [previous solution](https://github.com/Automattic/sensei/pull/7804) didn't fix the issue completely in the `trunk` workflow. See https://github.com/Automattic/sensei/actions/runs/14205462462/job/39802057735.

Now I added a timeout to see if we can avoid the flakiness. It doesn't seem the ideal solution, but I couldn't find the exact reason for that. The code seems good and safe, waiting for a promise request (`apiFetch`) to only after that call the `onClose`.