### PR TITLE
Fix "Calling get_class() without arguments is deprecated" notice

### DIFF
--- a/changelog/fix-deprecated-get_class
+++ b/changelog/fix-deprecated-get_class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix "Calling get_class() without arguments is deprecated" PHP notice

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -53,7 +53,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 */
 
 	public static function get_instance() {
-		return self::get_instance_for_subclass( get_class() );
+		return self::get_instance_for_subclass( __CLASS__ );
 	}
 
 	protected function get_prefix() {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1628,7 +1628,7 @@ class Sensei_Main {
 	public function load_modules_class() {
 		global $sensei_modules;
 
-		$class = is_null( $sensei_modules ) ? get_class() : get_class( $sensei_modules );
+		$class = is_null( $sensei_modules ) ? __CLASS__ : get_class( $sensei_modules );
 
 		if ( ! class_exists( 'Sensei_Modules' ) && 'Sensei_Modules' !== $class ) {
 			// Load the modules class.


### PR DESCRIPTION
Resolves #7400.

## Proposed Changes
Replaces `get_class` calls with `__CLASS__` magic constant.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch to PHP 8.3+.
2. Activate Sensei.
3. Ensure there are no PHP `get_class` deprecation notices.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions