### PR TITLE
Fix HPPS migrations for restricted hosting environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .idea
 .cache
+.worktrees
 .phpunit.result.cache
 .wp-env.override.json
 assets/dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,9 @@ All Composer production dependencies are scoped with `Sensei\ThirdParty` namespa
 - **CSS**: SCSS with WordPress Prettier config.
 - **Indentation**: Tabs (4-width) for code, spaces (2-width) for JSON/YAML.
 
+### PHP Inline Documentation
+Follow the [WordPress PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).
+
 ### Naming Conventions
 
 | Type | Convention | Example |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,9 @@ Composer production dependencies that may conflict with other plugins are scoped
 - **Blocks over shortcodes**: New UI features should use Gutenberg blocks (`assets/blocks/`), not shortcodes. Existing shortcodes are maintained for backward compatibility only.
 - **Action Scheduler over wp-cron**: Background/async processing uses Action Scheduler (`includes/background-jobs/`), not raw wp-cron.
 
+### PHP Inline Documentation
+Follow the [WordPress PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).
+
 ## Common Pitfalls
 
 - **CRITICAL: WordPress filters persist between test cases.** Always remove filters added during a test in `tearDown()` or the test will leak state into other tests.

--- a/changelog/fix-hpps-migration-time-budget
+++ b/changelog/fix-hpps-migration-time-budget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix HPPS data migration to work on restricted hosting environments by replacing set_time_limit with time-budgeted batch processing and adding retry logic for failed migrations.

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1246,21 +1246,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$key      = $args['key'];
 		$value    = $settings[ $key ];
 
-		// Disable the checkbox if we can't set time limit. That's our current limitation for running migrations.
-		$disabled_feature            = true;
-		$original_max_execution_time = (int) ini_get( 'max_execution_time' );
-		$disabled_php_functions      = array_map( 'trim', explode( ',', ini_get( 'disable_functions' ) ) );
-		$set_time_limit_disabled     = in_array( 'set_time_limit', $disabled_php_functions, true );
-		if ( 0 !== $original_max_execution_time && ! $set_time_limit_disabled ) {
-			// Set max execution time to 0 to check if we can set it in migrtions.
-			$disabled_feature           = ! set_time_limit( 0 );
-			$current_max_execution_time = (int) ini_get( 'max_execution_time' );
-			if ( $disabled_feature && 0 === $current_max_execution_time ) {
-				$disabled_feature = false;
-			}
-			// Restore original max execution time.
-			set_time_limit( $original_max_execution_time );
-		}
 		?>
 		<div>
 			<label>
@@ -1270,20 +1255,11 @@ class Sensei_Settings extends Sensei_Settings_API {
 					type="checkbox"
 					name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>"
 					value="1"
-					<?php disabled( true, $disabled_feature, true ); ?>
 					<?php checked( $value, true, true ); ?>
 				/>
 				<?php echo esc_html( $args['data']['description'] ); ?>
 			</label>
 
-			<?php if ( $disabled_feature ) : ?>
-				<input type="hidden" name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>" value="<?php echo esc_attr( $value ); ?>" />
-				<p>
-					<?php
-					echo esc_html( __( 'As this feature is currently experimental, it may not be available yet on some sites.', 'sensei-lms' ) );
-					?>
-				</p>
-			<?php endif; ?>
 		<?php if ( ! $value ) : ?>
 			<div class="notice notice-info inline sensei-settings__progress-storage-settings hidden">
 				<p>

--- a/includes/internal/migration/class-migration-abstract.php
+++ b/includes/internal/migration/class-migration-abstract.php
@@ -22,6 +22,22 @@ abstract class Migration_Abstract {
 	private $errors = array();
 
 	/**
+	 * Time budget in seconds for this migration run.
+	 *
+	 * @since 4.26.0
+	 * @var float|null
+	 */
+	private $time_budget = null;
+
+	/**
+	 * Timestamp when the time budget started.
+	 *
+	 * @since 4.26.0
+	 * @var float|null
+	 */
+	private $time_budget_start = null;
+
+	/**
 	 * Run the migration.
 	 *
 	 * @since 4.17.0
@@ -31,6 +47,37 @@ abstract class Migration_Abstract {
 	 * @return int The number of rows migrated.
 	 */
 	abstract public function run( bool $dry_run = true );
+
+	/**
+	 * Set the time budget for this migration run.
+	 *
+	 * @since 4.26.0
+	 *
+	 * @param float $seconds Maximum seconds this run should take.
+	 */
+	public function set_time_budget( float $seconds ): void {
+		$this->time_budget       = $seconds;
+		$this->time_budget_start = microtime( true );
+	}
+
+	/**
+	 * Check if the time budget has been exceeded.
+	 *
+	 * Returns true when 80% of the budget has been consumed.
+	 * Returns false if no budget has been set.
+	 *
+	 * @since 4.26.0
+	 *
+	 * @return bool
+	 */
+	public function is_time_exceeded(): bool {
+		if ( null === $this->time_budget || null === $this->time_budget_start ) {
+			return false;
+		}
+
+		$elapsed = microtime( true ) - $this->time_budget_start;
+		return $elapsed >= ( $this->time_budget * 0.8 );
+	}
 
 	/**
 	 * Return the errors that occurred during the migration.
@@ -54,4 +101,3 @@ abstract class Migration_Abstract {
 		}
 	}
 }
-

--- a/includes/internal/migration/class-migration-abstract.php
+++ b/includes/internal/migration/class-migration-abstract.php
@@ -54,6 +54,7 @@ abstract class Migration_Abstract {
 	 * @since 4.26.0
 	 *
 	 * @param float $seconds Maximum seconds this run should take.
+	 * @return void
 	 */
 	public function set_time_budget( float $seconds ): void {
 		$this->time_budget       = $seconds;

--- a/includes/internal/migration/class-migration-abstract.php
+++ b/includes/internal/migration/class-migration-abstract.php
@@ -24,7 +24,7 @@ abstract class Migration_Abstract {
 	/**
 	 * Time budget in seconds for this migration run.
 	 *
-	 * @since 4.26.0
+	 * @since $$next-version$$
 	 * @var float|null
 	 */
 	private $time_budget = null;
@@ -32,7 +32,7 @@ abstract class Migration_Abstract {
 	/**
 	 * Timestamp when the time budget started.
 	 *
-	 * @since 4.26.0
+	 * @since $$next-version$$
 	 * @var float|null
 	 */
 	private $time_budget_start = null;
@@ -51,7 +51,7 @@ abstract class Migration_Abstract {
 	/**
 	 * Set the time budget for this migration run.
 	 *
-	 * @since 4.26.0
+	 * @since $$next-version$$
 	 *
 	 * @param float $seconds Maximum seconds this run should take.
 	 * @return void
@@ -67,7 +67,7 @@ abstract class Migration_Abstract {
 	 * Returns true when 80% of the budget has been consumed.
 	 * Returns false if no budget has been set.
 	 *
-	 * @since 4.26.0
+	 * @since $$next-version$$
 	 *
 	 * @return bool
 	 */

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -59,6 +59,14 @@ class Migration_Job_Scheduler {
 	 */
 	public const COMPLETED_OPTION_NAME = 'sensei_lms_migration_job_completed';
 
+	/**
+	 * Migration retry count option name.
+	 *
+	 * @since 4.26.0
+	 * @var string
+	 */
+	public const RETRY_COUNT_OPTION_NAME = 'sensei_lms_migration_retry_count';
+
 	public const STATUS_NOT_STARTED = 'not_started';
 	public const STATUS_IN_PROGRESS = 'in_progress';
 	public const STATUS_COMPLETE    = 'complete';
@@ -213,7 +221,30 @@ class Migration_Job_Scheduler {
 		$this->add_error( array( $error['message'] ) );
 
 		$current_status = get_option( self::STATUS_OPTION_NAME, self::STATUS_NOT_STARTED );
-		if ( self::STATUS_FAILED !== $current_status ) {
+		if ( self::STATUS_FAILED === $current_status ) {
+			return;
+		}
+
+		$retry_count = (int) get_option( self::RETRY_COUNT_OPTION_NAME, 0 );
+
+		/**
+		 * Filter the maximum number of retry attempts for failed migrations.
+		 *
+		 * @since 4.26.0
+		 *
+		 * @param int $max_retries Maximum retry attempts. Default 3.
+		 */
+		$max_retries = (int) apply_filters( 'sensei_hpps_migration_max_retries', 3 );
+
+		if ( $retry_count < $max_retries ) {
+			update_option( self::RETRY_COUNT_OPTION_NAME, $retry_count + 1 );
+
+			// Find the failed job and reschedule it.
+			$job = $this->find_failed_job( $action_id );
+			if ( $job ) {
+				$this->schedule_job( $job );
+			}
+		} else {
 			$this->complete( self::STATUS_FAILED );
 		}
 	}
@@ -225,30 +256,36 @@ class Migration_Job_Scheduler {
 	 * @return bool
 	 */
 	private function is_migration_action( $action_id ): bool {
-		// Make sure the action ID is a string.
+		return null !== $this->find_failed_job( $action_id );
+	}
+
+	/**
+	 * Find the migration job associated with a failed action.
+	 *
+	 * @since 4.26.0
+	 *
+	 * @param string $action_id The action ID.
+	 * @return Migration_Job|null
+	 */
+	private function find_failed_job( $action_id ): ?Migration_Job {
 		$action_id = (string) $action_id;
 
-		$hooks = array();
 		foreach ( $this->jobs as $job ) {
-			$hooks[] = $this->get_job_hook_name( $job );
-		}
-
-		$args = array(
-			'status' => 'failed',
-		);
-
-		foreach ( $hooks as $hook ) {
-			$args['hook'] = $hook;
+			$hook = $this->get_job_hook_name( $job );
+			$args = array(
+				'status' => 'failed',
+				'hook'   => $hook,
+			);
 
 			$action_ids = $this->action_scheduler->get_scheduled_actions( $args, 'ids' );
-			// Make sure the action IDs are strings.
 			$action_ids = array_map( 'strval', $action_ids );
+
 			if ( in_array( $action_id, $action_ids, true ) ) {
-				return true;
+				return $job;
 			}
 		}
 
-		return false;
+		return null;
 	}
 
 	/**
@@ -284,6 +321,7 @@ class Migration_Job_Scheduler {
 		}
 
 		if ( $job->is_complete() ) {
+			delete_option( self::RETRY_COUNT_OPTION_NAME );
 			$next_job = $this->get_next_job( $job );
 			if ( $next_job && Progress_Storage_Settings::is_sync_enabled() ) {
 				$this->schedule_job( $next_job );
@@ -310,6 +348,7 @@ class Migration_Job_Scheduler {
 		delete_option( self::ERRORS_OPTION_NAME );
 		delete_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME );
 		delete_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME );
+		delete_option( self::RETRY_COUNT_OPTION_NAME );
 	}
 
 	/**

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -67,10 +67,37 @@ class Migration_Job_Scheduler {
 	 */
 	public const RETRY_COUNT_OPTION_NAME = 'sensei_lms_migration_retry_count';
 
+	/**
+	 * Migration status: not started.
+	 *
+	 * @since 4.17.0
+	 * @var string
+	 */
 	public const STATUS_NOT_STARTED = 'not_started';
+
+	/**
+	 * Migration status: in progress.
+	 *
+	 * @since 4.17.0
+	 * @var string
+	 */
 	public const STATUS_IN_PROGRESS = 'in_progress';
-	public const STATUS_COMPLETE    = 'complete';
-	public const STATUS_FAILED      = 'failed';
+
+	/**
+	 * Migration status: complete.
+	 *
+	 * @since 4.17.0
+	 * @var string
+	 */
+	public const STATUS_COMPLETE = 'complete';
+
+	/**
+	 * Migration status: failed.
+	 *
+	 * @since 4.17.0
+	 * @var string
+	 */
+	public const STATUS_FAILED = 'failed';
 
 	/**
 	 * Action_Scheduler instance.
@@ -97,6 +124,10 @@ class Migration_Job_Scheduler {
 
 	/**
 	 * Initialize the migration job scheduler.
+	 *
+	 * @since 4.26.0
+	 *
+	 * @return void
 	 */
 	public function init(): void {
 		add_action( 'action_scheduler_unexpected_shutdown', [ $this, 'collect_failed_job_errors' ], 10, 2 );

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -309,7 +309,7 @@ class Migration_Job_Scheduler {
 		delete_option( self::COMPLETED_OPTION_NAME );
 		delete_option( self::ERRORS_OPTION_NAME );
 		delete_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME );
-		delete_option( Student_Progress_Migration::LARST_COMMENT_ID_OPTION_NAME );
+		delete_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME );
 	}
 
 	/**

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -264,7 +264,7 @@ class Migration_Job_Scheduler {
 		 *
 		 * @param int $max_retries Maximum retry attempts. Default 3.
 		 */
-		$max_retries = (int) apply_filters( 'sensei_hpps_migration_max_retries', 3 );
+		$max_retries = (int) apply_filters( 'sensei_migration_max_retries', 3 );
 
 		if ( $retry_count < $max_retries ) {
 			update_option( self::RETRY_COUNT_OPTION_NAME, $retry_count + 1 );
@@ -341,7 +341,7 @@ class Migration_Job_Scheduler {
 		 *
 		 * @param float $time_budget Time budget in seconds. Default 20.
 		 */
-		$time_budget = (float) apply_filters( 'sensei_hpps_migration_time_budget', 20.0 );
+		$time_budget = (float) apply_filters( 'sensei_migration_time_budget', 20.0 );
 		$job->set_time_budget( $time_budget );
 
 		$job->run();

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -261,18 +261,21 @@ class Migration_Job_Scheduler {
 	 * @param string $job_name The job name.
 	 */
 	public function run_job( string $job_name ): void {
-		// Temporarily workaround: increase the time limit.
-		$max_execution_time = (int) ini_get( 'max_execution_time' );
-		if ( 0 !== $max_execution_time && function_exists( 'set_time_limit' ) ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			@set_time_limit( 0 );
-		}
-
 		if ( $this->is_first_run() ) {
 			$this->start();
 		}
 
 		$job = $this->jobs[ $job_name ];
+
+		/**
+		 * Filter the time budget (in seconds) for each migration run.
+		 *
+		 * @since 4.26.0
+		 *
+		 * @param float $time_budget Time budget in seconds. Default 20.
+		 */
+		$time_budget = (float) apply_filters( 'sensei_hpps_migration_time_budget', 20.0 );
+		$job->set_time_budget( $time_budget );
 
 		$job->run();
 

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -125,8 +125,6 @@ class Migration_Job_Scheduler {
 	/**
 	 * Initialize the migration job scheduler.
 	 *
-	 * @since 4.26.0
-	 *
 	 * @return void
 	 */
 	public function init(): void {
@@ -251,6 +249,7 @@ class Migration_Job_Scheduler {
 
 		$this->add_error( array( $error['message'] ) );
 
+		// Don't retry if retries were already exhausted and migration was marked failed.
 		$current_status = get_option( self::STATUS_OPTION_NAME, self::STATUS_NOT_STARTED );
 		if ( self::STATUS_FAILED === $current_status ) {
 			return;

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -62,7 +62,7 @@ class Migration_Job_Scheduler {
 	/**
 	 * Migration retry count option name.
 	 *
-	 * @since 4.26.0
+	 * @since $$next-version$$
 	 * @var string
 	 */
 	public const RETRY_COUNT_OPTION_NAME = 'sensei_lms_migration_retry_count';
@@ -260,7 +260,7 @@ class Migration_Job_Scheduler {
 		/**
 		 * Filter the maximum number of retry attempts for failed migrations.
 		 *
-		 * @since 4.26.0
+		 * @since $$next-version$$
 		 *
 		 * @param int $max_retries Maximum retry attempts. Default 3.
 		 */
@@ -292,7 +292,7 @@ class Migration_Job_Scheduler {
 	/**
 	 * Find the migration job associated with a failed action.
 	 *
-	 * @since 4.26.0
+	 * @since $$next-version$$
 	 *
 	 * @param string $action_id The action ID.
 	 * @return Migration_Job|null
@@ -337,7 +337,7 @@ class Migration_Job_Scheduler {
 		/**
 		 * Filter the time budget (in seconds) for each migration run.
 		 *
-		 * @since 4.26.0
+		 * @since $$next-version$$
 		 *
 		 * @param float $time_budget Time budget in seconds. Default 20.
 		 */

--- a/includes/internal/migration/class-migration-job.php
+++ b/includes/internal/migration/class-migration-job.php
@@ -105,7 +105,7 @@ class Migration_Job {
 	/**
 	 * Set the time budget for the migration.
 	 *
-	 * @since 4.26.0
+	 * @since $$next-version$$
 	 *
 	 * @param float $seconds Maximum seconds this run should take.
 	 * @return void

--- a/includes/internal/migration/class-migration-job.php
+++ b/includes/internal/migration/class-migration-job.php
@@ -108,6 +108,7 @@ class Migration_Job {
 	 * @since 4.26.0
 	 *
 	 * @param float $seconds Maximum seconds this run should take.
+	 * @return void
 	 */
 	public function set_time_budget( float $seconds ): void {
 		$this->migration->set_time_budget( $seconds );

--- a/includes/internal/migration/class-migration-job.php
+++ b/includes/internal/migration/class-migration-job.php
@@ -101,5 +101,15 @@ class Migration_Job {
 	public function get_name(): string {
 		return $this->name;
 	}
-}
 
+	/**
+	 * Set the time budget for the migration.
+	 *
+	 * @since 4.26.0
+	 *
+	 * @param float $seconds Maximum seconds this run should take.
+	 */
+	public function set_time_budget( float $seconds ): void {
+		$this->migration->set_time_budget( $seconds );
+	}
+}

--- a/includes/internal/migration/class-migration-job.php
+++ b/includes/internal/migration/class-migration-job.php
@@ -59,8 +59,8 @@ class Migration_Job {
 	 * @since 4.17.0
 	 */
 	public function run(): void {
-		$rows_inserted     = $this->migration->run( false );
-		$this->is_complete = 0 === $rows_inserted;
+		$comments_processed = $this->migration->run( false );
+		$this->is_complete  = 0 === $comments_processed;
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -51,7 +51,7 @@ class Quiz_Migration extends Migration_Abstract {
 		/**
 		 * Filter the batch size for quiz migration.
 		 *
-		 * @since 4.26.0
+		 * @since $$next-version$$
 		 *
 		 * @param int $batch_size The batch size.
 		 */

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -47,8 +47,15 @@ class Quiz_Migration extends Migration_Abstract {
 	 *
 	 * @param int $batch_size The size of a batch or how many quiz submissions to migrate in a single run.
 	 */
-	public function __construct( int $batch_size = 100 ) {
-		$this->batch_size = $batch_size;
+	public function __construct( int $batch_size = 50 ) {
+		/**
+		 * Filter the batch size for quiz migration.
+		 *
+		 * @since 4.26.0
+		 *
+		 * @param int $batch_size The batch size.
+		 */
+		$this->batch_size = (int) apply_filters( 'sensei_hpps_quiz_migration_batch_size', $batch_size );
 	}
 
 	/**
@@ -68,14 +75,24 @@ class Quiz_Migration extends Migration_Abstract {
 		}
 
 		$quiz_data = $this->get_quiz_data( $comments );
+		$processed = 0;
 		foreach ( $comments as $comment ) {
 			$submission_id = $this->insert_quiz_submission( $comment, $quiz_data );
 			if ( ! $submission_id ) {
+				++$processed;
 				continue;
 			}
 
 			$answer_ids = $this->insert_quiz_answers( $comment, $quiz_data, $submission_id );
 			$this->insert_quiz_grades( $comment, $quiz_data, $answer_ids );
+
+			++$processed;
+
+			// Update cursor and stop if time budget exceeded.
+			if ( $this->is_time_exceeded() && $processed < count( $comments ) ) {
+				update_option( self::LAST_COMMENT_ID_OPTION_NAME, $comment->comment_ID );
+				return $processed;
+			}
 		}
 
 		$last_comment_id = end( $comments )->comment_ID;

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -74,13 +74,14 @@ class Quiz_Migration extends Migration_Abstract {
 			return 0;
 		}
 
-		$quiz_data      = $this->get_quiz_data( $comments );
-		$last_comment_id = end( $comments )->comment_ID;
-		$processed       = 0;
+		$quiz_data         = $this->get_quiz_data( $comments );
+		$processed         = 0;
+		$last_processed_id = null;
 
 		foreach ( $comments as $comment ) {
 			$submission_id = $this->insert_quiz_submission( $comment, $quiz_data );
 			if ( ! $submission_id ) {
+				$last_processed_id = $comment->comment_ID;
 				++$processed;
 				continue;
 			}
@@ -88,6 +89,7 @@ class Quiz_Migration extends Migration_Abstract {
 			$answer_ids = $this->insert_quiz_answers( $comment, $quiz_data, $submission_id );
 			$this->insert_quiz_grades( $comment, $quiz_data, $answer_ids );
 
+			$last_processed_id = $comment->comment_ID;
 			++$processed;
 
 			if ( $this->is_time_exceeded() ) {
@@ -95,11 +97,12 @@ class Quiz_Migration extends Migration_Abstract {
 			}
 		}
 
-		// Only advance the cursor if we haven't exceeded the time budget.
-		// If time was exceeded, we re-process the same batch on the next run.
-		// INSERT IGNORE handles already-inserted duplicates safely.
-		if ( ! $this->is_time_exceeded() ) {
-			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_comment_id );
+		// Always advance the cursor to the last fully processed comment.
+		// Each comment is completely handled (submission + answers + grades)
+		// before $last_processed_id is updated, so no partial data is skipped.
+		// INSERT IGNORE ensures safe re-runs if any overlap occurs.
+		if ( $last_processed_id ) {
+			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_processed_id );
 		}
 
 		return $processed;

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -55,7 +55,7 @@ class Quiz_Migration extends Migration_Abstract {
 		 *
 		 * @param int $batch_size The batch size.
 		 */
-		$this->batch_size = (int) apply_filters( 'sensei_hpps_quiz_migration_batch_size', $batch_size );
+		$this->batch_size = (int) apply_filters( 'sensei_migration_quiz_batch_size', $batch_size );
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -38,15 +38,12 @@ class Quiz_Migration extends Migration_Abstract {
 	/**
 	 * The size of a batch or how many quiz submissions to migrate in a single run.
 	 *
-	 * @since 4.26.0
 	 * @var int
 	 */
 	private $batch_size;
 
 	/**
 	 * Constructs a new instance of the migration.
-	 *
-	 * @since 4.26.0
 	 *
 	 * @param int $batch_size The size of a batch or how many quiz submissions to migrate in a single run.
 	 */

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -22,7 +22,7 @@ use Sensei\Internal\Migration\Migration_Abstract;
  */
 class Quiz_Migration extends Migration_Abstract {
 	/**
-	 * Migration errors option name.
+	 * The name of the option that stores the last comment ID that was migrated.
 	 *
 	 * @var string
 	 */
@@ -38,12 +38,15 @@ class Quiz_Migration extends Migration_Abstract {
 	/**
 	 * The size of a batch or how many quiz submissions to migrate in a single run.
 	 *
+	 * @since 4.26.0
 	 * @var int
 	 */
 	private $batch_size;
 
 	/**
 	 * Constructs a new instance of the migration.
+	 *
+	 * @since 4.26.0
 	 *
 	 * @param int $batch_size The size of a batch or how many quiz submissions to migrate in a single run.
 	 */

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -74,8 +74,10 @@ class Quiz_Migration extends Migration_Abstract {
 			return 0;
 		}
 
-		$quiz_data = $this->get_quiz_data( $comments );
-		$processed = 0;
+		$quiz_data      = $this->get_quiz_data( $comments );
+		$last_comment_id = end( $comments )->comment_ID;
+		$processed       = 0;
+
 		foreach ( $comments as $comment ) {
 			$submission_id = $this->insert_quiz_submission( $comment, $quiz_data );
 			if ( ! $submission_id ) {
@@ -88,17 +90,19 @@ class Quiz_Migration extends Migration_Abstract {
 
 			++$processed;
 
-			// Update cursor and stop if time budget exceeded.
-			if ( $this->is_time_exceeded() && $processed < count( $comments ) ) {
-				update_option( self::LAST_COMMENT_ID_OPTION_NAME, $comment->comment_ID );
-				return $processed;
+			if ( $this->is_time_exceeded() ) {
+				break;
 			}
 		}
 
-		$last_comment_id = end( $comments )->comment_ID;
-		update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_comment_id );
+		// Only advance the cursor if we haven't exceeded the time budget.
+		// If time was exceeded, we re-process the same batch on the next run.
+		// INSERT IGNORE handles already-inserted duplicates safely.
+		if ( ! $this->is_time_exceeded() ) {
+			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_comment_id );
+		}
 
-		return count( $comments );
+		return $processed;
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -86,7 +86,6 @@ class Student_Progress_Migration extends Migration_Abstract {
 		$comments_processed = 0;
 		$pending_rows       = array();
 		$last_processed_id  = null;
-		$last_prepared_id   = null;
 
 		foreach ( $progress_comments as $progress_comment ) {
 			$meta = isset( $mapped_meta[ $progress_comment->comment_ID ] )
@@ -95,15 +94,14 @@ class Student_Progress_Migration extends Migration_Abstract {
 
 			$rows = $this->prepare_comment_rows( $progress_comment, $meta );
 
-			$pending_rows     = array_merge( $pending_rows, $rows );
-			$last_prepared_id = $progress_comment->comment_ID;
+			$pending_rows = array_merge( $pending_rows, $rows );
 			++$comments_processed;
 
 			// Flush when the buffer is full or time is running out.
 			if ( count( $pending_rows ) >= $this->insert_batch_size || $this->is_time_exceeded() ) {
 				$this->insert_comment_rows( $pending_rows, $dry_run );
 				$pending_rows      = array();
-				$last_processed_id = $last_prepared_id;
+				$last_processed_id = $progress_comment->comment_ID;
 
 				if ( $this->is_time_exceeded() ) {
 					break;
@@ -114,13 +112,11 @@ class Student_Progress_Migration extends Migration_Abstract {
 		// Flush any remaining rows.
 		if ( ! empty( $pending_rows ) ) {
 			$this->insert_comment_rows( $pending_rows, $dry_run );
-			$last_processed_id = $last_prepared_id;
+			$last_processed_id = $progress_comment->comment_ID;
 		}
 
 		// Always advance the cursor to the last fully processed comment.
-		// Each comment is completely handled before $last_processed_id is
-		// updated, so no partial data is skipped. INSERT IGNORE ensures
-		// safe re-runs if any overlap occurs.
+		// INSERT IGNORE ensures safe re-runs if any overlap occurs.
 		if ( $last_processed_id ) {
 			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_processed_id );
 		}

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -154,9 +154,8 @@ class Student_Progress_Migration extends Migration_Abstract {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$progress_comments = $wpdb->get_results( $comments_query );
 
-		$comment_ids      = array();
-		$post_ids         = array();
-		$trashed_post_ids = array();
+		$comment_ids = array();
+		$post_ids    = array();
 		foreach ( $progress_comments as $progress_comment ) {
 			$comment_ids[] = $progress_comment->comment_ID;
 
@@ -476,9 +475,9 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * Generate SQL for data insertion.
 	 *
-	 * @param array $batch Data to generate queries for. Will be 'data' array returned by `$this->fetch_data_for_migration_for_ids()` method.
+	 * @param array $batch Row data to generate queries for.
 	 *
-	 * @return string Generated queries for insertion for this batch, would be of the form:
+	 * @return string Generated query for insertion for this batch, of the form:
 	 * INSERT IGNORE INTO $table_name ($columns) values
 	 *  ($value for row 1)
 	 *  ($value for row 2)

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -108,7 +108,13 @@ class Student_Progress_Migration extends Migration_Abstract {
 		$this->prepare_progress_to_insert( $progress_comments, $mapped_meta );
 		$inserted_rows = $this->insert_with_batches( $dry_run );
 
-		update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_comment_id );
+		// Only advance the cursor if we haven't exceeded the time budget.
+		// If time was exceeded, insert_with_batches() may have stopped early,
+		// so we re-process the same batch on the next run.
+		// INSERT IGNORE handles already-inserted duplicates safely.
+		if ( ! $this->is_time_exceeded() ) {
+			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_comment_id );
+		}
 
 		return $inserted_rows;
 	}

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -34,7 +34,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	 *
 	 * @var int
 	 */
-	private $batch_size;
+	private $read_batch_size;
 
 	/**
 	 * The number of rows to accumulate before flushing with a multi-row INSERT.
@@ -46,18 +46,18 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * Constructs a new instance of the migration.
 	 *
-	 * @param int $batch_size The number of comments to fetch in a single run.
+	 * @param int $read_batch_size The number of comments to fetch in a single run.
 	 * @param int $insert_batch_size The number of rows to accumulate before flushing.
 	 */
-	public function __construct( int $batch_size = 250, int $insert_batch_size = 50 ) {
+	public function __construct( int $read_batch_size = 250, int $insert_batch_size = 50 ) {
 		/**
 		 * Filter the batch size for student progress migration.
 		 *
-		 * @since 4.26.0
+		 * @since $$next-version$$
 		 *
-		 * @param int $batch_size The batch size.
+		 * @param int $read_batch_size The batch size.
 		 */
-		$this->batch_size = (int) apply_filters( 'sensei_migration_student_progress_batch_size', $batch_size );
+		$this->read_batch_size = (int) apply_filters( 'sensei_migration_student_progress_batch_size', $read_batch_size );
 
 		$this->insert_batch_size = $insert_batch_size;
 	}
@@ -133,7 +133,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	private function get_comments_and_meta( int $after_comment_id, bool $dry_run ): array {
 		global $wpdb;
 
-		$limit = $this->batch_size;
+		$limit = $this->read_batch_size;
 
 		$comments_query = $wpdb->prepare(
 			"SELECT * FROM {$wpdb->comments} " .

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -96,12 +96,12 @@ class Student_Progress_Migration extends Migration_Abstract {
 
 			$pending_rows = array_merge( $pending_rows, $rows );
 			++$comments_processed;
+			$last_processed_id = $progress_comment->comment_ID;
 
 			// Flush when the buffer is full or time is running out.
 			if ( count( $pending_rows ) >= $this->insert_batch_size || $this->is_time_exceeded() ) {
 				$this->insert_comment_rows( $pending_rows, $dry_run );
-				$pending_rows      = array();
-				$last_processed_id = $progress_comment->comment_ID;
+				$pending_rows = array();
 
 				if ( $this->is_time_exceeded() ) {
 					break;
@@ -112,7 +112,6 @@ class Student_Progress_Migration extends Migration_Abstract {
 		// Flush any remaining rows.
 		if ( ! empty( $pending_rows ) ) {
 			$this->insert_comment_rows( $pending_rows, $dry_run );
-			$last_processed_id = $progress_comment->comment_ID;
 		}
 
 		// Always advance the cursor to the last fully processed comment.

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -30,15 +30,6 @@ class Student_Progress_Migration extends Migration_Abstract {
 	public const LAST_COMMENT_ID_OPTION_NAME = 'sensei_migrated_progress_last_comment_id';
 
 	/**
-	 * Deprecated. Use LAST_COMMENT_ID_OPTION_NAME instead.
-	 *
-	 * @since 4.26.0
-	 * @deprecated 4.26.0
-	 * @var string
-	 */
-	public const LARST_COMMENT_ID_OPTION_NAME = self::LAST_COMMENT_ID_OPTION_NAME;
-
-	/**
 	 * The course progress data to insert.
 	 *
 	 * @var array

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -30,18 +30,26 @@ class Student_Progress_Migration extends Migration_Abstract {
 	public const LAST_COMMENT_ID_OPTION_NAME = 'sensei_migrated_progress_last_comment_id';
 
 	/**
-	 * The size of a batch or how many comments to migrate in a single run.
+	 * The number of comments to fetch in a single run.
 	 *
 	 * @var int
 	 */
 	private $batch_size;
 
 	/**
+	 * The number of rows to accumulate before flushing with a multi-row INSERT.
+	 *
+	 * @var int
+	 */
+	private $insert_batch_size;
+
+	/**
 	 * Constructs a new instance of the migration.
 	 *
-	 * @param int $batch_size The size of a batch or how many comments to migrate in a single run.
+	 * @param int $batch_size The number of comments to fetch in a single run.
+	 * @param int $insert_batch_size The number of rows to accumulate before flushing.
 	 */
-	public function __construct( int $batch_size = 250 ) {
+	public function __construct( int $batch_size = 250, int $insert_batch_size = 50 ) {
 		/**
 		 * Filter the batch size for student progress migration.
 		 *
@@ -50,6 +58,8 @@ class Student_Progress_Migration extends Migration_Abstract {
 		 * @param int $batch_size The batch size.
 		 */
 		$this->batch_size = (int) apply_filters( 'sensei_migration_student_progress_batch_size', $batch_size );
+
+		$this->insert_batch_size = $insert_batch_size;
 	}
 
 	/**
@@ -74,21 +84,36 @@ class Student_Progress_Migration extends Migration_Abstract {
 		}
 
 		$inserted_rows     = 0;
+		$pending_rows      = array();
 		$last_processed_id = null;
+		$last_prepared_id  = null;
 
 		foreach ( $progress_comments as $progress_comment ) {
 			$meta = isset( $mapped_meta[ $progress_comment->comment_ID ] )
 				? $mapped_meta[ $progress_comment->comment_ID ]
 				: array();
 
-			$rows           = $this->prepare_comment_rows( $progress_comment, $meta );
-			$inserted_rows += $this->insert_comment_rows( $rows, $dry_run );
+			$rows = $this->prepare_comment_rows( $progress_comment, $meta );
 
-			$last_processed_id = $progress_comment->comment_ID;
+			$pending_rows     = array_merge( $pending_rows, $rows );
+			$last_prepared_id = $progress_comment->comment_ID;
 
-			if ( $this->is_time_exceeded() ) {
-				break;
+			// Flush when the buffer is full or time is running out.
+			if ( count( $pending_rows ) >= $this->insert_batch_size || $this->is_time_exceeded() ) {
+				$inserted_rows    += $this->insert_comment_rows( $pending_rows, $dry_run );
+				$pending_rows      = array();
+				$last_processed_id = $last_prepared_id;
+
+				if ( $this->is_time_exceeded() ) {
+					break;
+				}
 			}
+		}
+
+		// Flush any remaining rows.
+		if ( ! empty( $pending_rows ) ) {
+			$inserted_rows    += $this->insert_comment_rows( $pending_rows, $dry_run );
+			$last_processed_id = $last_prepared_id;
 		}
 
 		// Always advance the cursor to the last fully processed comment.

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -48,7 +48,6 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * The size of a batch.
 	 *
-	 * @since 4.26.0
 	 * @var int
 	 */
 	private $batch_size;
@@ -56,15 +55,12 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * The number of batches to insert in a single run.
 	 *
-	 * @since 4.26.0
 	 * @var int
 	 */
 	private $batch_count;
 
 	/**
 	 * Constructs a new instance of the migration.
-	 *
-	 * @since 4.26.0
 	 *
 	 * @param int $batch_size  The size of a batch (how many rows to insert in one insert query).
 	 * @param int $batch_count The number of batches to insert in a single run.

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -32,6 +32,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * Deprecated. Use LAST_COMMENT_ID_OPTION_NAME instead.
 	 *
+	 * @since 4.26.0
 	 * @deprecated 4.26.0
 	 * @var string
 	 */
@@ -47,6 +48,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * The size of a batch.
 	 *
+	 * @since 4.26.0
 	 * @var int
 	 */
 	private $batch_size;
@@ -54,6 +56,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * The number of batches to insert in a single run.
 	 *
+	 * @since 4.26.0
 	 * @var int
 	 */
 	private $batch_count;
@@ -61,7 +64,9 @@ class Student_Progress_Migration extends Migration_Abstract {
 	/**
 	 * Constructs a new instance of the migration.
 	 *
-	 * @param int $batch_size The size of a batch (how many rows to insert in one insert query).
+	 * @since 4.26.0
+	 *
+	 * @param int $batch_size  The size of a batch (how many rows to insert in one insert query).
 	 * @param int $batch_count The number of batches to insert in a single run.
 	 */
 	public function __construct( int $batch_size = 50, int $batch_count = 5 ) {

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -68,7 +68,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	 * @since 4.16.1
 	 *
 	 * @param bool $dry_run Whether to run the migration in dry-run mode.
-	 * @return int The number of rows inserted.
+	 * @return int The number of comments processed.
 	 */
 	public function run( bool $dry_run = true ) {
 		$since_comment_id                                      = (int) get_option( self::LAST_COMMENT_ID_OPTION_NAME, 0 );
@@ -83,10 +83,10 @@ class Student_Progress_Migration extends Migration_Abstract {
 			return 0;
 		}
 
-		$inserted_rows     = 0;
-		$pending_rows      = array();
-		$last_processed_id = null;
-		$last_prepared_id  = null;
+		$comments_processed = 0;
+		$pending_rows       = array();
+		$last_processed_id  = null;
+		$last_prepared_id   = null;
 
 		foreach ( $progress_comments as $progress_comment ) {
 			$meta = isset( $mapped_meta[ $progress_comment->comment_ID ] )
@@ -97,10 +97,11 @@ class Student_Progress_Migration extends Migration_Abstract {
 
 			$pending_rows     = array_merge( $pending_rows, $rows );
 			$last_prepared_id = $progress_comment->comment_ID;
+			++$comments_processed;
 
 			// Flush when the buffer is full or time is running out.
 			if ( count( $pending_rows ) >= $this->insert_batch_size || $this->is_time_exceeded() ) {
-				$inserted_rows    += $this->insert_comment_rows( $pending_rows, $dry_run );
+				$this->insert_comment_rows( $pending_rows, $dry_run );
 				$pending_rows      = array();
 				$last_processed_id = $last_prepared_id;
 
@@ -112,7 +113,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 
 		// Flush any remaining rows.
 		if ( ! empty( $pending_rows ) ) {
-			$inserted_rows    += $this->insert_comment_rows( $pending_rows, $dry_run );
+			$this->insert_comment_rows( $pending_rows, $dry_run );
 			$last_processed_id = $last_prepared_id;
 		}
 
@@ -124,7 +125,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_processed_id );
 		}
 
-		return $inserted_rows;
+		return $comments_processed;
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -27,7 +27,15 @@ class Student_Progress_Migration extends Migration_Abstract {
 	 *
 	 * @var string
 	 */
-	public const LARST_COMMENT_ID_OPTION_NAME = 'sensei_migrated_progress_last_comment_id';
+	public const LAST_COMMENT_ID_OPTION_NAME = 'sensei_migrated_progress_last_comment_id';
+
+	/**
+	 * Deprecated. Use LAST_COMMENT_ID_OPTION_NAME instead.
+	 *
+	 * @deprecated 4.26.0
+	 * @var string
+	 */
+	public const LARST_COMMENT_ID_OPTION_NAME = self::LAST_COMMENT_ID_OPTION_NAME;
 
 	/**
 	 * The course progress data to insert.
@@ -56,9 +64,24 @@ class Student_Progress_Migration extends Migration_Abstract {
 	 * @param int $batch_size The size of a batch (how many rows to insert in one insert query).
 	 * @param int $batch_count The number of batches to insert in a single run.
 	 */
-	public function __construct( int $batch_size = 100, int $batch_count = 10 ) {
-		$this->batch_size  = $batch_size;
-		$this->batch_count = $batch_count;
+	public function __construct( int $batch_size = 50, int $batch_count = 5 ) {
+		/**
+		 * Filter the batch size for student progress migration.
+		 *
+		 * @since 4.26.0
+		 *
+		 * @param int $batch_size The size of a batch.
+		 */
+		$this->batch_size = (int) apply_filters( 'sensei_hpps_student_progress_batch_size', $batch_size );
+
+		/**
+		 * Filter the batch count for student progress migration.
+		 *
+		 * @since 4.26.0
+		 *
+		 * @param int $batch_count The number of batches per run.
+		 */
+		$this->batch_count = (int) apply_filters( 'sensei_hpps_student_progress_batch_count', $batch_count );
 	}
 
 	/**
@@ -70,7 +93,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	 * @return int The number of rows inserted.
 	 */
 	public function run( bool $dry_run = true ) {
-		$since_comment_id                                      = (int) get_option( self::LARST_COMMENT_ID_OPTION_NAME, 0 );
+		$since_comment_id                                      = (int) get_option( self::LAST_COMMENT_ID_OPTION_NAME, 0 );
 		[ $progress_comments, $mapped_meta, $last_comment_id ] = $this->get_comments_and_meta( $since_comment_id, $dry_run );
 
 		if ( empty( $progress_comments ) ) {
@@ -85,7 +108,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 		$this->prepare_progress_to_insert( $progress_comments, $mapped_meta );
 		$inserted_rows = $this->insert_with_batches( $dry_run );
 
-		update_option( self::LARST_COMMENT_ID_OPTION_NAME, $last_comment_id );
+		update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_comment_id );
 
 		return $inserted_rows;
 	}
@@ -416,6 +439,11 @@ class Student_Progress_Migration extends Migration_Abstract {
 			}
 
 			$inserted_rows += $this->db_query( $insert_query );
+
+			// Stop processing if we're running out of time.
+			if ( $this->is_time_exceeded() ) {
+				break;
+			}
 		}
 
 		return $inserted_rows;

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -51,15 +51,22 @@ class Student_Progress_Migration extends Migration_Abstract {
 	 */
 	public function __construct( int $read_batch_size = 250, int $insert_batch_size = 50 ) {
 		/**
-		 * Filter the batch size for student progress migration.
+		 * Filter the read batch size for student progress migration.
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param int $read_batch_size The batch size.
+		 * @param int $read_batch_size The read batch size.
 		 */
-		$this->read_batch_size = (int) apply_filters( 'sensei_migration_student_progress_batch_size', $read_batch_size );
+		$this->read_batch_size = (int) apply_filters( 'sensei_migration_student_progress_read_batch_size', $read_batch_size );
 
-		$this->insert_batch_size = $insert_batch_size;
+		/**
+		 * Filter the insert batch size for student progress migration.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $insert_batch_size The insert batch size.
+		 */
+		$this->insert_batch_size = (int) apply_filters( 'sensei_migration_student_progress_insert_batch_size', $insert_batch_size );
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -64,7 +64,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 		 *
 		 * @param int $batch_size The size of a batch.
 		 */
-		$this->batch_size = (int) apply_filters( 'sensei_hpps_student_progress_batch_size', $batch_size );
+		$this->batch_size = (int) apply_filters( 'sensei_migration_student_progress_batch_size', $batch_size );
 
 		/**
 		 * Filter the batch count for student progress migration.
@@ -73,7 +73,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 		 *
 		 * @param int $batch_count The number of batches per run.
 		 */
-		$this->batch_count = (int) apply_filters( 'sensei_hpps_student_progress_batch_count', $batch_count );
+		$this->batch_count = (int) apply_filters( 'sensei_migration_student_progress_batch_count', $batch_count );
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -30,50 +30,26 @@ class Student_Progress_Migration extends Migration_Abstract {
 	public const LAST_COMMENT_ID_OPTION_NAME = 'sensei_migrated_progress_last_comment_id';
 
 	/**
-	 * The course progress data to insert.
-	 *
-	 * @var array
-	 */
-	private $progress_inserts = array();
-
-	/**
-	 * The size of a batch.
+	 * The size of a batch or how many comments to migrate in a single run.
 	 *
 	 * @var int
 	 */
 	private $batch_size;
 
 	/**
-	 * The number of batches to insert in a single run.
-	 *
-	 * @var int
-	 */
-	private $batch_count;
-
-	/**
 	 * Constructs a new instance of the migration.
 	 *
-	 * @param int $batch_size  The size of a batch (how many rows to insert in one insert query).
-	 * @param int $batch_count The number of batches to insert in a single run.
+	 * @param int $batch_size The size of a batch or how many comments to migrate in a single run.
 	 */
-	public function __construct( int $batch_size = 50, int $batch_count = 5 ) {
+	public function __construct( int $batch_size = 250 ) {
 		/**
 		 * Filter the batch size for student progress migration.
 		 *
 		 * @since 4.26.0
 		 *
-		 * @param int $batch_size The size of a batch.
+		 * @param int $batch_size The batch size.
 		 */
 		$this->batch_size = (int) apply_filters( 'sensei_migration_student_progress_batch_size', $batch_size );
-
-		/**
-		 * Filter the batch count for student progress migration.
-		 *
-		 * @since 4.26.0
-		 *
-		 * @param int $batch_count The number of batches per run.
-		 */
-		$this->batch_count = (int) apply_filters( 'sensei_migration_student_progress_batch_count', $batch_count );
 	}
 
 	/**
@@ -97,15 +73,30 @@ class Student_Progress_Migration extends Migration_Abstract {
 			return 0;
 		}
 
-		$this->prepare_progress_to_insert( $progress_comments, $mapped_meta );
-		$inserted_rows = $this->insert_with_batches( $dry_run );
+		$inserted_rows     = 0;
+		$last_processed_id = null;
 
-		// Only advance the cursor if we haven't exceeded the time budget.
-		// If time was exceeded, insert_with_batches() may have stopped early,
-		// so we re-process the same batch on the next run.
-		// INSERT IGNORE handles already-inserted duplicates safely.
-		if ( ! $this->is_time_exceeded() ) {
-			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_comment_id );
+		foreach ( $progress_comments as $progress_comment ) {
+			$meta = isset( $mapped_meta[ $progress_comment->comment_ID ] )
+				? $mapped_meta[ $progress_comment->comment_ID ]
+				: array();
+
+			$rows           = $this->prepare_comment_rows( $progress_comment, $meta );
+			$inserted_rows += $this->insert_comment_rows( $rows, $dry_run );
+
+			$last_processed_id = $progress_comment->comment_ID;
+
+			if ( $this->is_time_exceeded() ) {
+				break;
+			}
+		}
+
+		// Always advance the cursor to the last fully processed comment.
+		// Each comment is completely handled before $last_processed_id is
+		// updated, so no partial data is skipped. INSERT IGNORE ensures
+		// safe re-runs if any overlap occurs.
+		if ( $last_processed_id ) {
+			update_option( self::LAST_COMMENT_ID_OPTION_NAME, $last_processed_id );
 		}
 
 		return $inserted_rows;
@@ -121,7 +112,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 	private function get_comments_and_meta( int $after_comment_id, bool $dry_run ): array {
 		global $wpdb;
 
-		$limit = $this->batch_size * $this->batch_count;
+		$limit = $this->batch_size;
 
 		$comments_query = $wpdb->prepare(
 			"SELECT * FROM {$wpdb->comments} " .
@@ -230,53 +221,46 @@ class Student_Progress_Migration extends Migration_Abstract {
 
 
 	/**
-	 * Prepare the course progress data to be inserted.
+	 * Prepare the insert rows for a single comment.
 	 *
-	 * @param array $progress_comments The comments to migrate.
-	 * @param array $mapped_meta The comment meta to migrate.
+	 * @param object $progress_comment The comment to migrate.
+	 * @param array  $meta The comment meta.
+	 * @return array The rows to insert.
 	 */
-	private function prepare_progress_to_insert( $progress_comments, $mapped_meta ): void {
-		$this->progress_inserts = array();
-		foreach ( $progress_comments as $progress_comment ) {
-			$meta = isset( $mapped_meta[ $progress_comment->comment_ID ] )
-				? $mapped_meta[ $progress_comment->comment_ID ]
-				: array();
+	private function prepare_comment_rows( $progress_comment, $meta ): array {
+		// Process comments for trashed posts.
+		if ( 'post-trashed' === $progress_comment->comment_approved ) {
+			$progress_comment->comment_approved = isset( $meta['status'] )
+				? $meta['status']
+				: 'in-progress';
+		}
 
-			// Process comments for trashed posts.
-			if ( 'post-trashed' === $progress_comment->comment_approved ) {
-				$progress_comment->comment_approved = isset( $meta['status'] )
-					? $meta['status']
-					: 'in-progress';
-			}
-
-			switch ( $progress_comment->comment_type ) {
-				case 'sensei_course_status':
-					$this->prepare_course_progress_to_insert( $progress_comment, $meta );
-					break;
-				case 'sensei_lesson_status':
-					$this->prepare_lesson_progress_to_insert( $progress_comment, $meta );
-					break;
-				default:
-					$this->add_error(
-						sprintf(
-						/* translators: %s: comment type */
-							__( 'Unknown comment (id %1$d) type: %2$s', 'sensei-lms' ),
-							$progress_comment->comment_ID,
-							$progress_comment->comment_type
-						)
-					);
-
-			}
+		switch ( $progress_comment->comment_type ) {
+			case 'sensei_course_status':
+				return $this->prepare_course_progress_row( $progress_comment, $meta );
+			case 'sensei_lesson_status':
+				return $this->prepare_lesson_progress_rows( $progress_comment, $meta );
+			default:
+				$this->add_error(
+					sprintf(
+					/* translators: %s: comment type */
+						__( 'Unknown comment (id %1$d) type: %2$s', 'sensei-lms' ),
+						$progress_comment->comment_ID,
+						$progress_comment->comment_type
+					)
+				);
+				return array();
 		}
 	}
 
 	/**
-	 * Prepare the course progress data to be inserted.
+	 * Prepare the course progress row for a single comment.
 	 *
 	 * @param object $comment The comment to migrate.
-	 * @param array  $meta The comment meta to migrate.
+	 * @param array  $meta The comment meta.
+	 * @return array The rows to insert.
 	 */
-	private function prepare_course_progress_to_insert( $comment, $meta ): void {
+	private function prepare_course_progress_row( $comment, $meta ): array {
 		$course_status = 'in-progress';
 		if ( Course_Progress_Interface::STATUS_COMPLETE === $comment->comment_approved ) {
 			$course_status = 'complete';
@@ -303,26 +287,29 @@ class Student_Progress_Migration extends Migration_Abstract {
 			}
 		}
 
-		$this->progress_inserts[] = [
-			'post_id'        => (int) $comment->comment_post_ID,
-			'user_id'        => (int) $comment->user_id,
-			'parent_post_id' => null,
-			'type'           => 'course',
-			'status'         => $course_status,
-			'started_at'     => $started_at,
-			'completed_at'   => $completed_at,
-			'created_at'     => $comment->comment_date_gmt,
-			'updated_at'     => $comment->comment_date_gmt,
-		];
+		return array(
+			array(
+				'post_id'        => (int) $comment->comment_post_ID,
+				'user_id'        => (int) $comment->user_id,
+				'parent_post_id' => null,
+				'type'           => 'course',
+				'status'         => $course_status,
+				'started_at'     => $started_at,
+				'completed_at'   => $completed_at,
+				'created_at'     => $comment->comment_date_gmt,
+				'updated_at'     => $comment->comment_date_gmt,
+			),
+		);
 	}
 
 	/**
-	 * Prepare the lesson progress data to be inserted.
+	 * Prepare the lesson progress rows for a single comment.
 	 *
 	 * @param object $comment The comment to migrate.
-	 * @param array  $meta The comment meta to migrate.
+	 * @param array  $meta The comment meta.
+	 * @return array The rows to insert.
 	 */
-	private function prepare_lesson_progress_to_insert( $comment, $meta ): void {
+	private function prepare_lesson_progress_rows( $comment, $meta ): array {
 		$lesson_status = 'in-progress';
 		$completed_at  = null;
 		if ( in_array( $comment->comment_approved, [ 'complete', 'passed', 'graded' ], true ) ) {
@@ -355,17 +342,19 @@ class Student_Progress_Migration extends Migration_Abstract {
 			}
 		}
 
-		$this->progress_inserts[] = [
-			'post_id'        => (int) $comment->comment_post_ID,
-			'user_id'        => (int) $comment->user_id,
-			'parent_post_id' => null,
-			'type'           => 'lesson',
-			'status'         => $lesson_status,
-			'started_at'     => $started_at,
-			'completed_at'   => $completed_at,
-			'created_at'     => $comment->comment_date_gmt,
-			'updated_at'     => $comment->comment_date_gmt,
-		];
+		$rows = array(
+			array(
+				'post_id'        => (int) $comment->comment_post_ID,
+				'user_id'        => (int) $comment->user_id,
+				'parent_post_id' => null,
+				'type'           => 'lesson',
+				'status'         => $lesson_status,
+				'started_at'     => $started_at,
+				'completed_at'   => $completed_at,
+				'created_at'     => $comment->comment_date_gmt,
+				'updated_at'     => $comment->comment_date_gmt,
+			),
+		);
 
 		// In case there is a quiz associated with the lesson,
 		// we create a quiz progress entry as well.
@@ -393,7 +382,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 				$quiz_status = Quiz_Progress_Interface::STATUS_PASSED;
 			}
 
-			$this->progress_inserts[] = [
+			$rows[] = array(
 				'post_id'        => (int) $quiz_id,
 				'user_id'        => (int) $comment->user_id,
 				'parent_post_id' => null,
@@ -403,8 +392,10 @@ class Student_Progress_Migration extends Migration_Abstract {
 				'completed_at'   => $quiz_completed_at,
 				'created_at'     => $comment->comment_date_gmt,
 				'updated_at'     => $comment->comment_date_gmt,
-			];
+			);
 		}
+
+		return $rows;
 	}
 
 	/**
@@ -420,31 +411,25 @@ class Student_Progress_Migration extends Migration_Abstract {
 	}
 
 	/**
-	 * Insert the progress data in batches.
+	 * Insert the rows for a single comment.
 	 *
-	 * @param bool $dry_run Whether to run the migration in dry-run mode.
+	 * @param array $rows The rows to insert.
+	 * @param bool  $dry_run Whether to run the migration in dry-run mode.
+	 * @return int The number of rows inserted.
 	 */
-	private function insert_with_batches( bool $dry_run ): int {
-		$progress_count = count( $this->progress_inserts );
-		$inserted_rows  = 0;
-		for ( $i = 0; $i < $progress_count; $i += $this->batch_size ) {
-			$batch        = array_slice( $this->progress_inserts, $i, $this->batch_size );
-			$insert_query = $this->generate_insert_sql_for_batch( $batch );
-
-			if ( $dry_run ) {
-				echo esc_html( $insert_query . "\n" );
-				continue;
-			}
-
-			$inserted_rows += $this->db_query( $insert_query );
-
-			// Stop processing if we're running out of time.
-			if ( $this->is_time_exceeded() ) {
-				break;
-			}
+	private function insert_comment_rows( array $rows, bool $dry_run ): int {
+		if ( empty( $rows ) ) {
+			return 0;
 		}
 
-		return $inserted_rows;
+		$insert_query = $this->generate_insert_sql_for_batch( $rows );
+
+		if ( $dry_run ) {
+			echo esc_html( $insert_query . "\n" );
+			return 0;
+		}
+
+		return $this->db_query( $insert_query );
 	}
 
 	/**

--- a/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
@@ -125,38 +125,6 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 		$this->assertSame( $expected, $this->get_quiz_data( $quiz_id, $user_id ) );
 	}
 
-	public function testRun_DefaultBatchSize_UsesReducedDefault(): void {
-		/* Arrange. */
-		$migration  = new Quiz_Migration();
-		$reflection = new \ReflectionClass( $migration );
-
-		$batch_size_prop = $reflection->getProperty( 'batch_size' );
-		$batch_size_prop->setAccessible( true );
-
-		/* Assert. */
-		$this->assertSame( 50, $batch_size_prop->getValue( $migration ) );
-	}
-
-	public function testRun_BatchSizeFilter_UsesFilteredValue(): void {
-		/* Arrange. */
-		$filter = function () {
-			return 25;
-		};
-		add_filter( 'sensei_migration_quiz_batch_size', $filter );
-
-		$migration  = new Quiz_Migration();
-		$reflection = new \ReflectionClass( $migration );
-
-		$batch_size_prop = $reflection->getProperty( 'batch_size' );
-		$batch_size_prop->setAccessible( true );
-
-		/* Assert. */
-		$this->assertSame( 25, $batch_size_prop->getValue( $migration ) );
-
-		/* Cleanup. */
-		remove_filter( 'sensei_migration_quiz_batch_size', $filter );
-	}
-
 	public function testRun_TimeExceeded_StopsEarlyAndDoesNotAdvanceCursor(): void {
 		/* Arrange. */
 		$this->create_quiz_data();

--- a/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
@@ -125,6 +125,59 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 		$this->assertSame( $expected, $this->get_quiz_data( $quiz_id, $user_id ) );
 	}
 
+	public function testRun_DefaultBatchSize_UsesReducedDefault(): void {
+		/* Arrange. */
+		$migration  = new Quiz_Migration();
+		$reflection = new \ReflectionClass( $migration );
+
+		$batch_size_prop = $reflection->getProperty( 'batch_size' );
+		$batch_size_prop->setAccessible( true );
+
+		/* Assert. */
+		$this->assertSame( 50, $batch_size_prop->getValue( $migration ) );
+	}
+
+	public function testRun_BatchSizeFilter_UsesFilteredValue(): void {
+		/* Arrange. */
+		$filter = function () {
+			return 25;
+		};
+		add_filter( 'sensei_hpps_quiz_migration_batch_size', $filter );
+
+		$migration  = new Quiz_Migration();
+		$reflection = new \ReflectionClass( $migration );
+
+		$batch_size_prop = $reflection->getProperty( 'batch_size' );
+		$batch_size_prop->setAccessible( true );
+
+		/* Assert. */
+		$this->assertSame( 25, $batch_size_prop->getValue( $migration ) );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_hpps_quiz_migration_batch_size', $filter );
+	}
+
+	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {
+		/* Arrange. */
+		$this->create_quiz_data();
+		$this->create_quiz_data();
+		$this->create_quiz_data();
+
+		$this->cleanup_custom_tables();
+
+		$migration = new Quiz_Migration( 100 );
+		// Set a zero time budget so it stops after the first comment.
+		$migration->set_time_budget( 0.0 );
+
+		/* Act. */
+		$result = $migration->run( false );
+
+		/* Assert. */
+		// Should have processed some but not all 3 quiz submissions.
+		$this->assertGreaterThan( 0, $result );
+		$this->assertLessThan( 3, $result );
+	}
+
 	private function create_quiz_data() {
 		$user_id     = 1;
 		$lesson_id   = $this->factory->lesson->create();

--- a/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
@@ -157,7 +157,7 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 		remove_filter( 'sensei_migration_quiz_batch_size', $filter );
 	}
 
-	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {
+	public function testRun_TimeExceeded_StopsEarlyAndDoesNotAdvanceCursor(): void {
 		/* Arrange. */
 		$this->create_quiz_data();
 		$this->create_quiz_data();
@@ -165,17 +165,20 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 
 		$this->cleanup_custom_tables();
 
+		update_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME, 0 );
+
 		$migration = new Quiz_Migration( 100 );
-		// Set a zero time budget so it stops after the first comment.
+		// Set a zero time budget so it stops immediately.
 		$migration->set_time_budget( 0.0 );
 
 		/* Act. */
-		$result = $migration->run( false );
+		$migration->run( false );
 
 		/* Assert. */
-		// Should have processed some but not all 3 quiz submissions.
-		$this->assertGreaterThan( 0, $result );
-		$this->assertLessThan( 3, $result );
+		// Cursor should NOT have advanced because time was exceeded.
+		// The same batch will be re-processed on the next run.
+		$cursor = get_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME );
+		$this->assertSame( '0', $cursor );
 	}
 
 	private function create_quiz_data() {

--- a/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
@@ -125,7 +125,7 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 		$this->assertSame( $expected, $this->get_quiz_data( $quiz_id, $user_id ) );
 	}
 
-	public function testRun_TimeExceeded_StopsEarlyAndDoesNotAdvanceCursor(): void {
+	public function testRun_TimeExceeded_AdvancesCursorToLastProcessedComment(): void {
 		/* Arrange. */
 		$this->create_quiz_data();
 		$this->create_quiz_data();
@@ -136,17 +136,17 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 		update_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME, 0 );
 
 		$migration = new Quiz_Migration( 100 );
-		// Set a zero time budget so it stops immediately.
+		// Set a zero time budget so it stops after the first comment.
 		$migration->set_time_budget( 0.0 );
 
 		/* Act. */
 		$migration->run( false );
 
 		/* Assert. */
-		// Cursor should NOT have advanced because time was exceeded.
-		// The same batch will be re-processed on the next run.
-		$cursor = get_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME );
-		$this->assertSame( '0', $cursor );
+		// Cursor should have advanced to the first processed comment,
+		// guaranteeing forward progress even when time is exceeded.
+		$cursor = (int) get_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME );
+		$this->assertGreaterThan( 0, $cursor );
 	}
 
 	private function create_quiz_data() {

--- a/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-quiz-migration.php
@@ -142,7 +142,7 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 		$filter = function () {
 			return 25;
 		};
-		add_filter( 'sensei_hpps_quiz_migration_batch_size', $filter );
+		add_filter( 'sensei_migration_quiz_batch_size', $filter );
 
 		$migration  = new Quiz_Migration();
 		$reflection = new \ReflectionClass( $migration );
@@ -154,7 +154,7 @@ class Quiz_Migration_Test extends \WP_UnitTestCase {
 		$this->assertSame( 25, $batch_size_prop->getValue( $migration ) );
 
 		/* Cleanup. */
-		remove_filter( 'sensei_hpps_quiz_migration_batch_size', $filter );
+		remove_filter( 'sensei_migration_quiz_batch_size', $filter );
 	}
 
 	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -156,16 +156,11 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertSame( $expected, $actual_rows );
 	}
 
-	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {
+	public function testRun_TimeExceeded_StopsEarlyAndAdvancesCursor(): void {
 		/* Arrange. */
 		$course_id = $this->factory->course->create();
-		$lesson_id = $this->factory->lesson->create(
-			array(
-				'post_parent' => $course_id,
-			)
-		);
 
-		// Create progress for multiple users to ensure multiple batches.
+		// Create progress for multiple users.
 		for ( $i = 0; $i < 5; $i++ ) {
 			$user_id = $this->factory->user->create();
 			Sensei_Utils::start_user_on_course( $user_id, $course_id );
@@ -173,42 +168,43 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 
 		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
 
-		// Use batch_size=1, batch_count=10 so each row is a batch.
-		$migration = new Student_Progress_Migration( 1, 10 );
-		// Set a zero time budget so it stops after the first batch.
+		$migration = new Student_Progress_Migration( 250 );
+		// Set a zero time budget so it stops after the first comment.
 		$migration->set_time_budget( 0.0 );
 
 		/* Act. */
 		$result = $migration->run( false );
 
 		/* Assert. */
-		// Should have inserted some rows but not all 5.
-		$this->assertGreaterThan( 0, $result, 'Expected at least one row to be inserted before time exceeded.' );
-		$this->assertLessThan( 5, $result, 'Expected fewer than 5 rows because time budget should stop processing early.' );
+		// At least one comment should be processed (time check is after insert).
+		$this->assertGreaterThan( 0, $result, 'Expected at least one row to be inserted.' );
+
+		// Cursor should have advanced (not stuck at 0).
+		$cursor = (int) get_option( 'sensei_migrated_progress_last_comment_id' );
+		$this->assertGreaterThan( 0, $cursor, 'Expected cursor to advance after processing at least one comment.' );
 	}
 
-	public function testRun_TimeExceeded_DoesNotAdvanceCursor(): void {
+	public function testRun_TimeExceeded_DoesNotProcessAllComments(): void {
 		/* Arrange. */
 		$course_id = $this->factory->course->create();
-		for ( $i = 0; $i < 3; $i++ ) {
+
+		for ( $i = 0; $i < 5; $i++ ) {
 			$user_id = $this->factory->user->create();
 			Sensei_Utils::start_user_on_course( $user_id, $course_id );
 		}
 
 		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
 
-		$migration = new Student_Progress_Migration( 1, 10 );
-		// Zero budget so time is immediately exceeded after first batch.
+		$migration = new Student_Progress_Migration( 250 );
+		// Zero budget so time is immediately exceeded after first comment.
 		$migration->set_time_budget( 0.0 );
 
 		/* Act. */
-		$migration->run( false );
+		$result = $migration->run( false );
 
 		/* Assert. */
-		// Cursor should NOT have advanced to the last fetched comment ID
-		// because time was exceeded and not all rows may have been inserted.
-		$cursor = get_option( 'sensei_migrated_progress_last_comment_id' );
-		$this->assertSame( '0', $cursor );
+		// Should have inserted fewer than all 5 course progress rows.
+		$this->assertLessThan( 5, $result, 'Expected fewer than 5 rows because time budget should stop processing early.' );
 	}
 
 	private function get_table_based_progress(): array {

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -207,8 +207,8 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		// Cursor should NOT have advanced to the last fetched comment ID
 		// because time was exceeded and not all rows may have been inserted.
-		$cursor = (int) get_option( 'sensei_migrated_progress_last_comment_id', 0 );
-		$this->assertSame( 0, $cursor );
+		$cursor = get_option( 'sensei_migrated_progress_last_comment_id' );
+		$this->assertSame( '0', $cursor );
 	}
 
 	private function get_table_based_progress(): array {

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -232,6 +232,30 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertLessThan( 5, $result );
 	}
 
+	public function testRun_TimeExceeded_DoesNotAdvanceCursor(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$user_id = $this->factory->user->create();
+			Sensei_Utils::start_user_on_course( $user_id, $course_id );
+		}
+
+		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
+
+		$migration = new Student_Progress_Migration( 1, 10 );
+		// Zero budget so time is immediately exceeded after first batch.
+		$migration->set_time_budget( 0.0 );
+
+		/* Act. */
+		$migration->run( false );
+
+		/* Assert. */
+		// Cursor should NOT have advanced to the last fetched comment ID
+		// because time was exceeded and not all rows may have been inserted.
+		$cursor = (int) get_option( 'sensei_migrated_progress_last_comment_id', 0 );
+		$this->assertSame( 0, $cursor );
+	}
+
 	public function testLastCommentIdConstant_BackwardCompat_OldConstantMatchesNew(): void {
 		/* Assert. */
 		$this->assertSame(

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -207,6 +207,53 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertLessThan( 5, $result, 'Expected fewer than 5 rows because time budget should stop processing early.' );
 	}
 
+	public function testRun_AllRowsAreDuplicates_ReturnsGreaterThanZero(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
+		$user_id   = $this->factory->user->create();
+
+		Sensei_Utils::start_user_on_course( $user_id, $course_id );
+
+		update_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME, 0 );
+
+		// First run: inserts rows normally.
+		$this->migration->run( false );
+
+		// Simulate a crash before cursor update by resetting the cursor.
+		update_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME, 0 );
+
+		/* Act. */
+		// Second run: all rows are duplicates (INSERT IGNORE returns 0).
+		$result = $this->migration->run( false );
+
+		/* Assert. */
+		$this->assertGreaterThan( 0, $result, 'run() should return > 0 when comments were processed, even if all inserts were duplicates' );
+	}
+
+	public function testRun_AllRowsAreDuplicates_AdvancesCursorPastDuplicates(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
+		$user_id   = $this->factory->user->create();
+
+		Sensei_Utils::start_user_on_course( $user_id, $course_id );
+
+		update_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME, 0 );
+
+		// First run: inserts rows normally.
+		$this->migration->run( false );
+
+		// Simulate a crash before cursor update by resetting the cursor.
+		update_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME, 0 );
+
+		/* Act. */
+		// Second run: all rows are duplicates.
+		$this->migration->run( false );
+
+		/* Assert. */
+		$cursor = (int) get_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME );
+		$this->assertGreaterThan( 0, $cursor, 'Cursor should advance past duplicates' );
+	}
+
 	private function get_table_based_progress(): array {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -158,7 +158,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 
 	public function testRun_DefaultBatchSize_UsesReducedDefaults(): void {
 		/* Arrange. */
-		$migration = new Student_Progress_Migration();
+		$migration  = new Student_Progress_Migration();
 		$reflection = new \ReflectionClass( $migration );
 
 		$batch_size_prop = $reflection->getProperty( 'batch_size' );
@@ -174,7 +174,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 
 	public function testRun_BatchSizeFilter_UsesFilteredValues(): void {
 		/* Arrange. */
-		$size_filter = function () {
+		$size_filter  = function () {
 			return 10;
 		};
 		$count_filter = function () {

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -156,51 +156,6 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertSame( $expected, $actual_rows );
 	}
 
-	public function testRun_DefaultBatchSize_UsesReducedDefaults(): void {
-		/* Arrange. */
-		$migration  = new Student_Progress_Migration();
-		$reflection = new \ReflectionClass( $migration );
-
-		$batch_size_prop = $reflection->getProperty( 'batch_size' );
-		$batch_size_prop->setAccessible( true );
-
-		$batch_count_prop = $reflection->getProperty( 'batch_count' );
-		$batch_count_prop->setAccessible( true );
-
-		/* Assert. */
-		$this->assertSame( 50, $batch_size_prop->getValue( $migration ) );
-		$this->assertSame( 5, $batch_count_prop->getValue( $migration ) );
-	}
-
-	public function testRun_BatchSizeFilter_UsesFilteredValues(): void {
-		/* Arrange. */
-		$size_filter  = function () {
-			return 10;
-		};
-		$count_filter = function () {
-			return 2;
-		};
-		add_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
-		add_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
-
-		$migration  = new Student_Progress_Migration();
-		$reflection = new \ReflectionClass( $migration );
-
-		$batch_size_prop = $reflection->getProperty( 'batch_size' );
-		$batch_size_prop->setAccessible( true );
-
-		$batch_count_prop = $reflection->getProperty( 'batch_count' );
-		$batch_count_prop->setAccessible( true );
-
-		/* Assert. */
-		$this->assertSame( 10, $batch_size_prop->getValue( $migration ) );
-		$this->assertSame( 2, $batch_count_prop->getValue( $migration ) );
-
-		/* Cleanup. */
-		remove_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
-		remove_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
-	}
-
 	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {
 		/* Arrange. */
 		$course_id = $this->factory->course->create();
@@ -228,8 +183,8 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		// Should have inserted some rows but not all 5.
-		$this->assertGreaterThan( 0, $result );
-		$this->assertLessThan( 5, $result );
+		$this->assertGreaterThan( 0, $result, 'Expected at least one row to be inserted before time exceeded.' );
+		$this->assertLessThan( 5, $result, 'Expected fewer than 5 rows because time budget should stop processing early.' );
 	}
 
 	public function testRun_TimeExceeded_DoesNotAdvanceCursor(): void {
@@ -254,14 +209,6 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		// because time was exceeded and not all rows may have been inserted.
 		$cursor = (int) get_option( 'sensei_migrated_progress_last_comment_id', 0 );
 		$this->assertSame( 0, $cursor );
-	}
-
-	public function testLastCommentIdConstant_BackwardCompat_OldConstantMatchesNew(): void {
-		/* Assert. */
-		$this->assertSame(
-			Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME,
-			Student_Progress_Migration::LARST_COMMENT_ID_OPTION_NAME
-		);
 	}
 
 	private function get_table_based_progress(): array {

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -207,7 +207,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertLessThan( 5, $result, 'Expected fewer than 5 rows because time budget should stop processing early.' );
 	}
 
-	public function testRun_AllRowsAreDuplicates_ReturnsGreaterThanZero(): void {
+	public function testRun_AllRowsWereDuplicates_ReturnsGreaterThanZero(): void {
 		/* Arrange. */
 		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
 		$user_id   = $this->factory->user->create();
@@ -230,7 +230,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $result, 'run() should return > 0 when comments were processed, even if all inserts were duplicates' );
 	}
 
-	public function testRun_AllRowsAreDuplicates_AdvancesCursorPastDuplicates(): void {
+	public function testRun_AllRowsWereDuplicates_AdvancesCursorPastDuplicates(): void {
 		/* Arrange. */
 		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
 		$user_id   = $this->factory->user->create();

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -156,6 +156,90 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertSame( $expected, $actual_rows );
 	}
 
+	public function testRun_DefaultBatchSize_UsesReducedDefaults(): void {
+		/* Arrange. */
+		$migration = new Student_Progress_Migration();
+		$reflection = new \ReflectionClass( $migration );
+
+		$batch_size_prop = $reflection->getProperty( 'batch_size' );
+		$batch_size_prop->setAccessible( true );
+
+		$batch_count_prop = $reflection->getProperty( 'batch_count' );
+		$batch_count_prop->setAccessible( true );
+
+		/* Assert. */
+		$this->assertSame( 50, $batch_size_prop->getValue( $migration ) );
+		$this->assertSame( 5, $batch_count_prop->getValue( $migration ) );
+	}
+
+	public function testRun_BatchSizeFilter_UsesFilteredValues(): void {
+		/* Arrange. */
+		$size_filter = function () {
+			return 10;
+		};
+		$count_filter = function () {
+			return 2;
+		};
+		add_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
+		add_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
+
+		$migration  = new Student_Progress_Migration();
+		$reflection = new \ReflectionClass( $migration );
+
+		$batch_size_prop = $reflection->getProperty( 'batch_size' );
+		$batch_size_prop->setAccessible( true );
+
+		$batch_count_prop = $reflection->getProperty( 'batch_count' );
+		$batch_count_prop->setAccessible( true );
+
+		/* Assert. */
+		$this->assertSame( 10, $batch_size_prop->getValue( $migration ) );
+		$this->assertSame( 2, $batch_count_prop->getValue( $migration ) );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
+		remove_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
+	}
+
+	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'post_parent' => $course_id,
+			)
+		);
+
+		// Create progress for multiple users to ensure multiple batches.
+		for ( $i = 0; $i < 5; $i++ ) {
+			$user_id = $this->factory->user->create();
+			Sensei_Utils::start_user_on_course( $user_id, $course_id );
+		}
+
+		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
+
+		// Use batch_size=1, batch_count=10 so each row is a batch.
+		$migration = new Student_Progress_Migration( 1, 10 );
+		// Set a zero time budget so it stops after the first batch.
+		$migration->set_time_budget( 0.0 );
+
+		/* Act. */
+		$result = $migration->run( false );
+
+		/* Assert. */
+		// Should have inserted some rows but not all 5.
+		$this->assertGreaterThan( 0, $result );
+		$this->assertLessThan( 5, $result );
+	}
+
+	public function testLastCommentIdConstant_BackwardCompat_OldConstantMatchesNew(): void {
+		/* Assert. */
+		$this->assertSame(
+			Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME,
+			Student_Progress_Migration::LARST_COMMENT_ID_OPTION_NAME
+		);
+	}
+
 	private function get_table_based_progress(): array {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/tests/unit-tests/internal/migration/test-class-migration-abstract.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-abstract.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SenseiTest\Internal\Migration;
+
+use Sensei\Internal\Migration\Migration_Abstract;
+
+/**
+ * @covers \Sensei\Internal\Migration\Migration_Abstract
+ */
+class Migration_Abstract_Test extends \WP_UnitTestCase {
+
+	public function testIsTimeExceeded_NoBudgetSet_ReturnsFalse(): void {
+		/* Arrange. */
+		$migration = $this->get_concrete_migration();
+
+		/* Act & Assert. */
+		$this->assertFalse( $migration->is_time_exceeded() );
+	}
+
+	public function testIsTimeExceeded_WithinBudget_ReturnsFalse(): void {
+		/* Arrange. */
+		$migration = $this->get_concrete_migration();
+		$migration->set_time_budget( 30.0 );
+
+		/* Act & Assert. */
+		$this->assertFalse( $migration->is_time_exceeded() );
+	}
+
+	public function testIsTimeExceeded_BudgetExhausted_ReturnsTrue(): void {
+		/* Arrange. */
+		$migration = $this->get_concrete_migration();
+		// Set a tiny budget that will be immediately exceeded.
+		$migration->set_time_budget( 0.0 );
+
+		/* Act & Assert. */
+		$this->assertTrue( $migration->is_time_exceeded() );
+	}
+
+	private function get_concrete_migration(): Migration_Abstract {
+		return new class() extends Migration_Abstract {
+			public function run( bool $dry_run = true ) {
+				return 0;
+			}
+		};
+	}
+}

--- a/tests/unit-tests/internal/migration/test-class-migration-abstract.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-abstract.php
@@ -5,6 +5,8 @@ namespace SenseiTest\Internal\Migration;
 use Sensei\Internal\Migration\Migration_Abstract;
 
 /**
+ * Tests for Migration_Abstract.
+ *
  * @covers \Sensei\Internal\Migration\Migration_Abstract
  */
 class Migration_Abstract_Test extends \WP_UnitTestCase {

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -514,7 +514,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$filter = function () {
 			return 45.0;
 		};
-		add_filter( 'sensei_hpps_migration_time_budget', $filter );
+		add_filter( 'sensei_migration_time_budget', $filter );
 
 		/* Assert. */
 		$migration_job
@@ -526,7 +526,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$job_scheduler->run_job( $migration_job->get_name() );
 
 		/* Cleanup. */
-		remove_filter( 'sensei_hpps_migration_time_budget', $filter );
+		remove_filter( 'sensei_migration_time_budget', $filter );
 	}
 
 	public function testCollectFailedJobErrors_FirstFailure_ReschedulesInsteadOfFailing(): void {
@@ -600,7 +600,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$filter = function () {
 			return 1;
 		};
-		add_filter( 'sensei_hpps_migration_max_retries', $filter );
+		add_filter( 'sensei_migration_max_retries', $filter );
 
 		/* Act. */
 		$job_scheduler->collect_failed_job_errors( 'action_1', array( 'message' => 'Timeout' ) );
@@ -612,7 +612,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		);
 
 		/* Cleanup. */
-		remove_filter( 'sensei_hpps_migration_max_retries', $filter );
+		remove_filter( 'sensei_migration_max_retries', $filter );
 	}
 
 	public function testRunJob_SuccessfulCompletion_ResetsRetryCount(): void {

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -529,4 +529,208 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		remove_filter( 'sensei_hpps_migration_time_budget', $filter );
 	}
 
+	public function testRun_DefaultBatchSize_UsesReducedDefaults(): void {
+		/* Arrange. */
+		$migration = new Student_Progress_Migration();
+		$reflection = new \ReflectionClass( $migration );
+
+		$batch_size_prop = $reflection->getProperty( 'batch_size' );
+		$batch_size_prop->setAccessible( true );
+
+		$batch_count_prop = $reflection->getProperty( 'batch_count' );
+		$batch_count_prop->setAccessible( true );
+
+		/* Assert. */
+		$this->assertSame( 50, $batch_size_prop->getValue( $migration ) );
+		$this->assertSame( 5, $batch_count_prop->getValue( $migration ) );
+	}
+
+	public function testRun_BatchSizeFilter_UsesFilteredValues(): void {
+		/* Arrange. */
+		$size_filter = function () {
+			return 10;
+		};
+		$count_filter = function () {
+			return 2;
+		};
+		add_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
+		add_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
+
+		$migration  = new Student_Progress_Migration();
+		$reflection = new \ReflectionClass( $migration );
+
+		$batch_size_prop = $reflection->getProperty( 'batch_size' );
+		$batch_size_prop->setAccessible( true );
+
+		$batch_count_prop = $reflection->getProperty( 'batch_count' );
+		$batch_count_prop->setAccessible( true );
+
+		/* Assert. */
+		$this->assertSame( 10, $batch_size_prop->getValue( $migration ) );
+		$this->assertSame( 2, $batch_count_prop->getValue( $migration ) );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
+		remove_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
+	}
+
+	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'post_parent' => $course_id,
+			)
+		);
+
+		// Create progress for multiple users to ensure multiple batches.
+		for ( $i = 0; $i < 5; $i++ ) {
+			$user_id = $this->factory->user->create();
+			Sensei_Utils::start_user_on_course( $user_id, $course_id );
+		}
+
+		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
+
+		// Use batch_size=1, batch_count=10 so each row is a batch.
+		$migration = new Student_Progress_Migration( 1, 10 );
+		// Set a zero time budget so it stops after the first batch.
+		$migration->set_time_budget( 0.0 );
+
+		/* Act. */
+		$result = $migration->run( false );
+
+		/* Assert. */
+		// Should have inserted some rows but not all 5.
+		$this->assertGreaterThan( 0, $result );
+		$this->assertLessThan( 5, $result );
+	}
+
+	public function testLastCommentIdConstant_BackwardCompat_OldConstantMatchesNew(): void {
+		/* Assert. */
+		$this->assertSame(
+			Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME,
+			Student_Progress_Migration::LARST_COMMENT_ID_OPTION_NAME
+		);
+	}
+
+
+	public function testCollectFailedJobErrors_FirstFailure_ReschedulesInsteadOfFailing(): void {
+		/* Arrange. */
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_IN_PROGRESS );
+
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$action_scheduler->method( 'get_scheduled_actions' )->willReturn( array( 'action_1' ) );
+
+		$job = $this->createMock( Migration_Job::class );
+		$job->method( 'get_name' )->willReturn( 'test_job' );
+
+		$job_scheduler = new Migration_Job_Scheduler( $action_scheduler );
+		$job_scheduler->register_job( $job );
+
+		/* Assert. */
+		$action_scheduler
+			->expects( $this->once() )
+			->method( 'schedule_single_action' )
+			->with( 'sensei_lms_migration_job_test_job', [ 'job_name' => 'test_job' ], false );
+
+		/* Act. */
+		$job_scheduler->collect_failed_job_errors( 'action_1', array( 'message' => 'Timeout' ) );
+
+		/* Assert - status should still be in_progress, not failed. */
+		$this->assertSame(
+			Migration_Job_Scheduler::STATUS_IN_PROGRESS,
+			get_option( Migration_Job_Scheduler::STATUS_OPTION_NAME )
+		);
+	}
+
+	public function testCollectFailedJobErrors_AfterMaxRetries_MarksAsFailed(): void {
+		/* Arrange. */
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_IN_PROGRESS );
+		update_option( Migration_Job_Scheduler::RETRY_COUNT_OPTION_NAME, 3 );
+
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$action_scheduler->method( 'get_scheduled_actions' )->willReturn( array( 'action_1' ) );
+
+		$job = $this->createMock( Migration_Job::class );
+		$job->method( 'get_name' )->willReturn( 'test_job' );
+
+		$job_scheduler = new Migration_Job_Scheduler( $action_scheduler );
+		$job_scheduler->register_job( $job );
+
+		/* Act. */
+		$job_scheduler->collect_failed_job_errors( 'action_1', array( 'message' => 'Timeout' ) );
+
+		/* Assert. */
+		$this->assertSame(
+			Migration_Job_Scheduler::STATUS_FAILED,
+			get_option( Migration_Job_Scheduler::STATUS_OPTION_NAME )
+		);
+	}
+
+	public function testCollectFailedJobErrors_MaxRetriesFilterable_RespectsFilter(): void {
+		/* Arrange. */
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_IN_PROGRESS );
+		update_option( Migration_Job_Scheduler::RETRY_COUNT_OPTION_NAME, 1 );
+
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$action_scheduler->method( 'get_scheduled_actions' )->willReturn( array( 'action_1' ) );
+
+		$job = $this->createMock( Migration_Job::class );
+		$job->method( 'get_name' )->willReturn( 'test_job' );
+
+		$job_scheduler = new Migration_Job_Scheduler( $action_scheduler );
+		$job_scheduler->register_job( $job );
+
+		// Set max retries to 1, so retry count of 1 means we've exhausted retries.
+		$filter = function () {
+			return 1;
+		};
+		add_filter( 'sensei_hpps_migration_max_retries', $filter );
+
+		/* Act. */
+		$job_scheduler->collect_failed_job_errors( 'action_1', array( 'message' => 'Timeout' ) );
+
+		/* Assert. */
+		$this->assertSame(
+			Migration_Job_Scheduler::STATUS_FAILED,
+			get_option( Migration_Job_Scheduler::STATUS_OPTION_NAME )
+		);
+
+		/* Cleanup. */
+		remove_filter( 'sensei_hpps_migration_max_retries', $filter );
+	}
+
+	public function testRunJob_SuccessfulCompletion_ResetsRetryCount(): void {
+		/* Arrange. */
+		update_option( Migration_Job_Scheduler::RETRY_COUNT_OPTION_NAME, 2 );
+
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$migration_job    = $this->createMock( Migration_Job::class );
+		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+
+		$migration_job->method( 'is_complete' )->willReturn( true );
+		$migration_job->method( 'get_name' )->willReturn( 'foo' );
+
+		$job_scheduler->register_job( $migration_job );
+
+		/* Act. */
+		$job_scheduler->run_job( $migration_job->get_name() );
+
+		/* Assert. */
+		$this->assertFalse( get_option( Migration_Job_Scheduler::RETRY_COUNT_OPTION_NAME ) );
+	}
+
+	public function testClearState_Always_DeletesRetryCount(): void {
+		/* Arrange. */
+		update_option( Migration_Job_Scheduler::RETRY_COUNT_OPTION_NAME, 2 );
+
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+
+		/* Act. */
+		$job_scheduler->clear_state();
+
+		/* Assert. */
+		$this->assertFalse( get_option( Migration_Job_Scheduler::RETRY_COUNT_OPTION_NAME ) );
+	}
 }

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -484,4 +484,49 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$expected = array( 'c' );
 		$this->assertSame( $expected, $actual );
 	}
+
+	public function testRunJob_Always_SetsTimeBudgetOnJob(): void {
+		/* Arrange. */
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$migration_job    = $this->createMock( Migration_Job::class );
+		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+
+		$job_scheduler->register_job( $migration_job );
+
+		/* Assert. */
+		$migration_job
+			->expects( $this->once() )
+			->method( 'set_time_budget' )
+			->with( 20.0 );
+
+		/* Act. */
+		$job_scheduler->run_job( $migration_job->get_name() );
+	}
+
+	public function testRunJob_WithFilteredBudget_UsesFilteredValue(): void {
+		/* Arrange. */
+		$action_scheduler = $this->createMock( Action_Scheduler::class );
+		$migration_job    = $this->createMock( Migration_Job::class );
+		$job_scheduler    = new Migration_Job_Scheduler( $action_scheduler );
+
+		$job_scheduler->register_job( $migration_job );
+
+		$filter = function () {
+			return 45.0;
+		};
+		add_filter( 'sensei_hpps_migration_time_budget', $filter );
+
+		/* Assert. */
+		$migration_job
+			->expects( $this->once() )
+			->method( 'set_time_budget' )
+			->with( 45.0 );
+
+		/* Act. */
+		$job_scheduler->run_job( $migration_job->get_name() );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_hpps_migration_time_budget', $filter );
+	}
+
 }

--- a/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job-scheduler.php
@@ -181,7 +181,7 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		$job_scheduler->register_job( $migration_job );
 
 		$has_logged_event = false;
-		$sensei_log_event = function( $log_event, $event_name, $event_properties ) use ( &$has_logged_event ) {
+		$sensei_log_event = function ( $log_event, $event_name ) use ( &$has_logged_event ) {
 			if ( 'hpps_migration_complete' === $event_name ) {
 				$has_logged_event = true;
 			}
@@ -528,91 +528,6 @@ class Migration_Job_Scheduler_Test extends \WP_UnitTestCase {
 		/* Cleanup. */
 		remove_filter( 'sensei_hpps_migration_time_budget', $filter );
 	}
-
-	public function testRun_DefaultBatchSize_UsesReducedDefaults(): void {
-		/* Arrange. */
-		$migration = new Student_Progress_Migration();
-		$reflection = new \ReflectionClass( $migration );
-
-		$batch_size_prop = $reflection->getProperty( 'batch_size' );
-		$batch_size_prop->setAccessible( true );
-
-		$batch_count_prop = $reflection->getProperty( 'batch_count' );
-		$batch_count_prop->setAccessible( true );
-
-		/* Assert. */
-		$this->assertSame( 50, $batch_size_prop->getValue( $migration ) );
-		$this->assertSame( 5, $batch_count_prop->getValue( $migration ) );
-	}
-
-	public function testRun_BatchSizeFilter_UsesFilteredValues(): void {
-		/* Arrange. */
-		$size_filter = function () {
-			return 10;
-		};
-		$count_filter = function () {
-			return 2;
-		};
-		add_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
-		add_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
-
-		$migration  = new Student_Progress_Migration();
-		$reflection = new \ReflectionClass( $migration );
-
-		$batch_size_prop = $reflection->getProperty( 'batch_size' );
-		$batch_size_prop->setAccessible( true );
-
-		$batch_count_prop = $reflection->getProperty( 'batch_count' );
-		$batch_count_prop->setAccessible( true );
-
-		/* Assert. */
-		$this->assertSame( 10, $batch_size_prop->getValue( $migration ) );
-		$this->assertSame( 2, $batch_count_prop->getValue( $migration ) );
-
-		/* Cleanup. */
-		remove_filter( 'sensei_hpps_student_progress_batch_size', $size_filter );
-		remove_filter( 'sensei_hpps_student_progress_batch_count', $count_filter );
-	}
-
-	public function testRun_TimeExceeded_StopsEarlyAndReturnsPartialCount(): void {
-		/* Arrange. */
-		$course_id = $this->factory->course->create();
-		$lesson_id = $this->factory->lesson->create(
-			array(
-				'post_parent' => $course_id,
-			)
-		);
-
-		// Create progress for multiple users to ensure multiple batches.
-		for ( $i = 0; $i < 5; $i++ ) {
-			$user_id = $this->factory->user->create();
-			Sensei_Utils::start_user_on_course( $user_id, $course_id );
-		}
-
-		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
-
-		// Use batch_size=1, batch_count=10 so each row is a batch.
-		$migration = new Student_Progress_Migration( 1, 10 );
-		// Set a zero time budget so it stops after the first batch.
-		$migration->set_time_budget( 0.0 );
-
-		/* Act. */
-		$result = $migration->run( false );
-
-		/* Assert. */
-		// Should have inserted some rows but not all 5.
-		$this->assertGreaterThan( 0, $result );
-		$this->assertLessThan( 5, $result );
-	}
-
-	public function testLastCommentIdConstant_BackwardCompat_OldConstantMatchesNew(): void {
-		/* Assert. */
-		$this->assertSame(
-			Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME,
-			Student_Progress_Migration::LARST_COMMENT_ID_OPTION_NAME
-		);
-	}
-
 
 	public function testCollectFailedJobErrors_FirstFailure_ReschedulesInsteadOfFailing(): void {
 		/* Arrange. */

--- a/tests/unit-tests/internal/migration/test-class-migration-job.php
+++ b/tests/unit-tests/internal/migration/test-class-migration-job.php
@@ -3,6 +3,7 @@
 namespace SenseiTest\Internal\Migration;
 
 use Sensei\Internal\Migration\Migrations\Student_Progress_Migration;
+use Sensei\Internal\Migration\Migration_Abstract;
 use Sensei\Internal\Migration\Migration_Job;
 
 /**
@@ -95,5 +96,20 @@ class Migration_Job_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertSame( 'student_progress_migration', $actual );
+	}
+
+	public function testSetTimeBudget_Always_DelegatesToMigration(): void {
+		/* Arrange. */
+		$migration = $this->createMock( Migration_Abstract::class );
+		$job       = new Migration_Job( 'test_job', $migration );
+
+		/* Assert. */
+		$migration
+			->expects( $this->once() )
+			->method( 'set_time_budget' )
+			->with( 25.0 );
+
+		/* Act. */
+		$job->set_time_budget( 25.0 );
 	}
 }


### PR DESCRIPTION
## Summary

- Remove `set_time_limit(0)` from migration scheduler and replace with time-budgeted processing (default 20s, filterable)
- Refactor Student Progress migration to process one comment at a time with streaming inserts, flushing every 50 rows
- Reduce migration batch sizes (Student Progress: 1000→250 comments/run, Quiz: 100→50)
- Fix cursor tracking so it only advances after rows are flushed to the database
- Add retry logic for failed migrations (3 retries before marking as failed)
- Remove Settings UI gate that blocked HPPS on hosts where `set_time_limit` is disabled
- Fix typo: `LARST_COMMENT_ID_OPTION_NAME` → `LAST_COMMENT_ID_OPTION_NAME`

Note: I'm fixing up the PHP unit test jobs in a separate PR, so you can ignore any jobs that didn't complete.

## Context

HPPS (High-Performance Progress Storage) Stage 4 — Phase 1. Migrations previously required `set_time_limit(0)` which fails on WP.com Atomic and restricted hosting environments. This PR makes migrations work within normal PHP execution limits by introducing a time budget that allows migrations to stop mid-batch and safely resume on the next run.

## New filters

- `sensei_migration_time_budget` (float, default 20.0) — seconds per migration run
- `sensei_migration_max_retries` (int, default 3) — retry attempts before failing
- `sensei_migration_student_progress_read_batch_size` (int, default 250) — comments fetched per run
- `sensei_migration_student_progress_insert_batch_size` (int, default 50) — comments inserted per run
- `sensei_migration_quiz_batch_size` (int, default 50) — quiz submissions fetched per run

## Test plan

- [x] Verify HPPS toggle is enabled in settings on an Atomic site
- [x] Test migration completes successfully with reduced batch sizes