### PR TITLE
Prototype: HPPS Full Migration pattern #1

### DIFF
--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1385,28 +1385,7 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_course_users_grades_sum( $course_id ) {
-		global $wpdb;
-
-		$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
-		if ( ! $lesson_ids ) {
-			return 0;
-		}
-
-		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND {$wpdb->comments}.comment_approved IN ('graded', 'passed', 'failed') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
-				AND {$wpdb->comments}.comment_post_ID IN ({$lesson_ids_placeholder}) ",
-				$lesson_ids
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-
-		return $sum_of_all_grades;
+		return Sensei()->progress_query_service->get_course_users_grades_sum( (int) $course_id );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -29,6 +29,7 @@ use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progres
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface;
 use Sensei\Internal\Student_Progress\Services\Course_Deleted_Handler;
+use Sensei\Internal\Student_Progress\Services\Progress_Query_Service_Factory;
 use Sensei\Internal\Student_Progress\Services\Lesson_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\Quiz_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\User_Deleted_Handler;
@@ -408,6 +409,13 @@ class Sensei_Main {
 	 * @var Grade_Repository_Interface
 	 */
 	public $quiz_grade_repository;
+
+	/**
+	 * Progress query service.
+	 *
+	 * @var \Sensei\Internal\Student_Progress\Services\Progress_Query_Service_Interface
+	 */
+	public $progress_query_service;
 
 	/**
 	 * Migration job scheduler.
@@ -797,6 +805,9 @@ class Sensei_Main {
 		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
 		$this->quiz_answer_repository     = ( new Answer_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
 		$this->quiz_grade_repository      = ( new Grade_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
+
+		// Progress query service.
+		$this->progress_query_service = ( new Progress_Query_Service_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
 
 		// Progress tables eraser.
 		if ( $tables_feature_enabled ) {

--- a/includes/internal/student-progress/services/class-comments-based-progress-query-service.php
+++ b/includes/internal/student-progress/services/class-comments-based-progress-query-service.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * File containing the Comments_Based_Progress_Query_Service class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Progress_Query_Service.
+ *
+ * Queries student progress aggregate data from WordPress comments.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Comments_Based_Progress_Query_Service implements Progress_Query_Service_Interface {
+
+	/**
+	 * Get the sum of all user grades for the given course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $course_id Course ID.
+	 * @return int Sum of all grades.
+	 */
+	public function get_course_users_grades_sum( int $course_id ): int {
+		global $wpdb;
+
+		$lesson_ids = \Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
+		if ( ! $lesson_ids ) {
+			return 0;
+		}
+
+		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$sum = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
+				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
+				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND {$wpdb->comments}.comment_approved IN ('graded', 'passed', 'failed') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
+				AND {$wpdb->comments}.comment_post_ID IN ({$lesson_ids_placeholder}) ",
+				$lesson_ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		return $sum;
+	}
+}

--- a/includes/internal/student-progress/services/class-progress-query-service-factory.php
+++ b/includes/internal/student-progress/services/class-progress-query-service-factory.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * File containing the Progress_Query_Service_Factory class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Progress_Query_Service_Factory.
+ *
+ * Creates the appropriate Progress_Query_Service implementation based on
+ * the current HPPS storage settings.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Progress_Query_Service_Factory {
+
+	/**
+	 * Is tables based progress feature flag enabled.
+	 *
+	 * @var bool
+	 */
+	private $tables_enabled;
+
+	/**
+	 * Read from tables.
+	 *
+	 * @var bool
+	 */
+	private $read_tables;
+
+	/**
+	 * Progress_Query_Service_Factory constructor.
+	 *
+	 * @param bool $tables_enabled Is tables based progress feature flag enabled.
+	 * @param bool $read_tables    Read from tables.
+	 */
+	public function __construct( bool $tables_enabled, bool $read_tables ) {
+		$this->tables_enabled = $tables_enabled;
+		$this->read_tables    = $read_tables;
+	}
+
+	/**
+	 * Create a progress query service.
+	 *
+	 * @internal
+	 *
+	 * @return Progress_Query_Service_Interface
+	 */
+	public function create(): Progress_Query_Service_Interface {
+		if ( $this->tables_enabled && $this->read_tables ) {
+			global $wpdb;
+			return new Tables_Based_Progress_Query_Service( $wpdb );
+		}
+
+		return new Comments_Based_Progress_Query_Service();
+	}
+}

--- a/includes/internal/student-progress/services/class-progress-query-service-interface.php
+++ b/includes/internal/student-progress/services/class-progress-query-service-interface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * File containing the Progress_Query_Service_Interface interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Interface Progress_Query_Service_Interface.
+ *
+ * Provides aggregate query methods for student progress data.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+interface Progress_Query_Service_Interface {
+
+	/**
+	 * Get the sum of all user grades for the given course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $course_id Course ID.
+	 * @return int Sum of all grades.
+	 */
+	public function get_course_users_grades_sum( int $course_id ): int;
+}

--- a/includes/internal/student-progress/services/class-tables-based-progress-query-service.php
+++ b/includes/internal/student-progress/services/class-tables-based-progress-query-service.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * File containing the Tables_Based_Progress_Query_Service class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Tables_Based_Progress_Query_Service.
+ *
+ * Queries student progress aggregate data from HPPS custom tables.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Tables_Based_Progress_Query_Service implements Progress_Query_Service_Interface {
+
+	/**
+	 * WordPress database object.
+	 *
+	 * @var \wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * Tables_Based_Progress_Query_Service constructor.
+	 *
+	 * @param \wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( \wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Get the sum of all user grades for the given course.
+	 *
+	 * Queries sensei_lms_quiz_submissions.final_grade for quizzes belonging to
+	 * lessons in the given course, filtered to only include submissions where
+	 * the quiz progress status is graded, passed, or failed.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $course_id Course ID.
+	 * @return int Sum of all grades.
+	 */
+	public function get_course_users_grades_sum( int $course_id ): int {
+		$lesson_ids = \Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
+		if ( ! $lesson_ids ) {
+			return 0;
+		}
+
+		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+
+		$progress_table    = $this->wpdb->prefix . 'sensei_lms_progress';
+		$submissions_table = $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared -- Placeholders created dynamically.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$sum = (int) $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				"SELECT SUM(qs.final_grade)
+				FROM {$submissions_table} qs
+				INNER JOIN {$this->wpdb->posts} q ON qs.quiz_id = q.ID
+				INNER JOIN {$progress_table} qp ON qp.post_id = qs.quiz_id AND qp.user_id = qs.user_id AND qp.type = 'quiz'
+				WHERE q.post_parent IN ({$lesson_ids_placeholder})
+				AND qp.status IN ('graded', 'passed', 'failed')
+				AND qs.final_grade IS NOT NULL",
+				$lesson_ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared
+
+		return $sum;
+	}
+}

--- a/tests/unit-tests/internal/student-progress/services/test-class-progress-query-service.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-progress-query-service.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Tests for Progress_Query_Service implementations.
+ *
+ * @package sensei-tests
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+// phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+
+use Sensei\Internal\Student_Progress\Services\Comments_Based_Progress_Query_Service;
+use Sensei\Internal\Student_Progress\Services\Tables_Based_Progress_Query_Service;
+
+/**
+ * Class Progress_Query_Service_Test.
+ *
+ * Tests get_course_users_grades_sum in both comments and HPPS tables modes.
+ *
+ * @covers \Sensei\Internal\Student_Progress\Services\Comments_Based_Progress_Query_Service
+ * @covers \Sensei\Internal\Student_Progress\Services\Tables_Based_Progress_Query_Service
+ */
+class Progress_Query_Service_Test extends WP_UnitTestCase {
+
+	use Sensei_HPPS_Helpers;
+
+	/**
+	 * Factory for creating test data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	/**
+	 * Test that the comments-based service returns the correct sum.
+	 */
+	public function testGetCourseUsersGradesSum_CommentsMode_ReturnsCorrectSum() {
+		/* Arrange. */
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many(
+			2,
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_ids   = $this->factory->user->create_many( 2 );
+
+		$comment_ids   = [];
+		$comment_ids[] = $this->create_lesson_status( $lesson_ids[0], $user_ids[0], 'graded' );
+		$comment_ids[] = $this->create_lesson_status( $lesson_ids[0], $user_ids[1], 'passed' );
+		$comment_ids[] = $this->create_lesson_status( $lesson_ids[1], $user_ids[0], 'failed' );
+
+		add_comment_meta( $comment_ids[0], 'grade', '30' );
+		add_comment_meta( $comment_ids[1], 'grade', '80' );
+		add_comment_meta( $comment_ids[2], 'grade', '40' );
+
+		$service = new Comments_Based_Progress_Query_Service();
+
+		/* Act. */
+		$sum = $service->get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 150, $sum );
+	}
+
+	/**
+	 * Test that the comments-based service returns 0 for an empty course.
+	 */
+	public function testGetCourseUsersGradesSum_CommentsMode_EmptyCourse_ReturnsZero() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$service   = new Comments_Based_Progress_Query_Service();
+
+		/* Act. */
+		$sum = $service->get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 0, $sum );
+	}
+
+	/**
+	 * Test that the comments-based service excludes in-progress statuses.
+	 */
+	public function testGetCourseUsersGradesSum_CommentsMode_ExcludesInProgress() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_id   = $this->factory->user->create();
+
+		$graded_comment      = $this->create_lesson_status( $lesson_id, $user_id, 'graded' );
+		$in_progress_comment = $this->create_lesson_status( $lesson_id, $this->factory->user->create(), 'in-progress' );
+
+		add_comment_meta( $graded_comment, 'grade', '75' );
+		add_comment_meta( $in_progress_comment, 'grade', '50' );
+
+		$service = new Comments_Based_Progress_Query_Service();
+
+		/* Act. */
+		$sum = $service->get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 75, $sum );
+	}
+
+	/**
+	 * Test that the tables-based service returns the correct sum.
+	 */
+	public function testGetCourseUsersGradesSum_TablesMode_ReturnsCorrectSum() {
+		/* Arrange. */
+		global $wpdb;
+
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many(
+			2,
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$quiz_ids   = [];
+		foreach ( $lesson_ids as $lesson_id ) {
+			$quiz_ids[] = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+		}
+		$user_ids = $this->factory->user->create_many( 2 );
+
+		// Insert quiz progress and submissions into HPPS tables.
+		$this->insert_quiz_progress( $quiz_ids[0], $user_ids[0], 'graded' );
+		$this->insert_quiz_submission( $quiz_ids[0], $user_ids[0], 30.0 );
+
+		$this->insert_quiz_progress( $quiz_ids[0], $user_ids[1], 'passed' );
+		$this->insert_quiz_submission( $quiz_ids[0], $user_ids[1], 80.0 );
+
+		$this->insert_quiz_progress( $quiz_ids[1], $user_ids[0], 'failed' );
+		$this->insert_quiz_submission( $quiz_ids[1], $user_ids[0], 40.0 );
+
+		$service = new Tables_Based_Progress_Query_Service( $wpdb );
+
+		/* Act. */
+		$sum = $service->get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 150, $sum );
+	}
+
+	/**
+	 * Test that the tables-based service returns 0 for an empty course.
+	 */
+	public function testGetCourseUsersGradesSum_TablesMode_EmptyCourse_ReturnsZero() {
+		/* Arrange. */
+		global $wpdb;
+
+		$course_id = $this->factory->course->create();
+		$service   = new Tables_Based_Progress_Query_Service( $wpdb );
+
+		/* Act. */
+		$sum = $service->get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 0, $sum );
+	}
+
+	/**
+	 * Test that the tables-based service excludes in-progress statuses.
+	 */
+	public function testGetCourseUsersGradesSum_TablesMode_ExcludesInProgress() {
+		/* Arrange. */
+		global $wpdb;
+
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$quiz_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+		$user_ids  = $this->factory->user->create_many( 2 );
+
+		$this->insert_quiz_progress( $quiz_id, $user_ids[0], 'graded' );
+		$this->insert_quiz_submission( $quiz_id, $user_ids[0], 75.0 );
+
+		$this->insert_quiz_progress( $quiz_id, $user_ids[1], 'in-progress' );
+		$this->insert_quiz_submission( $quiz_id, $user_ids[1], 50.0 );
+
+		$service = new Tables_Based_Progress_Query_Service( $wpdb );
+
+		/* Act. */
+		$sum = $service->get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 75, $sum );
+	}
+
+	/**
+	 * Test that the delegated call in Sensei_Grading works in comments mode.
+	 */
+	public function testGetCourseUsersGradesSum_Delegated_CommentsMode_ReturnsCorrectSum() {
+		/* Arrange. */
+		$course_id  = $this->factory->course->create();
+		$lesson_id  = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_id    = $this->factory->user->create();
+		$comment_id = $this->create_lesson_status( $lesson_id, $user_id, 'passed' );
+		add_comment_meta( $comment_id, 'grade', '95' );
+
+		/* Act. */
+		$sum = Sensei_Grading::get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 95, $sum );
+	}
+
+	/**
+	 * Test that the delegated call in Sensei_Grading works in HPPS tables mode.
+	 */
+	public function testGetCourseUsersGradesSum_Delegated_TablesMode_ReturnsCorrectSum() {
+		/* Arrange. */
+		$this->enable_hpps_tables_repository();
+		$this->setup_hpps_progress_query_service();
+
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$quiz_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+		$user_id   = $this->factory->user->create();
+
+		$this->insert_quiz_progress( $quiz_id, $user_id, 'passed' );
+		$this->insert_quiz_submission( $quiz_id, $user_id, 95.0 );
+
+		/* Act. */
+		$sum = Sensei_Grading::get_course_users_grades_sum( $course_id );
+
+		/* Assert. */
+		$this->assertSame( 95, $sum );
+
+		/* Cleanup. */
+		$this->reset_hpps_progress_query_service();
+		$this->reset_hpps_repository();
+	}
+
+	/**
+	 * Create a lesson status comment.
+	 *
+	 * @param int    $lesson_id Lesson ID.
+	 * @param int    $user_id   User ID.
+	 * @param string $status    Status.
+	 * @return int Comment ID.
+	 */
+	private function create_lesson_status( int $lesson_id, int $user_id, string $status ): int {
+		return $this->factory->comment->create(
+			[
+				'comment_type'     => 'sensei_lesson_status',
+				'comment_approved' => $status,
+				'comment_post_ID'  => $lesson_id,
+				'user_id'          => $user_id,
+			]
+		);
+	}
+
+	/**
+	 * Insert a quiz progress record into the HPPS progress table.
+	 *
+	 * @param int    $quiz_id Quiz ID.
+	 * @param int    $user_id User ID.
+	 * @param string $status  Status.
+	 */
+	private function insert_quiz_progress( int $quiz_id, int $user_id, string $status ): void {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_progress',
+			[
+				'post_id'    => $quiz_id,
+				'user_id'    => $user_id,
+				'type'       => 'quiz',
+				'status'     => $status,
+				'created_at' => current_time( 'mysql', true ),
+				'updated_at' => current_time( 'mysql', true ),
+			]
+		);
+	}
+
+	/**
+	 * Insert a quiz submission record into the HPPS quiz submissions table.
+	 *
+	 * @param int   $quiz_id     Quiz ID.
+	 * @param int   $user_id     User ID.
+	 * @param float $final_grade Final grade.
+	 */
+	private function insert_quiz_submission( int $quiz_id, int $user_id, float $final_grade ): void {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_quiz_submissions',
+			[
+				'quiz_id'     => $quiz_id,
+				'user_id'     => $user_id,
+				'final_grade' => $final_grade,
+				'created_at'  => current_time( 'mysql', true ),
+				'updated_at'  => current_time( 'mysql', true ),
+			]
+		);
+	}
+
+	/**
+	 * Replace the progress query service with tables-based implementation.
+	 */
+	private function setup_hpps_progress_query_service(): void {
+		global $wpdb;
+		$this->_progress_query_service   = Sensei()->progress_query_service;
+		Sensei()->progress_query_service = new Tables_Based_Progress_Query_Service( $wpdb );
+	}
+
+	/**
+	 * Reset the progress query service to original.
+	 */
+	private function reset_hpps_progress_query_service(): void {
+		Sensei()->progress_query_service = $this->_progress_query_service;
+	}
+
+	/**
+	 * Original progress query service.
+	 *
+	 * @var \Sensei\Internal\Student_Progress\Services\Progress_Query_Service_Interface
+	 */
+	private $_progress_query_service;
+}


