### PR TITLE
Fix course structure API exposing the lesson AI generated bootstrap text

### DIFF
--- a/changelog/fix-course-structure-exposing-lesson-initial-content
+++ b/changelog/fix-course-structure-exposing-lesson-initial-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the course structure API exposing the lesson AI generated bootstrap text

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -187,7 +187,9 @@ class Sensei_Course_Structure {
 			'title'          => $lesson_post->post_title,
 			'draft'          => 'draft' === $lesson_post->post_status,
 			'preview'        => Sensei_Utils::is_preview_lesson( $lesson_post->ID ),
-			'initialContent' => get_post_meta( $lesson_post->ID, '_initial_content', true ),
+			'initialContent' => current_user_can( 'edit_lesson', $lesson_post->ID )
+				? get_post_meta( $lesson_post->ID, '_initial_content', true )
+				: '',
 		];
 	}
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -87,6 +87,8 @@
 				<element value="manage_sensei_grades"/>
 				<element value="edit_course"/>
 				<element value="edit_courses"/>
+				<element value="edit_lesson"/>
+				<element value="edit_lessons"/>
 				<element value="edit_published_lessons"/>
 			</property>
 		</properties>


### PR DESCRIPTION
Resolves [SEN-28](https://linear.app/a8c/issue/SEN-28/security-unauthenticated-course-structure-api-leaks-private-lesson)

## Proposed Changes

The course structure API returns the lesson AI-generated text (the `_initial_content` post meta) to unauthorized users. This text is generated when using Sensei Pro to generate the course and lesson content. Note that the meta is never updated with the real lesson content, so this is not a security issue.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have Sensei LMS and Sensei Pro.
2. Generate a course using the AI feature.
4. Run `curl https://sensei.test/wp-json/sensei-internal/v1/course-structure/[COURSE POST ID]?context=view`
5. Make sure the `initialContent` from the response is empty.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
