### PR TITLE
Remove the `memize` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "debug": "4.3.4",
         "interpolate-components": "1.1.1",
         "lodash": "4.17.21",
-        "memize": "1.1.0",
         "qrcode.react": "3.1.0",
         "react": "18.3.1",
         "react-animate-height": "2.0.23",
@@ -90,7 +89,7 @@
       },
       "engines": {
         "node": ">=20.10.0",
-        "npm": ">=10.2.3"
+        "npm": "^10.2.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -594,11 +593,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/@automattic/components/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@automattic/components/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -1071,11 +1065,6 @@
         "encoding": "^0.1.12",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "node_modules/@automattic/tour-kit/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@automattic/tour-kit/node_modules/uuid": {
       "version": "9.0.1",
@@ -7268,11 +7257,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/block-editor/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -7537,11 +7521,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/block-library/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/block-library/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -7693,11 +7672,6 @@
       "peerDependencies": {
         "redux": ">=4"
       }
-    },
-    "node_modules/@wordpress/blocks/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/blocks/node_modules/redux": {
       "version": "5.0.1",
@@ -7899,11 +7873,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/commands/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/commands/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -8021,11 +7990,6 @@
       "peerDependencies": {
         "react": "^18.0.0"
       }
-    },
-    "node_modules/@wordpress/components/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/components/node_modules/uuid": {
       "version": "9.0.1",
@@ -8331,11 +8295,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/core-data/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/core-data/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -8626,11 +8585,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/@wordpress/data/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/dataviews": {
       "version": "4.16.0",
       "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.16.0.tgz",
@@ -8805,11 +8759,6 @@
       "peerDependencies": {
         "redux": ">=4"
       }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/dataviews/node_modules/redux": {
       "version": "5.0.1",
@@ -9114,11 +9063,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/edit-post/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/edit-post/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -9256,11 +9200,6 @@
       "peerDependencies": {
         "redux": ">=4"
       }
-    },
-    "node_modules/@wordpress/editor/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/editor/node_modules/redux": {
       "version": "5.0.1",
@@ -9630,11 +9569,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/@wordpress/i18n/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/icons": {
       "version": "10.20.0",
       "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.20.0.tgz",
@@ -9849,11 +9783,6 @@
       "peerDependencies": {
         "redux": ">=4"
       }
-    },
-    "node_modules/@wordpress/interface/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/interface/node_modules/redux": {
       "version": "5.0.1",
@@ -10387,11 +10316,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/patterns/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/patterns/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -10533,11 +10457,6 @@
       "peerDependencies": {
         "react": "^18.0.0"
       }
-    },
-    "node_modules/@wordpress/plugins/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/plugins/node_modules/uuid": {
       "version": "9.0.1",
@@ -10755,11 +10674,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/preferences/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/preferences/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -10960,11 +10874,6 @@
         "encoding": "^0.1.12",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "node_modules/@wordpress/react-i18n/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/redux-routine": {
       "version": "4.58.0",
@@ -11199,11 +11108,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/reusable-blocks/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/reusable-blocks/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -11302,11 +11206,6 @@
       "peerDependencies": {
         "redux": ">=4"
       }
-    },
-    "node_modules/@wordpress/rich-text/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/rich-text/node_modules/redux": {
       "version": "5.0.1",
@@ -12261,11 +12160,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/server-side-render/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
-    },
     "node_modules/@wordpress/server-side-render/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -12306,11 +12200,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@wordpress/shortcode/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/style-engine": {
       "version": "2.20.0",
@@ -12865,11 +12754,6 @@
       "peerDependencies": {
         "redux": ">=4"
       }
-    },
-    "node_modules/@wordpress/widgets/node_modules/memize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/@wordpress/widgets/node_modules/redux": {
       "version": "5.0.1",
@@ -22378,9 +22262,10 @@
       }
     },
     "node_modules/memize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
-      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==",
+      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "debug": "4.3.4",
     "interpolate-components": "1.1.1",
     "lodash": "4.17.21",
-    "memize": "1.1.0",
     "qrcode.react": "3.1.0",
     "react": "18.3.1",
     "react-animate-height": "2.0.23",


### PR DESCRIPTION
Needed by https://github.com/Automattic/sensei-pro/pull/2648

## Proposed Changes
* This change removes the `memize` dependency from package.json, which forces it to use the latest version and cleans up the dependency structure.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

CI should be passing.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
