### PR TITLE
Update PHP test matrix based on real usage data

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -57,21 +57,27 @@ jobs:
             fail-fast: true
             max-parallel: 10
             matrix:
-                wp: ['latest']
-                php: ['7.4', '8.1', '8.2', '8.3']
                 include:
+                    - php: '7.4'
+                      wp: latest
+                    - php: '8.1'
+                      wp: latest
                     - php: '8.2'
                       wp: '6.7'
                     - php: '8.2'
                       wp: '6.8'
                     - php: '8.2'
                       wp: latest
-                      wpmu: 1
                     - php: '8.2'
-                      wp: nightly
+                      wp: latest
+                      wpmu: 1
                     - php: '8.2'
                       wp: latest
                       hpps: 1
+                    - php: '8.2'
+                      wp: nightly
+                    - php: '8.3'
+                      wp: latest
         env:
             WP_VERSION: ${{ matrix.wp }}
             WP_MULTISITE: ${{ matrix.wpmu }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -69,13 +69,13 @@ jobs:
                     - php: '8.2'
                       wp: latest
                     - php: '8.2'
+                      wp: nightly
+                    - php: '8.2'
                       wp: latest
                       wpmu: 1
                     - php: '8.2'
                       wp: latest
                       hpps: 1
-                    - php: '8.2'
-                      wp: nightly
         env:
             WP_VERSION: ${{ matrix.wp }}
             WP_MULTISITE: ${{ matrix.wpmu }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,7 +50,7 @@ jobs:
             - name: Check WPCOM rules
               run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
     test:
-        name: "PHP Unit Tests (${{ matrix.php }}, ${{ matrix.wp }}${{ matrix.hpps == 1 && ', HPPS' || '' }})"
+        name: "PHP Unit Tests (${{ matrix.php }}, ${{ matrix.wp }}${{ matrix.wpmu == 1 && ', multisite' || '' }}${{ matrix.hpps == 1 && ', HPPS' || '' }})"
         runs-on: ubuntu-latest
         continue-on-error: ${{ matrix.wp == 'nightly' }}
         strategy:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,6 @@ jobs:
             max-parallel: 10
             matrix:
                 wp: ['latest']
-                wpmu: [0]
                 php: ['7.4', '8.1', '8.2', '8.3']
                 include:
                     - php: '8.2'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -59,18 +59,18 @@ jobs:
             matrix:
                 wp: ['latest']
                 wpmu: [0]
-                php: ['7.4', '8.2']
+                php: ['7.4', '8.1', '8.2', '8.3']
                 include:
-                    - php: 7.4
+                    - php: '8.2'
                       wp: '6.7'
-                    - php: 7.4
+                    - php: '8.2'
                       wp: '6.8'
-                    - php: 7.4
+                    - php: '8.2'
                       wp: latest
                       wpmu: 1
-                    - php: 7.4
+                    - php: '8.2'
                       wp: nightly
-                    - php: 7.4
+                    - php: '8.2'
                       wp: latest
                       hpps: 1
         env:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -62,9 +62,9 @@ jobs:
                 php: ['7.4', '8.2']
                 include:
                     - php: 7.4
-                      wp: '6.1'
+                      wp: '6.7'
                     - php: 7.4
-                      wp: '6.2'
+                      wp: '6.8'
                     - php: 7.4
                       wp: latest
                       wpmu: 1

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -76,8 +76,6 @@ jobs:
                       hpps: 1
                     - php: '8.2'
                       wp: nightly
-                    - php: '8.3'
-                      wp: latest
         env:
             WP_VERSION: ${{ matrix.wp }}
             WP_MULTISITE: ${{ matrix.wpmu }}


### PR DESCRIPTION
## Summary
- Shift extended WP version coverage (6.7, 6.8, multisite, HPPS, nightly) from PHP 7.4 to PHP 8.2, which is the most popular version at 31% of Sensei sites
- Add PHP 8.1 to the default matrix, covering 67% of Sensei sites (7.4: 22%, 8.1: 14%, 8.2: 31%)
- Produces 8 CI jobs (up from 7) while focusing coverage where users actually are

### Resulting matrix (9 jobs)

| PHP | WP | Variant | Rationale |
|-----|----|---------|-----------|
| 7.4 | latest | - | Min supported PHP (22% of users) |
| 8.1 | latest | - | 14% of users |
| 8.2 | 6.7 | - | Most popular PHP + oldest supported WP |
| 8.2 | 6.8 | - | Most popular PHP + mid WP |
| 8.2 | latest | - | Most popular combo |
| 8.2 | latest | multisite | Multisite on most popular PHP |
| 8.2 | latest | HPPS | HPPS on most popular PHP |
| 8.2 | nightly | - | Forward-compat on most popular PHP |

Note: Leaving 8.3 off for now as the job failed on PHP 8.3, latest WP.

## Test plan
- [x] Verify the CI matrix generates exactly 8 jobs
- [x] Confirm all 8 jobs pass