### PR TITLE
Fix error when activating MailPoet

### DIFF
--- a/changelog/fix-mailpoet-error-on-plugin-activation
+++ b/changelog/fix-mailpoet-error-on-plugin-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix error when activating MailPoet

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -845,10 +845,19 @@ class Sensei_Main {
 		 * @return {bool} Whether to enable feature.
 		 */
 		if ( apply_filters( 'sensei_email_mailpoet_feature', true ) ) {
-			if ( class_exists( \MailPoet\API\API::class ) ) {
-				$mailpoet_api = \MailPoet\API\API::MP( 'v1' );
-				new Sensei\Emails\MailPoet\Main( $mailpoet_api );
-			}
+			add_action( 'mailpoet_initialized', [ $this, 'initialize_mailpoet' ] );
+		}
+	}
+
+	/**
+	 * Initialize MailPoet integration.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function initialize_mailpoet() {
+		if ( class_exists( \MailPoet\API\API::class ) ) {
+			$mailpoet_api = \MailPoet\API\API::MP( 'v1' );
+			new Sensei\Emails\MailPoet\Main( $mailpoet_api );
 		}
 	}
 


### PR DESCRIPTION
Resolves [SEN-26](https://linear.app/a8c/issue/SEN-26/sensei-lms-critical-error-conflict-when-activating-mailpoet)

## Proposed Changes
* Fix the MailPoet activation error by moving the initialization to the `mailpoet_initialized` hook.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have the Sensei LMS plugin active.
2. Activate the MailPoet plugin.
3. MailPoet should be activated successfully, and there should be no errors.
4. Make sure the MailPoet initialization is still working as before.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
