### PR TITLE
Fix silent insert failure in tables-based progress repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,6 @@
 
 ## Conventions
 - **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `npm run changelog` (entries stored in `changelog/`).
+
+## Pull Requests
+- **Test plans**: Do not include running tests or linters as test plan steps. CI already handles that. Test plans should only cover manual verification.

--- a/changelog/fix-tables-based-repo-insert-error-handling
+++ b/changelog/fix-tables-based-repo-insert-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add error handling for failed database inserts in tables-based progress repositories.

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -819,7 +819,16 @@ class Sensei_Frontend {
 				case __( 'Mark as Complete', 'sensei-lms' ):
 					$course_progress = Sensei()->course_progress_repository->get( $sanitized_course_id, $current_user->ID );
 					if ( null === $course_progress ) {
-						$course_progress = Sensei()->course_progress_repository->create( $sanitized_course_id, $current_user->ID );
+						try {
+							$course_progress = Sensei()->course_progress_repository->create( $sanitized_course_id, $current_user->ID );
+						} catch ( \RuntimeException $e ) {
+							error_log( 'Sensei: ' . $e->getMessage() );
+							Sensei()->notices->add_notice(
+								__( 'An error occurred while completing the course. Please try again.', 'sensei-lms' ),
+								'alert'
+							);
+							break;
+						}
 					}
 
 					$course_lesson_ids = Sensei()->course->course_lessons( $sanitized_course_id, 'any', 'ids' );

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -822,6 +822,7 @@ class Sensei_Frontend {
 						try {
 							$course_progress = Sensei()->course_progress_repository->create( $sanitized_course_id, $current_user->ID );
 						} catch ( \RuntimeException $e ) {
+							// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 							error_log( 'Sensei: ' . $e->getMessage() );
 							Sensei()->notices->add_notice(
 								__( 'An error occurred while completing the course. Please try again.', 'sensei-lms' ),

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -848,12 +848,6 @@ class Sensei_Grading {
 			} catch ( \RuntimeException $e ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 				error_log( 'Sensei: ' . $e->getMessage() );
-				add_settings_error(
-					'sensei_grading',
-					'progress_create_failed',
-					__( 'Could not create lesson progress record. Please try again.', 'sensei-lms' ),
-					'error'
-				);
 				return false;
 			}
 		}

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -843,7 +843,18 @@ class Sensei_Grading {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $quiz_lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id );
+			try {
+				$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id );
+			} catch ( \RuntimeException $e ) {
+				error_log( 'Sensei: ' . $e->getMessage() );
+				add_settings_error(
+					'sensei_grading',
+					'progress_create_failed',
+					__( 'Could not create lesson progress record. Please try again.', 'sensei-lms' ),
+					'error'
+				);
+				return false;
+			}
 		}
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -846,6 +846,7 @@ class Sensei_Grading {
 			try {
 				$lesson_progress = Sensei()->lesson_progress_repository->create( $quiz_lesson_id, $user_id );
 			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 				error_log( 'Sensei: ' . $e->getMessage() );
 				add_settings_error(
 					'sensei_grading',

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1150,9 +1150,20 @@ class Sensei_Quiz {
 			$answers_map[ $answer->get_question_id() ] = $answer;
 		}
 
-		foreach ( $quiz_grades as $question_id => $points ) {
-			$answer = $answers_map[ $question_id ];
-			Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, $points );
+		try {
+			foreach ( $quiz_grades as $question_id => $points ) {
+				$answer = $answers_map[ $question_id ];
+				Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, $points );
+			}
+		} catch ( \RuntimeException $e ) {
+			error_log( 'Sensei: ' . $e->getMessage() );
+			add_settings_error(
+				'sensei_grading',
+				'grade_create_failed',
+				__( 'Could not save quiz grades. Please try again.', 'sensei-lms' ),
+				'error'
+			);
+			return false;
 		}
 
 		$transient_key = 'quiz_grades_' . $user_id . '_' . $lesson_id;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -426,8 +426,8 @@ class Sensei_Quiz {
 		Sensei()->quiz_grade_repository->delete_all( $submission );
 		Sensei()->quiz_answer_repository->delete_all( $submission );
 
-		// Note: A mid-loop failure may leave partial answers saved. A user retry will
-		// delete_all and re-insert, which is the correct recovery path.
+		// If a create() fails partway through, some answers will already be saved.
+		// On retry, the delete_all() calls above clear old data before re-inserting.
 		try {
 			foreach ( $prepared_answers as $question_id => $answer ) {
 				Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer );
@@ -1155,8 +1155,8 @@ class Sensei_Quiz {
 			$answers_map[ $answer->get_question_id() ] = $answer;
 		}
 
-		// Note: A mid-loop failure may leave partial grades saved. A retry will
-		// delete_all and re-insert, which is the correct recovery path.
+		// If a create() fails partway through, some grades will already be saved.
+		// On retry, grade_repository->delete_all() is called before re-grading.
 		try {
 			foreach ( $quiz_grades as $question_id => $points ) {
 				$answer = $answers_map[ $question_id ];

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -414,6 +414,7 @@ class Sensei_Quiz {
 		try {
 			$submission = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
 		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 			error_log( 'Sensei: ' . $e->getMessage() );
 			Sensei()->notices->add_notice(
 				__( 'An error occurred while saving your answers. Please try again.', 'sensei-lms' ),
@@ -432,6 +433,7 @@ class Sensei_Quiz {
 				Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer );
 			}
 		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 			error_log( 'Sensei: ' . $e->getMessage() );
 			Sensei()->notices->add_notice(
 				__( 'An error occurred while saving your answers. Please try again.', 'sensei-lms' ),
@@ -974,6 +976,7 @@ class Sensei_Quiz {
 			try {
 				$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
 			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 				error_log( 'Sensei: ' . $e->getMessage() );
 				Sensei()->notices->add_notice(
 					__( 'An error occurred while submitting your quiz. Please try again.', 'sensei-lms' ),
@@ -1160,6 +1163,7 @@ class Sensei_Quiz {
 				Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, $points );
 			}
 		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 			error_log( 'Sensei: ' . $e->getMessage() );
 			add_settings_error(
 				'sensei_grading',
@@ -2471,6 +2475,7 @@ class Sensei_Quiz {
 		try {
 			$quiz_progress_repository->create( $quiz_id, $user_id );
 		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 			error_log( 'Sensei: ' . $e->getMessage() );
 			Sensei()->notices->add_notice(
 				__( 'An error occurred while loading the quiz. Please try again.', 'sensei-lms' ),

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -425,6 +425,8 @@ class Sensei_Quiz {
 		Sensei()->quiz_grade_repository->delete_all( $submission );
 		Sensei()->quiz_answer_repository->delete_all( $submission );
 
+		// Note: A mid-loop failure may leave partial answers saved. A user retry will
+		// delete_all and re-insert, which is the correct recovery path.
 		try {
 			foreach ( $prepared_answers as $question_id => $answer ) {
 				Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer );
@@ -1150,6 +1152,8 @@ class Sensei_Quiz {
 			$answers_map[ $answer->get_question_id() ] = $answer;
 		}
 
+		// Note: A mid-loop failure may leave partial grades saved. A retry will
+		// delete_all and re-insert, which is the correct recovery path.
 		try {
 			foreach ( $quiz_grades as $question_id => $points ) {
 				$answer = $answers_map[ $question_id ];

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -411,13 +411,31 @@ class Sensei_Quiz {
 		}
 
 		// save the user data
-		$submission = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
+		try {
+			$submission = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			error_log( 'Sensei: ' . $e->getMessage() );
+			Sensei()->notices->add_notice(
+				__( 'An error occurred while saving your answers. Please try again.', 'sensei-lms' ),
+				'alert'
+			);
+			return false;
+		}
 
 		Sensei()->quiz_grade_repository->delete_all( $submission );
 		Sensei()->quiz_answer_repository->delete_all( $submission );
 
-		foreach ( $prepared_answers as $question_id => $answer ) {
-			Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer );
+		try {
+			foreach ( $prepared_answers as $question_id => $answer ) {
+				Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer );
+			}
+		} catch ( \RuntimeException $e ) {
+			error_log( 'Sensei: ' . $e->getMessage() );
+			Sensei()->notices->add_notice(
+				__( 'An error occurred while saving your answers. Please try again.', 'sensei-lms' ),
+				'alert'
+			);
+			return false;
 		}
 
 		// Save transient to make retrieval faster.
@@ -951,7 +969,16 @@ class Sensei_Quiz {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			try {
+				$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			} catch ( \RuntimeException $e ) {
+				error_log( 'Sensei: ' . $e->getMessage() );
+				Sensei()->notices->add_notice(
+					__( 'An error occurred while submitting your quiz. Please try again.', 'sensei-lms' ),
+					'alert'
+				);
+				return false;
+			}
 		}
 
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
@@ -2426,7 +2453,16 @@ class Sensei_Quiz {
 			return;
 		}
 
-		$quiz_progress_repository->create( $quiz_id, $user_id );
+		try {
+			$quiz_progress_repository->create( $quiz_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			error_log( 'Sensei: ' . $e->getMessage() );
+			Sensei()->notices->add_notice(
+				__( 'An error occurred while loading the quiz. Please try again.', 'sensei-lms' ),
+				'alert'
+			);
+			return;
+		}
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1165,12 +1165,6 @@ class Sensei_Quiz {
 		} catch ( \RuntimeException $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 			error_log( 'Sensei: ' . $e->getMessage() );
-			add_settings_error(
-				'sensei_grading',
-				'grade_create_failed',
-				__( 'Could not save quiz grades. Please try again.', 'sensei-lms' ),
-				'error'
-			);
 			return false;
 		}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -603,8 +603,17 @@ class Sensei_Utils {
 
 		$lesson_progress = Sensei()->lesson_progress_repository->get( $lesson_id, $user_id );
 		if ( ! $lesson_progress ) {
-			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
-			$has_questions   = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
+			try {
+				$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			} catch ( \RuntimeException $e ) {
+				error_log( 'Sensei: ' . $e->getMessage() );
+				Sensei()->notices->add_notice(
+					__( 'An error occurred while starting the lesson. Please try again.', 'sensei-lms' ),
+					'alert'
+				);
+				return;
+			}
+			$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 			if ( $complete && $has_questions ) {
 				update_comment_meta( $lesson_progress->get_id(), 'grade', 0 );
 			}
@@ -1580,7 +1589,16 @@ class Sensei_Utils {
 
 		$course_progress = Sensei()->course_progress_repository->get( $course_id, $user_id );
 		if ( ! $course_progress ) {
-			$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
+			try {
+				$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
+			} catch ( \RuntimeException $e ) {
+				error_log( 'Sensei: ' . $e->getMessage() );
+				Sensei()->notices->add_notice(
+					__( 'An error occurred while completing the course. Please try again.', 'sensei-lms' ),
+					'alert'
+				);
+				return false;
+			}
 		}
 		if ( ! $course_progress->get_started_at() ) {
 			$course_progress->start();
@@ -2671,7 +2689,16 @@ class Sensei_Utils {
 	 * @return int Returns the ID of the user course progress or false on failure. The progress ID might have different meanings depending on the underlying implementation.
 	 */
 	public static function start_user_on_course( $user_id, $course_id ) {
-		$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
+		try {
+			$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			error_log( 'Sensei: ' . $e->getMessage() );
+			Sensei()->notices->add_notice(
+				__( 'An error occurred while starting the course. Please try again.', 'sensei-lms' ),
+				'alert'
+			);
+			return 0;
+		}
 
 		// Allow further actions.
 		$course_metadata = [

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2688,7 +2688,7 @@ class Sensei_Utils {
 	 *
 	 * @param int $user_id The user ID.
 	 * @param int $course_id The course ID.
-	 * @return int Returns the ID of the user course progress or false on failure. The progress ID might have different meanings depending on the underlying implementation.
+	 * @return int|false Returns the ID of the user course progress or false on failure. The progress ID might have different meanings depending on the underlying implementation.
 	 */
 	public static function start_user_on_course( $user_id, $course_id ) {
 		try {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -606,12 +606,13 @@ class Sensei_Utils {
 			try {
 				$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
 			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 				error_log( 'Sensei: ' . $e->getMessage() );
 				Sensei()->notices->add_notice(
 					__( 'An error occurred while starting the lesson. Please try again.', 'sensei-lms' ),
 					'alert'
 				);
-				return;
+				return false;
 			}
 			$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 			if ( $complete && $has_questions ) {
@@ -1592,6 +1593,7 @@ class Sensei_Utils {
 			try {
 				$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
 			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 				error_log( 'Sensei: ' . $e->getMessage() );
 				Sensei()->notices->add_notice(
 					__( 'An error occurred while completing the course. Please try again.', 'sensei-lms' ),
@@ -2692,6 +2694,7 @@ class Sensei_Utils {
 		try {
 			$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
 		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging database insert failure.
 			error_log( 'Sensei: ' . $e->getMessage() );
 			Sensei()->notices->add_notice(
 				__( 'An error occurred while starting the course. Please try again.', 'sensei-lms' ),

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2697,7 +2697,7 @@ class Sensei_Utils {
 				__( 'An error occurred while starting the course. Please try again.', 'sensei-lms' ),
 				'alert'
 			);
-			return 0;
+			return false;
 		}
 
 		// Allow further actions.

--- a/includes/internal/quiz-submission/answer/repositories/class-answer-repository-interface.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-answer-repository-interface.php
@@ -31,6 +31,7 @@ interface Answer_Repository_Interface {
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Answer_Interface The answer model.
 	 */
 	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface;

--- a/includes/internal/quiz-submission/answer/repositories/class-comment-reading-aggregate-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-comment-reading-aggregate-answer-repository.php
@@ -73,13 +73,19 @@ class Comment_Reading_Aggregate_Answer_Repository implements Answer_Repository_I
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
+	 * @throws \RuntimeException If answer creation fails.
 	 * @return Answer_Interface The answer model.
 	 */
 	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface {
 		$answer = $this->comments_based_repository->create( $submission, $question_id, $value );
 
-		$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
-		$this->tables_based_repository->create( $tables_based_submission, $question_id, $value );
+		try {
+			$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
+			$this->tables_based_repository->create( $tables_based_submission, $question_id, $value );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 
 		return $answer;
 	}
@@ -107,8 +113,13 @@ class Comment_Reading_Aggregate_Answer_Repository implements Answer_Repository_I
 	public function delete_all( Submission_Interface $submission ): void {
 		$this->comments_based_repository->delete_all( $submission );
 
-		$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
-		$this->tables_based_repository->delete_all( $tables_based_submission );
+		try {
+			$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
+			$this->tables_based_repository->delete_all( $tables_based_submission );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/internal/quiz-submission/answer/repositories/class-table-reading-aggregate-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-table-reading-aggregate-answer-repository.php
@@ -73,13 +73,19 @@ class Table_Reading_Aggregate_Answer_Repository implements Answer_Repository_Int
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Answer_Interface The answer model.
 	 */
 	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface {
 		$answer = $this->tables_based_repository->create( $submission, $question_id, $value );
 
-		$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
-		$this->comments_based_repository->create( $comments_based_submission, $question_id, $value );
+		try {
+			$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
+			$this->comments_based_repository->create( $comments_based_submission, $question_id, $value );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 
 		return $answer;
 	}
@@ -107,8 +113,13 @@ class Table_Reading_Aggregate_Answer_Repository implements Answer_Repository_Int
 	public function delete_all( Submission_Interface $submission ): void {
 		$this->tables_based_repository->delete_all( $submission );
 
-		$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
-		$this->comments_based_repository->delete_all( $comments_based_submission );
+		try {
+			$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
+			$this->comments_based_repository->delete_all( $comments_based_submission );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
@@ -117,7 +117,8 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 		);
 
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz answer for submission %d, question %d: %s', $submission_id, $question_id, $this->wpdb->last_error ) ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are for logging, not display.
+			throw new \RuntimeException( sprintf( 'Failed to create quiz answer for submission %d, question %d: %s', $submission_id, $question_id, $this->wpdb->last_error ) );
 		}
 
 		$answer = new Tables_Based_Answer(

--- a/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
@@ -66,6 +66,7 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 	 * @param int                  $question_id The question ID.
 	 * @param string               $value       The answer value.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Answer_Interface The answer model.
 	 */
 	public function create( Submission_Interface $submission, int $question_id, string $value ): Answer_Interface {

--- a/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-tables-based-answer-repository.php
@@ -97,7 +97,7 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
 
-		$this->wpdb->insert(
+		$result = $this->wpdb->insert(
 			$this->get_table_name(),
 			[
 				'submission_id' => $submission_id,
@@ -114,6 +114,10 @@ class Tables_Based_Answer_Repository implements Answer_Repository_Interface {
 				'%s',
 			]
 		);
+
+		if ( false === $result ) {
+			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz answer for submission %d, question %d: %s', $submission_id, $question_id, $this->wpdb->last_error ) ) );
+		}
 
 		$answer = new Tables_Based_Answer(
 			$this->wpdb->insert_id,

--- a/includes/internal/quiz-submission/grade/repositories/class-comment-reading-aggregate-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-comment-reading-aggregate-grade-repository.php
@@ -101,17 +101,23 @@ class Comment_Reading_Aggregate_Grade_Repository implements Grade_Repository_Int
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
+	 * @throws \RuntimeException If grade creation fails.
 	 * @return Grade_Interface The grade.
 	 */
 	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade_Interface {
 		$grade = $this->comments_based_repository->create( $submission, $answer, $question_id, $points, $feedback );
 
-		$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
-		$tables_based_answers    = $this->get_or_create_tables_based_answers( $submission, $tables_based_submission );
-		$tables_based_answer     = $tables_based_answers[ $question_id ] ?? null;
+		try {
+			$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
+			$tables_based_answers    = $this->get_or_create_tables_based_answers( $submission, $tables_based_submission );
+			$tables_based_answer     = $tables_based_answers[ $question_id ] ?? null;
 
-		if ( $tables_based_answer ) {
-			$this->tables_based_repository->create( $tables_based_submission, $tables_based_answer, $question_id, $points, $feedback );
+			if ( $tables_based_answer ) {
+				$this->tables_based_repository->create( $tables_based_submission, $tables_based_answer, $question_id, $points, $feedback );
+			}
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
 		}
 
 		return $grade;
@@ -131,7 +137,7 @@ class Comment_Reading_Aggregate_Grade_Repository implements Grade_Repository_Int
 		foreach ( $comments_based_answers as $comments_based_answer ) {
 			$filtered = array_filter(
 				$tables_based_answers,
-				function( Answer_Interface $answer ) use ( $comments_based_answer ) {
+				function ( Answer_Interface $answer ) use ( $comments_based_answer ) {
 					return $answer->get_question_id() === $comments_based_answer->get_question_id();
 				}
 			);
@@ -174,35 +180,40 @@ class Comment_Reading_Aggregate_Grade_Repository implements Grade_Repository_Int
 	public function save_many( Submission_Interface $submission, array $grades ): void {
 		$this->comments_based_repository->save_many( $submission, $grades );
 
-		$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
-		$tables_based_grades     = $this->get_or_create_tables_based_grades_for_save(
-			$submission,
-			$tables_based_submission,
-			$grades
-		);
+		try {
+			$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
+			$tables_based_grades     = $this->get_or_create_tables_based_grades_for_save(
+				$submission,
+				$tables_based_submission,
+				$grades
+			);
 
-		$grades_to_save = [];
-		foreach ( $grades as $grade ) {
-			$tables_based_grade = $tables_based_grades[ $grade->get_question_id() ] ?? null;
-			if ( null === $tables_based_grade ) {
-				continue;
+			$grades_to_save = [];
+			foreach ( $grades as $grade ) {
+				$tables_based_grade = $tables_based_grades[ $grade->get_question_id() ] ?? null;
+				if ( null === $tables_based_grade ) {
+					continue;
+				}
+
+				$created_at = new DateTimeImmutable( '@' . $grade->get_created_at()->getTimestamp() );
+				$updated_at = new DateTimeImmutable( '@' . $grade->get_updated_at()->getTimestamp() );
+
+				$grades_to_save[] = new Tables_Based_Grade(
+					$tables_based_grade->get_id(),
+					$tables_based_grade->get_answer_id(),
+					$tables_based_grade->get_question_id(),
+					$grade->get_points(),
+					$grade->get_feedback(),
+					$created_at,
+					$updated_at
+				);
 			}
 
-			$created_at = new DateTimeImmutable( '@' . $grade->get_created_at()->getTimestamp() );
-			$updated_at = new DateTimeImmutable( '@' . $grade->get_updated_at()->getTimestamp() );
-
-			$grades_to_save[] = new Tables_Based_Grade(
-				$tables_based_grade->get_id(),
-				$tables_based_grade->get_answer_id(),
-				$tables_based_grade->get_question_id(),
-				$grade->get_points(),
-				$grade->get_feedback(),
-				$created_at,
-				$updated_at
-			);
+			$this->tables_based_repository->save_many( $tables_based_submission, $grades_to_save );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
 		}
-
-		$this->tables_based_repository->save_many( $tables_based_submission, $grades_to_save );
 	}
 
 	/**
@@ -227,7 +238,7 @@ class Comment_Reading_Aggregate_Grade_Repository implements Grade_Repository_Int
 		foreach ( $comments_based_grades as $comments_based_grade ) {
 			$filtered = array_filter(
 				$tables_based_grades,
-				function( Grade_Interface $grade ) use ( $comments_based_grade ) {
+				function ( Grade_Interface $grade ) use ( $comments_based_grade ) {
 					return $grade->get_question_id() === $comments_based_grade->get_question_id();
 				}
 			);
@@ -263,8 +274,13 @@ class Comment_Reading_Aggregate_Grade_Repository implements Grade_Repository_Int
 	public function delete_all( Submission_Interface $submission ): void {
 		$this->comments_based_repository->delete_all( $submission );
 
-		$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
-		$this->tables_based_repository->delete_all( $tables_based_submission );
+		try {
+			$tables_based_submission = $this->get_or_create_tables_based_submission( $submission );
+			$this->tables_based_repository->delete_all( $tables_based_submission );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
@@ -37,7 +37,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, string $feedback = null ): Grade_Interface {
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade_Interface {
 		/**
 		 * Filters the submission ID when quiz grade is created.
 		 *

--- a/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
@@ -37,7 +37,7 @@ interface Grade_Repository_Interface {
 	 * @throws \RuntimeException If the database insert fails.
 	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, string $feedback = null ): Grade_Interface;
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade_Interface;
 
 	/**
 	 * Get all grades for a quiz submission.

--- a/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
@@ -34,6 +34,7 @@ interface Grade_Repository_Interface {
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Grade_Interface The grade.
 	 */
 	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, string $feedback = null ): Grade_Interface;

--- a/includes/internal/quiz-submission/grade/repositories/class-table-reading-aggregate-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-table-reading-aggregate-grade-repository.php
@@ -101,17 +101,23 @@ class Table_Reading_Aggregate_Grade_Repository implements Grade_Repository_Inter
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Grade_Interface The grade.
 	 */
 	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade_Interface {
 		$grade = $this->tables_based_repository->create( $submission, $answer, $question_id, $points, $feedback );
 
-		$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
-		$comments_based_answers    = $this->get_or_create_comments_based_answers( $submission, $comments_based_submission );
-		$comments_based_answer     = $comments_based_answers[ $question_id ] ?? null;
+		try {
+			$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
+			$comments_based_answers    = $this->get_or_create_comments_based_answers( $submission, $comments_based_submission );
+			$comments_based_answer     = $comments_based_answers[ $question_id ] ?? null;
 
-		if ( $comments_based_answer ) {
-			$this->comments_based_repository->create( $comments_based_submission, $comments_based_answer, $question_id, $points, $feedback );
+			if ( $comments_based_answer ) {
+				$this->comments_based_repository->create( $comments_based_submission, $comments_based_answer, $question_id, $points, $feedback );
+			}
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
 		}
 
 		return $grade;
@@ -131,7 +137,7 @@ class Table_Reading_Aggregate_Grade_Repository implements Grade_Repository_Inter
 		foreach ( $tables_based_answers as $tables_based_answer ) {
 			$filtered = array_filter(
 				$comments_based_answers,
-				function( Answer_Interface $answer ) use ( $tables_based_answer ) {
+				function ( Answer_Interface $answer ) use ( $tables_based_answer ) {
 					return $answer->get_question_id() === $tables_based_answer->get_question_id();
 				}
 			);
@@ -174,6 +180,7 @@ class Table_Reading_Aggregate_Grade_Repository implements Grade_Repository_Inter
 	public function save_many( Submission_Interface $submission, array $grades ): void {
 		$this->tables_based_repository->save_many( $submission, $grades );
 
+		try {
 			$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
 			$comments_based_grades     = $this->get_or_create_comments_based_grades_for_save(
 				$comments_based_submission,
@@ -182,25 +189,29 @@ class Table_Reading_Aggregate_Grade_Repository implements Grade_Repository_Inter
 			);
 
 			$grades_to_save = [];
-		foreach ( $grades as $grade ) {
-			$comments_based_grade = $comments_based_grades[ $grade->get_question_id() ] ?? null;
-			if ( null === $comments_based_grade ) {
-				continue;
+			foreach ( $grades as $grade ) {
+				$comments_based_grade = $comments_based_grades[ $grade->get_question_id() ] ?? null;
+				if ( null === $comments_based_grade ) {
+					continue;
+				}
+
+				$created_at = new DateTimeImmutable( '@' . $grade->get_created_at()->getTimestamp() );
+				$updated_at = new DateTimeImmutable( '@' . $grade->get_updated_at()->getTimestamp() );
+
+				$grades_to_save[] = new Comments_Based_Grade(
+					$comments_based_grade->get_question_id(),
+					$grade->get_points(),
+					$grade->get_feedback(),
+					$created_at,
+					$updated_at
+				);
 			}
 
-			$created_at = new DateTimeImmutable( '@' . $grade->get_created_at()->getTimestamp() );
-			$updated_at = new DateTimeImmutable( '@' . $grade->get_updated_at()->getTimestamp() );
-
-			$grades_to_save[] = new Comments_Based_Grade(
-				$comments_based_grade->get_question_id(),
-				$grade->get_points(),
-				$grade->get_feedback(),
-				$created_at,
-				$updated_at
-			);
-		}
-
 			$this->comments_based_repository->save_many( $comments_based_submission, $grades_to_save );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 	}
 
 	/**
@@ -225,7 +236,7 @@ class Table_Reading_Aggregate_Grade_Repository implements Grade_Repository_Inter
 		foreach ( $tables_based_grades as $tables_based_grade ) {
 			$filtered = array_filter(
 				$commments_based_grades,
-				function( Grade_Interface $grade ) use ( $tables_based_grade ) {
+				function ( Grade_Interface $grade ) use ( $tables_based_grade ) {
 					return $grade->get_question_id() === $tables_based_grade->get_question_id();
 				}
 			);
@@ -261,8 +272,13 @@ class Table_Reading_Aggregate_Grade_Repository implements Grade_Repository_Inter
 	public function delete_all( Submission_Interface $submission ): void {
 		$this->tables_based_repository->delete_all( $submission );
 
-		$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
-		$this->comments_based_repository->delete_all( $comments_based_submission );
+		try {
+			$comments_based_submission = $this->get_or_create_comments_based_submission( $submission );
+			$this->comments_based_repository->delete_all( $comments_based_submission );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
@@ -67,6 +67,7 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 	 * @param int                  $points      The points.
 	 * @param string|null          $feedback    The feedback.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Grade_Interface The grade.
 	 */
 	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade_Interface {

--- a/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
@@ -120,7 +120,8 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 		);
 
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz grade for answer %d, question %d: %s', $answer_id, $question_id, $this->wpdb->last_error ) ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are for logging, not display.
+			throw new \RuntimeException( sprintf( 'Failed to create quiz grade for answer %d, question %d: %s', $answer_id, $question_id, $this->wpdb->last_error ) );
 		}
 
 		$grade = new Tables_Based_Grade(

--- a/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-tables-based-grade-repository.php
@@ -98,7 +98,7 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 		$current_date = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 		$date_format  = 'Y-m-d H:i:s';
 
-		$this->wpdb->insert(
+		$result = $this->wpdb->insert(
 			$this->get_table_name(),
 			[
 				'answer_id'   => $answer_id,
@@ -117,6 +117,10 @@ class Tables_Based_Grade_Repository implements Grade_Repository_Interface {
 				'%s',
 			]
 		);
+
+		if ( false === $result ) {
+			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz grade for answer %d, question %d: %s', $answer_id, $question_id, $this->wpdb->last_error ) ) );
+		}
 
 		$grade = new Tables_Based_Grade(
 			$this->wpdb->insert_id,

--- a/includes/internal/quiz-submission/submission/repositories/class-comment-reading-aggregate-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-comment-reading-aggregate-submission-repository.php
@@ -59,11 +59,17 @@ class Comment_Reading_Aggregate_Submission_Repository implements Submission_Repo
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If submission creation fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
 		$submission = $this->comments_based_repository->create( $quiz_id, $user_id, $final_grade );
-		$this->tables_based_repository->create( $quiz_id, $user_id, $final_grade );
+		try {
+			$this->tables_based_repository->create( $quiz_id, $user_id, $final_grade );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 
 		return $submission;
 	}
@@ -77,6 +83,7 @@ class Comment_Reading_Aggregate_Submission_Repository implements Submission_Repo
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If submission creation fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
@@ -120,26 +127,31 @@ class Comment_Reading_Aggregate_Submission_Repository implements Submission_Repo
 	public function save( Submission_Interface $submission ): void {
 		$this->comments_based_repository->save( $submission );
 
-		$tables_based_submission = $this->tables_based_repository->get_or_create(
-			$submission->get_quiz_id(),
-			$submission->get_user_id(),
-			$submission->get_final_grade()
-		);
+		try {
+			$tables_based_submission = $this->tables_based_repository->get_or_create(
+				$submission->get_quiz_id(),
+				$submission->get_user_id(),
+				$submission->get_final_grade()
+			);
 
-		// Make sure the dates are in UTC.
-		$created_at = new DateTimeImmutable( '@' . $submission->get_created_at()->getTimestamp() );
-		$updated_at = new DateTimeImmutable( '@' . $submission->get_updated_at()->getTimestamp() );
+			// Make sure the dates are in UTC.
+			$created_at = new DateTimeImmutable( '@' . $submission->get_created_at()->getTimestamp() );
+			$updated_at = new DateTimeImmutable( '@' . $submission->get_updated_at()->getTimestamp() );
 
-		$submission_to_save = new Tables_Based_Submission(
-			$tables_based_submission->get_id(),
-			$submission->get_quiz_id(),
-			$submission->get_user_id(),
-			$submission->get_final_grade(),
-			$created_at,
-			$updated_at
-		);
+			$submission_to_save = new Tables_Based_Submission(
+				$tables_based_submission->get_id(),
+				$submission->get_quiz_id(),
+				$submission->get_user_id(),
+				$submission->get_final_grade(),
+				$created_at,
+				$updated_at
+			);
 
-		$this->tables_based_repository->save( $submission_to_save );
+			$this->tables_based_repository->save( $submission_to_save );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-submission-repository-interface.php
@@ -30,6 +30,7 @@ interface Submission_Repository_Interface {
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface;
@@ -43,6 +44,7 @@ interface Submission_Repository_Interface {
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface;

--- a/includes/internal/quiz-submission/submission/repositories/class-table-reading-aggregate-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-table-reading-aggregate-submission-repository.php
@@ -58,10 +58,16 @@ class Table_Reading_Aggregate_Submission_Repository implements Submission_Reposi
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
-		$this->comments_based_repository->create( $quiz_id, $user_id, $final_grade );
+		try {
+			$this->comments_based_repository->create( $quiz_id, $user_id, $final_grade );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 		$submission = $this->tables_based_repository->create( $quiz_id, $user_id, $final_grade );
 
 		return $submission;
@@ -76,6 +82,7 @@ class Table_Reading_Aggregate_Submission_Repository implements Submission_Reposi
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {
@@ -119,26 +126,31 @@ class Table_Reading_Aggregate_Submission_Repository implements Submission_Reposi
 	public function save( Submission_Interface $submission ): void {
 		$this->tables_based_repository->save( $submission );
 
-		$comments_based_submission = $this->comments_based_repository->get_or_create(
-			$submission->get_quiz_id(),
-			$submission->get_user_id(),
-			$submission->get_final_grade()
-		);
+		try {
+			$comments_based_submission = $this->comments_based_repository->get_or_create(
+				$submission->get_quiz_id(),
+				$submission->get_user_id(),
+				$submission->get_final_grade()
+			);
 
-		// Make sure the dates are in UTC.
-		$created_at = new \DateTimeImmutable( '@' . $submission->get_created_at()->getTimestamp() );
-		$updated_at = new \DateTimeImmutable( '@' . $submission->get_updated_at()->getTimestamp() );
+			// Make sure the dates are in UTC.
+			$created_at = new \DateTimeImmutable( '@' . $submission->get_created_at()->getTimestamp() );
+			$updated_at = new \DateTimeImmutable( '@' . $submission->get_updated_at()->getTimestamp() );
 
-		$submission_to_save = new Comments_Based_Submission(
-			$comments_based_submission->get_id(),
-			$submission->get_quiz_id(),
-			$submission->get_user_id(),
-			$submission->get_final_grade(),
-			$created_at,
-			$updated_at
-		);
+			$submission_to_save = new Comments_Based_Submission(
+				$comments_based_submission->get_id(),
+				$submission->get_quiz_id(),
+				$submission->get_user_id(),
+				$submission->get_final_grade(),
+				$created_at,
+				$updated_at
+			);
 
-		$this->comments_based_repository->save( $submission_to_save );
+			$this->comments_based_repository->save( $submission_to_save );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
@@ -65,6 +65,7 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {

--- a/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
@@ -132,6 +132,7 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 	 * @param int        $user_id     The user ID.
 	 * @param float|null $final_grade The final grade.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Submission_Interface The quiz submission.
 	 */
 	public function get_or_create( int $quiz_id, int $user_id, float $final_grade = null ): Submission_Interface {

--- a/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
@@ -103,7 +103,8 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 		);
 
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz submission for quiz %d, user %d: %s', $quiz_id, $user_id, $this->wpdb->last_error ) ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are for logging, not display.
+			throw new \RuntimeException( sprintf( 'Failed to create quiz submission for quiz %d, user %d: %s', $quiz_id, $user_id, $this->wpdb->last_error ) );
 		}
 
 		$submission = new Tables_Based_Submission(

--- a/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
@@ -83,7 +83,7 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
 
-		$this->wpdb->insert(
+		$result = $this->wpdb->insert(
 			$this->get_table_name(),
 			[
 				'quiz_id'     => $quiz_id,
@@ -100,6 +100,10 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 				'%s',
 			]
 		);
+
+		if ( false === $result ) {
+			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz submission for quiz %d, user %d: %s', $quiz_id, $user_id, $this->wpdb->last_error ) ) );
+		}
 
 		$submission = new Tables_Based_Submission(
 			$this->wpdb->insert_id,

--- a/includes/internal/student-progress/course-progress/repositories/class-comment-reading-aggregate-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-comment-reading-aggregate-course-progress-repository.php
@@ -58,11 +58,17 @@ class Comment_Reading_Aggregate_Course_Progress_Repository implements Course_Pro
 	 *
 	 * @param int $course_id The course ID.
 	 * @param int $user_id The user ID.
+	 * @throws \RuntimeException If progress creation fails.
 	 * @return Course_Progress_Interface The course progress.
 	 */
 	public function create( int $course_id, int $user_id ): Course_Progress_Interface {
 		$progress = $this->comments_based_repository->create( $course_id, $user_id );
-		$this->tables_based_repository->create( $course_id, $user_id );
+		try {
+			$this->tables_based_repository->create( $course_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 		return $progress;
 	}
 
@@ -104,10 +110,16 @@ class Comment_Reading_Aggregate_Course_Progress_Repository implements Course_Pro
 
 		$tables_based_progress = $this->tables_based_repository->get( $course_progress->get_course_id(), $course_progress->get_user_id() );
 		if ( ! $tables_based_progress ) {
-			$tables_based_progress = $this->tables_based_repository->create(
-				$course_progress->get_course_id(),
-				$course_progress->get_user_id()
-			);
+			try {
+				$tables_based_progress = $this->tables_based_repository->create(
+					$course_progress->get_course_id(),
+					$course_progress->get_user_id()
+				);
+			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+				error_log( 'Sensei: ' . $e->getMessage() );
+				return; // Primary save already completed; skip secondary sync.
+			}
 		}
 
 		$started_at = null;

--- a/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-interface.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-interface.php
@@ -28,6 +28,8 @@ interface Course_Progress_Repository_Interface {
 	 *
 	 * @param int $course_id The course ID.
 	 * @param int $user_id The user ID.
+	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Course_Progress_Interface The course progress.
 	 */
 	public function create( int $course_id, int $user_id ): Course_Progress_Interface;

--- a/includes/internal/student-progress/course-progress/repositories/class-table-reading-aggregate-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-table-reading-aggregate-course-progress-repository.php
@@ -55,10 +55,16 @@ class Table_Reading_Aggregate_Course_Progress_Repository implements Course_Progr
 	 *
 	 * @param int $course_id The course ID.
 	 * @param int $user_id The user ID.
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Course_Progress_Interface The course progress.
 	 */
 	public function create( int $course_id, int $user_id ): Course_Progress_Interface {
-		$this->comments_based_repository->create( $course_id, $user_id );
+		try {
+			$this->comments_based_repository->create( $course_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 		return $this->tables_based_repository->create( $course_id, $user_id );
 	}
 
@@ -93,7 +99,13 @@ class Table_Reading_Aggregate_Course_Progress_Repository implements Course_Progr
 		$this->tables_based_repository->save( $course_progress );
 		$comments_based_progress = $this->comments_based_repository->get( $course_progress->get_course_id(), $course_progress->get_user_id() );
 		if ( ! $comments_based_progress ) {
-			$comments_based_progress = $this->comments_based_repository->create( $course_progress->get_course_id(), $course_progress->get_user_id() );
+			try {
+				$comments_based_progress = $this->comments_based_repository->create( $course_progress->get_course_id(), $course_progress->get_user_id() );
+			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+				error_log( 'Sensei: ' . $e->getMessage() );
+				return; // Primary save already completed; skip secondary sync.
+			}
 		}
 		$updated_comments_based_progress = new Comments_Based_Course_Progress(
 			$comments_based_progress->get_id(),

--- a/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
@@ -108,7 +108,8 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 			]
 		);
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( sprintf( 'Failed to create course progress for course %d, user %d: %s', $course_id, $user_id, $this->wpdb->last_error ) ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are for logging, not display.
+			throw new \RuntimeException( sprintf( 'Failed to create course progress for course %d, user %d: %s', $course_id, $user_id, $this->wpdb->last_error ) );
 		}
 		$id = (int) $this->wpdb->insert_id;
 

--- a/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
@@ -63,6 +63,8 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 	 *
 	 * @param int $course_id The course ID.
 	 * @param int $user_id The user ID.
+	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Course_Progress_Interface The course progress.
 	 */
 	public function create( int $course_id, int $user_id ): Course_Progress_Interface {
@@ -80,7 +82,7 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
-		$this->wpdb->insert(
+		$result           = $this->wpdb->insert(
 			$this->wpdb->prefix . 'sensei_lms_progress',
 			[
 				'post_id'        => $course_id,
@@ -105,6 +107,9 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 				'%s',
 			]
 		);
+		if ( false === $result ) {
+			throw new \RuntimeException( esc_html( sprintf( 'Failed to create course progress for course %d, user %d: %s', $course_id, $user_id, $this->wpdb->last_error ) ) );
+		}
 		$id = (int) $this->wpdb->insert_id;
 
 		$progress = new Tables_Based_Course_Progress(

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comment-reading-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comment-reading-aggregate-lesson-progress-repository.php
@@ -58,11 +58,17 @@ class Comment_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Pro
 	 *
 	 * @param int $lesson_id The lesson ID.
 	 * @param int $user_id The user ID.
+	 * @throws \RuntimeException If progress creation fails.
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
 	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface {
 		$progress = $this->comments_based_repository->create( $lesson_id, $user_id );
-		$this->tables_based_repository->create( $lesson_id, $user_id );
+		try {
+			$this->tables_based_repository->create( $lesson_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 		return $progress;
 	}
 
@@ -104,10 +110,16 @@ class Comment_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Pro
 
 		$tables_based_progress = $this->tables_based_repository->get( $lesson_progress->get_lesson_id(), $lesson_progress->get_user_id() );
 		if ( ! $tables_based_progress ) {
-			$tables_based_progress = $this->tables_based_repository->create(
-				$lesson_progress->get_lesson_id(),
-				$lesson_progress->get_user_id()
-			);
+			try {
+				$tables_based_progress = $this->tables_based_repository->create(
+					$lesson_progress->get_lesson_id(),
+					$lesson_progress->get_user_id()
+				);
+			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+				error_log( 'Sensei: ' . $e->getMessage() );
+				return; // Primary save already completed; skip secondary sync.
+			}
 		}
 
 		$started_at = null;

--- a/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-interface.php
@@ -28,6 +28,8 @@ interface Lesson_Progress_Repository_Interface {
 	 *
 	 * @param int $lesson_id The lesson ID.
 	 * @param int $user_id The user ID.
+	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
 	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface;

--- a/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
@@ -50,10 +50,16 @@ class Table_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Progr
 	 *
 	 * @param int $lesson_id The lesson ID.
 	 * @param int $user_id   The user ID.
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
 	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface {
-		$this->comments_based_repository->create( $lesson_id, $user_id );
+		try {
+			$this->comments_based_repository->create( $lesson_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 		return $this->tables_based_repository->create( $lesson_id, $user_id );
 	}
 
@@ -91,10 +97,16 @@ class Table_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Progr
 			$lesson_progress->get_user_id()
 		);
 		if ( ! $comments_based_progress ) {
-			$comments_based_progress = $this->comments_based_repository->create(
-				$lesson_progress->get_lesson_id(),
-				$lesson_progress->get_user_id()
-			);
+			try {
+				$comments_based_progress = $this->comments_based_repository->create(
+					$lesson_progress->get_lesson_id(),
+					$lesson_progress->get_user_id()
+				);
+			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+				error_log( 'Sensei: ' . $e->getMessage() );
+				return; // Primary save already completed; skip secondary sync.
+			}
 		}
 
 		// If the status of the lesson progress is different from the status of the comments based lesson progress,

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -109,7 +109,8 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 			]
 		);
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( sprintf( 'Failed to create lesson progress for lesson %d, user %d: %s', $lesson_id, $user_id, $this->wpdb->last_error ) ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are for logging, not display.
+			throw new \RuntimeException( sprintf( 'Failed to create lesson progress for lesson %d, user %d: %s', $lesson_id, $user_id, $this->wpdb->last_error ) );
 		}
 		$id = (int) $this->wpdb->insert_id;
 

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -65,6 +65,7 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 	 * @param int $lesson_id The lesson ID.
 	 * @param int $user_id The user ID.
 	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Lesson_Progress_Interface The lesson progress.
 	 */
 	public function create( int $lesson_id, int $user_id ): Lesson_Progress_Interface {
@@ -82,7 +83,7 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
-		$this->wpdb->insert(
+		$result           = $this->wpdb->insert(
 			$this->wpdb->prefix . 'sensei_lms_progress',
 			[
 				'post_id'        => $lesson_id,
@@ -107,6 +108,9 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 				'%s',
 			]
 		);
+		if ( false === $result ) {
+			throw new \RuntimeException( esc_html( 'Failed to create lesson progress: ' . $this->wpdb->last_error ) );
+		}
 		$id = (int) $this->wpdb->insert_id;
 
 		$progress = new Tables_Based_Lesson_Progress(

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -109,7 +109,7 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 			]
 		);
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( 'Failed to create lesson progress: ' . $this->wpdb->last_error ) );
+			throw new \RuntimeException( esc_html( sprintf( 'Failed to create lesson progress for lesson %d, user %d: %s', $lesson_id, $user_id, $this->wpdb->last_error ) ) );
 		}
 		$id = (int) $this->wpdb->insert_id;
 

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comment-reading-aggregate-quiz-progress-repository.php
@@ -58,10 +58,16 @@ class Comment_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progres
 	 *
 	 * @param int $quiz_id The quiz ID.
 	 * @param int $user_id The user ID.
+	 * @throws \RuntimeException If progress creation fails.
 	 * @return Quiz_Progress_Interface The quiz progress.
 	 */
 	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
-		$this->tables_based_repository->create( $quiz_id, $user_id );
+		try {
+			$this->tables_based_repository->create( $quiz_id, $user_id );
+		} catch ( \RuntimeException $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+			error_log( 'Sensei: ' . $e->getMessage() );
+		}
 		return $this->comments_based_repository->create( $quiz_id, $user_id );
 	}
 
@@ -103,10 +109,16 @@ class Comment_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progres
 
 		$tables_based_progress = $this->tables_based_repository->get( $quiz_progress->get_quiz_id(), $quiz_progress->get_user_id() );
 		if ( ! $tables_based_progress ) {
-			$tables_based_progress = $this->tables_based_repository->create(
-				$quiz_progress->get_quiz_id(),
-				$quiz_progress->get_user_id()
-			);
+			try {
+				$tables_based_progress = $this->tables_based_repository->create(
+					$quiz_progress->get_quiz_id(),
+					$quiz_progress->get_user_id()
+				);
+			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+				error_log( 'Sensei: ' . $e->getMessage() );
+				return; // Primary save already completed; skip secondary sync.
+			}
 		}
 
 		$started_at = null;

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-interface.php
@@ -28,6 +28,8 @@ interface Quiz_Progress_Repository_Interface {
 	 *
 	 * @param int $quiz_id Quiz identifier.
 	 * @param int $user_id User identifier.
+	 *
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Quiz_Progress_Interface
 	 */
 	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface;

--- a/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php
@@ -68,6 +68,7 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	 *
 	 * @param int $quiz_id The quiz ID.
 	 * @param int $user_id The user ID.
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Quiz_Progress_Interface The quiz progress.
 	 */
 	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
@@ -78,7 +79,12 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 		if ( $lesson_id ) {
 			$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $user_id );
 			if ( ! $lesson_progress_exists ) {
-				$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id );
+				try {
+					$this->comments_based_lesson_progress_repository->create( $lesson_id, $user_id );
+				} catch ( \RuntimeException $e ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+					error_log( 'Sensei: ' . $e->getMessage() );
+				}
 			}
 		}
 
@@ -111,7 +117,6 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 	 * Save quiz progress.
 	 *
 	 * @param Quiz_Progress_Interface $quiz_progress The quiz progress.
-	 * @throws RuntimeException If the comments based quiz progress is not found.
 	 */
 	public function save( Quiz_Progress_Interface $quiz_progress ): void {
 		$this->tables_based_repository->save( $quiz_progress );
@@ -122,7 +127,13 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 			if ( $lesson_id ) {
 				$lesson_progress_exists = $this->comments_based_lesson_progress_repository->has( $lesson_id, $quiz_progress->get_user_id() );
 				if ( ! $lesson_progress_exists ) {
-					$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id() );
+					try {
+						$this->comments_based_lesson_progress_repository->create( $lesson_id, $quiz_progress->get_user_id() );
+					} catch ( \RuntimeException $e ) {
+						// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+						error_log( 'Sensei: ' . $e->getMessage() );
+						return;
+					}
 				}
 			}
 			$comments_based_quiz_progress = $this->comments_based_repository->get(
@@ -131,7 +142,9 @@ class Table_Reading_Aggregate_Quiz_Progress_Repository implements Quiz_Progress_
 			);
 
 			if ( ! $comments_based_quiz_progress ) {
-				throw new RuntimeException( 'Comments based quiz progress not found.' );
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging secondary store sync failure.
+				error_log( sprintf( 'Sensei: Comments based quiz progress not found for quiz %d, user %d.', $quiz_progress->get_quiz_id(), $quiz_progress->get_user_id() ) );
+				return;
 			}
 		}
 

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -108,7 +108,8 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			]
 		);
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz progress for quiz %d, user %d: %s', $quiz_id, $user_id, $this->wpdb->last_error ) ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception messages are for logging, not display.
+			throw new \RuntimeException( sprintf( 'Failed to create quiz progress for quiz %d, user %d: %s', $quiz_id, $user_id, $this->wpdb->last_error ) );
 		}
 		$id = (int) $this->wpdb->insert_id;
 

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -63,6 +63,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 	 *
 	 * @param int $quiz_id Quiz identifier.
 	 * @param int $user_id User identifier.
+	 *
 	 * @throws \RuntimeException If the database insert fails.
 	 * @return Quiz_Progress_Interface
 	 */

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -107,7 +107,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			]
 		);
 		if ( false === $result ) {
-			throw new \RuntimeException( esc_html( 'Failed to create quiz progress: ' . $this->wpdb->last_error ) );
+			throw new \RuntimeException( esc_html( sprintf( 'Failed to create quiz progress for quiz %d, user %d: %s', $quiz_id, $user_id, $this->wpdb->last_error ) ) );
 		}
 		$id = (int) $this->wpdb->insert_id;
 

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -63,6 +63,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 	 *
 	 * @param int $quiz_id Quiz identifier.
 	 * @param int $user_id User identifier.
+	 * @throws \RuntimeException If the database insert fails.
 	 * @return Quiz_Progress_Interface
 	 */
 	public function create( int $quiz_id, int $user_id ): Quiz_Progress_Interface {
@@ -80,7 +81,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 
 		$current_datetime = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$date_format      = 'Y-m-d H:i:s';
-		$this->wpdb->insert(
+		$result           = $this->wpdb->insert(
 			$this->wpdb->prefix . 'sensei_lms_progress',
 			[
 				'post_id'        => $quiz_id,
@@ -105,6 +106,9 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 				'%s',
 			]
 		);
+		if ( false === $result ) {
+			throw new \RuntimeException( esc_html( 'Failed to create quiz progress: ' . $this->wpdb->last_error ) );
+		}
 		$id = (int) $this->wpdb->insert_id;
 
 		$progress = new Tables_Based_Quiz_Progress(

--- a/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
+++ b/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
@@ -67,7 +67,8 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 				}
 			} catch ( \RuntimeException $e ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Background task needs to log failures.
-				error_log( 'Sensei: ' . $e->getMessage() );
+				error_log( sprintf( 'Sensei: Failed to migrate comment %d (quiz %d, user %d): %s', $comment_id, $quiz_id, $user_id, $e->getMessage() ) );
+				continue;
 			}
 
 			wp_delete_comment( $comment ); // Soft delete.

--- a/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
+++ b/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
@@ -68,7 +68,6 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 			} catch ( \RuntimeException $e ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Background task needs to log failures.
 				error_log( sprintf( 'Sensei: Failed to migrate comment %d (quiz %d, user %d): %s', $comment_id, $quiz_id, $user_id, $e->getMessage() ) );
-				continue;
 			}
 
 			wp_delete_comment( $comment ); // Soft delete.

--- a/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
+++ b/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
@@ -68,7 +68,6 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 			} catch ( \RuntimeException $e ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Background task needs to log failures.
 				error_log( 'Sensei: ' . $e->getMessage() );
-				continue;
 			}
 
 			wp_delete_comment( $comment ); // Soft delete.

--- a/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
+++ b/includes/update-tasks/class-sensei-update-legacy-quiz-data.php
@@ -19,7 +19,7 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 	 *
 	 * @return int
 	 */
-	protected function get_batch_size() : int {
+	protected function get_batch_size(): int {
 		return 20;
 	}
 
@@ -28,7 +28,7 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 	 *
 	 * @return bool
 	 */
-	protected function allow_multiple_instances() : bool {
+	protected function allow_multiple_instances(): bool {
 		return false;
 	}
 
@@ -39,7 +39,7 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 	 *
 	 * @return bool Returns true if there is more to do.
 	 */
-	protected function run_batch( int $offset ) : bool {
+	protected function run_batch( int $offset ): bool {
 		$answer_comments = $this->get_legacy_answers();
 		$run_again       = count( $answer_comments ) === $this->get_batch_size();
 
@@ -55,14 +55,20 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 			$user_id      = (int) $comment->user_id;
 			$quiz_id      = (int) get_post_meta( $question_id, '_quiz_id', true );
 			$points       = get_comment_meta( $comment_id, 'user_grade', true );
-			$submission   = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
-			$answer       = Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer_value );
+			try {
+				$submission = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
+				$answer     = Sensei()->quiz_answer_repository->create( $submission, $question_id, $answer_value );
 
-			if ( is_numeric( $points ) ) {
-				$feedback = get_comment_meta( $comment_id, 'answer_note', true );
-				$feedback = false === $feedback ? null : $feedback;
+				if ( is_numeric( $points ) ) {
+					$feedback = get_comment_meta( $comment_id, 'answer_note', true );
+					$feedback = false === $feedback ? null : $feedback;
 
-				Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, (int) $points, $feedback );
+					Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, (int) $points, $feedback );
+				}
+			} catch ( \RuntimeException $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Background task needs to log failures.
+				error_log( 'Sensei: ' . $e->getMessage() );
+				continue;
 			}
 
 			wp_delete_comment( $comment ); // Soft delete.
@@ -76,7 +82,7 @@ class Sensei_Update_Legacy_Quiz_Data extends Sensei_Background_Job_Batch {
 	 *
 	 * @return array An array of comments holding the legacy answers.
 	 */
-	protected function get_legacy_answers() : array {
+	protected function get_legacy_answers(): array {
 		$comments = Sensei_Utils::sensei_check_for_activity(
 			array(
 				'type'   => 'sensei_user_answer',

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-tables-based-answer-repository.php
@@ -365,6 +365,23 @@ class Tables_Based_Answer_Repository_Test extends \WP_UnitTestCase {
 		self::assertCount( 2, $fresh, 'Should have two answers after create invalidates cache.' );
 	}
 
+	public function testCreate_InsertFails_ThrowsRuntimeException(): void {
+		/* Arrange. */
+		$submission = $this->createMock( Submission_Interface::class );
+		$submission->method( 'get_id' )->willReturn( 1 );
+		$wpdb             = $this->createMock( wpdb::class );
+		$wpdb->last_error = 'Duplicate entry';
+		$wpdb
+			->method( 'insert' )
+			->willReturn( false );
+		$repository = new Tables_Based_Answer_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Failed to create quiz answer for submission 1, question 2: Duplicate entry' );
+		$repository->create( $submission, 2, 'answer value' );
+	}
+
 	private function export_answer( Tables_Based_Answer $answer ): array {
 		return [
 			'id'            => $answer->get_id(),

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
@@ -53,8 +53,8 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 
 	public function testCreate_InsertFails_ThrowsRuntimeException(): void {
 		/* Arrange. */
-		$submission = $this->createMock( Tables_Based_Submission::class );
-		$answer     = new Tables_Based_Answer( 2, 3, 4, 'value', new \DateTimeImmutable(), new \DateTimeImmutable() );
+		$submission       = $this->createMock( Tables_Based_Submission::class );
+		$answer           = new Tables_Based_Answer( 2, 3, 4, 'value', new \DateTimeImmutable(), new \DateTimeImmutable() );
 		$wpdb             = $this->createMock( \wpdb::class );
 		$wpdb->last_error = 'Duplicate entry';
 		$wpdb

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-tables-based-grade-repository.php
@@ -51,6 +51,23 @@ class Tables_Based_Grade_Repository_Test extends \WP_UnitTestCase {
 	}
 
 
+	public function testCreate_InsertFails_ThrowsRuntimeException(): void {
+		/* Arrange. */
+		$submission = $this->createMock( Tables_Based_Submission::class );
+		$answer     = new Tables_Based_Answer( 2, 3, 4, 'value', new \DateTimeImmutable(), new \DateTimeImmutable() );
+		$wpdb             = $this->createMock( \wpdb::class );
+		$wpdb->last_error = 'Duplicate entry';
+		$wpdb
+			->method( 'insert' )
+			->willReturn( false );
+		$repository = new Tables_Based_Grade_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Failed to create quiz grade for answer 2, question 4: Duplicate entry' );
+		$repository->create( $submission, $answer, 4, 10, 'feedback' );
+	}
+
 	public function testCreate_ParamsGiven_InsertsData(): void {
 		/* Arrange */
 		$submission = $this->createMock( Tables_Based_Submission::class );

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-tables-based-submission-repository.php
@@ -31,6 +31,21 @@ class Tables_Based_Submission_Repository_Test extends \WP_UnitTestCase {
 		wp_cache_flush();
 	}
 
+	public function testCreate_InsertFails_ThrowsRuntimeException(): void {
+		/* Arrange. */
+		$wpdb             = $this->createMock( wpdb::class );
+		$wpdb->last_error = 'Duplicate entry';
+		$wpdb
+			->method( 'insert' )
+			->willReturn( false );
+		$repository = new Tables_Based_Submission_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Failed to create quiz submission for quiz 1, user 2: Duplicate entry' );
+		$repository->create( 1, 2 );
+	}
+
 	public function testCreate_WhenCalled_InsertsToWpdb(): void {
 		/* Arrange. */
 		$wpdb       = $this->createMock( wpdb::class );

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-tables-based-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-tables-based-course-progress-repository.php
@@ -91,6 +91,21 @@ class Tables_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_progress( $progress ) );
 	}
 
+	public function testCreate_InsertFails_ThrowsRuntimeException(): void {
+		/* Arrange. */
+		$wpdb             = $this->createMock( wpdb::class );
+		$wpdb->last_error = 'Duplicate entry';
+		$wpdb
+			->method( 'insert' )
+			->willReturn( false );
+		$repository = new Tables_Based_Course_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Failed to create course progress for course 1, user 2: Duplicate entry' );
+		$repository->create( 1, 2 );
+	}
+
 	public function testCreate_CacheEnabled_FailedInsertDoesNotCache(): void {
 		/* Arrange. */
 		$wpdb            = $this->createMock( wpdb::class );

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
@@ -92,6 +92,21 @@ class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_progress( $progress ) );
 	}
 
+	public function testCreate_InsertFails_ThrowsRuntimeException(): void {
+		/* Arrange. */
+		$wpdb             = $this->createMock( wpdb::class );
+		$wpdb->last_error = 'Duplicate entry';
+		$wpdb
+			->method( 'insert' )
+			->willReturn( false );
+		$repository = new Tables_Based_Lesson_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Failed to create lesson progress: Duplicate entry' );
+		$repository->create( 1, 2 );
+	}
+
 	public function testGet_NotFound_ReturnsNull(): void {
 		/* Arrange. */
 		$wpdb = $this->createMock( wpdb::class );

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
@@ -103,7 +103,7 @@ class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 
 		/* Expect & Act. */
 		$this->expectException( \RuntimeException::class );
-		$this->expectExceptionMessage( 'Failed to create lesson progress: Duplicate entry' );
+		$this->expectExceptionMessage( 'Failed to create lesson progress for lesson 1, user 2: Duplicate entry' );
 		$repository->create( 1, 2 );
 	}
 

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
@@ -102,7 +102,7 @@ class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 
 		/* Expect & Act. */
 		$this->expectException( \RuntimeException::class );
-		$this->expectExceptionMessage( 'Failed to create quiz progress: Duplicate entry' );
+		$this->expectExceptionMessage( 'Failed to create quiz progress for quiz 1, user 2: Duplicate entry' );
 		$repository->create( 1, 2 );
 	}
 

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
@@ -91,6 +91,21 @@ class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_progress( $progress ) );
 	}
 
+	public function testCreate_InsertFails_ThrowsRuntimeException(): void {
+		/* Arrange. */
+		$wpdb             = $this->createMock( wpdb::class );
+		$wpdb->last_error = 'Duplicate entry';
+		$wpdb
+			->method( 'insert' )
+			->willReturn( false );
+		$repository = new Tables_Based_Quiz_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Failed to create quiz progress: Duplicate entry' );
+		$repository->create( 1, 2 );
+	}
+
 	public function testGet_NotFound_ReturnsNull(): void {
 		/* Arrange. */
 		$wpdb = $this->createMock( wpdb::class );


### PR DESCRIPTION
## Summary

`$wpdb->insert()` returns `false` on failure, but none of the tables-based repositories checked this return value. When an insert failed, the code silently continued with `$wpdb->insert_id` of `0`, constructing invalid objects and losing student data without any indication.

This PR:
- Throws a `RuntimeException` when `$wpdb->insert()` returns `false` in all tables-based repositories (progress, submission, answer, grade)
- Adds try-catch handling at all call sites so failures are logged rather than crashing
- Wraps secondary store (dual-write sync) operations in try-catch so a sync failure doesn't block the primary store
- Adds `@throws` annotations to repository interfaces and implementations

## Test plan

### Happy path
- [x] With storage set to **tables** (Sensei > Settings > Experimental), enroll as a student, start a lesson, complete it, take a quiz — progress saves normally
- [x] With storage set to **comments** (default), repeat the above — progress saves normally

### Error handling
To simulate a database insert failure, temporarily rename the progress table:

```sql
RENAME TABLE wp_sensei_lms_progress TO wp_sensei_lms_progress_backup;
```

With `WP_DEBUG_LOG` enabled and storage set to **tables**:
- [x] Visit a lesson page as an enrolled student — should see error notices ("An error occurred while starting the course/lesson. Please try again.") and log entries in `wp-content/debug.log`
- [x] Click "Complete Lesson" — should not crash; error notices remain, progress stays at 0%
- [x] Restore the table and flush the cache when done:
  ```sql
  RENAME TABLE wp_sensei_lms_progress_backup TO wp_sensei_lms_progress;
  ```
  ```
  wp cache flush
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)