### PR TITLE
Cleanup deprecated teacher role capabilities

### DIFF
--- a/changelog/update-remove-outdated-teacher-capabilities
+++ b/changelog/update-remove-outdated-teacher-capabilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cleanup deprecated teacher role capabilities

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -174,7 +174,6 @@ class Sensei_Teacher {
 				'manage_sensei_grades'           => true,
 				'moderate_comments'              => true,
 				'upload_files'                   => true,
-				'edit_files'                     => true,
 
 				// Lessons
 				'publish_lessons'                => true,


### PR DESCRIPTION
Related to p1749135629758919-slack-C07418EJ0

## Proposed Changes
* Remove the `edit_files` capability. It's no longer used in core.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No testing is needed.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions