### PR TITLE
Prototype: HPPS Parallel Implementations

### DIFF
--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -20,6 +20,15 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	public $page_slug = 'sensei_grading';
 
 	/**
+	 * Grading queries implementation.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var \Sensei\Internal\Grading\Grading_Queries_Interface|null
+	 */
+	private $grading_queries;
+
+	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
@@ -43,6 +52,8 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		if ( ! empty( $args['view'] ) && in_array( $args['view'], array( 'in-progress', 'graded', 'ungraded', 'all' ) ) ) {
 			$this->view = $args['view'];
 		}
+
+		$this->grading_queries = Sensei()->grading->get_grading_queries();
 
 		// Load Parent token into constructor
 		parent::__construct( 'grading_main' );
@@ -237,24 +248,14 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		 */
 		$activity_args = apply_filters( 'sensei_grading_filter_statuses', $activity_args );
 
-		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice
-		$total_statuses = Sensei_Utils::sensei_check_for_activity(
-			array_merge(
-				$activity_args,
-				array(
-					'count'  => true,
-					'offset' => 0,
-					'number' => 0,
-				)
-			)
-		);
+		$total_statuses = $this->grading_queries->count_grading_items( $activity_args );
 
 		// Ensure we change our range to fit (in case a search threw off the pagination) - Should this be added to all views?
 		if ( $total_statuses < $activity_args['offset'] ) {
 			$new_paged               = floor( $total_statuses / $activity_args['number'] );
 			$activity_args['offset'] = $new_paged * $activity_args['number'];
 		}
-		$statuses = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+		$statuses = $this->grading_queries->get_grading_items( $activity_args );
 		// Need to always return an array, even with only 1 item
 		if ( ! is_array( $statuses ) ) {
 			$statuses = array( $statuses );
@@ -282,19 +283,20 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	protected function get_row_data( $item ) {
 		global $wp_version;
 
-		$grade = '';
+		$grade      = '';
+		$item_grade = $this->grading_queries->get_item_grade( $item );
 		if ( 'complete' == $item->comment_approved ) {
 			$status_html = '<span class="graded">' . esc_html__( 'Completed', 'sensei-lms' ) . '</span>';
 			$grade       = __( 'No Grade', 'sensei-lms' );
 		} elseif ( 'graded' == $item->comment_approved ) {
 			$status_html = '<span class="graded">' . esc_html__( 'Graded', 'sensei-lms' ) . '</span>';
-			$grade       = get_comment_meta( $item->comment_ID, 'grade', true ) . '%';
+			$grade       = ( null !== $item_grade ? $item_grade : '' ) . '%';
 		} elseif ( 'passed' == $item->comment_approved ) {
 			$status_html = '<span class="passed">' . esc_html__( 'Passed', 'sensei-lms' ) . '</span>';
-			$grade       = get_comment_meta( $item->comment_ID, 'grade', true ) . '%';
+			$grade       = ( null !== $item_grade ? $item_grade : '' ) . '%';
 		} elseif ( 'failed' == $item->comment_approved ) {
 			$status_html = '<span class="failed">' . esc_html__( 'Failed', 'sensei-lms' ) . '</span>';
-			$grade       = get_comment_meta( $item->comment_ID, 'grade', true ) . '%';
+			$grade       = ( null !== $item_grade ? $item_grade : '' ) . '%';
 		} elseif ( 'ungraded' == $item->comment_approved ) {
 			$status_html = '<span class="ungraded">' . esc_html__( 'Ungraded', 'sensei-lms' ) . '</span>';
 			$grade       = __( 'N/A', 'sensei-lms' );
@@ -566,7 +568,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		 */
 		$count_args = apply_filters( 'sensei_grading_count_statuses', $count_args );
 
-		$counts = Sensei()->grading->count_statuses( $count_args );
+		$counts = $this->grading_queries->count_statuses( $count_args );
 
 		$inprogress_lessons_count = $counts['in-progress'];
 		$ungraded_lessons_count   = $counts['ungraded'];

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -19,6 +19,15 @@ class Sensei_Grading {
 	public $page_slug;
 
 	/**
+	 * Grading queries implementation.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var \Sensei\Internal\Grading\Grading_Queries_Interface|null
+	 */
+	private $grading_queries;
+
+	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
@@ -73,6 +82,31 @@ class Sensei_Grading {
 	 */
 	public function get_name() {
 		return __( 'Grading', 'sensei-lms' );
+	}
+
+	/**
+	 * Set the grading queries implementation.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \Sensei\Internal\Grading\Grading_Queries_Interface $grading_queries Grading queries implementation.
+	 */
+	public function set_grading_queries( \Sensei\Internal\Grading\Grading_Queries_Interface $grading_queries ): void {
+		$this->grading_queries = $grading_queries;
+	}
+
+	/**
+	 * Get the grading queries implementation.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return \Sensei\Internal\Grading\Grading_Queries_Interface
+	 */
+	public function get_grading_queries(): \Sensei\Internal\Grading\Grading_Queries_Interface {
+		if ( null === $this->grading_queries ) {
+			$this->grading_queries = ( new \Sensei\Internal\Grading\Grading_Queries_Factory() )->create();
+		}
+		return $this->grading_queries;
 	}
 
 	/**
@@ -543,6 +577,19 @@ class Sensei_Grading {
 	 * @return object
 	 */
 	public function count_statuses( $args = array() ) {
+		return $this->get_grading_queries()->count_statuses( $args );
+	}
+
+	/**
+	 * Count the various statuses for Course or Lesson (legacy implementation).
+	 *
+	 * @deprecated $$next-version$$ Use Grading_Queries_Interface::count_statuses() via get_grading_queries().
+	 *
+	 * @since  1.7.0
+	 * @param  array $args (default: array())
+	 * @return object
+	 */
+	private function count_statuses_legacy( $args = array() ) {
 		global  $wpdb;
 
 		/**
@@ -1385,28 +1432,7 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_course_users_grades_sum( $course_id ) {
-		global $wpdb;
-
-		$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
-		if ( ! $lesson_ids ) {
-			return 0;
-		}
-
-		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND {$wpdb->comments}.comment_approved IN ('graded', 'passed', 'failed') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
-				AND {$wpdb->comments}.comment_post_ID IN ({$lesson_ids_placeholder}) ",
-				$lesson_ids
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-
-		return $sum_of_all_grades;
+		return Sensei()->grading->get_grading_queries()->get_course_users_grades_sum( (int) $course_id );
 	}
 
 	/**
@@ -1418,38 +1444,7 @@ class Sensei_Grading {
 	 * @return double Average grade of all courses.
 	 */
 	public function get_courses_average_grade() {
-		global $wpdb;
-
-		/**
-		 * The subquery calculates the average grade per course, and the outer query then calculates the
-		 * average grade of all courses. To be included in the calculation, a lesson must:
-		 *   Have a status of 'graded', 'passed' or 'failed'.
-		 *   Have grade data.
-		 *   Be associated with a course.
-		 *   Have quiz questions (checking for the existence of '_quiz_has_questions' meta is sufficient;
-		 *   if it exists its value will be 1).
-		 */
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$result = $wpdb->get_row(
-			"SELECT AVG(course_average) as courses_average
-			FROM (
-				SELECT AVG(cm.meta_value) as course_average
-				FROM {$wpdb->comments} c
-				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
-				INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
-				INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
-				INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
-				WHERE c.comment_type = 'sensei_lesson_status'
-					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
-					AND cm.meta_key = 'grade'
-					AND course.meta_key = '_lesson_course'
-					AND course.meta_value <> ''
-					AND has_questions.meta_key = '_quiz_has_questions'
-				GROUP BY course.meta_value
-			) averages_by_course"
-		);
-
-		return floatval( $result->courses_average );
+		return $this->get_grading_queries()->get_courses_average_grade();
 	}
 }
 

--- a/includes/internal/grading/class-comments-based-grading-queries.php
+++ b/includes/internal/grading/class-comments-based-grading-queries.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * File containing the Comments_Based_Grading_Queries class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Grading;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Comments_Based_Grading_Queries.
+ *
+ * Comments-based implementation of grading queries.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Comments_Based_Grading_Queries implements Grading_Queries_Interface {
+
+	/**
+	 * WordPress database object.
+	 *
+	 * @var \wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * Comments_Based_Grading_Queries constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( \wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Count statuses for a given type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Arguments: type (course|lesson), post__in, post_id, user_id, query.
+	 * @return array Associative array of status => count.
+	 */
+	public function count_statuses( array $args ): array {
+		/**
+		 * Filter fires inside Sensei_Grading::count_statuses
+		 *
+		 * Alter the post_in array to determine which posts the comment query should be limited to.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @hook sensei_count_statuses_args
+		 *
+		 * @param {array} $args Array of arguments for the query.
+		 * @return {array} Filtered arguments.
+		 */
+		$args = apply_filters( 'sensei_count_statuses_args', $args );
+
+		$type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
+
+		$cache_key = 'sensei-statuses-' . md5( wp_json_encode( $args ) );
+
+		$query = $this->wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+			"SELECT comment_approved, COUNT( * ) AS total FROM {$this->wpdb->comments} WHERE comment_type = %s ",
+			$type
+		);
+
+		// Restrict to specific posts.
+		if ( isset( $args['post__in'] ) && ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$post__in_placeholder = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$query .= $this->wpdb->prepare( " AND comment_post_ID IN ( $post__in_placeholder )", $args['post__in'] );
+		} elseif ( ! empty( $args['post_id'] ) ) {
+			$query .= $this->wpdb->prepare( ' AND comment_post_ID = %d', $args['post_id'] );
+		}
+
+		// Restrict to specific users.
+		if ( isset( $args['user_id'] ) && is_array( $args['user_id'] ) ) {
+			$user_id_placeholder = implode( ', ', array_fill( 0, count( $args['user_id'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$query .= $this->wpdb->prepare( " AND user_id IN ( $user_id_placeholder )", $args['user_id'] );
+		} elseif ( ! empty( $args['user_id'] ) ) {
+			$query .= $this->wpdb->prepare( ' AND user_id = %d', $args['user_id'] );
+		}
+
+		// Append raw SQL query.
+		if ( isset( $args['query'] ) ) {
+			$query .= $args['query'];
+		}
+
+		$query .= ' GROUP BY comment_approved';
+
+		$counts = wp_cache_get( $cache_key, 'counts' );
+		if ( false === $counts ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL prepared in advance.
+			$results = (array) $this->wpdb->get_results( $query, ARRAY_A );
+			$counts  = array_fill_keys( $this->get_valid_statuses( $type ), 0 );
+
+			foreach ( $results as $row ) {
+				$counts[ $row['comment_approved'] ] = $row['total'];
+			}
+			wp_cache_set( $cache_key, $counts, 'counts' );
+		}
+
+		$counts = $this->ensure_default_status_keys( $counts );
+
+		/**
+		 * Filter the counts of statuses for a given type.
+		 *
+		 * @hook sensei_count_statuses
+		 *
+		 * @param {array}  $counts Array of counts for each status.
+		 * @param {string} $type   Type of status to count: sensei_course_status or sensei_lesson_status.
+		 * @return {array} Filtered counts.
+		 */
+		return apply_filters( 'sensei_count_statuses', $counts, $type );
+	}
+
+	/**
+	 * Get the sum of all user grades for a course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $course_id Course ID.
+	 * @return int Sum of grades.
+	 */
+	public function get_course_users_grades_sum( int $course_id ): int {
+		$lesson_ids = \Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
+		if ( ! $lesson_ids ) {
+			return 0;
+		}
+
+		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared -- Placeholders created dynamically.
+		$sum_of_all_grades = (int) $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				"SELECT SUM({$this->wpdb->commentmeta}.meta_value) AS meta_sum
+				FROM {$this->wpdb->comments} INNER JOIN {$this->wpdb->commentmeta} ON ( {$this->wpdb->comments}.comment_ID = {$this->wpdb->commentmeta}.comment_id )
+				WHERE {$this->wpdb->comments}.comment_type IN ('sensei_lesson_status') AND {$this->wpdb->comments}.comment_approved IN ('graded', 'passed', 'failed') AND ( {$this->wpdb->commentmeta}.meta_key = 'grade')
+				AND {$this->wpdb->comments}.comment_post_ID IN ({$lesson_ids_placeholder}) ",
+				$lesson_ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared
+
+		return $sum_of_all_grades;
+	}
+
+	/**
+	 * Get average grade across all courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return float Average grade.
+	 */
+	public function get_courses_average_grade(): float {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$result = $this->wpdb->get_row(
+			"SELECT AVG(course_average) as courses_average
+			FROM (
+				SELECT AVG(cm.meta_value) as course_average
+				FROM {$this->wpdb->comments} c
+				INNER JOIN {$this->wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+				INNER JOIN {$this->wpdb->postmeta} course ON c.comment_post_ID = course.post_id
+				INNER JOIN {$this->wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
+				INNER JOIN {$this->wpdb->posts} p ON p.ID = course.meta_value
+				WHERE c.comment_type = 'sensei_lesson_status'
+					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
+					AND cm.meta_key = 'grade'
+					AND course.meta_key = '_lesson_course'
+					AND course.meta_value <> ''
+					AND has_questions.meta_key = '_quiz_has_questions'
+				GROUP BY course.meta_value
+			) averages_by_course"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return floatval( $result->courses_average ?? 0 );
+	}
+
+	/**
+	 * Get grading items for the grading list table.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return array Array of comment objects.
+	 */
+	public function get_grading_items( array $args ): array {
+		$statuses = \Sensei_Utils::sensei_check_for_activity( $args, true );
+		if ( ! is_array( $statuses ) ) {
+			$statuses = array( $statuses );
+		}
+		return $statuses;
+	}
+
+	/**
+	 * Count grading items matching the given arguments.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return int Count of matching items.
+	 */
+	public function count_grading_items( array $args ): int {
+		return (int) \Sensei_Utils::sensei_check_for_activity(
+			array_merge(
+				$args,
+				array(
+					'count'  => true,
+					'offset' => 0,
+					'number' => 0,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Get the grade for a grading item.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param object $item A comment object.
+	 * @return string|null The grade value.
+	 */
+	public function get_item_grade( object $item ): ?string {
+		$grade = get_comment_meta( $item->comment_ID, 'grade', true );
+		return '' !== $grade ? $grade : null;
+	}
+
+	/**
+	 * Get valid statuses for a given comment type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $type The comment type (sensei_course_status or sensei_lesson_status).
+	 * @return array Array of valid statuses.
+	 */
+	private function get_valid_statuses( string $type ): array {
+		switch ( $type ) {
+			case 'sensei_course_status':
+				return array(
+					'in-progress',
+					'complete',
+				);
+
+			case 'sensei_lesson_status':
+				return array(
+					'in-progress',
+					'complete',
+					'ungraded',
+					'graded',
+					'passed',
+					'failed',
+				);
+
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Ensure default status keys exist in the counts array.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $counts The counts array.
+	 * @return array The counts array with default keys.
+	 */
+	private function ensure_default_status_keys( array $counts ): array {
+		$defaults = array(
+			'graded'      => 0,
+			'ungraded'    => 0,
+			'passed'      => 0,
+			'failed'      => 0,
+			'in-progress' => 0,
+			'complete'    => 0,
+		);
+
+		foreach ( $defaults as $key => $value ) {
+			if ( ! isset( $counts[ $key ] ) ) {
+				$counts[ $key ] = $value;
+			}
+		}
+
+		return $counts;
+	}
+}

--- a/includes/internal/grading/class-grading-queries-factory.php
+++ b/includes/internal/grading/class-grading-queries-factory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the Grading_Queries_Factory class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Grading;
+
+use Sensei\Internal\Services\Progress_Storage_Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Grading_Queries_Factory.
+ *
+ * Factory that creates the appropriate grading queries implementation based on HPPS settings.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Grading_Queries_Factory {
+
+	/**
+	 * Create a grading queries instance.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return Grading_Queries_Interface
+	 */
+	public function create(): Grading_Queries_Interface {
+		global $wpdb;
+
+		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+			return new Tables_Based_Grading_Queries( $wpdb );
+		}
+
+		return new Comments_Based_Grading_Queries( $wpdb );
+	}
+}

--- a/includes/internal/grading/class-grading-queries-interface.php
+++ b/includes/internal/grading/class-grading-queries-interface.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * File containing the Grading_Queries_Interface interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Grading;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Interface Grading_Queries_Interface.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+interface Grading_Queries_Interface {
+
+	/**
+	 * Count statuses for a given type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Arguments: type (course|lesson), post__in, post_id, user_id, query.
+	 * @return array Associative array of status => count.
+	 */
+	public function count_statuses( array $args ): array;
+
+	/**
+	 * Get the sum of all user grades for a course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $course_id Course ID.
+	 * @return int Sum of grades.
+	 */
+	public function get_course_users_grades_sum( int $course_id ): int;
+
+	/**
+	 * Get average grade across all courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return float Average grade.
+	 */
+	public function get_courses_average_grade(): float;
+
+	/**
+	 * Get grading items (lesson statuses) for the grading list table.
+	 *
+	 * Returns objects with properties compatible with WP_Comment:
+	 * comment_ID, comment_approved, comment_date, user_id, comment_post_ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments: type, number, offset, orderby, order, status, post_id, post__in, user_id.
+	 * @return array Array of objects.
+	 */
+	public function get_grading_items( array $args ): array;
+
+	/**
+	 * Count grading items matching the given arguments.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments (same as get_grading_items).
+	 * @return int Count of matching items.
+	 */
+	public function count_grading_items( array $args ): int;
+
+	/**
+	 * Get the grade for a grading item.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param object $item A grading item (from get_grading_items).
+	 * @return string|null The grade value, or null if not available.
+	 */
+	public function get_item_grade( object $item ): ?string;
+}

--- a/includes/internal/grading/class-tables-based-grading-queries.php
+++ b/includes/internal/grading/class-tables-based-grading-queries.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * File containing the Tables_Based_Grading_Queries class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Grading;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Tables_Based_Grading_Queries.
+ *
+ * Tables-based implementation of grading queries using custom progress and quiz submission tables.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Tables_Based_Grading_Queries implements Grading_Queries_Interface {
+
+	/**
+	 * WordPress database object.
+	 *
+	 * @var \wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * Tables_Based_Grading_Queries constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( \wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Count statuses for a given type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Arguments: type (course|lesson), post__in, post_id, user_id, query.
+	 * @return array Associative array of status => count.
+	 */
+	public function count_statuses( array $args ): array {
+		/**
+		 * Filter fires inside Sensei_Grading::count_statuses
+		 *
+		 * Alter the post_in array to determine which posts the comment query should be limited to.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @hook sensei_count_statuses_args
+		 *
+		 * @param {array} $args Array of arguments for the query.
+		 * @return {array} Filtered arguments.
+		 */
+		$args = apply_filters( 'sensei_count_statuses_args', $args );
+
+		$type = $args['type'];
+
+		$cache_key = 'sensei-statuses-' . md5( wp_json_encode( $args ) );
+
+		$progress_table = $this->wpdb->prefix . 'sensei_lms_progress';
+
+		$query = $this->wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+			"SELECT status, COUNT( * ) AS total FROM {$progress_table} WHERE type = %s ",
+			$type
+		);
+
+		// Restrict to specific posts.
+		if ( isset( $args['post__in'] ) && ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$post__in_placeholder = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$query .= $this->wpdb->prepare( " AND post_id IN ( $post__in_placeholder )", $args['post__in'] );
+		} elseif ( ! empty( $args['post_id'] ) ) {
+			$query .= $this->wpdb->prepare( ' AND post_id = %d', $args['post_id'] );
+		}
+
+		// Restrict to specific users.
+		if ( isset( $args['user_id'] ) && is_array( $args['user_id'] ) ) {
+			$user_id_placeholder = implode( ', ', array_fill( 0, count( $args['user_id'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$query .= $this->wpdb->prepare( " AND user_id IN ( $user_id_placeholder )", $args['user_id'] );
+		} elseif ( ! empty( $args['user_id'] ) ) {
+			$query .= $this->wpdb->prepare( ' AND user_id = %d', $args['user_id'] );
+		}
+
+		// Translate raw SQL query from comments table to progress table.
+		if ( isset( $args['query'] ) ) {
+			$query .= str_replace( 'comment_post_ID', 'post_id', $args['query'] );
+		}
+
+		$query .= ' GROUP BY status';
+
+		$counts = wp_cache_get( $cache_key, 'counts' );
+		if ( false === $counts ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL prepared in advance.
+			$results = (array) $this->wpdb->get_results( $query, ARRAY_A );
+			$counts  = array_fill_keys( $this->get_valid_statuses( $type ), 0 );
+
+			foreach ( $results as $row ) {
+				$counts[ $row['status'] ] = $row['total'];
+			}
+			wp_cache_set( $cache_key, $counts, 'counts' );
+		}
+
+		$counts = $this->ensure_default_status_keys( $counts );
+
+		// Use the comment type for the filter to maintain backward compatibility.
+		$comment_type = 'course' === $type ? 'sensei_course_status' : 'sensei_lesson_status';
+
+		/**
+		 * Filter the counts of statuses for a given type.
+		 *
+		 * @hook sensei_count_statuses
+		 *
+		 * @param {array}  $counts Array of counts for each status.
+		 * @param {string} $type   Type of status to count: sensei_course_status or sensei_lesson_status.
+		 * @return {array} Filtered counts.
+		 */
+		return apply_filters( 'sensei_count_statuses', $counts, $comment_type );
+	}
+
+	/**
+	 * Get the sum of all user grades for a course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $course_id Course ID.
+	 * @return int Sum of grades.
+	 */
+	public function get_course_users_grades_sum( int $course_id ): int {
+		$lesson_ids = \Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
+		if ( ! $lesson_ids ) {
+			return 0;
+		}
+
+		$submissions_table = $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+
+		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared -- Placeholders created dynamically.
+		$sum_of_all_grades = (int) $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				"SELECT SUM(qs.final_grade) AS grade_sum
+				FROM {$submissions_table} qs
+				INNER JOIN {$this->wpdb->posts} quiz ON qs.quiz_id = quiz.ID
+				WHERE quiz.post_parent IN ({$lesson_ids_placeholder})
+				AND qs.final_grade IS NOT NULL",
+				$lesson_ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared
+
+		return $sum_of_all_grades;
+	}
+
+	/**
+	 * Get average grade across all courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return float Average grade.
+	 */
+	public function get_courses_average_grade(): float {
+		$submissions_table = $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$result = $this->wpdb->get_row(
+			"SELECT AVG(course_average) as courses_average
+			FROM (
+				SELECT AVG(qs.final_grade) as course_average
+				FROM {$submissions_table} qs
+				INNER JOIN {$this->wpdb->posts} quiz ON qs.quiz_id = quiz.ID
+				INNER JOIN {$this->wpdb->postmeta} course ON quiz.post_parent = course.post_id
+				INNER JOIN {$this->wpdb->postmeta} has_questions ON quiz.post_parent = has_questions.post_id
+				INNER JOIN {$this->wpdb->posts} p ON p.ID = course.meta_value
+				WHERE qs.final_grade IS NOT NULL
+					AND course.meta_key = '_lesson_course'
+					AND course.meta_value <> ''
+					AND has_questions.meta_key = '_quiz_has_questions'
+				GROUP BY course.meta_value
+			) averages_by_course"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return floatval( $result->courses_average ?? 0 );
+	}
+
+	/**
+	 * Get grading items for the grading list table.
+	 *
+	 * Returns objects with WP_Comment-compatible properties for seamless integration
+	 * with existing list table code.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return array Array of objects with comment-compatible properties.
+	 */
+	public function get_grading_items( array $args ): array {
+		$progress_table    = $this->wpdb->prefix . 'sensei_lms_progress';
+		$submissions_table = $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+
+		$query = 'SELECT p.id AS comment_ID, p.status AS comment_approved, p.updated_at AS comment_date, p.user_id, p.post_id AS comment_post_ID, qs.final_grade AS grade'
+			. " FROM {$progress_table} p"
+			. " LEFT JOIN {$this->wpdb->posts} quiz ON quiz.post_parent = p.post_id AND quiz.post_type = 'quiz'"
+			. " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = quiz.ID AND qs.user_id = p.user_id"
+			. $this->wpdb->prepare( ' WHERE p.type = %s', 'lesson' );
+
+		$query .= $this->build_grading_items_where( $args );
+
+		// Ordering.
+		$orderby = $args['orderby'] ?? '';
+		$order   = $args['order'] ?? 'DESC';
+		$order   = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? strtoupper( $order ) : 'DESC';
+
+		$orderby_map = array(
+			'title'       => 'p.user_id',
+			'lesson'      => 'p.post_id',
+			'updated'     => 'p.updated_at',
+			'user_status' => 'p.status',
+			'user_grade'  => 'qs.final_grade',
+		);
+
+		if ( ! empty( $orderby ) && isset( $orderby_map[ $orderby ] ) ) {
+			$query .= ' ORDER BY ' . $orderby_map[ $orderby ] . ' ' . $order;
+		} else {
+			$query .= " ORDER BY p.updated_at {$order}";
+		}
+
+		// Pagination.
+		if ( ! empty( $args['number'] ) ) {
+			$query .= $this->wpdb->prepare( ' LIMIT %d', $args['number'] );
+		}
+		if ( ! empty( $args['offset'] ) ) {
+			$query .= $this->wpdb->prepare( ' OFFSET %d', $args['offset'] );
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Query built dynamically above.
+		return $this->wpdb->get_results( $query );
+	}
+
+	/**
+	 * Count grading items matching the given arguments.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return int Count of matching items.
+	 */
+	public function count_grading_items( array $args ): int {
+		$progress_table = $this->wpdb->prefix . 'sensei_lms_progress';
+
+		$query = $this->wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+			"SELECT COUNT(*) FROM {$progress_table} p WHERE p.type = %s",
+			'lesson'
+		);
+
+		$query .= $this->build_grading_items_where( $args );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Query built dynamically above.
+		return (int) $this->wpdb->get_var( $query );
+	}
+
+	/**
+	 * Get the grade for a grading item.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param object $item A grading item from get_grading_items.
+	 * @return string|null The grade value.
+	 */
+	public function get_item_grade( object $item ): ?string {
+		return isset( $item->grade ) && null !== $item->grade ? (string) $item->grade : null;
+	}
+
+	/**
+	 * Build WHERE clause additions for grading items queries.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL WHERE additions.
+	 */
+	private function build_grading_items_where( array $args ): string {
+		$where = '';
+
+		// Filter by post.
+		if ( ! empty( $args['post_id'] ) ) {
+			$where .= $this->wpdb->prepare( ' AND p.post_id = %d', $args['post_id'] );
+		} elseif ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$where .= $this->wpdb->prepare( " AND p.post_id IN ( {$placeholders} )", $args['post__in'] );
+		}
+
+		// Filter by user.
+		if ( isset( $args['user_id'] ) && is_array( $args['user_id'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['user_id'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$where .= $this->wpdb->prepare( " AND p.user_id IN ( {$placeholders} )", $args['user_id'] );
+		} elseif ( ! empty( $args['user_id'] ) ) {
+			$where .= $this->wpdb->prepare( ' AND p.user_id = %d', $args['user_id'] );
+		}
+
+		// Filter by status.
+		$status = $args['status'] ?? 'any';
+		if ( 'any' !== $status ) {
+			if ( is_array( $status ) ) {
+				$placeholders = implode( ', ', array_fill( 0, count( $status ), '%s' ) );
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+				$where .= $this->wpdb->prepare( " AND p.status IN ( {$placeholders} )", $status );
+			} else {
+				$where .= $this->wpdb->prepare( ' AND p.status = %s', $status );
+			}
+		}
+
+		return $where;
+	}
+
+	/**
+	 * Get valid statuses for a given type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $type The progress type (course or lesson).
+	 * @return array Array of valid statuses.
+	 */
+	private function get_valid_statuses( string $type ): array {
+		switch ( $type ) {
+			case 'course':
+				return array(
+					'in-progress',
+					'complete',
+				);
+
+			case 'lesson':
+				return array(
+					'in-progress',
+					'complete',
+					'ungraded',
+					'graded',
+					'passed',
+					'failed',
+				);
+
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Ensure default status keys exist in the counts array.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $counts The counts array.
+	 * @return array The counts array with default keys.
+	 */
+	private function ensure_default_status_keys( array $counts ): array {
+		$defaults = array(
+			'graded'      => 0,
+			'ungraded'    => 0,
+			'passed'      => 0,
+			'failed'      => 0,
+			'in-progress' => 0,
+			'complete'    => 0,
+		);
+
+		foreach ( $defaults as $key => $value ) {
+			if ( ! isset( $counts[ $key ] ) ) {
+				$counts[ $key ] = $value;
+			}
+		}
+
+		return $counts;
+	}
+}

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses-tables.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses-tables.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * File containing the Sensei_Reports_Overview_Data_Provider_Courses_Tables class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+/**
+ * Class Sensei_Reports_Overview_Data_Provider_Courses_Tables
+ *
+ * Tables-based implementation that replaces comment queries with HPPS custom table queries.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Reports_Overview_Data_Provider_Courses_Tables implements Sensei_Reports_Overview_Data_Provider_Interface {
+
+	/**
+	 * Total number of courses found with given criteria.
+	 *
+	 * @var int Total number of items
+	 */
+	private $last_total_items = 0;
+
+	/**
+	 * Contains start date and time for filtering.
+	 *
+	 * @var string|null
+	 */
+	private $date_from;
+
+	/**
+	 * Contains end date and time for filtering.
+	 *
+	 * @var string|null
+	 */
+	private $date_to;
+
+	/**
+	 * Get the data for the overview report.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $filters Filters to apply to the data.
+	 *
+	 * @return array
+	 */
+	public function get_items( array $filters ): array {
+		$this->date_from = $filters['last_activity_date_from'] ?? null;
+		$this->date_to   = $filters['last_activity_date_to'] ?? null;
+
+		$course_args = array(
+			'post_type'        => 'course',
+			'post_status'      => array( 'publish', 'private' ),
+			'posts_per_page'   => $filters['number'],
+			'offset'           => $filters['offset'],
+			'fields'           => $filters['fields'] ?? '',
+			'orderby'          => $filters['orderby'] ?? '',
+			'order'            => $filters['order'] ?? 'ASC',
+			'suppress_filters' => 0,
+		);
+
+		if ( isset( $filters['search'] ) ) {
+			$course_args['s'] = $filters['search'];
+		}
+
+		add_filter( 'posts_clauses', [ $this, 'add_last_activity_to_courses_query' ] );
+		add_filter( 'posts_clauses', [ $this, 'add_days_to_completion_to_courses_query' ] );
+		add_filter( 'posts_clauses', [ $this, 'filter_courses_by_last_activity' ] );
+
+		if ( 'count_of_completions' === $course_args['orderby'] ) {
+			add_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 );
+		}
+
+		/**
+		 * Filter the courses query arguments.
+		 *
+		 * @hook sensei_analysis_overview_filter_courses
+		 *
+		 * @param {array} $course_args Array of arguments for the courses query.
+		 * @return {array} Filtered array of arguments for the courses query.
+		 */
+		$course_args   = apply_filters( 'sensei_analysis_overview_filter_courses', $course_args );
+		$courses_query = new WP_Query( $course_args );
+
+		remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 );
+		remove_filter( 'posts_clauses', [ $this, 'filter_courses_by_last_activity' ] );
+		remove_filter( 'posts_clauses', [ $this, 'add_days_to_completion_to_courses_query' ] );
+		remove_filter( 'posts_clauses', [ $this, 'add_last_activity_to_courses_query' ] );
+		remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_query' ), 10, 2 );
+
+		$this->last_total_items = $courses_query->found_posts;
+
+		return $courses_query->posts;
+	}
+
+	/**
+	 * Order query based on the custom field.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 *
+	 * @param array  $args Arguments Old orderby arguments.
+	 * @param object $query Query.
+	 */
+	public function add_orderby_custom_field_to_query( $args, $query ) {
+		return $query->query_vars['orderby'] . ' ' . $query->query_vars['order'];
+	}
+
+	/**
+	 * Add last activity date for each course.
+	 *
+	 * Uses the HPPS progress table instead of comments to determine the latest
+	 * lesson activity per course.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 *
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_last_activity_to_courses_query( array $clauses ): array {
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+
+		$lessons_query = "SELECT sp.post_id AS lesson_id, MAX(sp.updated_at) AS last_activity_date
+			FROM {$progress_table} sp
+			WHERE sp.status IN ('complete', 'passed', 'graded')
+			AND sp.type = 'lesson'
+			GROUP BY sp.post_id";
+
+		$course_query = "SELECT DISTINCT pm.meta_value AS course_id, lp.last_activity_date
+			FROM {$wpdb->postmeta} pm JOIN ({$lessons_query}) lp
+			ON lp.lesson_id = pm.post_id
+			AND pm.meta_key = '_lesson_course'
+			GROUP BY pm.meta_value
+		";
+
+		$clauses['fields'] .= ', la.last_activity_date AS last_activity_date';
+		$clauses['join']   .= " LEFT JOIN ({$course_query}) AS la ON la.course_id = {$wpdb->posts}.ID";
+
+		return $clauses;
+	}
+
+	/**
+	 * Filter the courses by last activity start/end date.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 *
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function filter_courses_by_last_activity( array $clauses ): array {
+		global $wpdb;
+
+		// Filter by start date.
+		if ( $this->date_from ) {
+			$clauses['where'] .= $wpdb->prepare(
+				' AND la.last_activity_date >= %s',
+				$this->date_from
+			);
+		}
+
+		// Filter by end date.
+		if ( $this->date_to ) {
+			$clauses['where'] .= $wpdb->prepare(
+				' AND la.last_activity_date <= %s',
+				$this->date_to
+			);
+		}
+
+		return $clauses;
+	}
+
+	/**
+	 * Add the sum of days taken by each student to complete a course and the number of completions for each course.
+	 *
+	 * Uses the HPPS progress table instead of comments/commentmeta to calculate
+	 * days to completion and completion counts.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 *
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_days_to_completion_to_courses_query( array $clauses ): array {
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+
+		// Get the number of days to complete a course: `days to complete = completed_at - started_at + 1`.
+		$clauses['fields'] .= ', SUM( ABS( DATEDIFF( cp.completed_at, cp.started_at ) ) + 1 ) AS days_to_completion';
+		// We consider the course as completed if there is a progress row with status complete and both dates present.
+		$clauses['fields']  .= ', COUNT(cp.id) AS count_of_completions';
+		$clauses['join']    .= " LEFT JOIN {$progress_table} cp ON cp.post_id = {$wpdb->posts}.ID";
+		$clauses['join']    .= " AND cp.type = 'course'";
+		$clauses['join']    .= " AND cp.status = 'complete'";
+		$clauses['join']    .= ' AND cp.started_at IS NOT NULL';
+		$clauses['join']    .= ' AND cp.completed_at IS NOT NULL';
+		$clauses['groupby'] .= " {$wpdb->posts}.ID";
+
+		return $clauses;
+	}
+
+	/**
+	 * Get the total number of items found for the last query.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int
+	 */
+	public function get_last_total_items(): int {
+		return $this->last_total_items;
+	}
+}

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons-tables.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons-tables.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * File containing the Sensei_Reports_Overview_Data_Provider_Lessons_Tables class.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tables-based data provider for lesson reports.
+ *
+ * Extends the comments-based lesson data provider, replacing the days to complete
+ * and last activity subqueries to use the `sensei_lms_progress` table instead of
+ * the comments table.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+class Sensei_Reports_Overview_Data_Provider_Lessons_Tables extends Sensei_Reports_Overview_Data_Provider_Lessons {
+
+	/**
+	 * Add the sum of days taken by each student to complete a lesson with returning lesson row.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 *
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_days_to_complete_to_lessons_query( array $clauses ): array {
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+
+		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( {$progress_table}.completed_at, {$progress_table}.started_at ) ) + 1 ) as days_to_complete";
+		$clauses['fields'] .= " FROM {$progress_table}";
+		$clauses['fields'] .= " WHERE {$progress_table}.post_id = {$wpdb->posts}.ID";
+		$clauses['fields'] .= " AND {$progress_table}.type = 'lesson'";
+		$clauses['fields'] .= " AND {$progress_table}.status IN ( 'complete', 'graded', 'passed', 'failed', 'ungraded' )";
+		$clauses['fields'] .= ') as days_to_complete';
+
+		return $clauses;
+	}
+
+	/**
+	 * Add the `last_activity` field to the query.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 *
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_last_activity_to_lessons_query( array $clauses ): array {
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+
+		$clauses['fields'] .= ", (
+			SELECT MAX({$progress_table}.updated_at)
+			FROM {$progress_table}
+			WHERE {$progress_table}.post_id = {$wpdb->posts}.ID
+			AND {$progress_table}.status IN ('complete', 'passed', 'graded')
+			AND {$progress_table}.type = 'lesson'
+			ORDER BY {$progress_table}.updated_at DESC
+		) AS last_activity_date";
+
+		return $clauses;
+	}
+}

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students-tables.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students-tables.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * File containing the Sensei_Reports_Overview_Data_Provider_Students_Tables class.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tables-based data provider for student reports.
+ *
+ * Extends the comments-based student data provider, replacing the last activity
+ * subquery to use the `sensei_lms_progress` table instead of the comments table.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+class Sensei_Reports_Overview_Data_Provider_Students_Tables extends Sensei_Reports_Overview_Data_Provider_Students {
+
+	/**
+	 * Add last activity date to the user query using the progress table.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param WP_User_Query $query The user query.
+	 */
+	public function add_last_activity_to_user_query( WP_User_Query $query ) {
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+
+		$query->query_fields .= ', last_activity_date';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+		$query->query_from .= $wpdb->prepare(
+			" LEFT JOIN (
+				SELECT {$progress_table}.user_id, MAX({$progress_table}.updated_at) AS last_activity_date
+				FROM {$progress_table}
+				WHERE {$progress_table}.status IN (%s, %s, %s)
+				AND {$progress_table}.type = %s
+				GROUP BY {$progress_table}.user_id
+			) AS l ON {$wpdb->users}.ID = l.user_id",
+			'complete',
+			'passed',
+			'graded',
+			'lesson'
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+}

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -32,7 +32,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	/**
 	 * Sensei reports courses service.
 	 *
-	 * @var Sensei_Reports_Overview_Service_Courses
+	 * @var Sensei_Reports_Overview_Service_Courses_Interface
 	 */
 	private $reports_overview_service_courses;
 
@@ -40,12 +40,12 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	/**
 	 * Constructor
 	 *
-	 * @param Sensei_Grading                                  $grading Sensei grading related services.
-	 * @param Sensei_Course                                   $course Sensei course related services.
-	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider Report data provider.
-	 * @param Sensei_Reports_Overview_Service_Courses         $reports_overview_service_courses reports courses service.
+	 * @param Sensei_Grading                                    $grading                          Sensei grading related services.
+	 * @param Sensei_Course                                     $course                           Sensei course related services.
+	 * @param Sensei_Reports_Overview_Data_Provider_Interface   $data_provider                    Report data provider.
+	 * @param Sensei_Reports_Overview_Service_Courses_Interface $reports_overview_service_courses  Reports courses service.
 	 */
-	public function __construct( Sensei_Grading $grading, Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Courses $reports_overview_service_courses ) {
+	public function __construct( Sensei_Grading $grading, Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Courses_Interface $reports_overview_service_courses ) {
 		// Load Parent token into constructor.
 		parent::__construct( 'courses', $data_provider );
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
@@ -26,27 +26,51 @@ class Sensei_Reports_Overview_List_Table_Factory {
 	 * @throws InvalidArgumentException If the report type is not supported.
 	 */
 	public function create( string $type ) {
+		$use_tables = $this->use_tables();
+
 		switch ( $type ) {
 			case 'users':
 			case 'students':
 				return new Sensei_Reports_Overview_List_Table_Students(
-					new Sensei_Reports_Overview_Data_Provider_Students(),
-					new Sensei_Reports_Overview_Service_Students()
+					$use_tables
+						? new Sensei_Reports_Overview_Data_Provider_Students_Tables()
+						: new Sensei_Reports_Overview_Data_Provider_Students(),
+					$use_tables
+						? new Sensei_Reports_Overview_Service_Students_Tables()
+						: new Sensei_Reports_Overview_Service_Students()
 				);
 			case 'courses':
 				return new Sensei_Reports_Overview_List_Table_Courses(
 					Sensei()->grading,
 					Sensei()->course,
-					new Sensei_Reports_Overview_Data_Provider_Courses(),
-					new Sensei_Reports_Overview_Service_Courses()
+					$use_tables
+						? new Sensei_Reports_Overview_Data_Provider_Courses_Tables()
+						: new Sensei_Reports_Overview_Data_Provider_Courses(),
+					$use_tables
+						? new Sensei_Reports_Overview_Service_Courses_Tables()
+						: new Sensei_Reports_Overview_Service_Courses()
 				);
 			case 'lessons':
 				return new Sensei_Reports_Overview_List_Table_Lessons(
 					Sensei()->course,
-					new Sensei_Reports_Overview_Data_Provider_Lessons( Sensei()->course )
+					$use_tables
+						? new Sensei_Reports_Overview_Data_Provider_Lessons_Tables( Sensei()->course )
+						: new Sensei_Reports_Overview_Data_Provider_Lessons( Sensei()->course )
 				);
 			default:
 				throw new InvalidArgumentException( 'Unknown list table type' );
 		}
+	}
+
+	/**
+	 * Check if HPPS tables mode is active.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	private function use_tables(): bool {
+		return \Sensei\Internal\Services\Progress_Storage_Settings::is_hpps_enabled()
+			&& \Sensei\Internal\Services\Progress_Storage_Settings::is_tables_repository();
 	}
 }

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses-interface.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses-interface.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the Sensei_Reports_Overview_Service_Courses_Interface interface.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Courses overview service interface.
+ *
+ * @since $$next-version$$
+ */
+interface Sensei_Reports_Overview_Service_Courses_Interface {
+
+	/**
+	 * Get total average progress value for courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids Courses ids.
+	 * @return float Total average progress value for all the courses.
+	 */
+	public function get_total_average_progress( array $course_ids ): float;
+
+	/**
+	 * Get the average grade of the courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids Courses ids to filter by.
+	 * @return double Average grade of all courses.
+	 */
+	public function get_courses_average_grade( array $course_ids );
+
+	/**
+	 * Get average days to completion by courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids Courses ids to filter by.
+	 * @return float Average days to completion, rounded to the highest integer.
+	 */
+	public function get_average_days_to_completion( array $course_ids ): float;
+
+	/**
+	 * Get total of enrollments.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids Courses ids to filter by.
+	 * @return int Total of enrollments.
+	 */
+	public function get_total_enrollments( $course_ids ): int;
+}

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses-tables.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses-tables.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * File containing the Sensei_Reports_Overview_Service_Courses_Tables class.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Tables-based courses overview service class.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Reports_Overview_Service_Courses_Tables implements Sensei_Reports_Overview_Service_Courses_Interface {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Get total average progress value for courses.
+	 *
+	 * @since $$next-version$$
+	 * @access public
+	 *
+	 * @param array $course_ids Courses ids.
+	 * @return float Total average progress value for all the courses.
+	 */
+	public function get_total_average_progress( array $course_ids ): float {
+		if ( empty( $course_ids ) ) {
+			return 0.0;
+		}
+		$lessons_count_per_courses = $this->get_lessons_in_courses( $course_ids );
+		$lessons_completions       = $this->get_lessons_completions();
+		$student_count_per_courses = $this->get_students_count_in_courses( $course_ids );
+		$total_average_progress    = 0;
+
+		foreach ( $course_ids as $course_id ) {
+			if ( ! isset( $lessons_count_per_courses[ $course_id ] ) || ! isset( $student_count_per_courses[ $course_id ] ) ) {
+				continue;
+			}
+			// Get lessons in the course.
+			$lessons = $lessons_count_per_courses[ $course_id ]->lessons;
+			$lessons = array_map( 'intval', explode( ',', $lessons ) );
+			if ( empty( $lessons ) ) {
+				continue;
+			}
+
+			// Get students count.
+			$students_count = $student_count_per_courses[ $course_id ]->students_count;
+			if ( ! $students_count ) {
+				continue;
+			}
+
+			// Get all completed lessons for all the students.
+			$completed_count = array_reduce(
+				$lessons,
+				function ( $carry, $lesson ) use ( $lessons_completions ) {
+					if ( ! isset( $lessons_completions[ $lesson ] ) ) {
+						return $carry;
+					}
+					$carry += $lessons_completions[ $lesson ]->completion_count;
+					return $carry;
+				},
+				0
+			);
+
+			// Calculate average progress for a course.
+			$course_average_progress = $completed_count / ( $students_count * count( $lessons ) ) * 100;
+
+			// Add value to the total average progress.
+			$total_average_progress += $course_average_progress;
+		}
+		// Divide total value to get average total value for average progress for courses.
+		$average_total_average_progress = ceil( $total_average_progress / count( $course_ids ) );
+		return $average_total_average_progress;
+	}
+
+	/**
+	 * Get the average grade of the courses.
+	 *
+	 * @since $$next-version$$
+	 * @access public
+	 *
+	 * @param array $course_ids Courses ids to filter by.
+	 * @return double Average grade of all courses.
+	 */
+	public function get_courses_average_grade( array $course_ids ) {
+		if ( empty( $course_ids ) ) {
+			return 0;
+		}
+		global $wpdb;
+
+		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
+
+		$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+
+		/**
+		 * The subquery calculates the average grade per course, and the outer query then calculates the
+		 * average grade of all courses. To be included in the calculation, a quiz submission must:
+		 *   Have a non-null final_grade.
+		 *   Be associated with a course via the lesson's _lesson_course meta.
+		 *   Have quiz questions (checking for the existence of '_quiz_has_questions' meta).
+		 */
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names and placeholders are safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT AVG(course_average) as courses_average
+				FROM (
+					SELECT AVG(qs.final_grade) as course_average
+					FROM {$submissions_table} qs
+					INNER JOIN {$wpdb->posts} quiz ON qs.quiz_id = quiz.ID
+					INNER JOIN {$wpdb->postmeta} course ON quiz.post_parent = course.post_id
+					INNER JOIN {$wpdb->postmeta} has_questions ON quiz.post_parent = has_questions.post_id
+					INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
+					WHERE qs.final_grade IS NOT NULL
+						AND course.meta_key = '_lesson_course'
+						AND course.meta_value <> ''
+						AND has_questions.meta_key = '_quiz_has_questions'
+						AND course.meta_value IN ( {$placeholders} )
+					GROUP BY course.meta_value
+				) averages_by_course",
+				...$course_ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		return floatval( $result->courses_average );
+	}
+
+	/**
+	 * Get average days to completion by courses.
+	 *
+	 * @since $$next-version$$
+	 * @access public
+	 *
+	 * @param array $course_ids Courses ids to filter by.
+	 * @return float Average days to completion, rounded to the highest integer.
+	 */
+	public function get_average_days_to_completion( array $course_ids ): float {
+		if ( empty( $course_ids ) ) {
+			return 0;
+		}
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+		$placeholders   = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names and placeholders are safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		return (float) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT AVG(aggregated.days_to_completion)
+				FROM (
+					SELECT CEIL(SUM(ABS(DATEDIFF(p.completed_at, p.started_at)) + 1) / COUNT(p.id)) AS days_to_completion
+					FROM {$progress_table} p
+					WHERE p.type = 'course'
+						AND p.status = 'complete'
+						AND p.post_id IN ( {$placeholders} )
+						AND p.started_at IS NOT NULL
+					GROUP BY p.post_id
+				) AS aggregated",
+				...$course_ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	}
+
+	/**
+	 * Get total of enrollments.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids Courses ids to filter by.
+	 * @return int Total of enrollments.
+	 */
+	public function get_total_enrollments( $course_ids ): int {
+		if ( empty( $course_ids ) ) {
+			return 0;
+		}
+		$total_grouped_by_course = $this->get_students_count_in_courses( $course_ids );
+
+		if ( empty( $total_grouped_by_course ) ) {
+			return 0;
+		}
+
+		$to_total = function ( $acc, $current ) {
+			return $acc + $current->students_count;
+		};
+
+		return array_reduce( $total_grouped_by_course, $to_total, 0 );
+	}
+
+	/**
+	 * Get all lessons completions.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array Lessons completions.
+	 */
+	private function get_lessons_completions(): array {
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		return $wpdb->get_results(
+			"SELECT p.post_id AS lesson_id, COUNT(*) AS completion_count
+			FROM {$progress_table} p
+			WHERE p.status IN ('graded', 'ungraded', 'passed', 'failed', 'complete')
+			AND p.type = 'lesson'
+			AND p.post_id IN (
+				SELECT wpm.post_id FROM {$wpdb->posts} wpc
+				JOIN {$wpdb->postmeta} wpm ON wpm.meta_value = wpc.id
+				WHERE wpm.meta_key = '_lesson_course'
+				AND wpc.post_status IN ('publish', 'private')
+			)
+			GROUP BY p.post_id",
+			'OBJECT_K'
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Get lessons grouped by courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids The list of courses ids.
+	 * @return array Lessons count in courses.
+	 */
+	private function get_lessons_in_courses( $course_ids ): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		return $wpdb->get_results(
+			"SELECT pm.meta_value as course_id, GROUP_CONCAT(pm.post_id) as lessons
+			FROM {$wpdb->postmeta} pm
+			WHERE pm.meta_value IN ( " . implode( ',', $course_ids ) . ' )' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			. " AND pm.meta_key = '_lesson_course'
+			GROUP BY pm.meta_value",
+			'OBJECT_K'
+		);
+	}
+
+	/**
+	 * Get students count by courses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids The array of courses ids.
+	 * @return array Students in courses.
+	 */
+	private function get_students_count_in_courses( array $course_ids ): array {
+		global $wpdb;
+
+		$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+		$placeholders   = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names and placeholders are safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT p.post_id AS course_id, COUNT(p.post_id) AS students_count
+				FROM {$progress_table} p
+				WHERE p.post_id IN ( {$placeholders} )
+				AND p.type = 'course'
+				AND p.status IN ('in-progress', 'complete')
+				GROUP BY p.post_id",
+				...$course_ids
+			),
+			'OBJECT_K'
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	}
+}

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 4.4.1
  */
-class Sensei_Reports_Overview_Service_Courses {
+class Sensei_Reports_Overview_Service_Courses implements Sensei_Reports_Overview_Service_Courses_Interface {
 
 	/**
 	 * Constructor

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students-tables.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students-tables.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the Sensei_Reports_Overview_Service_Students_Tables class.
+ *
+ * @package sensei
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Tables-based students overview service class.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Reports_Overview_Service_Students_Tables extends Sensei_Reports_Overview_Service_Students {
+
+	/**
+	 * Get average grade of all lessons graded in all the courses filtered by students.
+	 *
+	 * @since $$next-version$$
+	 * @access public
+	 *
+	 * @param array $user_ids User ids.
+	 * @return double Average value of all the graded lessons in all the courses.
+	 */
+	public function get_graded_lessons_average_grade( $user_ids ) {
+		if ( empty( $user_ids ) ) {
+			return 0;
+		}
+		global $wpdb;
+
+		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
+		$placeholders      = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
+
+		// Fetching all the grades of all the quizzes that have been graded.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names and placeholders are safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$sum_result = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM(qs.final_grade) AS grade_sum, COUNT(*) as grade_count
+				FROM {$submissions_table} qs
+				WHERE qs.user_id IN ( {$placeholders} )
+				AND qs.final_grade IS NOT NULL",
+				...$user_ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		$average_grade_value = 0;
+		if ( ! $sum_result->grade_count || '0' === $sum_result->grade_count ) {
+			return $average_grade_value;
+		}
+		$average_grade_value = ceil( $sum_result->grade_sum / $sum_result->grade_count );
+		return $average_grade_value;
+	}
+}


### PR DESCRIPTION
## Summary

Prototype of **Plan A** for HPPS backend integration — parallel implementations behind existing interfaces, factory-switched at the composition root.

### What's included (all 4 phases)

**Phase 1 — Reports data providers** (3 new files)
- Tables-based courses, students, and lessons data providers that JOIN `sensei_lms_progress` instead of `wp_comments`

**Phase 2 — Reports services** (3 new files)
- `Sensei_Reports_Overview_Service_Courses_Interface` (extracted from concrete class)
- Tables-based courses and students services querying `sensei_lms_progress` / `sensei_lms_quiz_submissions`

**Phase 3 — Grading queries** (4 new files)
- `Grading_Queries_Interface` with `count_statuses()`, `get_course_users_grades_sum()`, `get_courses_average_grade()`, `get_grading_items()`, `count_grading_items()`, `get_item_grade()`
- Comments-based and tables-based implementations + factory

**Phase 4 — Grading main list table** (modified)
- `Sensei_Grading_Main` delegates to `Grading_Queries_Interface` instead of `sensei_check_for_activity()` / `get_comment_meta()`

### Trade-offs
- **Pro**: Follows existing factory + interface pattern (same as repository layer)
- **Pro**: No conditionals in business logic — clean separation
- **Pro**: Each phase ships independently
- **Con**: Largest number of new files (10 new, 5 modified)
- **Con**: Partial duplication with existing comments-based code

### For comparison with
- Plan B (hook-based interception): #7912
- Plan C (full migration): #7913

🤖 Generated with [Claude Code](https://claude.com/claude-code)