### PR TITLE
Allow multiple choice quiz questions with no wrong answers

### DIFF
--- a/changelog/fix-some-questions-not-showing
+++ b/changelog/fix-some-questions-not-showing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow multiple choice quiz questions with no wrong answers

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2207,13 +2207,11 @@ class Sensei_Quiz {
 		$right_answers = get_post_meta( $question_id, '_question_right_answer', true );
 		$wrong_answers = get_post_meta( $question_id, '_question_wrong_answers', true );
 
-		// Multiple choice question is incomplete if there isn't at least one right answer.
-		// Wrong answers are optional - it's valid to have all answers be correct.
+		// Multiple choice question is incomplete if there isn't at least one right answer. Wrong answers are optional - it's valid to have all answers be correct.
 		if ( ! is_array( $right_answers ) || count( $right_answers ) < 1 ) {
 			return false;
 		}
 
-		// Ensure wrong_answers is an array (even if empty).
 		if ( ! is_array( $wrong_answers ) ) {
 			$wrong_answers = array();
 		}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2207,11 +2207,18 @@ class Sensei_Quiz {
 		$right_answers = get_post_meta( $question_id, '_question_right_answer', true );
 		$wrong_answers = get_post_meta( $question_id, '_question_wrong_answers', true );
 
-		// Multiple choice question is incomplete if there isn't at least one right and one wrong answer.
-		if ( ! is_array( $right_answers ) || count( $right_answers ) < 1 || ! is_array( $wrong_answers ) || count( $wrong_answers ) < 1 ) {
+		// Multiple choice question is incomplete if there isn't at least one right answer.
+		// Wrong answers are optional - it's valid to have all answers be correct.
+		if ( ! is_array( $right_answers ) || count( $right_answers ) < 1 ) {
 			return false;
 		}
-		// Wrong or right answers values can't be whitespace.
+
+		// Ensure wrong_answers is an array (even if empty).
+		if ( ! is_array( $wrong_answers ) ) {
+			$wrong_answers = array();
+		}
+
+		// Wrong or right answer values can't be whitespace.
 		return ! count(
 			array_filter(
 				array_merge( $right_answers, $wrong_answers ),

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -198,6 +198,43 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Testing that multiple choice questions with all correct answers are not filtered out.
+	 *
+	 * This test verifies that questions where all answer options are correct
+	 * (i.e., no wrong answers) are still considered complete and rendered on the frontend.
+	 */
+	public function testGetQuestionsFiltersIncompleteQuestionsAllCorrectAnswers() {
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+
+		// Create a question with multiple right answers and no wrong answers (all answers are correct).
+		$question_id = $this->factory->question->create(
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [ 'Answer A', 'Answer B', 'Answer C' ],
+				'question_wrong_answers' => [],
+			]
+		);
+
+		// Create a normal question with both right and wrong answers for comparison.
+		$normal_question_id = $this->factory->question->create(
+			[
+				'quiz_id'       => $quiz_id,
+				'question_type' => 'multiple-choice',
+			]
+		);
+
+		// When filtering incomplete questions, both should be included.
+		$questions_filtered = Sensei()->quiz->get_questions( $quiz_id, 'any', 'meta_value_num title', 'ASC', true );
+		$question_ids       = wp_list_pluck( $questions_filtered, 'ID' );
+
+		$this->assertContains( $question_id, $question_ids, 'Question with all correct answers should not be filtered out' );
+		$this->assertContains( $normal_question_id, $question_ids, 'Normal question should not be filtered out' );
+		$this->assertCount( 2, $questions_filtered, 'Both questions should be included when filtering' );
+	}
+
+	/**
 	 * This test Woothemes_Sensei()->quiz->save_user_answers.
 	 */
 	public function testSaveUserAnswers() {


### PR DESCRIPTION
Resolves #7868.

## Proposed Changes
This updates the logic such that a multiple choice question is allowed to have no wrong answers. Previously, the logic prevented this.

Determining whether to have questions with no wrong answer is best left to a teacher to decide what makes the most sense for their content, not enforced as a technical constraint.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a course and a lesson.
2. Add a Quiz block to the lesson, and add two or more multiple choice questions.
3. For one of the multiple choice questions, mark all answers as correct.
4. View the course and ensure all questions are displayed on the frontend.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions