### PR TITLE
Fix PHP fatal when removing student from a course

### DIFF
--- a/changelog/fix-error-removing-student
+++ b/changelog/fix-error-removing-student
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PHP fatal when calling array_rand on empty array

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3836,7 +3836,7 @@ class Sensei_Lesson {
 				$show_questions = (int) get_post_meta( $quiz_id, '_show_questions', true );
 
 				// Negative amount is considered as All (same as zero).
-				if ( $show_questions > 0 ) {
+				if ( $show_questions > 0 && ! empty( $questions_array ) ) {
 					// Get random set of array keys from selected questions array.
 					$questions_count    = is_countable( $questions_array ) ? count( $questions_array ) : 0;
 					$selected_questions = array_rand(


### PR DESCRIPTION
Resolves #7740.

## Proposed Changes
Checks if `$questions_array` is empty before running code that manipulates it.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I wasn't actually able to reproduce, but this is a fairly benign change that should resolve the fatal.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions