### PR TITLE
Fix lesson comment status not syncing to 'passed' for quizzed lessons

### DIFF
--- a/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-table-reading-aggregate-lesson-progress-repository.php
@@ -97,16 +97,16 @@ class Table_Reading_Aggregate_Lesson_Progress_Repository implements Lesson_Progr
 			);
 		}
 
-		// If the status of the lesson progress is different from the status of the comments based lesson progress,
-		// update the comments based lesson progress to match the status of the lesson progress.
-		// We can't just use the status of the lesson progress because the comments based lesson lesson_progress
-		// has a different underlying set of statuses.
-		if ( $lesson_progress->get_status() !== $comments_based_progress->get_status() ) {
-			if ( $lesson_progress->is_complete() ) {
-				$comments_based_progress->complete();
-			} else {
-				$comments_based_progress->start();
-			}
+		// Always sync the status from the tables-based progress to the comments-based progress.
+		// We can't just use the status of the lesson progress because the comments based lesson progress
+		// has a different underlying set of statuses (e.g. 'passed' for quizzed lessons).
+		// We must always call complete() or start() rather than comparing normalized statuses,
+		// because Comments_Based_Lesson_Progress::get_status() normalizes 'passed' to 'complete',
+		// which would cause the comparison to short-circuit and skip the sync.
+		if ( $lesson_progress->is_complete() ) {
+			$comments_based_progress->complete();
+		} else {
+			$comments_based_progress->start();
 		}
 
 		// Use reflection to get underlying status value.

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-table-reading-aggregate-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-table-reading-aggregate-lesson-progress-repository.php
@@ -377,6 +377,57 @@ class Table_Reading_Aggregate_Lesson_Progress_Repository_Test extends \WP_UnitTe
 		$repository->find( $args );
 	}
 
+	public function testSave_WhenTablesCompleteAndCommentAlreadyComplete_StillCallsCompleteOnComment(): void {
+		/* Arrange. */
+		$date_mock = new \DateTimeImmutable( '2020-01-01' );
+
+		// Create a lesson with quiz questions meta so Comments_Based_Lesson_Progress::complete()
+		// sets the status to 'passed' instead of 'complete'.
+		$lesson_id = $this->factory->post->create(
+			array( 'post_type' => 'lesson' )
+		);
+		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
+
+		// Tables-based progress has status 'complete'.
+		$tables_based_progress = new Tables_Based_Lesson_Progress( 3, $lesson_id, 2, 'complete', $date_mock, $date_mock, $date_mock, $date_mock );
+
+		// Comments-based progress also has raw status 'complete'.
+		// Since get_status() normalizes 'complete' to 'complete', both statuses match.
+		// Before the fix, the sync would be skipped, and the comment would keep 'complete'
+		// instead of being updated to 'passed'.
+		$comments_based_progress = new Comments_Based_Lesson_Progress( 4, $lesson_id, 2, 'complete', $date_mock, $date_mock, $date_mock, $date_mock );
+
+		$comments_based_repository = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );
+		$comments_based_repository
+			->method( 'get' )
+			->with( $lesson_id, 2 )
+			->willReturn( $comments_based_progress );
+
+		$tables_based_repository = $this->createMock( Tables_Based_Lesson_Progress_Repository::class );
+
+		$repository = new Table_Reading_Aggregate_Lesson_Progress_Repository( $comments_based_repository, $tables_based_repository );
+
+		/* Act. */
+		$comments_based_repository
+			->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->callback(
+					function ( Lesson_Progress_Interface $progress ) {
+						// Use reflection to get the raw underlying status,
+						// since get_status() normalizes 'passed' to 'complete'.
+						$reflection_class    = new \ReflectionClass( Comments_Based_Lesson_Progress::class );
+						$reflection_property = $reflection_class->getProperty( 'status' );
+						$reflection_property->setAccessible( true );
+						$raw_status = $reflection_property->getValue( $progress );
+
+						return 'passed' === $raw_status;
+					}
+				)
+			);
+		$repository->save( $tables_based_progress );
+	}
+
 	public function testFind_Never_CallsCommentsBasedRepository(): void {
 		/* Arrange. */
 		$comments_based = $this->createMock( Comments_Based_Lesson_Progress_Repository::class );


### PR DESCRIPTION
## Summary
- The aggregate lesson progress repository compared normalized statuses to decide whether to sync. Since `Comments_Based_Lesson_Progress::get_status()` normalizes `passed`, `graded`, and `complete` all to `complete`, the comparison always short-circuited — leaving the raw comment as `complete` instead of `passed` for lessons with quiz questions.
- Remove the status comparison guard so `complete()` or `start()` is always called, allowing `Comments_Based_Lesson_Progress::complete()` to set the correct underlying status.

## Test plan
- [ ] New unit test `testSave_WhenTablesCompleteAndCommentAlreadyComplete_StillCallsCompleteOnComment` verifies the fix
- [ ] Existing aggregate repository tests pass (21/21)
- [ ] On a site with HPPS enabled, complete a quiz on a lesson — verify the lesson comment status is `passed` (not `complete`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)