### PR TITLE
Fix module order reset when Editor saves a lesson

### DIFF
--- a/changelog/fix-broken-module-order-for-editors
+++ b/changelog/fix-broken-module-order-for-editors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix module order reset and module disassociation when a non-admin user (e.g. Editor) saves a lesson in a course with modules owned by another user.

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1492,13 +1492,17 @@ class Sensei_Admin {
 		if ( $course_id ) {
 			remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
 			// Temporarily remove the module ownership filters so the full unfiltered set of modules
-			// is read back. Without this, non-admin users (e.g. Editors) would only retrieve their
-			// own modules, and saving the structure would disassociate all other modules from the course.
+			// is used throughout the read-and-save cycle. Without this, non-admin users (e.g. Editors)
+			// would only see their own modules: get_course_structure() would return a partial list,
+			// and save() — which internally re-reads the current structure for diffing — would
+			// disassociate all other modules from the course. Filters are restored after save().
 			remove_filter( 'get_terms', array( Sensei()->modules, 'filter_module_terms' ), 20 );
 			remove_filter( 'get_object_terms', array( Sensei()->modules, 'filter_course_selected_terms' ), 20 );
 
 			$course_structure = $this->get_course_structure( intval( $course_id ) );
 
+			// Restore the display-only filter early — it only appends teacher names and does not
+			// filter out terms, unlike the ownership filters which must remain off through save().
 			add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
 
 			$order            = array_map( 'absint', explode( ',', $order_string ) );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1491,11 +1491,17 @@ class Sensei_Admin {
 
 		if ( $course_id ) {
 			remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
+			// Temporarily remove the module ownership filters so the full unfiltered set of modules
+			// is read back. Without this, non-admin users (e.g. Editors) would only retrieve their
+			// own modules, and saving the structure would disassociate all other modules from the course.
+			remove_filter( 'get_terms', array( Sensei()->modules, 'filter_module_terms' ), 20 );
+			remove_filter( 'get_object_terms', array( Sensei()->modules, 'filter_course_selected_terms' ), 20 );
+
 			$course_structure = $this->get_course_structure( intval( $course_id ) );
+
 			add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
 
-			$order = array_map( 'absint', explode( ',', $order_string ) );
-
+			$order            = array_map( 'absint', explode( ',', $order_string ) );
 			$course_structure = Sensei_Course_Structure::sort_structure( $course_structure, $order, 'lesson' );
 
 			// Sort module lessons.
@@ -1517,7 +1523,11 @@ class Sensei_Admin {
 				}
 			}
 
-			if ( true === Sensei_Course_Structure::instance( $course_id )->save( $course_structure ) ) {
+			$save_result = Sensei_Course_Structure::instance( $course_id )->save( $course_structure );
+			add_filter( 'get_terms', array( Sensei()->modules, 'filter_module_terms' ), 20, 3 );
+			add_filter( 'get_object_terms', array( Sensei()->modules, 'filter_course_selected_terms' ), 20, 3 );
+
+			if ( true === $save_result ) {
 				return true;
 			}
 		}

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -409,6 +409,9 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$this->assertCount( 3, $course_modules, 'All modules should remain associated with the course.' );
 
 		// Clean up.
+		wp_delete_term( $module_a['term_id'], 'module' );
+		wp_delete_term( $module_b['term_id'], 'module' );
+		wp_delete_term( $module_c['term_id'], 'module' );
 		set_current_screen( 'front' );
 	}
 

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -346,6 +346,71 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that saving a lesson as an Editor does not reset the module order.
+	 *
+	 * @covers Sensei_Lesson::add_lesson_to_course_order
+	 */
+	public function testAddLessonToCourseOrder_AsEditor_PreservesModuleOrder() {
+		if ( ! isset( Sensei()->admin ) ) {
+			Sensei()->admin = new WooThemes_Sensei_Admin();
+		}
+
+		// Create an admin user to own the modules.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		// Create a course and modules.
+		$course_id = $this->factory->course->create();
+		$module_a  = wp_insert_term( 'Module A', 'module' );
+		$module_b  = wp_insert_term( 'Module B', 'module' );
+		$module_c  = wp_insert_term( 'Module C', 'module' );
+
+		// Set admin as the module author.
+		update_term_meta( $module_a['term_id'], 'module_author', $admin_id );
+		update_term_meta( $module_b['term_id'], 'module_author', $admin_id );
+		update_term_meta( $module_c['term_id'], 'module_author', $admin_id );
+
+		// Associate modules with the course in a custom order: C, A, B.
+		$custom_order = array( $module_c['term_id'], $module_a['term_id'], $module_b['term_id'] );
+		wp_set_object_terms( $course_id, $custom_order, 'module' );
+		update_post_meta( $course_id, '_module_order', array_map( 'strval', $custom_order ) );
+
+		// Create a lesson belonging to this course.
+		$lesson_id = $this->factory->lesson->create();
+		update_post_meta( $lesson_id, '_lesson_course', $course_id );
+
+		// Verify modules are associated before switching users.
+		$modules_before = wp_get_object_terms( $course_id, 'module', array( 'fields' => 'ids' ) );
+		$this->assertCount( 3, $modules_before, 'Modules should be associated before save.' );
+
+		// Switch to an Editor user.
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+		set_current_screen( 'edit-lesson' );
+		clean_object_term_cache( $course_id, 'course' );
+
+		// Trigger the lesson save hook.
+		Sensei()->lesson->add_lesson_to_course_order( $lesson_id );
+
+		// Verify module order is preserved.
+		$saved_order = get_post_meta( $course_id, '_module_order', true );
+		$this->assertEquals(
+			array_map( 'strval', $custom_order ),
+			$saved_order,
+			'Module order should be preserved when an Editor saves a lesson.'
+		);
+
+		// Verify all modules are still associated with the course.
+		// Switch back to admin to bypass the module ownership filter for this assertion.
+		wp_set_current_user( $admin_id );
+		$course_modules = wp_get_object_terms( $course_id, 'module', array( 'fields' => 'ids' ) );
+		$this->assertCount( 3, $course_modules, 'All modules should remain associated with the course.' );
+
+		// Clean up.
+		set_current_screen( 'front' );
+	}
+
+	/**
 	 * @covers Sensei_Lesson::lesson_has_quiz_with_graded_questions()
 	 */
 	public function testLessonHasQuizWithGradedQuestionsLessonWithNoQuiz() {

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -346,9 +346,11 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that saving a lesson as an Editor does not reset the module order.
+	 * Test that saving a lesson as an Editor preserves module order and does not
+	 * disassociate modules owned by other users.
 	 *
 	 * @covers Sensei_Lesson::add_lesson_to_course_order
+	 * @covers Sensei_Admin::save_lesson_order
 	 */
 	public function testAddLessonToCourseOrder_AsEditor_PreservesModuleOrder() {
 		if ( ! isset( Sensei()->admin ) ) {


### PR DESCRIPTION
## Summary
- When a non-admin user (e.g. Editor) saves a lesson in a course with modules owned by another user (e.g. Admin), the module ownership filters (`filter_module_terms`, `filter_course_selected_terms`) strip modules the Editor doesn't own during the read/save cycle in `save_lesson_order()`.
- This causes all non-owned modules to be disassociated from the course and the module order to be reset.
- Fix: temporarily remove the ownership filters before reading and saving the course structure, then restore them after.

Fixes #7889

## Test plan
- [x] Run `npm run test-php:wp-env -- --filter testAddLessonToCourseOrder_AsEditor_PreservesModuleOrder` — should pass
- [x] Run full test suite `npm run test-php:wp-env` — only pre-existing `Sensei_Class_Feature_Flags_Test` failures expected
- [x] Manual: Log in as Admin, create a course with modules and lessons. Log in as Editor, edit a lesson in that course and save. Verify modules remain associated and order is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)