### PR TITLE
Fix lesson comments being visible to unregistered users in some cases

### DIFF
--- a/changelog/fix-lesson-comments-visible-to-unregistered-users
+++ b/changelog/fix-lesson-comments-visible-to-unregistered-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix lesson comments being visible to unregistered users in some cases

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -76,7 +76,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		add_filter( 'template_include', array( $this, 'force_page_template' ) );
 
 		// Disable comments if not block theme and post type is not lesson.
-		if ( ! $this->is_lesson_cpt_in_block_fse_theme() ) {
+		if ( ! $this->should_show_comments() ) {
 			Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
 		}
 
@@ -121,7 +121,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		$content  = $renderer->render();
 
 		// Disable theme comments.
-		if ( ! $this->is_lesson_cpt_in_block_fse_theme() ) {
+		if ( ! $this->should_show_comments() ) {
 			Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
 		}
 
@@ -246,5 +246,20 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 */
 	private function is_lesson_cpt_in_block_fse_theme() {
 		return 'lesson' === $this->post_type && Sensei_Utils::is_fse_theme();
+	}
+
+	/**
+	 * Determine if comments should be shown.
+	 *
+	 * Comments are only shown for lessons in block themes if the user can view
+	 * the lesson.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	private function should_show_comments(): bool {
+		return $this->is_lesson_cpt_in_block_fse_theme()
+			&& sensei_can_user_view_lesson();
 	}
 }

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -260,6 +260,6 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 */
 	private function should_show_comments(): bool {
 		return $this->is_lesson_cpt_in_block_fse_theme()
-			&& sensei_can_user_view_lesson();
+			&& sensei_can_user_view_lesson( $this->post_id );
 	}
 }


### PR DESCRIPTION
Reported in 10207255-zd-a8c 
Discussion 10207255-zd-a8cp1757609717205269-slack-C07418EJ0

## Proposed Changes

This PR disables the lesson comments for users who are unregistered or don't have access to the lesson. This is only a case when Learning Mode is off and the theme supports Full Site Editing.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Disable learning mode.
2. Activate a Full Site Editing theme, e.g., Course.
3. Create e course with lessons and add a comment to one of the lessons.
4. Make sure the comment is not visible to unregistered users or ones who don't have access.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions