### PR TITLE
Remove Playground Preview from GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,23 +38,6 @@ jobs:
                   path: ${{ github.workspace }}/sensei-lms/
                   retention-days: 7
 
-    playground-preview:
-        if: github.event_name == 'pull_request'
-        name: Playground Preview
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                node-version-file: '.nvmrc'
-            - name: Create comment with Playground preview
-              uses: peter-evans/create-or-update-comment@v4
-              with:
-                issue-number: ${{ github.event.pull_request.number }}
-                body: |
-                    Test the previous changes of this PR with [WordPress Playground](https://playground.wordpress.net/#{"landingPage":"/wp-admin/admin.php?page=sensei","phpExtensionBundles":["kitchen-sink"],"steps":[{"step":"setSiteOptions","options":{"site_intent":"sensei"}},{"step":"login","username":"admin","password":"password"},{"step":"installPlugin","pluginZipFile":{"resource":"url","url":"https://playground.wordpress.net/plugin-proxy.php?org=Automattic&repo=sensei&workflow=Plugin%20Build&artifact=sensei-lms-${{ github.event.pull_request.head.sha }}&pr=${{ github.event.pull_request.number }}"}},{"step":"installTheme","themeZipFile":{"resource":"wordpress.org\/themes","slug":"course"}}]}).
-
     syntax-check:
         name: PHP Syntax Check
         needs: build


### PR DESCRIPTION
## Proposed Changes
Removes the ability to test PRs using WordPress Playground. It was broken and didn't seem like it was being used much as per p1743615630031689-slack-C02NWDZBL0H.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check that there is no comment with a Playground link in this PR.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions