### PR TITLE
Populate parent_post_id in HPPS progress table

### DIFF
--- a/changelog/add-hpps-parent-post-id
+++ b/changelog/add-hpps-parent-post-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Populate parent_post_id in HPPS progress table for future reusable lessons support.

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -843,8 +843,7 @@ class Sensei_Grading {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $quiz_lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$course_id       = (int) get_post_meta( $quiz_lesson_id, '_lesson_course', true );
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id, $course_id ?: null );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id, Sensei_Utils::get_lesson_course_id( $quiz_lesson_id ) );
 		}
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -843,7 +843,8 @@ class Sensei_Grading {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $quiz_lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id );
+			$course_id       = (int) get_post_meta( $quiz_lesson_id, '_lesson_course', true );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id, $course_id ?: null );
 		}
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -843,7 +843,7 @@ class Sensei_Grading {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $quiz_lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id, Sensei_Utils::get_lesson_course_id( $quiz_lesson_id ) );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id, Sensei_Utils::get_lesson_course_id( (int) $quiz_lesson_id ) );
 		}
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -951,7 +951,8 @@ class Sensei_Quiz {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			$course_id       = (int) get_post_meta( $lesson_id, '_lesson_course', true );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, $course_id ?: null );
 		}
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
@@ -2426,7 +2427,8 @@ class Sensei_Quiz {
 			return;
 		}
 
-		$quiz_progress_repository->create( $quiz_id, $user_id );
+		$lesson_id = (int) get_post_meta( $quiz_id, '_quiz_lesson', true );
+		$quiz_progress_repository->create( $quiz_id, $user_id, $lesson_id ?: null );
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -951,8 +951,7 @@ class Sensei_Quiz {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$course_id       = (int) get_post_meta( $lesson_id, '_lesson_course', true );
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, $course_id ?: null );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, Sensei_Utils::get_lesson_course_id( $lesson_id ) );
 		}
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
@@ -2427,8 +2426,7 @@ class Sensei_Quiz {
 			return;
 		}
 
-		$lesson_id = (int) get_post_meta( $quiz_id, '_quiz_lesson', true );
-		$quiz_progress_repository->create( $quiz_id, $user_id, $lesson_id ?: null );
+		$quiz_progress_repository->create( $quiz_id, $user_id, Sensei_Utils::get_quiz_lesson_id( $quiz_id ) );
 	}
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -130,9 +130,15 @@ class Sensei_Updates {
 			return;
 		}
 
-		// Reset status so the job runner treats this as a fresh start.
-		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_NOT_STARTED );
-		$scheduler->schedule_job_by_name( 'parent_post_id_migration' );
+		try {
+			$scheduler->schedule_job_by_name( 'parent_post_id_migration' );
+
+			// Reset status so the job runner treats this as a fresh start.
+			update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_NOT_STARTED );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional error logging for failed migration scheduling.
+			error_log( 'Sensei LMS: Failed to schedule parent_post_id backfill: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -10,6 +10,8 @@ use Sensei\Internal\Emails\Email_Seeder_Data;
 use Sensei\Internal\Emails\Email_Repository;
 use Sensei\Internal\Emails\Email_Seeder;
 use Sensei\Internal\Emails\Email_Template_Repository;
+use Sensei\Internal\Migration\Migration_Job_Scheduler;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -89,6 +91,7 @@ class Sensei_Updates {
 		$this->v4_12_create_default_emails();
 		$this->v4_19_2_update_legacy_quiz_data();
 		$this->v4_24_1_update_capabilities();
+		$this->backfill_parent_post_id();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
@@ -106,6 +109,30 @@ class Sensei_Updates {
 		// Update the other roles capabilities.
 		Sensei()->add_sensei_admin_caps();
 		Sensei()->add_editor_caps();
+	}
+
+	/**
+	 * Schedule parent_post_id backfill for sites that already completed the HPPS migration.
+	 *
+	 * @since $$next-version$$
+	 */
+	private function backfill_parent_post_id() {
+		if ( ! $this->is_upgrade ) {
+			return;
+		}
+
+		if ( ! Progress_Storage_Settings::is_sync_enabled() ) {
+			return;
+		}
+
+		$scheduler = Sensei()->migration_scheduler;
+		if ( ! $scheduler || ! $scheduler->is_complete() ) {
+			return;
+		}
+
+		// Reset status so the job runner treats this as a fresh start.
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_NOT_STARTED );
+		$scheduler->schedule_job_by_name( 'parent_post_id_migration' );
 	}
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -91,7 +91,7 @@ class Sensei_Updates {
 		$this->v4_12_create_default_emails();
 		$this->v4_19_2_update_legacy_quiz_data();
 		$this->v4_24_1_update_capabilities();
-		$this->backfill_parent_post_id();
+		$this->v4_26_0_backfill_parent_post_id();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
@@ -116,7 +116,7 @@ class Sensei_Updates {
 	 *
 	 * @since $$next-version$$
 	 */
-	private function backfill_parent_post_id() {
+	private function v4_26_0_backfill_parent_post_id() {
 		if ( ! $this->is_upgrade ) {
 			return;
 		}

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -131,11 +131,15 @@ class Sensei_Updates {
 		}
 
 		try {
-			$scheduler->schedule_job_by_name( 'parent_post_id_migration' );
-
-			// Reset status so the job runner treats this as a fresh start.
+			// Reset status first to prevent duplicate scheduling from concurrent requests
+			// that all see is_complete() === true before any of them writes NOT_STARTED.
 			update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_NOT_STARTED );
+
+			$scheduler->schedule_job_by_name( 'parent_post_id_migration' );
 		} catch ( \RuntimeException $e ) {
+			// Restore status so the backfill can be retried on the next upgrade.
+			update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
+
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional error logging for failed migration scheduling.
 			error_log( 'Sensei LMS: Failed to schedule parent_post_id backfill: ' . $e->getMessage() );
 		}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -603,7 +603,8 @@ class Sensei_Utils {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			$course_id       = (int) get_post_meta( $lesson_id, '_lesson_course', true );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, $course_id ?: null );
 			$has_questions   = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 			if ( $complete && $has_questions ) {
 				update_comment_meta( $lesson_progress->get_id(), 'grade', 0 );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -603,8 +603,7 @@ class Sensei_Utils {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$course_id       = (int) get_post_meta( $lesson_id, '_lesson_course', true );
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, $course_id ?: null );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, self::get_lesson_course_id( (int) $lesson_id ) );
 			$has_questions   = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 			if ( $complete && $has_questions ) {
 				update_comment_meta( $lesson_progress->get_id(), 'grade', 0 );
@@ -3194,6 +3193,32 @@ class Sensei_Utils {
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 
 		return ! empty( $screen ) && in_array( $screen->id, [ 'widgets', 'site-editor', 'customize', 'appearance_page_gutenberg-edit-site' ], true );
+	}
+
+	/**
+	 * Get the course ID for a lesson.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $lesson_id The lesson post ID.
+	 * @return int|null The course ID, or null if not found.
+	 */
+	public static function get_lesson_course_id( int $lesson_id ): ?int {
+		$course_id = (int) get_post_meta( $lesson_id, '_lesson_course', true );
+		return $course_id ? $course_id : null;
+	}
+
+	/**
+	 * Get the lesson ID for a quiz.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $quiz_id The quiz post ID.
+	 * @return int|null The lesson ID, or null if not found.
+	 */
+	public static function get_quiz_lesson_id( int $quiz_id ): ?int {
+		$lesson_id = (int) get_post_meta( $quiz_id, '_quiz_lesson', true );
+		return $lesson_id ? $lesson_id : null;
 	}
 }
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -603,7 +603,7 @@ class Sensei_Utils {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, self::get_lesson_course_id( (int) $lesson_id ) );
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, self::get_lesson_course_id( $lesson_id ) );
 			$has_questions   = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 			if ( $complete && $has_questions ) {
 				update_comment_meta( $lesson_progress->get_id(), 'grade', 0 );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -14,6 +14,7 @@ use Sensei\Internal\Installer\Updates_Factory;
 use Sensei\Internal\Migration\Migration_Job;
 use Sensei\Internal\Migration\Migration_Job_Scheduler;
 use Sensei\Internal\Migration\Migrations\Quiz_Migration;
+use Sensei\Internal\Migration\Migrations\Parent_Post_Id_Migration;
 use Sensei\Internal\Migration\Migrations\Student_Progress_Migration;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Interface;
@@ -876,6 +877,9 @@ class Sensei_Main {
 		);
 		$this->migration_scheduler->register_job(
 			new Migration_Job( 'quiz_migration', new Quiz_Migration() )
+		);
+		$this->migration_scheduler->register_job(
+			new Migration_Job( 'parent_post_id_migration', new Parent_Post_Id_Migration() )
 		);
 	}
 

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -220,6 +220,24 @@ class Migration_Job_Scheduler {
 	}
 
 	/**
+	 * Schedule a specific job by name.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $job_name The job name.
+	 * @throws \RuntimeException If the job is not registered.
+	 */
+	public function schedule_job_by_name( string $job_name ): void {
+		if ( ! isset( $this->jobs[ $job_name ] ) ) {
+			throw new \RuntimeException( esc_html( "Unknown job: $job_name" ) );
+		}
+
+		$this->schedule_job( $this->jobs[ $job_name ] );
+	}
+
+	/**
 	 * Schedule a job.
 	 *
 	 * @param Migration_Job $job The migration job.

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -8,6 +8,7 @@
 namespace Sensei\Internal\Migration;
 
 use Sensei\Internal\Action_Scheduler\Action_Scheduler;
+use Sensei\Internal\Migration\Migrations\Parent_Post_Id_Migration;
 use Sensei\Internal\Migration\Migrations\Quiz_Migration;
 use Sensei\Internal\Migration\Migrations\Student_Progress_Migration;
 use Sensei\Internal\Services\Progress_Storage_Settings;
@@ -378,6 +379,8 @@ class Migration_Job_Scheduler {
 		delete_option( self::ERRORS_OPTION_NAME );
 		delete_option( Quiz_Migration::LAST_COMMENT_ID_OPTION_NAME );
 		delete_option( Student_Progress_Migration::LAST_COMMENT_ID_OPTION_NAME );
+		delete_option( Parent_Post_Id_Migration::LAST_ID_OPTION_NAME );
+		delete_option( Parent_Post_Id_Migration::LESSONS_COMPLETE_OPTION_NAME );
 		delete_option( self::RETRY_COUNT_OPTION_NAME );
 	}
 

--- a/includes/internal/migration/class-migration-job-scheduler.php
+++ b/includes/internal/migration/class-migration-job-scheduler.php
@@ -231,7 +231,8 @@ class Migration_Job_Scheduler {
 	 */
 	public function schedule_job_by_name( string $job_name ): void {
 		if ( ! isset( $this->jobs[ $job_name ] ) ) {
-			throw new \RuntimeException( esc_html( "Unknown job: $job_name" ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are not rendered as HTML.
+			throw new \RuntimeException( sprintf( 'Unknown job: %s', $job_name ) );
 		}
 
 		$this->schedule_job( $this->jobs[ $job_name ] );

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -124,15 +124,44 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$rows = $wpdb->get_results( $select_query );
 
+		if ( null === $rows ) {
+			$this->add_error( 'Database error fetching lesson progress: ' . $wpdb->last_error );
+			return $this->batch_size;
+		}
+
 		if ( empty( $rows ) ) {
 			return 0;
+		}
+
+		// Bulk-fetch _lesson_course meta for all post_ids in this batch.
+		$post_ids     = array_unique( array_map( 'intval', wp_list_pluck( $rows, 'post_id' ) ) );
+		$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$meta_query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_lesson_course' AND post_id IN ( {$placeholders} )",
+			...$post_ids
+		);
+
+		if ( $dry_run ) {
+			echo esc_html( $meta_query . "\n" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$meta_rows = $wpdb->get_results( $meta_query );
+		$meta_map  = array();
+		if ( $meta_rows ) {
+			foreach ( $meta_rows as $meta ) {
+				$meta_map[ (int) $meta->post_id ] = (int) $meta->meta_value;
+			}
 		}
 
 		$processed      = 0;
 		$last_processed = $last_id;
 
 		foreach ( $rows as $row ) {
-			$course_id = (int) get_post_meta( (int) $row->post_id, '_lesson_course', true );
+			$course_id = isset( $meta_map[ (int) $row->post_id ] ) ? $meta_map[ (int) $row->post_id ] : 0;
 
 			if ( $course_id ) {
 				if ( $dry_run ) {
@@ -148,10 +177,13 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 						array( '%d' )
 					);
 
-					if ( false === $result && '' !== $wpdb->last_error ) {
-						$this->add_error( $wpdb->last_error );
+					if ( false === $result ) {
+						$error_message = $wpdb->last_error ? $wpdb->last_error : "Unknown error updating lesson progress id={$row->id}";
+						$this->add_error( $error_message );
 					}
 				}
+			} else {
+				$this->add_error( "Skipped lesson progress id={$row->id}: no meta for post_id={$row->post_id}" );
 			}
 
 			$last_processed = (int) $row->id;
@@ -192,15 +224,44 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$rows = $wpdb->get_results( $select_query );
 
+		if ( null === $rows ) {
+			$this->add_error( 'Database error fetching quiz progress: ' . $wpdb->last_error );
+			return $this->batch_size;
+		}
+
 		if ( empty( $rows ) ) {
 			return 0;
+		}
+
+		// Bulk-fetch _quiz_lesson meta for all post_ids in this batch.
+		$post_ids     = array_unique( array_map( 'intval', wp_list_pluck( $rows, 'post_id' ) ) );
+		$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$meta_query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_quiz_lesson' AND post_id IN ( {$placeholders} )",
+			...$post_ids
+		);
+
+		if ( $dry_run ) {
+			echo esc_html( $meta_query . "\n" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$meta_rows = $wpdb->get_results( $meta_query );
+		$meta_map  = array();
+		if ( $meta_rows ) {
+			foreach ( $meta_rows as $meta ) {
+				$meta_map[ (int) $meta->post_id ] = (int) $meta->meta_value;
+			}
 		}
 
 		$processed      = 0;
 		$last_processed = $last_id;
 
 		foreach ( $rows as $row ) {
-			$lesson_id = (int) get_post_meta( (int) $row->post_id, '_quiz_lesson', true );
+			$lesson_id = isset( $meta_map[ (int) $row->post_id ] ) ? $meta_map[ (int) $row->post_id ] : 0;
 
 			if ( $lesson_id ) {
 				if ( $dry_run ) {
@@ -216,10 +277,13 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 						array( '%d' )
 					);
 
-					if ( false === $result && '' !== $wpdb->last_error ) {
-						$this->add_error( $wpdb->last_error );
+					if ( false === $result ) {
+						$error_message = $wpdb->last_error ? $wpdb->last_error : "Unknown error updating quiz progress id={$row->id}";
+						$this->add_error( $error_message );
 					}
 				}
+			} else {
+				$this->add_error( "Skipped quiz progress id={$row->id}: no meta for post_id={$row->post_id}" );
 			}
 
 			$last_processed = (int) $row->id;

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -30,14 +30,14 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 	 *
 	 * @var string
 	 */
-	public const LAST_ID_OPTION_NAME = 'sensei_parent_post_id_migration_last_id';
+	public const LAST_ID_OPTION_NAME = 'sensei_migrated_parent_post_id_last_id';
 
 	/**
 	 * The name of the option that stores whether lesson backfill is complete.
 	 *
 	 * @var string
 	 */
-	private const LESSONS_COMPLETE_OPTION_NAME = 'sensei_parent_post_id_migration_lessons_complete';
+	public const LESSONS_COMPLETE_OPTION_NAME = 'sensei_migrated_parent_post_id_lessons_complete';
 
 	/**
 	 * The number of rows to process in a single run.

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -104,6 +104,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 	 *
 	 * @param bool $dry_run Whether to run in dry-run mode.
 	 * @return int The number of rows processed.
+	 * @throws \RuntimeException If the database query fails.
 	 */
 	private function backfill_lesson_progress( bool $dry_run ): int {
 		global $wpdb;
@@ -125,8 +126,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$rows = $wpdb->get_results( $select_query );
 
 		if ( null === $rows ) {
-			$this->add_error( 'Database error fetching lesson progress: ' . $wpdb->last_error );
-			return $this->batch_size;
+			throw new \RuntimeException( esc_html( 'Database error fetching lesson progress: ' . $wpdb->last_error ) );
 		}
 
 		if ( empty( $rows ) ) {
@@ -205,6 +205,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 	 *
 	 * @param bool $dry_run Whether to run in dry-run mode.
 	 * @return int The number of rows processed.
+	 * @throws \RuntimeException If the database query fails.
 	 */
 	private function backfill_quiz_progress( bool $dry_run ): int {
 		global $wpdb;
@@ -226,8 +227,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$rows = $wpdb->get_results( $select_query );
 
 		if ( null === $rows ) {
-			$this->add_error( 'Database error fetching quiz progress: ' . $wpdb->last_error );
-			return $this->batch_size;
+			throw new \RuntimeException( esc_html( 'Database error fetching quiz progress: ' . $wpdb->last_error ) );
 		}
 
 		if ( empty( $rows ) ) {

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -124,7 +124,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 			return 0;
 		}
 
-		$processed     = 0;
+		$processed      = 0;
 		$last_processed = $last_id;
 
 		foreach ( $rows as $row ) {
@@ -132,13 +132,17 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 
 			if ( $course_id && ! $dry_run ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$wpdb->update(
+				$result = $wpdb->update(
 					$table,
 					array( 'parent_post_id' => $course_id ),
 					array( 'id' => (int) $row->id ),
 					array( '%d' ),
 					array( '%d' )
 				);
+
+				if ( false === $result && '' !== $wpdb->last_error ) {
+					$this->add_error( $wpdb->last_error );
+				}
 			}
 
 			$last_processed = (int) $row->id;
@@ -179,7 +183,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 			return 0;
 		}
 
-		$processed     = 0;
+		$processed      = 0;
 		$last_processed = $last_id;
 
 		foreach ( $rows as $row ) {
@@ -187,13 +191,17 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 
 			if ( $lesson_id && ! $dry_run ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$wpdb->update(
+				$result = $wpdb->update(
 					$table,
 					array( 'parent_post_id' => $lesson_id ),
 					array( 'id' => (int) $row->id ),
 					array( '%d' ),
 					array( '%d' )
 				);
+
+				if ( false === $result && '' !== $wpdb->last_error ) {
+					$this->add_error( $wpdb->last_error );
+				}
 			}
 
 			$last_processed = (int) $row->id;

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -110,15 +110,19 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$table   = $wpdb->prefix . 'sensei_lms_progress';
 		$last_id = (int) get_option( self::LAST_ID_OPTION_NAME, 0 );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT id, post_id FROM {$table} WHERE type = 'lesson' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
-				$last_id,
-				$this->batch_size
-			)
+		$select_query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT id, post_id FROM {$table} WHERE type = 'lesson' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
+			$last_id,
+			$this->batch_size
 		);
+
+		if ( $dry_run ) {
+			echo esc_html( $select_query . "\n" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $select_query );
 
 		if ( empty( $rows ) ) {
 			return 0;
@@ -130,18 +134,23 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		foreach ( $rows as $row ) {
 			$course_id = (int) get_post_meta( (int) $row->post_id, '_lesson_course', true );
 
-			if ( $course_id && ! $dry_run ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$result = $wpdb->update(
-					$table,
-					array( 'parent_post_id' => $course_id ),
-					array( 'id' => (int) $row->id ),
-					array( '%d' ),
-					array( '%d' )
-				);
+			if ( $course_id ) {
+				if ( $dry_run ) {
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					echo esc_html( $wpdb->prepare( "UPDATE {$table} SET parent_post_id = %d WHERE id = %d", $course_id, (int) $row->id ) . "\n" );
+				} else {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+					$result = $wpdb->update(
+						$table,
+						array( 'parent_post_id' => $course_id ),
+						array( 'id' => (int) $row->id ),
+						array( '%d' ),
+						array( '%d' )
+					);
 
-				if ( false === $result && '' !== $wpdb->last_error ) {
-					$this->add_error( $wpdb->last_error );
+					if ( false === $result && '' !== $wpdb->last_error ) {
+						$this->add_error( $wpdb->last_error );
+					}
 				}
 			}
 
@@ -169,15 +178,19 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$table   = $wpdb->prefix . 'sensei_lms_progress';
 		$last_id = (int) get_option( self::LAST_ID_OPTION_NAME, 0 );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT id, post_id FROM {$table} WHERE type = 'quiz' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
-				$last_id,
-				$this->batch_size
-			)
+		$select_query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT id, post_id FROM {$table} WHERE type = 'quiz' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
+			$last_id,
+			$this->batch_size
 		);
+
+		if ( $dry_run ) {
+			echo esc_html( $select_query . "\n" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $select_query );
 
 		if ( empty( $rows ) ) {
 			return 0;
@@ -189,18 +202,23 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		foreach ( $rows as $row ) {
 			$lesson_id = (int) get_post_meta( (int) $row->post_id, '_quiz_lesson', true );
 
-			if ( $lesson_id && ! $dry_run ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$result = $wpdb->update(
-					$table,
-					array( 'parent_post_id' => $lesson_id ),
-					array( 'id' => (int) $row->id ),
-					array( '%d' ),
-					array( '%d' )
-				);
+			if ( $lesson_id ) {
+				if ( $dry_run ) {
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					echo esc_html( $wpdb->prepare( "UPDATE {$table} SET parent_post_id = %d WHERE id = %d", $lesson_id, (int) $row->id ) . "\n" );
+				} else {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+					$result = $wpdb->update(
+						$table,
+						array( 'parent_post_id' => $lesson_id ),
+						array( 'id' => (int) $row->id ),
+						array( '%d' ),
+						array( '%d' )
+					);
 
-				if ( false === $result && '' !== $wpdb->last_error ) {
-					$this->add_error( $wpdb->last_error );
+					if ( false === $result && '' !== $wpdb->last_error ) {
+						$this->add_error( $wpdb->last_error );
+					}
 				}
 			}
 

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -137,6 +137,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$post_ids     = array_unique( array_map( 'intval', wp_list_pluck( $rows, 'post_id' ) ) );
 		$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
 
+		// Placeholders are built dynamically, so the sniff can't verify the count.
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$meta_query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
@@ -237,6 +238,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$post_ids     = array_unique( array_map( 'intval', wp_list_pluck( $rows, 'post_id' ) ) );
 		$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
 
+		// Placeholders are built dynamically, so the sniff can't verify the count.
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$meta_query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * File containing the class Parent_Post_Id_Migration.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Migration\Migrations;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+use Sensei\Internal\Migration\Migration_Abstract;
+
+/**
+ * Class Parent_Post_Id_Migration.
+ *
+ * Backfills NULL parent_post_id values in sensei_lms_progress for sites
+ * that already have HPPS enabled. Lesson progress gets the course ID,
+ * quiz progress gets the lesson ID, course progress stays NULL.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Parent_Post_Id_Migration extends Migration_Abstract {
+	/**
+	 * The name of the option that stores the last progress ID that was migrated.
+	 *
+	 * @var string
+	 */
+	public const LAST_ID_OPTION_NAME = 'sensei_parent_post_id_migration_last_id';
+
+	/**
+	 * The name of the option that stores whether lesson backfill is complete.
+	 *
+	 * @var string
+	 */
+	private const LESSONS_COMPLETE_OPTION_NAME = 'sensei_parent_post_id_migration_lessons_complete';
+
+	/**
+	 * The number of rows to process in a single run.
+	 *
+	 * @var int
+	 */
+	private $batch_size;
+
+	/**
+	 * Constructs a new instance of the migration.
+	 *
+	 * @param int $batch_size The number of rows to process in a single run.
+	 */
+	public function __construct( int $batch_size = 250 ) {
+		/**
+		 * Filter the batch size for parent_post_id backfill migration.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $batch_size The batch size.
+		 */
+		$this->batch_size = (int) apply_filters( 'sensei_migration_parent_post_id_batch_size', $batch_size );
+	}
+
+	/**
+	 * Run the migration.
+	 *
+	 * Processes lesson progress first, then quiz progress. Returns the number
+	 * of rows processed, or 0 when all backfilling is complete.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $dry_run Whether to run the migration in dry-run mode.
+	 * @return int The number of rows processed.
+	 */
+	public function run( bool $dry_run = true ) {
+		$lessons_complete = get_option( self::LESSONS_COMPLETE_OPTION_NAME, false );
+
+		if ( ! $lessons_complete ) {
+			$processed = $this->backfill_lesson_progress( $dry_run );
+			if ( $processed > 0 ) {
+				return $processed;
+			}
+
+			// Lessons are done, mark complete and reset cursor for quiz phase.
+			update_option( self::LESSONS_COMPLETE_OPTION_NAME, true );
+			update_option( self::LAST_ID_OPTION_NAME, 0 );
+		}
+
+		$processed = $this->backfill_quiz_progress( $dry_run );
+		if ( $processed > 0 ) {
+			return $processed;
+		}
+
+		// All done — clean up cursor options.
+		delete_option( self::LAST_ID_OPTION_NAME );
+		delete_option( self::LESSONS_COMPLETE_OPTION_NAME );
+
+		return 0;
+	}
+
+	/**
+	 * Backfill lesson progress parent_post_id with the course ID.
+	 *
+	 * @param bool $dry_run Whether to run in dry-run mode.
+	 * @return int The number of rows processed.
+	 */
+	private function backfill_lesson_progress( bool $dry_run ): int {
+		global $wpdb;
+		$table   = $wpdb->prefix . 'sensei_lms_progress';
+		$last_id = (int) get_option( self::LAST_ID_OPTION_NAME, 0 );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT id, post_id FROM {$table} WHERE type = 'lesson' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
+				$last_id,
+				$this->batch_size
+			)
+		);
+
+		if ( empty( $rows ) ) {
+			return 0;
+		}
+
+		$processed     = 0;
+		$last_processed = $last_id;
+
+		foreach ( $rows as $row ) {
+			$course_id = (int) get_post_meta( (int) $row->post_id, '_lesson_course', true );
+
+			if ( $course_id && ! $dry_run ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->update(
+					$table,
+					array( 'parent_post_id' => $course_id ),
+					array( 'id' => (int) $row->id ),
+					array( '%d' ),
+					array( '%d' )
+				);
+			}
+
+			$last_processed = (int) $row->id;
+			++$processed;
+
+			if ( $this->is_time_exceeded() ) {
+				break;
+			}
+		}
+
+		update_option( self::LAST_ID_OPTION_NAME, $last_processed );
+
+		return $processed;
+	}
+
+	/**
+	 * Backfill quiz progress parent_post_id with the lesson ID.
+	 *
+	 * @param bool $dry_run Whether to run in dry-run mode.
+	 * @return int The number of rows processed.
+	 */
+	private function backfill_quiz_progress( bool $dry_run ): int {
+		global $wpdb;
+		$table   = $wpdb->prefix . 'sensei_lms_progress';
+		$last_id = (int) get_option( self::LAST_ID_OPTION_NAME, 0 );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT id, post_id FROM {$table} WHERE type = 'quiz' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
+				$last_id,
+				$this->batch_size
+			)
+		);
+
+		if ( empty( $rows ) ) {
+			return 0;
+		}
+
+		$processed     = 0;
+		$last_processed = $last_id;
+
+		foreach ( $rows as $row ) {
+			$lesson_id = (int) get_post_meta( (int) $row->post_id, '_quiz_lesson', true );
+
+			if ( $lesson_id && ! $dry_run ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->update(
+					$table,
+					array( 'parent_post_id' => $lesson_id ),
+					array( 'id' => (int) $row->id ),
+					array( '%d' ),
+					array( '%d' )
+				);
+			}
+
+			$last_processed = (int) $row->id;
+			++$processed;
+
+			if ( $this->is_time_exceeded() ) {
+				break;
+			}
+		}
+
+		update_option( self::LAST_ID_OPTION_NAME, $last_processed );
+
+		return $processed;
+	}
+}

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -130,7 +130,8 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$rows = $wpdb->get_results( $select_query );
 
 		if ( null === $rows ) {
-			throw new \RuntimeException( esc_html( "Database error fetching {$type} progress: " . $wpdb->last_error ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are not rendered as HTML.
+			throw new \RuntimeException( "Database error fetching {$type} progress: " . $wpdb->last_error );
 		}
 
 		if ( empty( $rows ) ) {
@@ -157,7 +158,8 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$meta_rows = $wpdb->get_results( $meta_query );
 
 		if ( null === $meta_rows ) {
-			throw new \RuntimeException( esc_html( "Database error fetching {$type} post meta: " . $wpdb->last_error ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are not rendered as HTML.
+			throw new \RuntimeException( "Database error fetching {$type} post meta: " . $wpdb->last_error );
 		}
 
 		$meta_map = array();
@@ -192,8 +194,6 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 						$this->add_error( $error_message );
 					}
 				}
-			} else {
-				$this->add_error( "Skipped {$type} progress id={$row->id}: no meta for post_id={$row->post_id}" );
 			}
 
 			$last_processed = (int) $row->id;

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -59,7 +59,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		 *
 		 * @param int $batch_size The batch size.
 		 */
-		$this->batch_size = (int) apply_filters( 'sensei_migration_parent_post_id_batch_size', $batch_size );
+		$this->batch_size = max( 1, (int) apply_filters( 'sensei_migration_parent_post_id_batch_size', $batch_size ) );
 	}
 
 	/**
@@ -155,7 +155,12 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$meta_rows = $wpdb->get_results( $meta_query );
-		$meta_map  = array();
+
+		if ( null === $meta_rows ) {
+			throw new \RuntimeException( esc_html( "Database error fetching {$type} post meta: " . $wpdb->last_error ) );
+		}
+
+		$meta_map = array();
 		if ( $meta_rows ) {
 			foreach ( $meta_rows as $meta ) {
 				$meta_map[ (int) $meta->post_id ] = (int) $meta->meta_value;

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -72,6 +72,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 	 *
 	 * @param bool $dry_run Whether to run the migration in dry-run mode.
 	 * @return int The number of rows processed.
+	 * @throws \RuntimeException If a database query fails.
 	 */
 	public function run( bool $dry_run = true ) {
 		$lessons_complete = get_option( self::LESSONS_COMPLETE_OPTION_NAME, false );
@@ -142,8 +143,9 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		// Placeholders are built dynamically, so the sniff can't verify the count.
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$meta_query = $wpdb->prepare(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '{$meta_key}' AND post_id IN ( {$placeholders} )",
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN ( {$placeholders} )",
+			$meta_key,
 			...$post_ids
 		);
 

--- a/includes/internal/migration/migrations/class-parent-post-id-migration.php
+++ b/includes/internal/migration/migrations/class-parent-post-id-migration.php
@@ -77,7 +77,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$lessons_complete = get_option( self::LESSONS_COMPLETE_OPTION_NAME, false );
 
 		if ( ! $lessons_complete ) {
-			$processed = $this->backfill_lesson_progress( $dry_run );
+			$processed = $this->backfill_progress( 'lesson', '_lesson_course', $dry_run );
 			if ( $processed > 0 ) {
 				return $processed;
 			}
@@ -87,7 +87,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 			update_option( self::LAST_ID_OPTION_NAME, 0 );
 		}
 
-		$processed = $this->backfill_quiz_progress( $dry_run );
+		$processed = $this->backfill_progress( 'quiz', '_quiz_lesson', $dry_run );
 		if ( $processed > 0 ) {
 			return $processed;
 		}
@@ -100,20 +100,23 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 	}
 
 	/**
-	 * Backfill lesson progress parent_post_id with the course ID.
+	 * Backfill parent_post_id for a given progress type.
 	 *
-	 * @param bool $dry_run Whether to run in dry-run mode.
+	 * @param string $type     The progress type ('lesson' or 'quiz').
+	 * @param string $meta_key The post meta key that holds the parent post ID.
+	 * @param bool   $dry_run  Whether to run in dry-run mode.
 	 * @return int The number of rows processed.
 	 * @throws \RuntimeException If the database query fails.
 	 */
-	private function backfill_lesson_progress( bool $dry_run ): int {
+	private function backfill_progress( string $type, string $meta_key, bool $dry_run ): int {
 		global $wpdb;
 		$table   = $wpdb->prefix . 'sensei_lms_progress';
 		$last_id = (int) get_option( self::LAST_ID_OPTION_NAME, 0 );
 
 		$select_query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT id, post_id FROM {$table} WHERE type = 'lesson' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
+			"SELECT id, post_id FROM {$table} WHERE type = %s AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
+			$type,
 			$last_id,
 			$this->batch_size
 		);
@@ -126,14 +129,13 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$rows = $wpdb->get_results( $select_query );
 
 		if ( null === $rows ) {
-			throw new \RuntimeException( esc_html( 'Database error fetching lesson progress: ' . $wpdb->last_error ) );
+			throw new \RuntimeException( esc_html( "Database error fetching {$type} progress: " . $wpdb->last_error ) );
 		}
 
 		if ( empty( $rows ) ) {
 			return 0;
 		}
 
-		// Bulk-fetch _lesson_course meta for all post_ids in this batch.
 		$post_ids     = array_unique( array_map( 'intval', wp_list_pluck( $rows, 'post_id' ) ) );
 		$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
 
@@ -141,7 +143,7 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$meta_query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_lesson_course' AND post_id IN ( {$placeholders} )",
+			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '{$meta_key}' AND post_id IN ( {$placeholders} )",
 			...$post_ids
 		);
 
@@ -162,130 +164,29 @@ class Parent_Post_Id_Migration extends Migration_Abstract {
 		$last_processed = $last_id;
 
 		foreach ( $rows as $row ) {
-			$course_id = isset( $meta_map[ (int) $row->post_id ] ) ? $meta_map[ (int) $row->post_id ] : 0;
+			$parent_id = isset( $meta_map[ (int) $row->post_id ] ) ? $meta_map[ (int) $row->post_id ] : 0;
 
-			if ( $course_id ) {
+			if ( $parent_id ) {
 				if ( $dry_run ) {
 					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-					echo esc_html( $wpdb->prepare( "UPDATE {$table} SET parent_post_id = %d WHERE id = %d", $course_id, (int) $row->id ) . "\n" );
+					echo esc_html( $wpdb->prepare( "UPDATE {$table} SET parent_post_id = %d WHERE id = %d", $parent_id, (int) $row->id ) . "\n" );
 				} else {
 					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 					$result = $wpdb->update(
 						$table,
-						array( 'parent_post_id' => $course_id ),
+						array( 'parent_post_id' => $parent_id ),
 						array( 'id' => (int) $row->id ),
 						array( '%d' ),
 						array( '%d' )
 					);
 
 					if ( false === $result ) {
-						$error_message = $wpdb->last_error ? $wpdb->last_error : "Unknown error updating lesson progress id={$row->id}";
+						$error_message = $wpdb->last_error ? $wpdb->last_error : "Unknown error updating {$type} progress id={$row->id}";
 						$this->add_error( $error_message );
 					}
 				}
 			} else {
-				$this->add_error( "Skipped lesson progress id={$row->id}: no meta for post_id={$row->post_id}" );
-			}
-
-			$last_processed = (int) $row->id;
-			++$processed;
-
-			if ( $this->is_time_exceeded() ) {
-				break;
-			}
-		}
-
-		update_option( self::LAST_ID_OPTION_NAME, $last_processed );
-
-		return $processed;
-	}
-
-	/**
-	 * Backfill quiz progress parent_post_id with the lesson ID.
-	 *
-	 * @param bool $dry_run Whether to run in dry-run mode.
-	 * @return int The number of rows processed.
-	 * @throws \RuntimeException If the database query fails.
-	 */
-	private function backfill_quiz_progress( bool $dry_run ): int {
-		global $wpdb;
-		$table   = $wpdb->prefix . 'sensei_lms_progress';
-		$last_id = (int) get_option( self::LAST_ID_OPTION_NAME, 0 );
-
-		$select_query = $wpdb->prepare(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT id, post_id FROM {$table} WHERE type = 'quiz' AND parent_post_id IS NULL AND id > %d ORDER BY id ASC LIMIT %d",
-			$last_id,
-			$this->batch_size
-		);
-
-		if ( $dry_run ) {
-			echo esc_html( $select_query . "\n" );
-		}
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$rows = $wpdb->get_results( $select_query );
-
-		if ( null === $rows ) {
-			throw new \RuntimeException( esc_html( 'Database error fetching quiz progress: ' . $wpdb->last_error ) );
-		}
-
-		if ( empty( $rows ) ) {
-			return 0;
-		}
-
-		// Bulk-fetch _quiz_lesson meta for all post_ids in this batch.
-		$post_ids     = array_unique( array_map( 'intval', wp_list_pluck( $rows, 'post_id' ) ) );
-		$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
-
-		// Placeholders are built dynamically, so the sniff can't verify the count.
-		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		$meta_query = $wpdb->prepare(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_quiz_lesson' AND post_id IN ( {$placeholders} )",
-			...$post_ids
-		);
-
-		if ( $dry_run ) {
-			echo esc_html( $meta_query . "\n" );
-		}
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-		$meta_rows = $wpdb->get_results( $meta_query );
-		$meta_map  = array();
-		if ( $meta_rows ) {
-			foreach ( $meta_rows as $meta ) {
-				$meta_map[ (int) $meta->post_id ] = (int) $meta->meta_value;
-			}
-		}
-
-		$processed      = 0;
-		$last_processed = $last_id;
-
-		foreach ( $rows as $row ) {
-			$lesson_id = isset( $meta_map[ (int) $row->post_id ] ) ? $meta_map[ (int) $row->post_id ] : 0;
-
-			if ( $lesson_id ) {
-				if ( $dry_run ) {
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-					echo esc_html( $wpdb->prepare( "UPDATE {$table} SET parent_post_id = %d WHERE id = %d", $lesson_id, (int) $row->id ) . "\n" );
-				} else {
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-					$result = $wpdb->update(
-						$table,
-						array( 'parent_post_id' => $lesson_id ),
-						array( 'id' => (int) $row->id ),
-						array( '%d' ),
-						array( '%d' )
-					);
-
-					if ( false === $result ) {
-						$error_message = $wpdb->last_error ? $wpdb->last_error : "Unknown error updating quiz progress id={$row->id}";
-						$this->add_error( $error_message );
-					}
-				}
-			} else {
-				$this->add_error( "Skipped quiz progress id={$row->id}: no meta for post_id={$row->post_id}" );
+				$this->add_error( "Skipped {$type} progress id={$row->id}: no meta for post_id={$row->post_id}" );
 			}
 
 			$last_processed = (int) $row->id;

--- a/includes/internal/migration/migrations/class-quiz-migration.php
+++ b/includes/internal/migration/migrations/class-quiz-migration.php
@@ -55,7 +55,7 @@ class Quiz_Migration extends Migration_Abstract {
 		 *
 		 * @param int $batch_size The batch size.
 		 */
-		$this->batch_size = (int) apply_filters( 'sensei_migration_quiz_batch_size', $batch_size );
+		$this->batch_size = max( 1, (int) apply_filters( 'sensei_migration_quiz_batch_size', $batch_size ) );
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -198,8 +198,9 @@ class Student_Progress_Migration extends Migration_Abstract {
 			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 			$post_meta_query = $wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT * FROM {$wpdb->postmeta} WHERE  meta_key IN ( %s, %s ) AND post_id IN ( {$placeholders} )",
+				"SELECT * FROM {$wpdb->postmeta} WHERE  meta_key IN ( %s, %s, %s ) AND post_id IN ( {$placeholders} )",
 				'_lesson_quiz',
+				'_lesson_course',
 				'_wp_trash_meta_comments_status',
 				...$ids
 			);
@@ -369,11 +370,13 @@ class Student_Progress_Migration extends Migration_Abstract {
 			}
 		}
 
+		$course_id = isset( $meta['_lesson_course'] ) ? (int) $meta['_lesson_course'] : null;
+
 		$rows = array(
 			array(
 				'post_id'        => (int) $comment->comment_post_ID,
 				'user_id'        => (int) $comment->user_id,
-				'parent_post_id' => null,
+				'parent_post_id' => $course_id ? $course_id : null,
 				'type'           => 'lesson',
 				'status'         => $lesson_status,
 				'started_at'     => $started_at,
@@ -412,7 +415,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 			$rows[] = array(
 				'post_id'        => (int) $quiz_id,
 				'user_id'        => (int) $comment->user_id,
-				'parent_post_id' => null,
+				'parent_post_id' => (int) $comment->comment_post_ID ? (int) $comment->comment_post_ID : null,
 				'type'           => 'quiz',
 				'status'         => $quiz_status,
 				'started_at'     => $started_at,

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -57,7 +57,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 		 *
 		 * @param int $read_batch_size The read batch size.
 		 */
-		$this->read_batch_size = (int) apply_filters( 'sensei_migration_student_progress_read_batch_size', $read_batch_size );
+		$this->read_batch_size = max( 1, (int) apply_filters( 'sensei_migration_student_progress_read_batch_size', $read_batch_size ) );
 
 		/**
 		 * Filter the insert batch size for student progress migration.
@@ -66,7 +66,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 		 *
 		 * @param int $insert_batch_size The insert batch size.
 		 */
-		$this->insert_batch_size = (int) apply_filters( 'sensei_migration_student_progress_insert_batch_size', $insert_batch_size );
+		$this->insert_batch_size = max( 1, (int) apply_filters( 'sensei_migration_student_progress_insert_batch_size', $insert_batch_size ) );
 	}
 
 	/**

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -413,10 +413,11 @@ class Student_Progress_Migration extends Migration_Abstract {
 			}
 
 			// comment_post_ID is the lesson ID (comment is on the lesson post), which is the quiz's parent.
-			$rows[] = array(
+			$parent_lesson_id = (int) $comment->comment_post_ID;
+			$rows[]           = array(
 				'post_id'        => (int) $quiz_id,
 				'user_id'        => (int) $comment->user_id,
-				'parent_post_id' => (int) $comment->comment_post_ID ? (int) $comment->comment_post_ID : null,
+				'parent_post_id' => $parent_lesson_id ? $parent_lesson_id : null,
 				'type'           => 'quiz',
 				'status'         => $quiz_status,
 				'started_at'     => $started_at,

--- a/includes/internal/migration/migrations/class-student-progress-migration.php
+++ b/includes/internal/migration/migrations/class-student-progress-migration.php
@@ -412,6 +412,7 @@ class Student_Progress_Migration extends Migration_Abstract {
 				$quiz_status = Quiz_Progress_Interface::STATUS_PASSED;
 			}
 
+			// comment_post_ID is the lesson ID (comment is on the lesson post), which is the quiz's parent.
 			$rows[] = array(
 				'post_id'        => (int) $quiz_id,
 				'user_id'        => (int) $comment->user_id,

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comment-reading-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comment-reading-aggregate-lesson-progress-repository.php
@@ -56,13 +56,14 @@ class Comment_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Pro
 	 *
 	 * @internal
 	 *
-	 * @param int $lesson_id The lesson ID.
-	 * @param int $user_id The user ID.
+	 * @param int      $lesson_id The lesson ID.
+	 * @param int      $user_id The user ID.
+	 * @param int|null $parent_post_id The parent post ID (course ID for lessons).
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
-	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface {
-		$progress = $this->comments_based_repository->create( $lesson_id, $user_id );
-		$this->tables_based_repository->create( $lesson_id, $user_id );
+	public function create( int $lesson_id, int $user_id, ?int $parent_post_id = null ): Lesson_Progress_Interface {
+		$progress = $this->comments_based_repository->create( $lesson_id, $user_id, $parent_post_id );
+		$this->tables_based_repository->create( $lesson_id, $user_id, $parent_post_id );
 		return $progress;
 	}
 

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
@@ -33,13 +33,14 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 	 *
 	 * @internal
 	 *
-	 * @param int $lesson_id The lesson ID.
-	 * @param int $user_id The user ID.
+	 * @param int      $lesson_id The lesson ID.
+	 * @param int      $user_id The user ID.
+	 * @param int|null $parent_post_id The parent post ID (unused in comments-based storage).
 	 *
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 * @throws RuntimeException When the lesson progress could not be created.
 	 */
-	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface {
+	public function create( int $lesson_id, int $user_id, ?int $parent_post_id = null ): Lesson_Progress_Interface {
 		/**
 		 * Filter lesson id for lesson progress creation.
 		 *

--- a/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
@@ -26,11 +26,12 @@ interface Lesson_Progress_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param int $lesson_id The lesson ID.
-	 * @param int $user_id The user ID.
+	 * @param int      $lesson_id The lesson ID.
+	 * @param int      $user_id The user ID.
+	 * @param int|null $parent_post_id The parent post ID (course ID for lessons).
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
-	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface;
+	public function create( int $lesson_id, int $user_id, ?int $parent_post_id = null ): Lesson_Progress_Interface;
 
 	/**
 	 * Finds a lesson progress by lesson and user.

--- a/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
@@ -48,13 +48,14 @@ class Table_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Progr
 	/**
 	 * Creates a new lesson progress.
 	 *
-	 * @param int $lesson_id The lesson ID.
-	 * @param int $user_id   The user ID.
+	 * @param int      $lesson_id The lesson ID.
+	 * @param int      $user_id   The user ID.
+	 * @param int|null $parent_post_id The parent post ID (course ID for lessons).
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
-	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface {
-		$this->comments_based_repository->create( $lesson_id, $user_id );
-		return $this->tables_based_repository->create( $lesson_id, $user_id );
+	public function create( int $lesson_id, int $user_id, ?int $parent_post_id = null ): Lesson_Progress_Interface {
+		$this->comments_based_repository->create( $lesson_id, $user_id, $parent_post_id );
+		return $this->tables_based_repository->create( $lesson_id, $user_id, $parent_post_id );
 	}
 
 	/**

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -62,12 +62,13 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 	 *
 	 * @internal
 	 *
-	 * @param int $lesson_id The lesson ID.
-	 * @param int $user_id The user ID.
+	 * @param int      $lesson_id The lesson ID.
+	 * @param int      $user_id The user ID.
+	 * @param int|null $parent_post_id The parent post ID (course ID for lessons).
 	 *
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
-	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface {
+	public function create( int $lesson_id, int $user_id, ?int $parent_post_id = null ): Lesson_Progress_Interface {
 		/**
 		 * Filter lesson id for lesson progress creation.
 		 *
@@ -87,7 +88,7 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 			[
 				'post_id'        => $lesson_id,
 				'user_id'        => $user_id,
-				'parent_post_id' => null,
+				'parent_post_id' => $parent_post_id,
 				'type'           => 'lesson',
 				'status'         => Lesson_Progress_Interface::STATUS_IN_PROGRESS,
 				'started_at'     => $current_datetime->format( $date_format ),
@@ -98,7 +99,7 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 			[
 				'%d',
 				'%d',
-				null,
+				$parent_post_id ? '%d' : null,
 				'%s',
 				'%s',
 				'%s',

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -69,6 +69,8 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
 	public function create( int $lesson_id, int $user_id, ?int $parent_post_id = null ): Lesson_Progress_Interface {
+		$parent_post_id = $parent_post_id ? $parent_post_id : null;
+
 		/**
 		 * Filter lesson id for lesson progress creation.
 		 *

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
@@ -56,13 +56,14 @@ class Comment_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progres
 	 *
 	 * @internal
 	 *
-	 * @param int $quiz_id The quiz ID.
-	 * @param int $user_id The user ID.
+	 * @param int      $quiz_id The quiz ID.
+	 * @param int      $user_id The user ID.
+	 * @param int|null $parent_post_id The parent post ID (lesson ID for quizzes).
 	 * @return Quiz_Progress_Interface The quiz progress.
 	 */
-	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
-		$this->tables_based_repository->create( $quiz_id, $user_id );
-		return $this->comments_based_repository->create( $quiz_id, $user_id );
+	public function create( int $quiz_id, int $user_id, ?int $parent_post_id = null ): Quiz_Progress_Interface {
+		$this->tables_based_repository->create( $quiz_id, $user_id, $parent_post_id );
+		return $this->comments_based_repository->create( $quiz_id, $user_id, $parent_post_id );
 	}
 
 	/**

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -31,12 +31,13 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	 *
 	 * @internal
 	 *
-	 * @param int $quiz_id Quiz identifier.
-	 * @param int $user_id User identifier.
+	 * @param int      $quiz_id Quiz identifier.
+	 * @param int      $user_id User identifier.
+	 * @param int|null $parent_post_id The parent post ID (unused in comments-based storage).
 	 * @return Quiz_Progress_Interface
 	 * @throws \RuntimeException When the quiz progress doesn't exist. In this implementation we re-use lesson progress.
 	 */
-	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
+	public function create( int $quiz_id, int $user_id, ?int $parent_post_id = null ): Quiz_Progress_Interface {
 		/**
 		 * Filter quiz id for quiz progress creation.
 		 *

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
@@ -26,11 +26,12 @@ interface Quiz_Progress_Repository_Interface {
 	 *
 	 * @internal
 	 *
-	 * @param int $quiz_id Quiz identifier.
-	 * @param int $user_id User identifier.
+	 * @param int      $quiz_id Quiz identifier.
+	 * @param int      $user_id User identifier.
+	 * @param int|null $parent_post_id The parent post ID (lesson ID for quizzes).
 	 * @return Quiz_Progress_Interface
 	 */
-	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface;
+	public function create( int $quiz_id, int $user_id, ?int $parent_post_id = null ): Quiz_Progress_Interface;
 
 	/**
 	 * Find a quiz progress by quiz and user identifiers.

--- a/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
@@ -79,7 +79,8 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 		if ( $lesson_id ) {
 			$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $user_id );
 			if ( ! $lesson_progress_exists ) {
-				$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id );
+				$course_id = (int) get_post_meta( $lesson_id, '_lesson_course', true );
+				$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id, $course_id ?: null );
 			}
 		}
 
@@ -123,7 +124,8 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 			if ( $lesson_id ) {
 				$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $quiz_progress->get_user_id() );
 				if ( ! $lesson_progress_exists ) {
-					$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id() );
+					$course_id = (int) get_post_meta( $lesson_id, '_lesson_course', true );
+					$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id(), $course_id ?: null );
 				}
 			}
 			$comments_based_quiz_progress = $this->comments_based_repository->get(

--- a/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
@@ -66,11 +66,12 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	/**
 	 * Creates a new quiz progress.
 	 *
-	 * @param int $quiz_id The quiz ID.
-	 * @param int $user_id The user ID.
+	 * @param int      $quiz_id The quiz ID.
+	 * @param int      $user_id The user ID.
+	 * @param int|null $parent_post_id The parent post ID (lesson ID for quizzes).
 	 * @return Quiz_Progress_Interface The quiz progress.
 	 */
-	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
+	public function create( int $quiz_id, int $user_id, ?int $parent_post_id = null ): Quiz_Progress_Interface {
 		// We don't try to create comments-based quiz progress: it is part of lesson progress.
 		// The attempt to create the comments-based quiz progress will cause an exception.
 		// Try to create the comments-based lesson progress instead.
@@ -82,7 +83,7 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 			}
 		}
 
-		return $this->tables_based_repository->create( $quiz_id, $user_id );
+		return $this->tables_based_repository->create( $quiz_id, $user_id, $parent_post_id );
 	}
 
 	/**

--- a/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
@@ -79,8 +79,7 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 		if ( $lesson_id ) {
 			$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $user_id );
 			if ( ! $lesson_progress_exists ) {
-				$course_id = (int) get_post_meta( $lesson_id, '_lesson_course', true );
-				$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id, $course_id ?: null );
+				$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id, \Sensei_Utils::get_lesson_course_id( $lesson_id ) );
 			}
 		}
 
@@ -124,8 +123,7 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 			if ( $lesson_id ) {
 				$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $quiz_progress->get_user_id() );
 				if ( ! $lesson_progress_exists ) {
-					$course_id = (int) get_post_meta( $lesson_id, '_lesson_course', true );
-					$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id(), $course_id ?: null );
+					$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id(), \Sensei_Utils::get_lesson_course_id( $lesson_id ) );
 				}
 			}
 			$comments_based_quiz_progress = $this->comments_based_repository->get(

--- a/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
@@ -79,7 +79,7 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 		if ( $lesson_id ) {
 			$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $user_id );
 			if ( ! $lesson_progress_exists ) {
-				$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id, \Sensei_Utils::get_lesson_course_id( $lesson_id ) );
+				$this->comments_based_lesson_progress_repository->create( (int) $lesson_id, $user_id, \Sensei_Utils::get_lesson_course_id( (int) $lesson_id ) );
 			}
 		}
 
@@ -123,7 +123,7 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 			if ( $lesson_id ) {
 				$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $quiz_progress->get_user_id() );
 				if ( ! $lesson_progress_exists ) {
-					$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id(), \Sensei_Utils::get_lesson_course_id( $lesson_id ) );
+					$this->comments_based_lesson_progress_repository->create( (int) $lesson_id, $quiz_progress->get_user_id(), \Sensei_Utils::get_lesson_course_id( (int) $lesson_id ) );
 				}
 			}
 			$comments_based_quiz_progress = $this->comments_based_repository->get(

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -67,6 +67,8 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 	 * @return Quiz_Progress_Interface
 	 */
 	public function create( int $quiz_id, int $user_id, ?int $parent_post_id = null ): Quiz_Progress_Interface {
+		$parent_post_id = $parent_post_id ? $parent_post_id : null;
+
 		/**
 		 * Filter quiz id for quiz progress creation.
 		 *

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -61,11 +61,12 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 	 *
 	 * @internal
 	 *
-	 * @param int $quiz_id Quiz identifier.
-	 * @param int $user_id User identifier.
+	 * @param int      $quiz_id Quiz identifier.
+	 * @param int      $user_id User identifier.
+	 * @param int|null $parent_post_id The parent post ID (lesson ID for quizzes).
 	 * @return Quiz_Progress_Interface
 	 */
-	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
+	public function create( int $quiz_id, int $user_id, ?int $parent_post_id = null ): Quiz_Progress_Interface {
 		/**
 		 * Filter quiz id for quiz progress creation.
 		 *
@@ -85,7 +86,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			[
 				'post_id'        => $quiz_id,
 				'user_id'        => $user_id,
-				'parent_post_id' => null,
+				'parent_post_id' => $parent_post_id,
 				'type'           => 'quiz',
 				'status'         => Quiz_Progress_Interface::STATUS_IN_PROGRESS,
 				'started_at'     => $current_datetime->format( $date_format ),
@@ -96,7 +97,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			[
 				'%d',
 				'%d',
-				null,
+				$parent_post_id ? '%d' : null,
 				'%s',
 				'%s',
 				'%s',

--- a/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace SenseiTest\Internal\Migration\Migrations;
+
+use Sensei\Internal\Migration\Migrations\Parent_Post_Id_Migration;
+use Sensei_Factory;
+
+/**
+ * Class Parent_Post_Id_Migration_Test
+ *
+ * @covers \Sensei\Internal\Migration\Migrations\Parent_Post_Id_Migration
+ */
+class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Migration instance.
+	 *
+	 * @var Parent_Post_Id_Migration
+	 */
+	private $migration;
+
+	protected $factory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->migration = new Parent_Post_Id_Migration();
+		$this->factory   = new Sensei_Factory();
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . 'sensei_lms_progress' );
+
+		delete_option( Parent_Post_Id_Migration::LAST_ID_OPTION_NAME );
+	}
+
+	public function testRun_NoRows_ReturnsZero(): void {
+		$actual = $this->migration->run( false );
+
+		$this->assertSame( 0, $actual );
+	}
+
+	public function testRun_LessonProgress_BackfillsCourseId(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+		$user_id   = $this->factory->user->create();
+
+		$this->insert_progress_row( $lesson_id, $user_id, 'lesson' );
+
+		/* Act. */
+		$this->migration->run( false );
+
+		/* Assert. */
+		$parent = $this->get_parent_post_id( $lesson_id, $user_id, 'lesson' );
+		$this->assertEquals( $course_id, (int) $parent );
+	}
+
+	public function testRun_QuizProgress_BackfillsLessonId(): void {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->quiz->create(
+			array(
+				'meta_input' => array(
+					'_quiz_lesson' => $lesson_id,
+				),
+			)
+		);
+		$user_id   = $this->factory->user->create();
+
+		// First run processes lessons (none), second processes quizzes.
+		$this->insert_progress_row( $quiz_id, $user_id, 'quiz' );
+
+		/* Act. */
+		// First call completes lesson phase (0 rows), then processes quiz.
+		$this->migration->run( false );
+
+		/* Assert. */
+		$parent = $this->get_parent_post_id( $quiz_id, $user_id, 'quiz' );
+		$this->assertEquals( $lesson_id, (int) $parent );
+	}
+
+	public function testRun_CourseProgress_RemainsNull(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$user_id   = $this->factory->user->create();
+
+		$this->insert_progress_row( $course_id, $user_id, 'course' );
+
+		/* Act. */
+		$this->migration->run( false );
+		$this->migration->run( false );
+
+		/* Assert. */
+		$parent = $this->get_parent_post_id( $course_id, $user_id, 'course' );
+		$this->assertNull( $parent );
+	}
+
+	public function testRun_AlreadyPopulated_DoesNotModify(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+		$user_id   = $this->factory->user->create();
+
+		// Insert with parent_post_id already set to a different value.
+		$this->insert_progress_row( $lesson_id, $user_id, 'lesson', 99999 );
+
+		/* Act. */
+		$this->migration->run( false );
+
+		/* Assert. */
+		$parent = $this->get_parent_post_id( $lesson_id, $user_id, 'lesson' );
+		$this->assertEquals( 99999, (int) $parent, 'Already-populated rows should not be modified.' );
+	}
+
+	public function testRun_OrphanedLesson_RemainsNull(): void {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create(); // No _lesson_course meta.
+		$user_id   = $this->factory->user->create();
+
+		$this->insert_progress_row( $lesson_id, $user_id, 'lesson' );
+
+		/* Act. */
+		$this->migration->run( false );
+
+		/* Assert. */
+		$parent = $this->get_parent_post_id( $lesson_id, $user_id, 'lesson' );
+		$this->assertNull( $parent, 'Orphaned lesson progress should remain NULL.' );
+	}
+
+	public function testRun_ReturnsZeroWhenComplete(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+		$user_id   = $this->factory->user->create();
+
+		$this->insert_progress_row( $lesson_id, $user_id, 'lesson' );
+
+		/* Act. */
+		$this->migration->run( false ); // Processes lesson rows.
+		$result = $this->migration->run( false ); // Should return 0 (complete).
+
+		/* Assert. */
+		$this->assertSame( 0, $result );
+	}
+
+	public function testRun_BatchesCorrectly(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$migration = new Parent_Post_Id_Migration( 2 ); // Batch size of 2.
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$lesson_id = $this->factory->lesson->create(
+				array(
+					'meta_input' => array(
+						'_lesson_course' => $course_id,
+					),
+				)
+			);
+			$user_id = $this->factory->user->create();
+			$this->insert_progress_row( $lesson_id, $user_id, 'lesson' );
+		}
+
+		/* Act. */
+		$first_batch  = $migration->run( false );
+		$second_batch = $migration->run( false );
+		$third_batch  = $migration->run( false );
+		$final        = $migration->run( false );
+
+		/* Assert. */
+		$this->assertSame( 2, $first_batch );
+		$this->assertSame( 2, $second_batch );
+		$this->assertSame( 1, $third_batch );
+		$this->assertSame( 0, $final );
+	}
+
+	/**
+	 * Insert a progress row directly into the database.
+	 *
+	 * @param int         $post_id The post ID.
+	 * @param int         $user_id The user ID.
+	 * @param string      $type The progress type.
+	 * @param int|null    $parent_post_id The parent post ID.
+	 */
+	private function insert_progress_row( int $post_id, int $user_id, string $type, ?int $parent_post_id = null ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . 'sensei_lms_progress';
+
+		$data   = array(
+			'post_id'        => $post_id,
+			'user_id'        => $user_id,
+			'parent_post_id' => $parent_post_id,
+			'type'           => $type,
+			'status'         => 'in-progress',
+			'started_at'     => current_time( 'mysql', true ),
+			'created_at'     => current_time( 'mysql', true ),
+			'updated_at'     => current_time( 'mysql', true ),
+		);
+		$format = array(
+			'%d',
+			'%d',
+			$parent_post_id ? '%d' : null,
+			'%s',
+			'%s',
+			'%s',
+			'%s',
+			'%s',
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert( $table, $data, $format );
+	}
+
+	/**
+	 * Get the parent_post_id for a progress row.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param int    $user_id The user ID.
+	 * @param string $type The progress type.
+	 * @return string|null The parent_post_id value.
+	 */
+	private function get_parent_post_id( int $post_id, int $user_id, string $type ) {
+		global $wpdb;
+		$table = $wpdb->prefix . 'sensei_lms_progress';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT parent_post_id FROM {$table} WHERE post_id = %d AND user_id = %d AND type = %s",
+				$post_id,
+				$user_id,
+				$type
+			)
+		);
+	}
+}

--- a/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
@@ -32,6 +32,7 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . 'sensei_lms_progress' );
 
 		delete_option( Parent_Post_Id_Migration::LAST_ID_OPTION_NAME );
+		delete_option( Parent_Post_Id_Migration::LESSONS_COMPLETE_OPTION_NAME );
 	}
 
 	public function testRun_NoRows_ReturnsZero(): void {
@@ -135,6 +136,57 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$parent = $this->get_parent_post_id( $lesson_id, $user_id, 'lesson' );
 		$this->assertNull( $parent, 'Orphaned lesson progress should remain NULL.' );
+	}
+
+	public function testRun_OrphanedQuiz_RemainsNull(): void {
+		/* Arrange. */
+		$quiz_id = $this->factory->quiz->create(); // No _quiz_lesson meta.
+		$user_id = $this->factory->user->create();
+
+		$this->insert_progress_row( $quiz_id, $user_id, 'quiz' );
+
+		/* Act. */
+		$this->migration->run( false );
+
+		/* Assert. */
+		$parent = $this->get_parent_post_id( $quiz_id, $user_id, 'quiz' );
+		$this->assertNull( $parent, 'Orphaned quiz progress should remain NULL.' );
+	}
+
+	public function testRun_LessonAndQuizRows_BackfillsBothPhases(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+		$quiz_id   = $this->factory->quiz->create(
+			array(
+				'meta_input' => array(
+					'_quiz_lesson' => $lesson_id,
+				),
+			)
+		);
+		$user_id   = $this->factory->user->create();
+
+		$this->insert_progress_row( $lesson_id, $user_id, 'lesson' );
+		$this->insert_progress_row( $quiz_id, $user_id, 'quiz' );
+
+		/* Act. */
+		$result = 1;
+		while ( $result > 0 ) {
+			$result = $this->migration->run( false );
+		}
+
+		/* Assert. */
+		$lesson_parent = $this->get_parent_post_id( $lesson_id, $user_id, 'lesson' );
+		$this->assertEquals( $course_id, (int) $lesson_parent, 'Lesson progress should have the course as parent.' );
+
+		$quiz_parent = $this->get_parent_post_id( $quiz_id, $user_id, 'quiz' );
+		$this->assertEquals( $lesson_id, (int) $quiz_parent, 'Quiz progress should have the lesson as parent.' );
 	}
 
 	public function testRun_ReturnsZeroWhenComplete(): void {

--- a/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
@@ -74,11 +74,9 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 		);
 		$user_id   = $this->factory->user->create();
 
-		// First run processes lessons (none), second processes quizzes.
 		$this->insert_progress_row( $quiz_id, $user_id, 'quiz' );
 
 		/* Act. */
-		// First call completes lesson phase (0 rows), then processes quiz.
 		$this->migration->run( false );
 
 		/* Assert. */
@@ -94,7 +92,6 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 		$this->insert_progress_row( $course_id, $user_id, 'course' );
 
 		/* Act. */
-		$this->migration->run( false );
 		$this->migration->run( false );
 
 		/* Assert. */
@@ -175,7 +172,7 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 					),
 				)
 			);
-			$user_id = $this->factory->user->create();
+			$user_id   = $this->factory->user->create();
 			$this->insert_progress_row( $lesson_id, $user_id, 'lesson' );
 		}
 
@@ -186,10 +183,10 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 		$final        = $migration->run( false );
 
 		/* Assert. */
-		$this->assertSame( 2, $first_batch );
-		$this->assertSame( 2, $second_batch );
-		$this->assertSame( 1, $third_batch );
-		$this->assertSame( 0, $final );
+		$this->assertSame( 2, $first_batch, 'First batch should process 2 rows.' );
+		$this->assertSame( 2, $second_batch, 'Second batch should process 2 rows.' );
+		$this->assertSame( 1, $third_batch, 'Third batch should process the remaining 1 row.' );
+		$this->assertSame( 0, $final, 'Final run should return 0 when complete.' );
 	}
 
 	/**

--- a/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
@@ -118,6 +118,7 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 		$user_id   = $this->factory->user->create();
 
 		// Insert with parent_post_id already set to a different value.
+		$this->assertNotEquals( 99999, $course_id, 'Test precondition: course_id must differ from the dummy parent_post_id.' );
 		$this->insert_progress_row( $lesson_id, $user_id, 'lesson', 99999 );
 
 		/* Act. */

--- a/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-parent-post-id-migration.php
@@ -19,6 +19,11 @@ class Parent_Post_Id_Migration_Test extends \WP_UnitTestCase {
 	 */
 	private $migration;
 
+	/**
+	 * Sensei factory.
+	 *
+	 * @var Sensei_Factory
+	 */
 	protected $factory;
 
 	protected function setUp(): void {

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -254,6 +254,74 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $cursor, 'Cursor should advance past duplicates' );
 	}
 
+	public function testRun_WithLessonAndQuiz_PopulatesParentPostId(): void {
+		/* Arrange. */
+		$course_id = $this->factory->course->create( array( 'post_title' => 'Course 1' ) );
+		$quiz_id   = $this->factory->quiz->create(
+			array(
+				'post_title' => 'Quiz 1',
+			)
+		);
+		$lesson_id = $this->factory->lesson->create(
+			array(
+				'post_title'  => 'Lesson 1',
+				'post_parent' => $course_id,
+				'meta_input'  => array(
+					'_lesson_quiz'   => $quiz_id,
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+		$user_id   = $this->factory->user->create();
+
+		update_post_meta( $quiz_id, '_quiz_lesson', $lesson_id );
+
+		Sensei_Utils::start_user_on_course( $user_id, $course_id );
+		Sensei_Utils::user_start_lesson( $user_id, $lesson_id, true );
+
+		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
+
+		/* Act. */
+		$this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+
+		/* Assert. */
+		global $wpdb;
+		$table = $wpdb->prefix . 'sensei_lms_progress';
+
+		// Course progress: parent_post_id should be NULL.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$course_parent = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT parent_post_id FROM {$table} WHERE post_id = %d AND user_id = %d AND type = 'course'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$course_id,
+				$user_id
+			)
+		);
+		$this->assertNull( $course_parent, 'Course progress parent_post_id should be NULL.' );
+
+		// Lesson progress: parent_post_id should be the course ID.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$lesson_parent = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT parent_post_id FROM {$table} WHERE post_id = %d AND user_id = %d AND type = 'lesson'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$lesson_id,
+				$user_id
+			)
+		);
+		$this->assertEquals( $course_id, (int) $lesson_parent, 'Lesson progress parent_post_id should be the course ID.' );
+
+		// Quiz progress: parent_post_id should be the lesson ID.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$quiz_parent = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT parent_post_id FROM {$table} WHERE post_id = %d AND user_id = %d AND type = 'quiz'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$quiz_id,
+				$user_id
+			)
+		);
+		$this->assertEquals( $lesson_id, (int) $quiz_parent, 'Quiz progress parent_post_id should be the lesson ID.' );
+	}
+
 	private function get_table_based_progress(): array {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
+++ b/tests/unit-tests/internal/migration/migrations/test-class-student-progress-migration.php
@@ -46,7 +46,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		$expected = 0;
 
 		/* Act. */
-		$actual = $this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+		$actual = $this->migration->run( false );
 
 		/* Assert. */
 		$this->assertEquals( $expected, $actual );
@@ -68,7 +68,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
 
 		/* Act. */
-		$this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+		$this->migration->run( false );
 
 		/* Assert. */
 		global $wpdb;
@@ -111,7 +111,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
 
 		/* Act. */
-		$this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+		$this->migration->run( false );
 
 		/* Assert. */
 		$actual_rows = $this->get_table_based_progress();
@@ -282,7 +282,7 @@ class Student_Progress_Migration_Test extends \WP_UnitTestCase {
 		update_option( 'sensei_migrated_progress_last_comment_id', 0 );
 
 		/* Act. */
-		$this->migration->run( $dry_run = false ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+		$this->migration->run( false );
 
 		/* Assert. */
 		global $wpdb;

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
@@ -642,6 +642,32 @@ class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertSame( $expected, $actual );
 	}
 
+	public function testCreate_WhenParentPostIdProvided_StoresIt(): void {
+		/* Arrange. */
+		$lesson_id = $this->factory->post->create( array( 'post_type' => 'lesson' ) );
+		$course_id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$user_id   = $this->factory->user->create();
+
+		global $wpdb;
+		$repository = new Tables_Based_Lesson_Progress_Repository( $wpdb );
+
+		/* Act. */
+		$repository->create( $lesson_id, $user_id, $course_id );
+
+		/* Assert. */
+		$table  = $wpdb->prefix . 'sensei_lms_progress';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT parent_post_id FROM {$table} WHERE post_id = %d AND user_id = %d AND type = 'lesson'",
+				$lesson_id,
+				$user_id
+			)
+		);
+		$this->assertEquals( $course_id, (int) $result );
+	}
+
 	public function testFind_CacheEnabled_WarmsIndividualCaches(): void {
 		/* Arrange. */
 		$wpdb = $this->createMock( wpdb::class );

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
@@ -655,7 +655,7 @@ class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->create( $lesson_id, $user_id, $course_id );
 
 		/* Assert. */
-		$table  = $wpdb->prefix . 'sensei_lms_progress';
+		$table = $wpdb->prefix . 'sensei_lms_progress';
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $wpdb->get_var(
 			$wpdb->prepare(

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
@@ -608,6 +608,32 @@ class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertSame( $expected, $actual );
 	}
 
+	public function testCreate_WhenParentPostIdProvided_StoresIt(): void {
+		/* Arrange. */
+		$quiz_id   = $this->factory->post->create( array( 'post_type' => 'quiz' ) );
+		$lesson_id = $this->factory->post->create( array( 'post_type' => 'lesson' ) );
+		$user_id   = $this->factory->user->create();
+
+		global $wpdb;
+		$repository = new Tables_Based_Quiz_Progress_Repository( $wpdb );
+
+		/* Act. */
+		$repository->create( $quiz_id, $user_id, $lesson_id );
+
+		/* Assert. */
+		$table  = $wpdb->prefix . 'sensei_lms_progress';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT parent_post_id FROM {$table} WHERE post_id = %d AND user_id = %d AND type = 'quiz'",
+				$quiz_id,
+				$user_id
+			)
+		);
+		$this->assertEquals( $lesson_id, (int) $result );
+	}
+
 	public function testFind_CacheEnabled_WarmsIndividualCaches(): void {
 		/* Arrange. */
 		$wpdb = $this->createMock( wpdb::class );

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
@@ -621,7 +621,7 @@ class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->create( $quiz_id, $user_id, $lesson_id );
 
 		/* Assert. */
-		$table  = $wpdb->prefix . 'sensei_lms_progress';
+		$table = $wpdb->prefix . 'sensei_lms_progress';
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $wpdb->get_var(
 			$wpdb->prepare(

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -5,6 +5,8 @@
  * @package sensei
  */
 
+use Sensei\Internal\Migration\Migration_Job_Scheduler;
+
 /**
  * Tests for the class `Sensei_Updates`.
  *
@@ -217,5 +219,145 @@ END;
 				'question_category_id' => 0,
 			]
 		);
+	}
+
+	/**
+	 * Test that new installs skip the parent_post_id backfill.
+	 */
+	public function testBackfillParentPostIdSkippedOnNewInstall() {
+		$scheduler = $this->createMock( Migration_Job_Scheduler::class );
+		$scheduler->expects( $this->never() )
+			->method( 'schedule_job_by_name' );
+
+		$original_scheduler           = Sensei()->migration_scheduler;
+		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
+		Sensei()->migration_scheduler = $scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
+
+		$updates = new Sensei_Updates( null, true, false );
+		$updates->run_updates();
+
+		Sensei()->migration_scheduler = $original_scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
+		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
+	}
+
+	/**
+	 * Test that upgrades without HPPS sync enabled skip the backfill.
+	 */
+	public function testBackfillParentPostIdSkippedWhenSyncDisabled() {
+		$scheduler = $this->createMock( Migration_Job_Scheduler::class );
+		$scheduler->expects( $this->never() )
+			->method( 'schedule_job_by_name' );
+
+		$original_scheduler           = Sensei()->migration_scheduler;
+		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
+		Sensei()->migration_scheduler = $scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = false;
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
+
+		$updates = new Sensei_Updates( '4.25.0', false, true );
+		$updates->run_updates();
+
+		Sensei()->migration_scheduler = $original_scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
+		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
+	}
+
+	/**
+	 * Test that upgrades where previous migration is not complete skip the backfill.
+	 */
+	public function testBackfillParentPostIdSkippedWhenMigrationNotComplete() {
+		$scheduler = $this->getMockBuilder( Migration_Job_Scheduler::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'is_complete', 'schedule_job_by_name' ] )
+			->getMock();
+		$scheduler->expects( $this->once() )
+			->method( 'is_complete' )
+			->willReturn( false );
+		$scheduler->expects( $this->never() )
+			->method( 'schedule_job_by_name' );
+
+		$original_scheduler           = Sensei()->migration_scheduler;
+		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
+		Sensei()->migration_scheduler = $scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+
+		$updates = new Sensei_Updates( '4.25.0', false, true );
+		$updates->run_updates();
+
+		Sensei()->migration_scheduler = $original_scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
+	}
+
+	/**
+	 * Test that the backfill job is scheduled and status is reset when all conditions are met.
+	 */
+	public function testBackfillParentPostIdScheduledWhenConditionsMet() {
+		$scheduler = $this->getMockBuilder( Migration_Job_Scheduler::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'is_complete', 'schedule_job_by_name' ] )
+			->getMock();
+		$scheduler->expects( $this->once() )
+			->method( 'is_complete' )
+			->willReturn( true );
+		$scheduler->expects( $this->once() )
+			->method( 'schedule_job_by_name' )
+			->with( 'parent_post_id_migration' );
+
+		$original_scheduler           = Sensei()->migration_scheduler;
+		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
+		Sensei()->migration_scheduler = $scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
+
+		$updates = new Sensei_Updates( '4.25.0', false, true );
+		$updates->run_updates();
+
+		$this->assertEquals(
+			Migration_Job_Scheduler::STATUS_NOT_STARTED,
+			get_option( Migration_Job_Scheduler::STATUS_OPTION_NAME ),
+			'Migration status should be reset to NOT_STARTED after scheduling.'
+		);
+
+		Sensei()->migration_scheduler = $original_scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
+		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
+	}
+
+	/**
+	 * Test that status is not reset when scheduling fails.
+	 */
+	public function testBackfillParentPostIdStatusNotResetOnSchedulingFailure() {
+		$scheduler = $this->getMockBuilder( Migration_Job_Scheduler::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'is_complete', 'schedule_job_by_name' ] )
+			->getMock();
+		$scheduler->expects( $this->once() )
+			->method( 'is_complete' )
+			->willReturn( true );
+		$scheduler->expects( $this->once() )
+			->method( 'schedule_job_by_name' )
+			->willThrowException( new \RuntimeException( 'Unknown job: parent_post_id_migration' ) );
+
+		$original_scheduler           = Sensei()->migration_scheduler;
+		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
+		Sensei()->migration_scheduler = $scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
+
+		$updates = new Sensei_Updates( '4.25.0', false, true );
+		$updates->run_updates();
+
+		$this->assertEquals(
+			Migration_Job_Scheduler::STATUS_COMPLETE,
+			get_option( Migration_Job_Scheduler::STATUS_OPTION_NAME ),
+			'Migration status should remain COMPLETE when scheduling fails.'
+		);
+
+		Sensei()->migration_scheduler = $original_scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
+		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -24,6 +24,20 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 	protected $factory;
 
 	/**
+	 * Original migration scheduler, saved before backfill tests.
+	 *
+	 * @var Migration_Job_Scheduler|null
+	 */
+	private $original_scheduler;
+
+	/**
+	 * Original sync setting, saved before backfill tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_sync;
+
+	/**
 	 * Setup function.
 	 */
 	public function setUp(): void {
@@ -34,6 +48,21 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 		self::restoreShimScheduler();
 
 		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Teardown function.
+	 */
+	public function tearDown(): void {
+		if ( null !== $this->original_scheduler ) {
+			Sensei()->migration_scheduler = $this->original_scheduler;
+			Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $this->original_sync;
+			$this->original_scheduler = null;
+			$this->original_sync      = null;
+			delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
+		}
+
+		parent::tearDown();
 	}
 
 	/**
@@ -229,18 +258,11 @@ END;
 		$scheduler->expects( $this->never() )
 			->method( 'schedule_job_by_name' );
 
-		$original_scheduler           = Sensei()->migration_scheduler;
-		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
-		Sensei()->migration_scheduler = $scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+		$this->set_backfill_test_context( $scheduler, true );
 		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
 
 		$updates = new Sensei_Updates( null, true, false );
 		$updates->run_updates();
-
-		Sensei()->migration_scheduler = $original_scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
-		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
 	}
 
 	/**
@@ -251,18 +273,11 @@ END;
 		$scheduler->expects( $this->never() )
 			->method( 'schedule_job_by_name' );
 
-		$original_scheduler           = Sensei()->migration_scheduler;
-		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
-		Sensei()->migration_scheduler = $scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = false;
+		$this->set_backfill_test_context( $scheduler, false );
 		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
 
 		$updates = new Sensei_Updates( '4.25.0', false, true );
 		$updates->run_updates();
-
-		Sensei()->migration_scheduler = $original_scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
-		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
 	}
 
 	/**
@@ -279,16 +294,10 @@ END;
 		$scheduler->expects( $this->never() )
 			->method( 'schedule_job_by_name' );
 
-		$original_scheduler           = Sensei()->migration_scheduler;
-		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
-		Sensei()->migration_scheduler = $scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+		$this->set_backfill_test_context( $scheduler, true );
 
 		$updates = new Sensei_Updates( '4.25.0', false, true );
 		$updates->run_updates();
-
-		Sensei()->migration_scheduler = $original_scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
 	}
 
 	/**
@@ -306,10 +315,7 @@ END;
 			->method( 'schedule_job_by_name' )
 			->with( 'parent_post_id_migration' );
 
-		$original_scheduler           = Sensei()->migration_scheduler;
-		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
-		Sensei()->migration_scheduler = $scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+		$this->set_backfill_test_context( $scheduler, true );
 		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
 
 		$updates = new Sensei_Updates( '4.25.0', false, true );
@@ -320,10 +326,6 @@ END;
 			get_option( Migration_Job_Scheduler::STATUS_OPTION_NAME ),
 			'Migration status should be reset to NOT_STARTED after scheduling.'
 		);
-
-		Sensei()->migration_scheduler = $original_scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
-		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
 	}
 
 	/**
@@ -341,10 +343,7 @@ END;
 			->method( 'schedule_job_by_name' )
 			->willThrowException( new \RuntimeException( 'Unknown job: parent_post_id_migration' ) );
 
-		$original_scheduler           = Sensei()->migration_scheduler;
-		$original_sync                = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
-		Sensei()->migration_scheduler = $scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = true;
+		$this->set_backfill_test_context( $scheduler, true );
 		update_option( Migration_Job_Scheduler::STATUS_OPTION_NAME, Migration_Job_Scheduler::STATUS_COMPLETE );
 
 		$updates = new Sensei_Updates( '4.25.0', false, true );
@@ -355,9 +354,21 @@ END;
 			get_option( Migration_Job_Scheduler::STATUS_OPTION_NAME ),
 			'Migration status should remain COMPLETE when scheduling fails.'
 		);
+	}
 
-		Sensei()->migration_scheduler = $original_scheduler;
-		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $original_sync;
-		delete_option( Migration_Job_Scheduler::STATUS_OPTION_NAME );
+	/**
+	 * Set up the migration scheduler mock and sync setting for backfill tests.
+	 *
+	 * Saves originals so tearDown() can restore them automatically.
+	 *
+	 * @param Migration_Job_Scheduler|\PHPUnit\Framework\MockObject\MockObject $scheduler The mock scheduler.
+	 * @param bool                                                              $sync_enabled Whether sync is enabled.
+	 */
+	private function set_backfill_test_context( $scheduler, bool $sync_enabled ): void {
+		$this->original_scheduler = Sensei()->migration_scheduler;
+		$this->original_sync      = Sensei()->settings->settings['experimental_progress_storage_synchronization'] ?? false;
+
+		Sensei()->migration_scheduler = $scheduler;
+		Sensei()->settings->settings['experimental_progress_storage_synchronization'] = $sync_enabled;
 	}
 }

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -224,7 +224,7 @@ END;
 	/**
 	 * Test that new installs skip the parent_post_id backfill.
 	 */
-	public function testBackfillParentPostIdSkippedOnNewInstall() {
+	public function testBackfillParentPostId_NewInstall_Skipped() {
 		$scheduler = $this->createMock( Migration_Job_Scheduler::class );
 		$scheduler->expects( $this->never() )
 			->method( 'schedule_job_by_name' );
@@ -246,7 +246,7 @@ END;
 	/**
 	 * Test that upgrades without HPPS sync enabled skip the backfill.
 	 */
-	public function testBackfillParentPostIdSkippedWhenSyncDisabled() {
+	public function testBackfillParentPostId_SyncDisabled_Skipped() {
 		$scheduler = $this->createMock( Migration_Job_Scheduler::class );
 		$scheduler->expects( $this->never() )
 			->method( 'schedule_job_by_name' );
@@ -268,7 +268,7 @@ END;
 	/**
 	 * Test that upgrades where previous migration is not complete skip the backfill.
 	 */
-	public function testBackfillParentPostIdSkippedWhenMigrationNotComplete() {
+	public function testBackfillParentPostId_MigrationNotComplete_Skipped() {
 		$scheduler = $this->getMockBuilder( Migration_Job_Scheduler::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'is_complete', 'schedule_job_by_name' ] )
@@ -294,7 +294,7 @@ END;
 	/**
 	 * Test that the backfill job is scheduled and status is reset when all conditions are met.
 	 */
-	public function testBackfillParentPostIdScheduledWhenConditionsMet() {
+	public function testBackfillParentPostId_AllConditionsMet_SchedulesJob() {
 		$scheduler = $this->getMockBuilder( Migration_Job_Scheduler::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'is_complete', 'schedule_job_by_name' ] )
@@ -329,7 +329,7 @@ END;
 	/**
 	 * Test that status is not reset when scheduling fails.
 	 */
-	public function testBackfillParentPostIdStatusNotResetOnSchedulingFailure() {
+	public function testBackfillParentPostId_SchedulingFails_StatusNotReset() {
 		$scheduler = $this->getMockBuilder( Migration_Job_Scheduler::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'is_complete', 'schedule_job_by_name' ] )


### PR DESCRIPTION
## Summary

This prepares the data model for reusable lessons by storing hierarchy relationships directly in the `sensei_lms_progress` table, eliminating the need for `postmeta` joins.

This data wasn't populated prior to shipping HPPS, so it needs to be backfilled for those sites that have it enabled and are actively syncing between comments and custom tables.

- Adds an optional `$parent_post_id` parameter to all progress repository `create()` interfaces and implementations (backward-compatible, defaults to `null`)
- Updates all callers (`Sensei_Utils::user_start_lesson()`, `Sensei_Quiz`, `Sensei_Grading`) to look up and pass the parent ID: **course ID** for lesson progress, **lesson ID** for quiz progress
- Updates the comments-to-tables `Student_Progress_Migration` to populate `parent_post_id` during initial migration
- Adds a new `Parent_Post_Id_Migration` backfill job for existing HPPS sites that already have progress rows with `NULL` parent_post_id

## Test plan

### Automated tests

- [x] `vendor/bin/phpunit --filter=testCreate_WhenParentPostIdProvided` — verifies both lesson and quiz repositories store parent_post_id
- [x] `vendor/bin/phpunit --filter=Parent_Post_Id_Migration_Test` — 8 tests covering backfill migration (batching, idempotency, orphaned rows, completion)
- [x] `vendor/bin/phpunit --filter=testRun_WithLessonAndQuiz_PopulatesParentPostId` — verifies comments-to-tables migration populates parent_post_id
- [x] `vendor/bin/phpunit --filter=testBackfillParentPostId` — 5 tests covering upgrade handler conditions

### Manual testing — new progress creation

1. Set up a local site with HPPS enabled (`Sensei > Settings > Experimental Features > High Performance Progress Storage`)
2. Create a course with a lesson and a quiz
3. Enroll a student and have them start the lesson
4. Check the `sensei_lms_progress` table:
   ```sql
   SELECT id, post_id, parent_post_id, type FROM wp_sensei_lms_progress ORDER BY id DESC;
   ```
5. Verify:
   - [x] Lesson progress row has `parent_post_id` = the course ID
   - [x] Quiz progress row (if quiz was started) has `parent_post_id` = the lesson ID
   - [x] Course progress row has `parent_post_id` = NULL

### Manual testing — backfill migration

1. On a site with HPPS enabled and existing progress data, null out `parent_post_id` to simulate pre-existing rows:
   ```sql
   UPDATE wp_sensei_lms_progress SET parent_post_id = NULL WHERE type IN ('lesson', 'quiz');
   SELECT COUNT(*) FROM wp_sensei_lms_progress WHERE parent_post_id IS NULL AND type IN ('lesson', 'quiz');
   ```
2. Trigger the upgrade handler by decrementing the stored version:
   ```bash
   wp option update sensei-version 4.25.0
   ```
3. Visit any admin page — `run_updates()` fires and schedules the Action Scheduler job (`sensei_lms_migration_job_parent_post_id_migration`)
4. Run the scheduled action:
   ```bash
   wp action-scheduler run
   ```
5. After migration completes, verify NULL count is 0 (or only orphaned records with no postmeta):
   ```sql
   SELECT COUNT(*) FROM wp_sensei_lms_progress WHERE parent_post_id IS NULL AND type IN ('lesson', 'quiz');
   ```
6. Verify values are correct:
   ```sql
   -- Lesson progress: parent_post_id should match _lesson_course meta
   SELECT p.id, p.post_id AS lesson_id, p.parent_post_id, pm.meta_value AS expected_course_id
   FROM wp_sensei_lms_progress p
   LEFT JOIN wp_postmeta pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_course'
   WHERE p.type = 'lesson' AND p.parent_post_id IS NOT NULL;

   -- Quiz progress: parent_post_id should match _quiz_lesson meta
   SELECT p.id, p.post_id AS quiz_id, p.parent_post_id, pm.meta_value AS expected_lesson_id
   FROM wp_sensei_lms_progress p
   LEFT JOIN wp_postmeta pm ON pm.post_id = p.post_id AND pm.meta_key = '_quiz_lesson'
   WHERE p.type = 'quiz' AND p.parent_post_id IS NOT NULL;
   ```
7. - [x] Confirm `parent_post_id` matches the expected value from postmeta in both queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