### PR DESCRIPTION
## Summary

Prototype for SEN-32: HPPS backend integration using the **Full Migration** pattern.

Converts `Sensei_Grading::get_course_users_grades_sum()` as a representative function to compare implementation strategies.

**Pattern:** Interface + comments-based/tables-based implementations + factory (mirrors existing repo pattern).

- Adds `Progress_Query_Service_Interface` with `get_course_users_grades_sum()` method
- `Comments_Based_Progress_Query_Service` — copies existing SQL from `Sensei_Grading`
- `Tables_Based_Progress_Query_Service` — queries `sensei_lms_quiz_submissions.final_grade`
- `Progress_Query_Service_Factory` — same `$tables_enabled`/`$read_tables` pattern as existing repo factories
- Wired up in `class-sensei.php`, caller in `class-sensei-grading.php` delegates to service

**Stats:** 4 new files (240 production LOC), 2 modified files, 1 test file (8 tests, both modes)

## Comparison with Plan C (Query Router)

See [companion PR](https://github.com/Automattic/sensei/pull/7908) for the Query Router prototype. Key tradeoffs:

| Criterion | This PR (Full Migration) | Query Router |
|-----------|------------------------|--------------|
| New files | 4 | 1 |
| Production LOC | 240 | 117 |
| Consistency with existing pattern | Matches factory pattern exactly | Different (runtime routing) |
| Adding next method | 3 files per method | 1 file per method |
| Test behavior in HPPS mode | All 8 tests run in both modes | 4 skipped in HPPS mode |
| [God object](https://en.wikipedia.org/wiki/God_object) risk | Low (separate classes) | Higher (single class grows) |

## Test plan

- [x] `npm run test-php:wp-env -- --filter Progress_Query_Service_Test` — 8/8 pass
- [x] `npm run test-php:wp-env:hpps -- --filter Progress_Query_Service_Test` — 8/8 pass
- [x] Existing `testGetCourseUsersGradesSum_WhenCalled_ReturnsCorrectSum` still passes
- [x] `phpcs` clean on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)