### PR TITLE
Add CLI command for recalculating course enrolment

### DIFF
--- a/changelog/update-add-command-for-course-enrolment-recalculation
+++ b/changelog/update-add-command-for-course-enrolment-recalculation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: development
+
+Add CLI command for recalculating course enrolment

--- a/includes/class-sensei-cli.php
+++ b/includes/class-sensei-cli.php
@@ -29,5 +29,6 @@ class Sensei_CLI {
 		WP_CLI::add_command( 'sensei db seed', Sensei_DB_Seed_Command::class );
 		WP_CLI::add_command( 'sensei validate progress', Sensei_Validate_Progress_Command::class );
 		WP_CLI::add_command( 'sensei validate quiz-submission', Sensei_Validate_Quiz_Submission_Command::class );
+		WP_CLI::add_command( 'sensei enrolment calculate-course', Sensei_Enrolment_Course_Calculation_Command::class );
 	}
 }

--- a/includes/cli/class-sensei-enrolment-course-calculation-command.php
+++ b/includes/cli/class-sensei-enrolment-course-calculation-command.php
@@ -66,12 +66,6 @@ class Sensei_Enrolment_Course_Calculation_Command {
 		);
 
 		if ( $should_restart || ! $job->resume() ) {
-			$job = $job_scheduler->start_course_calculation_job( $course_id );
-
-			if ( ! $job ) {
-				WP_CLI::error( __( 'Unable to start the course enrolment calculation job.', 'sensei-lms' ) );
-			}
-
 			WP_CLI::log(
 				sprintf(
 					/* translators: Placeholder is the course ID. */

--- a/includes/cli/class-sensei-enrolment-course-calculation-command.php
+++ b/includes/cli/class-sensei-enrolment-course-calculation-command.php
@@ -46,8 +46,10 @@ class Sensei_Enrolment_Course_Calculation_Command {
 			WP_CLI::error( __( 'You must provide a course ID.', 'sensei-lms' ) );
 		}
 
-		if ( 'course' !== get_post_type( $course_id ) ) {
-			WP_CLI::error( __( 'The provided course ID is not valid.', 'sensei-lms' ) );
+		$course = get_post( $course_id );
+		if ( ! $course || 'course' !== get_post_type( $course ) ) {
+			/* translators: Placeholder is the course ID. */
+			WP_CLI::error( sprintf( __( 'The course with ID %d does not exist.', 'sensei-lms' ), $course_id ) );
 		}
 
 		$job_scheduler = Sensei_Enrolment_Job_Scheduler::instance();

--- a/includes/cli/class-sensei-enrolment-course-calculation-command.php
+++ b/includes/cli/class-sensei-enrolment-course-calculation-command.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * File containing the Sensei_Enrolment_Course_Calculation_Command class.
+ *
+ * @package sensei
+ */
+
+use WP_CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * WP-CLI command that runs the course enrolment calculation job.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Enrolment_Course_Calculation_Command {
+
+	/**
+	 * Run the course enrolment calculation job for a course.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <course_id>
+	 * : Course post ID to recalculate.
+	 *
+	 * [--restart]
+	 * : Start a new job even if one already exists.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp sensei enrolment calculate-course 123
+	 *     wp sensei enrolment calculate-course 123 --restart
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Command arguments.
+	 * @param array $assoc_args Command arguments with names.
+	 */
+	public function __invoke( array $args = [], array $assoc_args = [] ) {
+		$course_id = isset( $args[0] ) ? absint( $args[0] ) : 0;
+
+		if ( ! $course_id ) {
+			WP_CLI::error( __( 'You must provide a course ID.', 'sensei-lms' ) );
+		}
+
+		if ( 'course' !== get_post_type( $course_id ) ) {
+			WP_CLI::error( __( 'The provided course ID is not valid.', 'sensei-lms' ) );
+		}
+
+		$job_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
+
+		if ( ! $job_scheduler->is_background_job_enabled( Sensei_Enrolment_Course_Calculation_Job::NAME ) ) {
+			WP_CLI::error( __( 'The course enrolment calculation job is disabled.', 'sensei-lms' ) );
+		}
+
+		$should_restart = isset( $assoc_args['restart'] );
+		$job            = new Sensei_Enrolment_Course_Calculation_Job(
+			[
+				'course_id' => $course_id,
+			]
+		);
+
+		if ( $should_restart || ! $job->resume() ) {
+			$job = $job_scheduler->start_course_calculation_job( $course_id );
+
+			if ( ! $job ) {
+				WP_CLI::error( __( 'Unable to start the course enrolment calculation job.', 'sensei-lms' ) );
+			}
+
+			WP_CLI::log(
+				sprintf(
+					/* translators: Placeholder is the course ID. */
+					__( 'Starting enrolment calculation for course %d.', 'sensei-lms' ),
+					$course_id
+				)
+			);
+		} else {
+			WP_CLI::log(
+				sprintf(
+					/* translators: Placeholder is the course ID. */
+					__( 'Resuming enrolment calculation for course %d.', 'sensei-lms' ),
+					$course_id
+				)
+			);
+		}
+
+		do {
+			Sensei_Scheduler::instance()->run( $job );
+
+			$last_user_id = $job->get_last_user_id();
+			if ( $last_user_id ) {
+				WP_CLI::log(
+					sprintf(
+						/* translators: Placeholder is the last processed user ID. */
+						__( 'Last processed user ID: %d', 'sensei-lms' ),
+						$last_user_id
+					)
+				);
+			}
+		} while ( ! $job->is_complete() );
+
+		WP_CLI::success(
+			sprintf(
+				/* translators: Placeholder is the course ID. */
+				__( 'Finished calculating enrolment for course %d.', 'sensei-lms' ),
+				$course_id
+			)
+		);
+	}
+}


### PR DESCRIPTION
Resolves p1765271554391509/1764356489.827829-slack-C07418EJ0
Related to 10527031-zd-a8c

## Proposed Changes
- This adds a WP CLI command for recalculating course enrolment - `wp sensei enrolment calculate-course [course_id]`

Some users reported timeouts on larger sites when the course enrolment calculation is triggered. Having this CLI command offers an alternative to solving the issue.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `wp sensei enrolment calculate-course [course_id]` and verify that the `Sensei_Enrolment_Course_Calculation_Job` is triggered as expected.

## Pre-Merge Checklist
<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions