### PR TITLE
Check that author variable is of the expected type

### DIFF
--- a/changelog/fix-variable-type-mismatch
+++ b/changelog/fix-variable-type-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check that author variable is of the expected type

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2720,7 +2720,6 @@ class Sensei_Core_Modules {
 			}
 
 			$author = self::get_term_author( $term->slug );
-			$author = false;
 
 			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) && $author instanceof WP_User ) {
 				$term->name = $term->name . ' (' . $author->display_name . ') ';

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2724,15 +2724,9 @@ class Sensei_Core_Modules {
 			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) && $author instanceof WP_User ) {
 				$term->name = $term->name . ' (' . $author->display_name . ') ';
 			}
-}
-
-			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) ) {
-				$term->name = $term->name . ' (' . $author->display_name . ') ';
-			}
 
 			// add the term to the teachers terms
 			$users_terms[] = $term;
-
 		}
 
 		return $users_terms;

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2720,6 +2720,12 @@ class Sensei_Core_Modules {
 			}
 
 			$author = self::get_term_author( $term->slug );
+			$author = false;
+
+			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) && $author instanceof WP_User ) {
+				$term->name = $term->name . ' (' . $author->display_name . ') ';
+			}
+}
 
 			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) ) {
 				$term->name = $term->name . ' (' . $author->display_name . ') ';

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2334,8 +2334,8 @@ class Sensei_Core_Modules {
 	 *
 	 * @since 1.8.0
 	 *
-	 * @param $slug
-	 * @return WP_User $author if no author is found or invalid term is passed the admin user will be returned.
+	 * @param string $slug
+	 * @return WP_User|false WP_User if found, false if no valid author found.
 	 */
 	public static function get_term_author( $slug = '' ) {
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2721,7 +2721,7 @@ class Sensei_Core_Modules {
 
 			$author = self::get_term_author( $term->slug );
 
-			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) && $author instanceof WP_User ) {
+			if ( $author instanceof WP_User && ! user_can( $author, 'manage_options' ) && isset( $term->name ) ) {
 				$term->name = $term->name . ' (' . $author->display_name . ') ';
 			}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2334,7 +2334,7 @@ class Sensei_Core_Modules {
 	 *
 	 * @since 1.8.0
 	 *
-	 * @param string $slug
+	 * @param string $slug The term slug to get the author for.
 	 * @return WP_User|false WP_User if found, false if no valid author found.
 	 */
 	public static function get_term_author( $slug = '' ) {


### PR DESCRIPTION
Fixes an issue reported by Team51:

> When using Safety Net on a site with the Sensei plugin, the following warning was encountered:
> ```
> Warning: Attempt to read property "display_name" on bool in /plugins/sensei-lms/includes/class-sensei-modules.php on line 2653
> ```

## Proposed Changes
Check that `$author` is a `WP_User` object before trying to access the `display_name` property.

Though I wasn't able to reproduce the reported issue, this seems like a safe change. 

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
