### PR TITLE
Add support for changing text color of Course Overview block

### DIFF
--- a/assets/blocks/course-overview-block/block.json
+++ b/assets/blocks/course-overview-block/block.json
@@ -6,6 +6,12 @@
 	"category": "sensei-lms",
 	"description": "Displays a link to the course.",
 	"textdomain": "sensei-lms",
+	"supports": {
+		"color": {
+			"background": false,
+			"text": true
+		}
+	},
 	"usesContext": [ "postType" ],
 	"example": {}
 }

--- a/changelog/add-course-overview-color-settings
+++ b/changelog/add-course-overview-color-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for changing text color of Course Overview block


### PR DESCRIPTION
Resolves #7812.

## Proposed Changes
Adds support for changing the text color of the Course Overview block. Adding support for background color would be a bit more complicated, so I've left it off for now.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add the Course List block to a page.
2. Select the Course Overview block.
3. Change the text color.
4. View the page on the frontend and ensure the color of the link has changed.

![Screenshot 2025-05-24 at 8 13 53 PM](https://github.com/user-attachments/assets/d9b1494a-75ed-429f-bc22-e5873b4bda14)

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
