### PR TITLE
Fix reports screen times out on larger sites

### DIFF
--- a/changelog/fix-slow-query-on-reports-screen
+++ b/changelog/fix-slow-query-on-reports-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Optimize a slow query on the reports screen

--- a/changelog/fix-slow-query-on-reports-screen
+++ b/changelog/fix-slow-query-on-reports-screen
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Optimize a slow query on the reports screen
+Fix reports screen times out on larger sites

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
@@ -203,15 +203,16 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 	public function add_last_activity_to_user_query( WP_User_Query $query ) {
 		global $wpdb;
 
-		$query->query_fields .= ", (
-			SELECT MAX({$wpdb->comments}.comment_date_gmt)
-			FROM {$wpdb->comments}
-			USE INDEX (sensei_comment_type_user_id)
-			WHERE {$wpdb->comments}.user_id = {$wpdb->users}.ID
-			AND {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
-			AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
-			ORDER BY {$wpdb->comments}.comment_date_gmt DESC
-		) AS last_activity_date";
+		$query->query_fields .= ', last_activity_date';
+
+		$query->query_from .= "
+			LEFT JOIN (
+				SELECT {$wpdb->comments}.user_id, MAX({$wpdb->comments}.comment_date_gmt) AS last_activity_date
+				FROM {$wpdb->comments}
+				WHERE {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
+				AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
+				GROUP BY {$wpdb->comments}.user_id
+			) AS l ON {$wpdb->users}.ID = l.user_id";
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/7857
Resolves [SEN-23](https://linear.app/a8c/issue/SEN-23/reports-page-times-out-on-large-sites)
Probably resolves https://github.com/Automattic/sensei/issues/4962
Relates to https://github.com/Automattic/sensei/pull/7858

## Proposed Changes
* The PR fixes a slow query on the reports screen that causes a timeout on bigger sites. The performance increase is more than 10-fold.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have the Query Monitor plugin installed.
2. Go to Sensei LMS > Reports 
3. Look for the query in the screenshot below and compare it `trunk`.
4. Make sure the listed users and last activity dates are still the same as in `trunk`
5. Make sure the "Last Activity" date filter still works as before.
6. Make sure the "Last Activity" table sorting still works as before.
7. Make sure the "Export all rows" still works as before.

| Before      | After |
| ----------- | ----------- |
| <img width="1496" height="817" alt="image" src="https://github.com/user-attachments/assets/77fe2d2d-8cda-41c1-993d-86cb9c810ab3" /> | <img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/9834addc-e37d-47e7-b097-6e3d9a87300b" /> |

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
