### PR TITLE
Fix invalid property notice for messages

### DIFF
--- a/changelog/fix-invalid-property-notice
+++ b/changelog/fix-invalid-property-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invalid property notice for messages

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -760,15 +760,14 @@ class Sensei_Messages {
 	}
 
 	/**
-	 * Hide content of message
+	 * Filter the content of a message.
 	 *
-	 * @param  string $content Original message content
-	 * @return string          Empty string if user does not have access to this message
+	 * @param string $content The post content.
+	 * @return string The filtered content.
 	 */
 	public function message_content( $content ) {
-		global $post;
-
-		if ( ! $post || get_post_type( $post->ID ) !== $this->post_type ) {
+		$post = get_post();
+		if ( ! ( $post instanceof WP_Post ) || get_post_type( $post->ID ) !== $this->post_type ) {
 			return $content;
 		}
 


### PR DESCRIPTION
Resolves #6412.

## Proposed Changes
In certain scenarios such as custom queries, the global `$post` variable may not be set or may not be an instance of `WP_Post`. This can occur if `the_content` is applied outside the main loop or if other plugins/themes manipulate the global `$post` variable.

To be safe, switching to using `get_post` instead.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A. I wasn't able to reproduce, but the code now does an extra check that `$post` is actually an instance of `WP_Post` before trying to access the `ID` property.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
