### PR TITLE
Fix course list block unit tests failing

### DIFF
--- a/tests/unit-tests/blocks/test-class-sensei-course-list-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-block.php
@@ -62,6 +62,8 @@ class Sensei_Course_List_Block_Test extends WP_UnitTestCase {
 
 	public function get_block_instance( $block_content, $block_parent, \WP_Block $instance ) {
 		$this->block_instance = $instance;
+
+		return $block_content;
 	}
 
 	public function testCourseListBlock_AddsAttributeToInnerTakeCourseButton_WhenRendered() {


### PR DESCRIPTION
## Proposed Changes
* This fixes the PHP unit tests failing.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. The PHP unit tests should be passing in CI.
