### PR TITLE
Update class-sensei-messages.php

### DIFF
--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -79,6 +79,7 @@ class Sensei_Messages {
 
 		// Redirect and show a success notice.
 		add_action( 'sensei_new_private_message', [ $this, 'show_success_notice' ], 999 );
+		add_action( 'template_redirect', array( $this, 'prevent_message_redirect' ), 1 );
 	}
 
 	public function only_show_messages_to_owner( $query ) {
@@ -1056,6 +1057,26 @@ class Sensei_Messages {
 			wp_safe_redirect( esc_url_raw( add_query_arg( [ 'send' => 'complete' ] ) ) );
 			exit;
 		}
+	}
+	/**
+ * Prevent WordPress from redirecting to pretty permalinks for messages
+ */
+	public function prevent_message_redirect() {
+	    global $wp;
+	    
+	    // Check if this is a message post
+	    if ( isset( $wp->query_vars['p'] ) ) {
+	        $post_id = $wp->query_vars['p'];
+	        if ( get_post_type( $post_id ) === $this->post_type ) {
+	            // If user doesn't have access, redirect to home
+	            if ( ! $this->view_message( $post_id ) ) {
+	                wp_safe_redirect( home_url(), 303 );
+	                exit;
+	            }
+	            // If they do have access, prevent the pretty permalink redirect
+	            remove_action( 'template_redirect', 'redirect_canonical' );
+	        }
+	    }
 	}
 
 }


### PR DESCRIPTION
Resolves https://hackerone.com/reports/2904382

## Proposed Changes
* Add early template_redirect hook to prevent message URL leaks
* Remove canonical redirect for message posts
* Add proper permission checks before redirects
* Redirect unauthorized users to home page

## Testing Instructions
1. Try accessing a message URL directly (e.g. /?p=92) 
2. Verify you are redirected to home page instead of seeing the message URL in Location header

## New/Updated Hooks
* Added `template_redirect` hook with priority 1 to catch requests before canonical redirect
* Removed default `redirect_canonical` action for message posts

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards
- [x] All strings are translatable
- [x] Follows our naming conventions
- [x] Hooks and functions are documented
- [x] Code is tested on the minimum supported PHP and WordPress versions