### PR TITLE
Remove "new" badge from Appearance settings tab

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1115,18 +1115,6 @@ $promo_highlight: #43af99;
 	}
 }
 
-.sensei-settings-tab {
-	&__badge {
-		background-color: var(--wp-admin-theme-color);
-		color: white;
-		font-size: 11px;
-		height: 16px;
-		line-height: 16px;
-		border-radius: 12px;
-		padding: 1px 5px 3px;
-	}
-}
-
 .sensei-settings {
 	&__description--small {
 		max-width: 320px;

--- a/changelog/remove-new-label-appearance-settings
+++ b/changelog/remove-new-label-appearance-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove "new" badge from Appearance settings tab

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -346,10 +346,6 @@ class Sensei_Settings_API {
 					'name'  => esc_attr( $v['name'] ),
 					'class' => esc_attr( $classes ),
 				);
-
-				if ( ! empty( $v['badge'] ) ) {
-					$sections[ $k ]['badge'] = esc_html( $v['badge'] );
-				}
 			}
 
 			$count = 1;
@@ -359,9 +355,6 @@ class Sensei_Settings_API {
 				if ( isset( $v['class'] ) && ( '' !== $v['class'] ) ) {
 					$html .= ' class="' . esc_attr( $v['class'] ) . '"'; }
 				$html .= '>' . esc_html( $v['name'] );
-				if ( ! empty( $v['badge'] ) ) {
-					$html .= ' <span class="sensei-settings-tab__badge">' . $v['badge'] . '</span>';
-				}
 				$html .= '</a>';
 				if ( $count <= count( $sections ) ) {
 					$html .= ' | '; }

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -255,7 +255,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$sections['appearance-settings'] = array(
 			'name'        => __( 'Appearance', 'sensei-lms' ),
 			'description' => __( 'Settings that apply to the entire plugin.', 'sensei-lms' ),
-			'badge'       => __( 'new', 'sensei-lms' ),
 		);
 
 		$sections['course-settings'] = array(


### PR DESCRIPTION
## Proposed Changes
Removes the "new" badge that appeared beside the Appearance tab of Sensei's settings. Learning Mode isn't that new anymore.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Sensei's setting.
2. Ensure there is no "new" badge beside the _Appearance_ tab.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
