### PR TITLE
Sensei_Course_Completed_Actions_Block: Run filter only on core/button blocks

### DIFF
--- a/changelog/reduce-scope-completed-actions-filter
+++ b/changelog/reduce-scope-completed-actions-filter
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: fixed
 
-Sensei_Course_Completed_Actions_Block: Run filter only on core/button blocks
+Prevent duplicate queries from happening on every block render

--- a/changelog/reduce-scope-completed-actions-filter
+++ b/changelog/reduce-scope-completed-actions-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sensei_Course_Completed_Actions_Block: Run filter only on core/button blocks

--- a/includes/blocks/class-sensei-course-completed-actions-block.php
+++ b/includes/blocks/class-sensei-course-completed-actions-block.php
@@ -19,7 +19,7 @@ class Sensei_Course_Completed_Actions_Block {
 	 * Sensei_Course_Completed_Actions_Block constructor.
 	 */
 	public function __construct() {
-		add_filter( 'render_block', [ $this, 'update_more_courses_button_url' ], 10, 2 );
+		add_filter( 'render_block_core/button', [ $this, 'update_more_courses_button_url' ], 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

* The `Sensei_Course_Completed_Actions_Block` runs a filter on all block renders, but it calls into `update_button_block_url` which is only concerned with one block type, enforced by a guard clause at the top:

```php
	public static function update_button_block_url( $block_content, $block, $class_name, $url ): string {
		if (
			! isset( $block['blockName'] )
			|| 'core/button' !== $block['blockName']
			|| ! isset( $block['attrs']['className'] )
			|| false === strpos( $block['attrs']['className'], $class_name )
		) {
			return $block_content;
		}
```

Because it's only concerned with core/button, and because WordPress gives us a more specific filter: (https://github.com/WordPress/wordpress-develop/blob/26230c33261cf559907a90547b4827ea66ff9f30/src/wp-includes/class-wp-block.php#L666)

```php 
		$block_content = apply_filters( 'render_block', $block_content, $this->parsed_block, $this );
		$block_content = apply_filters( "render_block_{$this->name}", $block_content, $this->parsed_block, $this );
```

Let's reduce the scope of this filter so it only runs on the button blocks we are concerned with.

Note that this has the side effect of reducing 100+ duplicate SQL queries on (internal url). This seems to be a separate problem, but reducing of the scope of this filter is a pretty big mitigation, since it stops a query from running on every block render.



## Testing Instructions

1.
2.
3.

## New/Updated Hooks

*

## Deprecated Code

*

## Pre-Merge Checklist
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
