### PR TITLE
Skip failing E2E test

### DIFF
--- a/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
+++ b/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
@@ -54,7 +54,7 @@ describe( 'Courses List Block', () => {
 	} );
 
 	/**
-	 * This test is failing because the course list block patterns now working on WordPress 6.9. A fix was merged but not released yet.
+	 * This test is failing because the course list block patterns are now not working on WordPress 6.9. A fix was merged but not released yet.
 	 *
 	 * @see https://github.com/Automattic/sensei/issues/7873
 	 */

--- a/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
+++ b/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
@@ -53,7 +53,12 @@ describe( 'Courses List Block', () => {
 		} );
 	} );
 
-	test( 'it should render a list of courses', async ( { page } ) => {
+	/**
+	 * This test is failing because the course list block patterns now working on WordPress 6.9. A fix was merged but not released yet.
+	 *
+	 * @see https://github.com/Automattic/sensei/issues/7873
+	 */
+	test.fixme( 'it should render a list of courses', async ( { page } ) => {
 		const postTypePage = new PostType( page, 'page' );
 
 		await postTypePage.goToPostTypeCreationPage();


### PR DESCRIPTION
Related to https://github.com/Automattic/sensei/issues/7873

## Proposed Changes
* This skips a failing E2E test related to the Course List block.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. The E2E test suite should be green.
