### PR TITLE
Add (type, post_id) index to sensei_lms_progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 ## Linting
 - **PHPCS**: Run `npm run lint-php`.
+- **Psalm**: Run `vendor/bin/psalm --no-cache --diff`.
+- **Before pushing**: The pre-commit hook only lints new files. CI lints all changed lines. Always run both PHPCS and Psalm on modified files before pushing to avoid CI failures.
 
 ## Conventions
 - **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `npm run changelog` (entries stored in `changelog/`).

--- a/changelog/add-grading-query-index
+++ b/changelog/add-grading-query-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Internal: Add database index to speed up Grading page queries.

--- a/changelog/add-hpps-reports-grading-migration
+++ b/changelog/add-hpps-reports-grading-migration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Internal: Integrate HPPS in reports and grading backend.

--- a/changelog/fix-course-last-activity-date
+++ b/changelog/fix-course-last-activity-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Course Reports Last Activity showing an arbitrary date instead of the most recent activity date across all lessons.

--- a/changelog/fix-days-to-complete-ungraded-failed
+++ b/changelog/fix-days-to-complete-ungraded-failed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Days to Completion calculation in Reports to exclude lessons with ungraded or failed quizzes, which do not have a valid completion date.

--- a/changelog/fix-grading-hide-lessons-without-quiz-answers
+++ b/changelog/fix-grading-hide-lessons-without-quiz-answers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide lessons with no quiz answers from the Grading page, including completed lessons where the student never submitted the quiz and orphaned records with quiz-derived statuses but no answer data.

--- a/changelog/fix-grading-tab-counts-lesson-filter
+++ b/changelog/fix-grading-tab-counts-lesson-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Grading page status tab counts not updating when filtering by a specific lesson.

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -4583,6 +4583,9 @@
       <code>$row-&gt;updated_at</code>
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
+    <UndefinedConstant occurrences="1">
+      <code>ARRAY_A</code>
+    </UndefinedConstant>
   </file>
   <file src="includes/internal/services/class-tables-based-progress-aggregation-service.php">
     <PossiblyInvalidPropertyFetch occurrences="5">

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -4561,7 +4561,8 @@
     </InvalidScalarArgument>
   </file>
   <file src="includes/internal/services/class-comments-based-progress-aggregation-service.php">
-    <PossiblyInvalidPropertyFetch occurrences="4">
+    <PossiblyInvalidPropertyFetch occurrences="5">
+      <code>$row-&gt;days_to_complete_count</code>
       <code>$row-&gt;days_to_complete_sum</code>
       <code>$row-&gt;lesson_completed_count</code>
       <code>$row-&gt;lesson_start_count</code>
@@ -4584,7 +4585,8 @@
     </PossiblyInvalidPropertyFetch>
   </file>
   <file src="includes/internal/services/class-tables-based-progress-aggregation-service.php">
-    <PossiblyInvalidPropertyFetch occurrences="4">
+    <PossiblyInvalidPropertyFetch occurrences="5">
+      <code>$row-&gt;days_to_complete_count</code>
       <code>$row-&gt;days_to_complete_sum</code>
       <code>$row-&gt;lesson_completed_count</code>
       <code>$row-&gt;lesson_start_count</code>

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -1620,9 +1620,13 @@
   </file>
   <file src="includes/class-sensei-grading-main.php">
     <ArgumentTypeCoercion occurrences="1"/>
-    <MissingParamType occurrences="1">
-      <code>$args</code>
-    </MissingParamType>
+    <InternalProperty occurrences="5">
+      <code>$item-&gt;grade</code>
+      <code>$item-&gt;lesson_id</code>
+      <code>$item-&gt;status</code>
+      <code>$item-&gt;updated_at</code>
+      <code>$item-&gt;user_id</code>
+    </InternalProperty>
     <MissingPropertyType occurrences="6">
       <code>$course_id</code>
       <code>$lesson_id</code>
@@ -1634,6 +1638,9 @@
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>$search</code>
     </PossiblyFalsePropertyAssignmentValue>
+    <PossiblyNullArgument occurrences="1">
+      <code>$args</code>
+    </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="8">
       <code>Sensei_Grading_Main</code>
       <code>Sensei_Grading_Main</code>
@@ -4548,12 +4555,41 @@
       <code>$row-&gt;user_id</code>
     </PossiblyInvalidPropertyFetch>
   </file>
+  <file src="includes/internal/services/class-comments-based-grading-listing-service.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$comment-&gt;comment_ID</code>
+    </InvalidScalarArgument>
+  </file>
   <file src="includes/internal/services/class-comments-based-progress-aggregation-service.php">
+    <PossiblyInvalidPropertyFetch occurrences="4">
+      <code>$row-&gt;days_to_complete_sum</code>
+      <code>$row-&gt;lesson_completed_count</code>
+      <code>$row-&gt;lesson_start_count</code>
+      <code>$row-&gt;unique_student_count</code>
+    </PossiblyInvalidPropertyFetch>
     <UndefinedConstant occurrences="1">
       <code>ARRAY_A</code>
     </UndefinedConstant>
   </file>
+  <file src="includes/internal/services/class-tables-based-grading-listing-service.php">
+    <PossiblyInvalidCast occurrences="1">
+      <code>$column</code>
+    </PossiblyInvalidCast>
+    <PossiblyInvalidPropertyFetch occurrences="5">
+      <code>$row-&gt;effective_status</code>
+      <code>$row-&gt;final_grade</code>
+      <code>$row-&gt;post_id</code>
+      <code>$row-&gt;updated_at</code>
+      <code>$row-&gt;user_id</code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
   <file src="includes/internal/services/class-tables-based-progress-aggregation-service.php">
+    <PossiblyInvalidPropertyFetch occurrences="4">
+      <code>$row-&gt;days_to_complete_sum</code>
+      <code>$row-&gt;lesson_completed_count</code>
+      <code>$row-&gt;lesson_start_count</code>
+      <code>$row-&gt;unique_student_count</code>
+    </PossiblyInvalidPropertyFetch>
     <UndefinedConstant occurrences="2">
       <code>ARRAY_A</code>
     </UndefinedConstant>
@@ -4827,7 +4863,8 @@
     <InvalidArgument occurrences="1">
       <code>$lessons</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument occurrences="2">
+      <code>$lesson_students</code>
       <code>$value</code>
     </InvalidScalarArgument>
     <PossibleRawObjectIteration occurrences="1">

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -569,7 +569,23 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		 */
 		$count_args = apply_filters( 'sensei_grading_count_statuses', $count_args );
 
-		$counts = Sensei()->grading->count_statuses( $count_args );
+		// Use cached per-status counts from prepare_items() when available,
+		// avoiding a second full-table scan with the same JOINs.
+		$cached_counts = $this->grading_listing_service->get_status_counts();
+		if ( null !== $cached_counts ) {
+			// Ensure all expected statuses exist with 0 defaults, matching
+			// the shape that count_statuses() returns.
+			$defaults = array_fill_keys(
+				array( 'graded', 'ungraded', 'passed', 'failed', 'in-progress', 'complete' ),
+				0
+			);
+			$counts   = array_merge( $defaults, $cached_counts );
+
+			/** This filter is documented in includes/class-sensei-grading.php */
+			$counts = apply_filters( 'sensei_count_statuses', $counts, 'sensei_lesson_status' );
+		} else {
+			$counts = Sensei()->grading->count_statuses( $count_args );
+		}
 
 		$inprogress_lessons_count = $counts['in-progress'];
 		$ungraded_lessons_count   = $counts['ungraded'];

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -503,6 +503,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		// Setup counters.
 		$count_args = array(
 			'type' => 'lesson',
+			'exclude_unsubmitted_quiz_completions' => true,
 		);
 		$query_args = array(
 			'page' => $this->page_slug,

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -3,6 +3,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+use Sensei\Internal\Services\Grading_Listing_Service_Interface;
+use Sensei\Internal\Services\Grading_Item;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 /**
  * Admin Grading Overview Data Table in Sensei.
  *
@@ -20,11 +24,21 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	public $page_slug = 'sensei_grading';
 
 	/**
+	 * The grading listing service.
+	 *
+	 * @var Grading_Listing_Service_Interface
+	 */
+	private Grading_Listing_Service_Interface $grading_listing_service;
+
+	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
+	 *
+	 * @param array|null                             $args                    Constructor arguments.
+	 * @param Grading_Listing_Service_Interface|null $grading_listing_service The grading listing service.
 	 */
-	public function __construct( $args = null ) {
+	public function __construct( $args = null, ?Grading_Listing_Service_Interface $grading_listing_service = null ) {
 
 		$defaults = array(
 			'course_id' => 0,
@@ -43,6 +57,9 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		if ( ! empty( $args['view'] ) && in_array( $args['view'], array( 'in-progress', 'graded', 'ungraded', 'all' ) ) ) {
 			$this->view = $args['view'];
 		}
+
+		$this->grading_listing_service = $grading_listing_service
+			?? ( new Progress_Query_Service_Factory() )->create_grading_listing_service();
 
 		// Load Parent token into constructor
 		parent::__construct( 'grading_main' );
@@ -237,30 +254,9 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		 */
 		$activity_args = apply_filters( 'sensei_grading_filter_statuses', $activity_args );
 
-		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so instead do this twice
-		$total_statuses = Sensei_Utils::sensei_check_for_activity(
-			array_merge(
-				$activity_args,
-				array(
-					'count'  => true,
-					'offset' => 0,
-					'number' => 0,
-				)
-			)
-		);
-
-		// Ensure we change our range to fit (in case a search threw off the pagination) - Should this be added to all views?
-		if ( $total_statuses < $activity_args['offset'] ) {
-			$new_paged               = floor( $total_statuses / $activity_args['number'] );
-			$activity_args['offset'] = $new_paged * $activity_args['number'];
-		}
-		$statuses = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
-		// Need to always return an array, even with only 1 item
-		if ( ! is_array( $statuses ) ) {
-			$statuses = array( $statuses );
-		}
-		$this->total_items = $total_statuses;
-		$this->items       = $statuses;
+		$result            = $this->grading_listing_service->get_lesson_progress_items( $activity_args );
+		$this->total_items = $result['total_count'];
+		$this->items       = $result['items'];
 
 		$total_items = $this->total_items;
 		$total_pages = ceil( $total_items / $per_page );
@@ -277,25 +273,31 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	 * Generates content for a single row of the table, overriding parent
 	 *
 	 * @since  1.7.0
-	 * @param object $item The current item
+	 * @param Grading_Item $item The current item.
 	 */
 	protected function get_row_data( $item ) {
-		global $wp_version;
+		$status    = $item->status;
+		$user_id   = $item->user_id;
+		$lesson_id = $item->lesson_id;
+		$updated   = $item->updated_at;
+		$grade_val = $item->grade;
+
+		$grade_display = ( null !== $grade_val ? $grade_val : '' ) . '%';
 
 		$grade = '';
-		if ( 'complete' == $item->comment_approved ) {
+		if ( 'complete' == $status ) {
 			$status_html = '<span class="graded">' . esc_html__( 'Completed', 'sensei-lms' ) . '</span>';
 			$grade       = __( 'No Grade', 'sensei-lms' );
-		} elseif ( 'graded' == $item->comment_approved ) {
+		} elseif ( 'graded' == $status ) {
 			$status_html = '<span class="graded">' . esc_html__( 'Graded', 'sensei-lms' ) . '</span>';
-			$grade       = get_comment_meta( $item->comment_ID, 'grade', true ) . '%';
-		} elseif ( 'passed' == $item->comment_approved ) {
+			$grade       = $grade_display;
+		} elseif ( 'passed' == $status ) {
 			$status_html = '<span class="passed">' . esc_html__( 'Passed', 'sensei-lms' ) . '</span>';
-			$grade       = get_comment_meta( $item->comment_ID, 'grade', true ) . '%';
-		} elseif ( 'failed' == $item->comment_approved ) {
+			$grade       = $grade_display;
+		} elseif ( 'failed' == $status ) {
 			$status_html = '<span class="failed">' . esc_html__( 'Failed', 'sensei-lms' ) . '</span>';
-			$grade       = get_comment_meta( $item->comment_ID, 'grade', true ) . '%';
-		} elseif ( 'ungraded' == $item->comment_approved ) {
+			$grade       = $grade_display;
+		} elseif ( 'ungraded' == $status ) {
 			$status_html = '<span class="ungraded">' . esc_html__( 'Ungraded', 'sensei-lms' ) . '</span>';
 			$grade       = __( 'N/A', 'sensei-lms' );
 		} else {
@@ -303,20 +305,20 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			$grade       = __( 'N/A', 'sensei-lms' );
 		}
 
-		$title = Sensei_Learner::get_full_name( $item->user_id );
+		$title = Sensei_Learner::get_full_name( $user_id );
 
-		$quiz_id   = Sensei()->lesson->lesson_quizzes( $item->comment_post_ID, 'any' );
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id, 'any' );
 		$quiz_link = add_query_arg(
 			array(
 				'page'    => $this->page_slug,
-				'user'    => $item->user_id,
+				'user'    => $user_id,
 				'quiz_id' => $quiz_id,
 			),
 			admin_url( 'admin.php' )
 		);
 
 		$grade_link = '';
-		switch ( $item->comment_approved ) {
+		switch ( $status ) {
 			case 'ungraded':
 				$grade_link = '<a class="button-primary button" href="' . esc_url( $quiz_link ) . '">' . esc_html__( 'Grade quiz', 'sensei-lms' ) . '</a>';
 				break;
@@ -328,7 +330,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				break;
 		}
 
-		$course_id    = get_post_meta( $item->comment_post_ID, '_lesson_course', true );
+		$course_id    = get_post_meta( $lesson_id, '_lesson_course', true );
 		$course_title = '';
 
 		if ( ! empty( $course_id ) ) {
@@ -347,11 +349,11 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			add_query_arg(
 				array(
 					'page'      => $this->page_slug,
-					'lesson_id' => $item->comment_post_ID,
+					'lesson_id' => $lesson_id,
 				),
 				admin_url( 'admin.php' )
 			)
-		) . '">' . esc_html( get_the_title( $item->comment_post_ID ) ) . '</a>';
+		) . '">' . esc_html( get_the_title( $lesson_id ) ) . '</a>';
 
 		/**
 		 * Filter columns data for the Grading list table.
@@ -359,7 +361,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		 * @hook sensei_grading_main_column_data
 		 *
 		 * @param {array}  $column_data Column data for a row.
-		 * @param {object} $item Activity comment object.
+		 * @param {Grading_Item} $item Grading item for the row.
 		 * @param {int}    $course_id The course ID.
 		 * @return {array} Filtered column data.
 		 */
@@ -370,14 +372,14 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 					add_query_arg(
 						array(
 							'page'    => $this->page_slug,
-							'user_id' => $item->user_id,
+							'user_id' => $user_id,
 						),
 						admin_url( 'admin.php' )
 					)
 				) . '">' . esc_html( $title ) . '</a></strong>',
 				'course'      => $course_title,
 				'lesson'      => $lesson_title,
-				'updated'     => $item->comment_date,
+				'updated'     => $updated,
 				'user_status' => $status_html,
 				'user_grade'  => $grade,
 				'action'      => $grade_link,

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -502,7 +502,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 
 		// Setup counters.
 		$count_args = array(
-			'type' => 'lesson',
+			'type'                                 => 'lesson',
 			'exclude_unsubmitted_quiz_completions' => true,
 		);
 		$query_args = array(

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -282,7 +282,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		$updated   = $item->updated_at;
 		$grade_val = $item->grade;
 
-		$grade_display = ( null !== $grade_val ? $grade_val : '' ) . '%';
+		$grade_display = null !== $grade_val ? $grade_val . '%' : __( 'N/A', 'sensei-lms' );
 
 		$grade = '';
 		if ( 'complete' == $status ) {

--- a/includes/internal/installer/class-schema.php
+++ b/includes/internal/installer/class-schema.php
@@ -107,7 +107,8 @@ CREATE TABLE {$wpdb->prefix}sensei_lms_progress (
 	updated_at datetime NOT NULL,
 	PRIMARY KEY  (id),
 	UNIQUE KEY user_progress (post_id, user_id, type),
-	KEY status (status)
+	KEY status (status),
+	KEY type_post_id (type, post_id)
 ) $collate;
 ",
 			"{$wpdb->prefix}sensei_lms_quiz_submissions" => "
@@ -197,4 +198,3 @@ CREATE TABLE {$wpdb->prefix}sensei_lms_quiz_grades (
 		return $tables;
 	}
 }
-

--- a/includes/internal/services/class-comments-based-grading-listing-service.php
+++ b/includes/internal/services/class-comments-based-grading-listing-service.php
@@ -105,4 +105,17 @@ class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_
 			'total_count' => (int) $total_count,
 		];
 	}
+
+	/**
+	 * Get cached per-status counts.
+	 *
+	 * Not supported by comments-based implementation.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array<string, int>|null Always null for comments-based storage.
+	 */
+	public function get_status_counts(): ?array {
+		return null;
+	}
 }

--- a/includes/internal/services/class-comments-based-grading-listing-service.php
+++ b/includes/internal/services/class-comments-based-grading-listing-service.php
@@ -31,6 +31,24 @@ class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_
 	 * @return array{ items: Grading_Item[], total_count: int }
 	 */
 	public function get_lesson_progress_items( array $args ): array {
+		// Add a SQL-level filter to exclude lessons where a quiz exists but
+		// the student has no quiz answers — there is nothing to grade.
+		// This covers both 'complete' (never submitted) and orphaned
+		// 'passed'/'graded'/'failed' records with no answer data.
+		// In-progress students are kept since they haven't submitted yet.
+		$exclusion_filter = function ( $clauses ) {
+			global $wpdb;
+			$clauses['where'] .= " AND NOT ( {$wpdb->comments}.comment_approved != 'in-progress'"
+				. " AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} pm"
+				. " WHERE pm.post_id = {$wpdb->comments}.comment_post_ID"
+				. " AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0 )"
+				. " AND NOT EXISTS ( SELECT 1 FROM {$wpdb->commentmeta} cm"
+				. " WHERE cm.comment_id = {$wpdb->comments}.comment_ID"
+				. " AND cm.meta_key = 'quiz_answers' ) )";
+			return $clauses;
+		};
+		add_filter( 'comments_clauses', $exclusion_filter );
+
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so run
 		// a separate count query first with no limit/offset.
 		$total_count = \Sensei_Utils::sensei_check_for_activity(
@@ -54,6 +72,8 @@ class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_
 		}
 
 		$statuses = \Sensei_Utils::sensei_check_for_activity( $args, true );
+
+		remove_filter( 'comments_clauses', $exclusion_filter );
 
 		// sensei_check_for_activity returns a single object when there is
 		// exactly one result — normalize to an array.

--- a/includes/internal/services/class-comments-based-grading-listing-service.php
+++ b/includes/internal/services/class-comments-based-grading-listing-service.php
@@ -36,7 +36,7 @@ class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_
 		// This covers both 'complete' (never submitted) and orphaned
 		// 'passed'/'graded'/'failed' records with no answer data.
 		// In-progress students are kept since they haven't submitted yet.
-		$exclusion_filter = function ( $clauses ) {
+		$exclusion_filter = function ( array $clauses ): array {
 			global $wpdb;
 			$clauses['where'] .= " AND NOT ( {$wpdb->comments}.comment_approved != 'in-progress'"
 				. " AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} pm"

--- a/includes/internal/services/class-comments-based-grading-listing-service.php
+++ b/includes/internal/services/class-comments-based-grading-listing-service.php
@@ -76,7 +76,7 @@ class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_
 				(int) $comment->user_id,
 				(int) $comment->comment_post_ID,
 				$comment->comment_date,
-				'' !== $grade_value ? (int) $grade_value : null
+				'' !== $grade_value ? (float) $grade_value : null
 			);
 		}
 

--- a/includes/internal/services/class-comments-based-grading-listing-service.php
+++ b/includes/internal/services/class-comments-based-grading-listing-service.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * File containing the Comments_Based_Grading_Listing_Service class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Comments_Based_Grading_Listing_Service.
+ *
+ * Comments-based implementation of the Grading_Listing_Service_Interface.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_Interface {
+
+	/**
+	 * Get lesson progress items for the grading listing.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Arguments for the query (see interface).
+	 * @return array{ items: Grading_Item[], total_count: int }
+	 */
+	public function get_lesson_progress_items( array $args ): array {
+		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so run
+		// a separate count query first with no limit/offset.
+		$total_count = \Sensei_Utils::sensei_check_for_activity(
+			array_merge(
+				$args,
+				[
+					'count'  => true,
+					'offset' => 0,
+					'number' => 0,
+				]
+			)
+		);
+
+		// If the requested offset is beyond the total (e.g. in case a search
+		// threw off the pagination), snap back to the last valid page.
+		$offset = $args['offset'] ?? 0;
+		$number = $args['number'] ?? 10;
+		if ( $number > 0 && $total_count < $offset ) {
+			$new_paged      = floor( $total_count / $number );
+			$args['offset'] = $new_paged * $number;
+		}
+
+		$statuses = \Sensei_Utils::sensei_check_for_activity( $args, true );
+
+		// sensei_check_for_activity returns a single object when there is
+		// exactly one result — normalize to an array.
+		if ( ! is_array( $statuses ) ) {
+			$statuses = [ $statuses ];
+		}
+
+		$items = [];
+		foreach ( $statuses as $comment ) {
+			// sensei_check_for_activity can return false when no results are
+			// found; skip anything that isn't a real comment.
+			if ( ! $comment instanceof \WP_Comment ) {
+				continue;
+			}
+
+			$grade_value = get_comment_meta( $comment->comment_ID, 'grade', true );
+
+			$items[] = new Grading_Item(
+				$comment->comment_approved,
+				(int) $comment->user_id,
+				(int) $comment->comment_post_ID,
+				$comment->comment_date,
+				'' !== $grade_value ? (int) $grade_value : null
+			);
+		}
+
+		return [
+			'items'       => $items,
+			'total_count' => (int) $total_count,
+		];
+	}
+}

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -154,14 +154,16 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	private function build_post_filter_clause( array $args ): string {
 		$wpdb = $this->wpdb;
 
+		// Prefer post_id (single lesson filter) over post__in (course lessons)
+		// so that counts reflect the specific lesson when both are set.
+		if ( ! empty( $args['post_id'] ) ) {
+			return $wpdb->prepare( ' AND comment_post_ID = %d', $args['post_id'] );
+		}
+
 		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
 			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
 			return $wpdb->prepare( " AND comment_post_ID IN ( $placeholders )", $args['post__in'] );
-		}
-
-		if ( ! empty( $args['post_id'] ) ) {
-			return $wpdb->prepare( ' AND comment_post_ID = %d', $args['post_id'] );
 		}
 
 		return '';

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -92,6 +92,58 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	}
 
 	/**
+	 * Get aggregate totals for a set of lessons.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $lesson_ids Array of lesson post IDs.
+	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_sum.
+	 */
+	public function get_lesson_totals( array $lesson_ids ): array {
+		$defaults = [
+			'unique_student_count'   => 0,
+			'lesson_start_count'     => 0,
+			'lesson_completed_count' => 0,
+			'days_to_complete_sum'   => 0,
+		];
+
+		if ( empty( $lesson_ids ) ) {
+			return $defaults;
+		}
+
+		$wpdb         = $this->wpdb;
+		$placeholders = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+		$completed    = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb. Placeholders created dynamically. Date format string uses literal %s for MySQL STR_TO_DATE.
+		$query = $wpdb->prepare(
+			"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
+			, COUNT(lesson_students.comment_id) lesson_start_count
+			, SUM(IF(lesson_students.comment_approved IN ($completed), 1, 0)) lesson_completed_count
+			, SUM(IF(lesson_students.comment_approved IN ($completed), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
+			FROM {$wpdb->comments} lesson_students
+			LEFT JOIN {$wpdb->commentmeta} lesson_start ON lesson_start.comment_id = lesson_students.comment_id
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $placeholders )",
+			array_merge( [ '%Y-%m-%d %H:%i:%s' ], $lesson_ids )
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$row = $wpdb->get_row( $query );
+
+		if ( ! $row ) {
+			return $defaults;
+		}
+
+		return [
+			'unique_student_count'   => (int) $row->unique_student_count,
+			'lesson_start_count'     => (int) $row->lesson_start_count,
+			'lesson_completed_count' => (int) $row->lesson_completed_count,
+			'days_to_complete_sum'   => (int) $row->days_to_complete_sum,
+		];
+	}
+
+	/**
 	 * Build SQL clause for filtering by post ID(s).
 	 *
 	 * @since $$next-version$$

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -111,16 +111,17 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 			return $defaults;
 		}
 
-		$wpdb         = $this->wpdb;
-		$placeholders = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-		$completed    = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
+		$wpdb           = $this->wpdb;
+		$placeholders   = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+		$completed      = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
+		$has_completion = "'" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "'";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb. Placeholders created dynamically. Date format string uses literal %s for MySQL STR_TO_DATE.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
 			, COUNT(lesson_students.comment_id) lesson_start_count
 			, SUM(IF(lesson_students.comment_approved IN ($completed), 1, 0)) lesson_completed_count
-			, SUM(IF(lesson_students.comment_approved IN ($completed), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
+			, SUM(IF(lesson_students.comment_approved IN ($has_completion), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM {$wpdb->comments} lesson_students
 			LEFT JOIN {$wpdb->commentmeta} lesson_start ON lesson_start.comment_id = lesson_students.comment_id
 			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $placeholders )",

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -73,6 +73,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
 		$query .= $this->build_user_exclusion_clause( $args );
+		$query .= $this->build_unsubmitted_quiz_exclusion_clause( $args );
 
 		if ( isset( $args['query'] ) ) {
 			$query .= $args['query'];
@@ -232,5 +233,37 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		}
 
 		return " AND $exclusion_sql";
+	}
+
+	/**
+	 * Build SQL clause for excluding completed lessons with no quiz submission.
+	 *
+	 * When enabled, excludes lessons where a quiz exists but the student has
+	 * no quiz answers — there is nothing to grade. This covers both 'complete'
+	 * (never submitted) and orphaned 'passed'/'graded'/'failed' records with
+	 * no answer data.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_unsubmitted_quiz_exclusion_clause( array $args ): string {
+		$exclude = $args['exclude_unsubmitted_quiz_completions'] ?? false;
+
+		if ( ! $exclude ) {
+			return '';
+		}
+
+		$wpdb = $this->wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
+		return " AND NOT ( comment_approved != 'in-progress'"
+			. " AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} pm"
+			. " WHERE pm.post_id = {$wpdb->comments}.comment_post_ID"
+			. " AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0 )"
+			. " AND NOT EXISTS ( SELECT 1 FROM {$wpdb->commentmeta} cm"
+			. " WHERE cm.comment_id = {$wpdb->comments}.comment_ID"
+			. " AND cm.meta_key = 'quiz_answers' ) )";
 	}
 }

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -113,14 +113,13 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 
 		$wpdb           = $this->wpdb;
 		$placeholders   = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-		$completed      = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
 		$has_completion = "'" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "'";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb. Placeholders created dynamically. Date format string uses literal %s for MySQL STR_TO_DATE.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
 			, COUNT(lesson_students.comment_id) lesson_start_count
-			, SUM(IF(lesson_students.comment_approved IN ($completed), 1, 0)) lesson_completed_count
+			, SUM(IF(lesson_students.comment_approved IN ($has_completion), 1, 0)) lesson_completed_count
 			, SUM(IF(lesson_students.comment_approved IN ($has_completion), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM {$wpdb->comments} lesson_students
 			LEFT JOIN {$wpdb->commentmeta} lesson_start ON lesson_start.comment_id = lesson_students.comment_id

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -97,13 +97,14 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	 * @since $$next-version$$
 	 *
 	 * @param int[] $lesson_ids Array of lesson post IDs.
-	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_sum.
+	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_count, days_to_complete_sum.
 	 */
 	public function get_lesson_totals( array $lesson_ids ): array {
 		$defaults = [
 			'unique_student_count'   => 0,
 			'lesson_start_count'     => 0,
 			'lesson_completed_count' => 0,
+			'days_to_complete_count' => 0,
 			'days_to_complete_sum'   => 0,
 		];
 
@@ -113,13 +114,15 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 
 		$wpdb           = $this->wpdb;
 		$placeholders   = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+		$completed      = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
 		$has_completion = "'" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "'";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb. Placeholders created dynamically. Date format string uses literal %s for MySQL STR_TO_DATE.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
 			, COUNT(lesson_students.comment_id) lesson_start_count
-			, SUM(IF(lesson_students.comment_approved IN ($has_completion), 1, 0)) lesson_completed_count
+			, SUM(IF(lesson_students.comment_approved IN ($completed), 1, 0)) lesson_completed_count
+			, SUM(IF(lesson_students.comment_approved IN ($has_completion), 1, 0)) days_to_complete_count
 			, SUM(IF(lesson_students.comment_approved IN ($has_completion), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM {$wpdb->comments} lesson_students
 			LEFT JOIN {$wpdb->commentmeta} lesson_start ON lesson_start.comment_id = lesson_students.comment_id
@@ -139,6 +142,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 			'unique_student_count'   => (int) $row->unique_student_count,
 			'lesson_start_count'     => (int) $row->lesson_start_count,
 			'lesson_completed_count' => (int) $row->lesson_completed_count,
+			'days_to_complete_count' => (int) $row->days_to_complete_count,
 			'days_to_complete_sum'   => (int) $row->days_to_complete_sum,
 		];
 	}

--- a/includes/internal/services/class-comments-based-progress-clauses-service.php
+++ b/includes/internal/services/class-comments-based-progress-clauses-service.php
@@ -163,15 +163,15 @@ class Comments_Based_Progress_Clauses_Service implements Progress_Clauses_Servic
 	 * @return array Modified associative array of the clauses for the query.
 	 */
 	public function add_days_to_completion_to_lessons_clauses( array $clauses ): array {
-		$wpdb = $this->wpdb;
+		$wpdb           = $this->wpdb;
+		$has_completion = "'" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "'";
 
 		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date )) + 1 ) as days_to_complete";
 		$clauses['fields'] .= " FROM {$wpdb->comments}";
 		$clauses['fields'] .= " INNER JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id";
 		$clauses['fields'] .= " WHERE {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
 		$clauses['fields'] .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
-		$completed          = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
-		$clauses['fields'] .= " AND {$wpdb->comments}.comment_approved IN ( $completed )";
+		$clauses['fields'] .= " AND {$wpdb->comments}.comment_approved IN ( $has_completion )";
 		$clauses['fields'] .= " AND {$wpdb->commentmeta}.meta_key = 'start') as days_to_complete";
 
 		return $clauses;

--- a/includes/internal/services/class-comments-based-progress-clauses-service.php
+++ b/includes/internal/services/class-comments-based-progress-clauses-service.php
@@ -131,4 +131,49 @@ class Comments_Based_Progress_Clauses_Service implements Progress_Clauses_Servic
 
 		return $clauses;
 	}
+
+	/**
+	 * Modify WP_Query clauses to add last activity date to lesson posts.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_last_activity_to_lessons_clauses( array $clauses ): array {
+		$wpdb = $this->wpdb;
+
+		$clauses['fields'] .= ", (
+			SELECT MAX({$wpdb->comments}.comment_date_gmt)
+			FROM {$wpdb->comments}
+			WHERE {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID
+			AND {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
+			AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
+		) AS last_activity_date";
+
+		return $clauses;
+	}
+
+	/**
+	 * Modify WP_Query clauses to add days-to-complete data to lesson posts.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_days_to_completion_to_lessons_clauses( array $clauses ): array {
+		$wpdb = $this->wpdb;
+
+		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date )) + 1 ) as days_to_complete";
+		$clauses['fields'] .= " FROM {$wpdb->comments}";
+		$clauses['fields'] .= " INNER JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id";
+		$clauses['fields'] .= " WHERE {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
+		$clauses['fields'] .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
+		$completed          = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
+		$clauses['fields'] .= " AND {$wpdb->comments}.comment_approved IN ( $completed )";
+		$clauses['fields'] .= " AND {$wpdb->commentmeta}.meta_key = 'start') as days_to_complete";
+
+		return $clauses;
+	}
 }

--- a/includes/internal/services/class-grading-item.php
+++ b/includes/internal/services/class-grading-item.php
@@ -25,20 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Grading_Item {
 
 	/**
-	 * Statuses that indicate a lesson has been completed (including quiz outcomes).
+	 * Statuses that indicate a lesson has been completed with a valid completion date.
 	 *
-	 * @since $$next-version$$
-	 *
-	 * @var string[]
-	 */
-	public const COMPLETED_STATUSES = [ 'complete', 'graded', 'passed', 'failed', 'ungraded' ];
-
-	/**
-	 * Statuses that indicate a lesson has a valid completion date.
-	 *
-	 * Unlike COMPLETED_STATUSES, this excludes 'failed' and 'ungraded' because
-	 * those statuses do not have a completion date set in the data model.
-	 * Used for days-to-complete calculations where a reliable date is required.
+	 * Excludes 'failed' and 'ungraded' because those statuses do not have a
+	 * completion date set in the data model. Used for lesson completion counts
+	 * and days-to-complete calculations in reports.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/internal/services/class-grading-item.php
+++ b/includes/internal/services/class-grading-item.php
@@ -34,6 +34,19 @@ class Grading_Item {
 	public const COMPLETED_STATUSES = [ 'complete', 'graded', 'passed', 'failed', 'ungraded' ];
 
 	/**
+	 * Statuses that indicate a lesson has a valid completion date.
+	 *
+	 * Unlike COMPLETED_STATUSES, this excludes 'failed' and 'ungraded' because
+	 * those statuses do not have a completion date set in the data model.
+	 * Used for days-to-complete calculations where a reliable date is required.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string[]
+	 */
+	public const STATUSES_WITH_COMPLETION_DATE = [ 'complete', 'graded', 'passed' ];
+
+	/**
 	 * The progress status. For HPPS tables-based storage, this is the
 	 * effective status coalesced from quiz progress when available.
 	 * For comments-based storage, this is the raw comment_approved value.

--- a/includes/internal/services/class-grading-item.php
+++ b/includes/internal/services/class-grading-item.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * File containing the Grading_Item class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Grading_Item.
+ *
+ * Value object representing a single grading row. Abstracts away the
+ * difference between comment-based and table-based storage so that
+ * the grading UI code can work with a uniform interface.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Grading_Item {
+
+	/**
+	 * Statuses that indicate a lesson has been completed (including quiz outcomes).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string[]
+	 */
+	public const COMPLETED_STATUSES = [ 'complete', 'graded', 'passed', 'failed', 'ungraded' ];
+
+	/**
+	 * The progress status. For HPPS tables-based storage, this is the
+	 * effective status coalesced from quiz progress when available.
+	 * For comments-based storage, this is the raw comment_approved value.
+	 *
+	 * @var string
+	 */
+	public string $status;
+
+	/**
+	 * The user ID.
+	 *
+	 * @var int
+	 */
+	public int $user_id;
+
+	/**
+	 * The lesson post ID.
+	 *
+	 * @var int
+	 */
+	public int $lesson_id;
+
+	/**
+	 * The date string of the last update.
+	 *
+	 * @var string
+	 */
+	public string $updated_at;
+
+	/**
+	 * The grade percentage, or null if not graded.
+	 *
+	 * @var int|null
+	 */
+	public ?int $grade;
+
+	/**
+	 * Mapping of legacy WP_Comment property names to Grading_Item properties.
+	 *
+	 * @var array<string, string>
+	 */
+	private const LEGACY_PROPERTY_MAP = [
+		'comment_approved' => 'status',
+		'comment_post_ID'  => 'lesson_id',
+		'comment_date'     => 'updated_at',
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string   $status     The progress status.
+	 * @param int      $user_id    The user ID.
+	 * @param int      $lesson_id  The lesson post ID.
+	 * @param string   $updated_at The date string of the last update.
+	 * @param int|null $grade      The grade percentage, or null if not graded.
+	 */
+	public function __construct( string $status, int $user_id, int $lesson_id, string $updated_at, ?int $grade ) {
+		$this->status     = $status;
+		$this->user_id    = $user_id;
+		$this->lesson_id  = $lesson_id;
+		$this->updated_at = $updated_at;
+		$this->grade      = $grade;
+	}
+
+	/**
+	 * Provide backward-compatible access to legacy WP_Comment property names.
+	 *
+	 * This allows third-party code that hooks into `sensei_grading_main_column_data`
+	 * and reads WP_Comment properties (e.g. `$item->comment_approved`) to continue
+	 * working transparently.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key The property name.
+	 * @return mixed|null The property value, or null if not mapped.
+	 */
+	public function __get( $key ) {
+		if ( isset( self::LEGACY_PROPERTY_MAP[ $key ] ) ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- _deprecated_argument handles its own output.
+			_deprecated_argument(
+				'Grading_Item::$' . $key,
+				'$$next-version$$',
+				sprintf(
+					/* translators: 1: old property name, 2: new property name */
+					'Accessing Grading_Item via legacy WP_Comment property "%1$s" is deprecated. Use "%2$s" instead.',
+					$key,
+					self::LEGACY_PROPERTY_MAP[ $key ]
+				)
+			);
+			// phpcs:enable
+
+			return $this->{self::LEGACY_PROPERTY_MAP[ $key ]};
+		}
+
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong handles its own output.
+		_doing_it_wrong(
+			'Grading_Item::$' . $key,
+			sprintf(
+				/* translators: %s: property name */
+				'Property "%s" does not exist on Grading_Item. The grading list table no longer uses WP_Comment objects.',
+				$key
+			),
+			'$$next-version$$'
+		);
+		// phpcs:enable
+
+		return null;
+	}
+}

--- a/includes/internal/services/class-grading-item.php
+++ b/includes/internal/services/class-grading-item.php
@@ -50,6 +50,24 @@ class Grading_Item {
 	public const STATUSES_WITH_COMPLETION_DATE = [ 'complete', 'graded', 'passed' ];
 
 	/**
+	 * Get the site's UTC offset in '+HH:MM' / '-HH:MM' format for CONVERT_TZ.
+	 *
+	 * Uses a numeric offset so that MySQL timezone tables are not required.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string UTC offset string, e.g. '+05:00' or '-05:00'.
+	 */
+	public static function get_utc_offset_string(): string {
+		$offset  = (float) get_option( 'gmt_offset' );
+		$hours   = (int) $offset;
+		$minutes = abs( (int) ( ( $offset - $hours ) * 60 ) );
+		$sign    = $offset < 0 ? '-' : '+';
+
+		return sprintf( '%s%02d:%02d', $sign, abs( $hours ), $minutes );
+	}
+
+	/**
 	 * The progress status. For HPPS tables-based storage, this is the
 	 * effective status coalesced from quiz progress when available.
 	 * For comments-based storage, this is the raw comment_approved value.

--- a/includes/internal/services/class-grading-item.php
+++ b/includes/internal/services/class-grading-item.php
@@ -70,9 +70,9 @@ class Grading_Item {
 	/**
 	 * The grade percentage, or null if not graded.
 	 *
-	 * @var int|null
+	 * @var float|null
 	 */
-	public ?int $grade;
+	public ?float $grade;
 
 	/**
 	 * Mapping of legacy WP_Comment property names to Grading_Item properties.
@@ -90,13 +90,13 @@ class Grading_Item {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string   $status     The progress status.
-	 * @param int      $user_id    The user ID.
-	 * @param int      $lesson_id  The lesson post ID.
-	 * @param string   $updated_at The date string of the last update.
-	 * @param int|null $grade      The grade percentage, or null if not graded.
+	 * @param string     $status     The progress status.
+	 * @param int        $user_id    The user ID.
+	 * @param int        $lesson_id  The lesson post ID.
+	 * @param string     $updated_at The date string of the last update.
+	 * @param float|null $grade      The grade percentage, or null if not graded.
 	 */
-	public function __construct( string $status, int $user_id, int $lesson_id, string $updated_at, ?int $grade ) {
+	public function __construct( string $status, int $user_id, int $lesson_id, string $updated_at, ?float $grade ) {
 		$this->status     = $status;
 		$this->user_id    = $user_id;
 		$this->lesson_id  = $lesson_id;

--- a/includes/internal/services/class-grading-item.php
+++ b/includes/internal/services/class-grading-item.php
@@ -25,11 +25,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Grading_Item {
 
 	/**
-	 * Statuses that indicate a lesson has been completed with a valid completion date.
+	 * All statuses that indicate a lesson is no longer in progress.
+	 *
+	 * Used for "Completed" counts and completion rate in reports.
+	 * Includes 'failed' and 'ungraded' because the student has finished
+	 * the lesson activity even if they did not pass.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string[]
+	 */
+	public const COMPLETED_STATUSES = [ 'complete', 'graded', 'passed', 'failed', 'ungraded' ];
+
+	/**
+	 * Statuses that have a valid completion date in the data model.
 	 *
 	 * Excludes 'failed' and 'ungraded' because those statuses do not have a
-	 * completion date set in the data model. Used for lesson completion counts
-	 * and days-to-complete calculations in reports.
+	 * completion date set. Used as the divisor for days-to-complete calculations.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/internal/services/class-grading-listing-service-interface.php
+++ b/includes/internal/services/class-grading-listing-service-interface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * File containing the Grading_Listing_Service_Interface interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Interface Grading_Listing_Service_Interface.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+interface Grading_Listing_Service_Interface {
+
+	/**
+	 * Get lesson progress items for the grading listing.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args {
+	 *     Arguments for the query.
+	 *
+	 *     @type string       $type     Comment type, e.g. 'sensei_lesson_status'.
+	 *     @type int          $number   Number of items to return.
+	 *     @type int          $offset   Offset for pagination.
+	 *     @type string       $orderby  Column to order by.
+	 *     @type string       $order    'ASC' or 'DESC'.
+	 *     @type string|array $status   Status filter ('any' for all).
+	 *     @type int          $post_id  Restrict to a single post ID.
+	 *     @type int[]        $post__in Restrict to specific post IDs.
+	 *     @type int|int[]    $user_id  Restrict to specific user(s).
+	 * }
+	 * @return array{ items: Grading_Item[], total_count: int }
+	 */
+	public function get_lesson_progress_items( array $args ): array;
+}

--- a/includes/internal/services/class-grading-listing-service-interface.php
+++ b/includes/internal/services/class-grading-listing-service-interface.php
@@ -41,4 +41,16 @@ interface Grading_Listing_Service_Interface {
 	 * @return array{ items: Grading_Item[], total_count: int }
 	 */
 	public function get_lesson_progress_items( array $args ): array;
+
+	/**
+	 * Get cached per-status counts from the most recent query.
+	 *
+	 * Returns null if counts are not available (e.g. comments-based
+	 * implementation, or if get_lesson_progress_items has not been called yet).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array<string, int>|null Associative array of status => count, or null.
+	 */
+	public function get_status_counts(): ?array;
 }

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -41,4 +41,19 @@ interface Progress_Aggregation_Service_Interface {
 	 * @return array Associative array of status => count.
 	 */
 	public function count_statuses( array $args ): array;
+
+	/**
+	 * Get aggregate totals for a set of lessons.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $lesson_ids Array of lesson post IDs.
+	 * @return array {
+	 *     @type int $unique_student_count   Number of distinct students.
+	 *     @type int $lesson_start_count     Number of lesson starts.
+	 *     @type int $lesson_completed_count Number of completed lessons.
+	 *     @type int $days_to_complete_sum   Sum of days to complete.
+	 * }
+	 */
+	public function get_lesson_totals( array $lesson_ids ): array;
 }

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -51,7 +51,8 @@ interface Progress_Aggregation_Service_Interface {
 	 * @return array {
 	 *     @type int $unique_student_count   Number of distinct students.
 	 *     @type int $lesson_start_count     Number of lesson starts.
-	 *     @type int $lesson_completed_count Number of completed lessons.
+	 *     @type int $lesson_completed_count Number of completed lessons (all non-in-progress statuses).
+	 *     @type int $days_to_complete_count Number of lessons with a valid completion date.
 	 *     @type int $days_to_complete_sum   Sum of days to complete.
 	 * }
 	 */

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -35,8 +35,9 @@ interface Progress_Aggregation_Service_Interface {
 	 *     @type array     $post__in                     Restrict to specific post IDs.
 	 *     @type int       $post_id                      Restrict to a single post ID.
 	 *     @type int|array $user_id                      Restrict to specific user IDs.
-	 *     @type string[]  $exclude_user_login_prefixes  User login prefixes to exclude.
-	 *     @type string[]  $include_statuses_override    Statuses that bypass user exclusion.
+	 *     @type string[]  $exclude_user_login_prefixes           User login prefixes to exclude.
+	 *     @type string[]  $include_statuses_override             Statuses that bypass user exclusion.
+	 *     @type bool      $exclude_unsubmitted_quiz_completions Exclude completed lessons with no quiz submission (default: false).
 	 * }
 	 * @return array Associative array of status => count.
 	 */

--- a/includes/internal/services/class-progress-clauses-service-interface.php
+++ b/includes/internal/services/class-progress-clauses-service-interface.php
@@ -57,4 +57,24 @@ interface Progress_Clauses_Service_Interface {
 	 * @return array Modified associative array of the clauses for the query.
 	 */
 	public function filter_courses_by_last_activity( array $clauses, string $from = '', string $to = '' ): array;
+
+	/**
+	 * Modify WP_Query clauses to add last activity date to lesson posts.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_last_activity_to_lessons_clauses( array $clauses ): array;
+
+	/**
+	 * Modify WP_Query clauses to add days-to-complete data to lesson posts.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_days_to_completion_to_lessons_clauses( array $clauses ): array;
 }

--- a/includes/internal/services/class-progress-query-service-factory.php
+++ b/includes/internal/services/class-progress-query-service-factory.php
@@ -44,6 +44,23 @@ class Progress_Query_Service_Factory {
 	}
 
 	/**
+	 * Create a Grading_Listing_Service_Interface instance.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return Grading_Listing_Service_Interface The grading listing service.
+	 */
+	public function create_grading_listing_service(): Grading_Listing_Service_Interface {
+		global $wpdb;
+
+		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+			return new Tables_Based_Grading_Listing_Service( $wpdb );
+		}
+
+		return new Comments_Based_Grading_Listing_Service();
+	}
+
+	/**
 	 * Create a Progress_Aggregation_Service_Interface instance.
 	 *
 	 * Returns a tables-based implementation when HPPS is enabled and the tables

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -30,6 +30,13 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 	private \wpdb $wpdb;
 
 	/**
+	 * Cached per-status counts from the most recent query.
+	 *
+	 * @var array<string, int>|null
+	 */
+	private ?array $status_counts = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since $$next-version$$
@@ -64,14 +71,35 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 		$table             = $this->get_progress_table_name();
 		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
 
-		// Build the base query with JOINs for quiz status coalescing and
-		// grade retrieval, plus any post/user/status filters.
-		$base_query = $this->build_base_query( $table, $submissions_table, $args );
+		// Build the base query WITHOUT status filter for per-status counts.
+		// This produces counts for all tabs (All/Ungraded/Graded/In Progress)
+		// in a single query.
+		$count_args           = $args;
+		$count_args['status'] = 'any';
+		$count_base_query     = $this->build_base_query( $table, $submissions_table, $count_args );
 
-		// Get total count by wrapping the filtered base query in a COUNT(*).
-		$count_query = "SELECT COUNT(*) FROM ( $base_query ) AS counted";
+		// Get per-status counts from a single GROUP BY query.
+		$status_count_query = "SELECT effective_status, COUNT(*) AS total FROM ( $count_base_query ) AS counted GROUP BY effective_status";
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared via build_base_query. Caching handled by callers.
-		$total_count = (int) $wpdb->get_var( $count_query );
+		$status_rows = (array) $wpdb->get_results( $status_count_query, ARRAY_A );
+
+		$this->status_counts = [];
+		foreach ( $status_rows as $row ) {
+			$this->status_counts[ $row['effective_status'] ] = (int) $row['total'];
+		}
+
+		// Derive total_count from status counts.
+		if ( empty( $args['status'] ) || 'any' === $args['status'] ) {
+			$total_count = array_sum( $this->status_counts );
+		} else {
+			$total_count = 0;
+			foreach ( (array) $args['status'] as $s ) {
+				$total_count += $this->status_counts[ $s ] ?? 0;
+			}
+		}
+
+		// Build the full base query WITH status filter for the paginated listing.
+		$base_query = $this->build_base_query( $table, $submissions_table, $args );
 
 		// If the requested offset is beyond the total (e.g. in case a search
 		// threw off the pagination), snap back to the last valid page.
@@ -207,6 +235,20 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 		$placeholders = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		return $wpdb->prepare( " AND COALESCE( CASE WHEN qs.id IS NOT NULL THEN q.status END, p.status ) IN ( $placeholders )", $statuses );
+	}
+
+	/**
+	 * Get cached per-status counts from the most recent query.
+	 *
+	 * Returns null if counts are not available (e.g. if
+	 * get_lesson_progress_items has not been called yet).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array<string, int>|null Associative array of status => count, or null.
+	 */
+	public function get_status_counts(): ?array {
+		return $this->status_counts;
 	}
 
 	/**

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -97,7 +97,7 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 				(int) $row->user_id,
 				(int) $row->post_id,
 				get_date_from_gmt( $row->updated_at ),
-				null !== $row->final_grade ? (int) $row->final_grade : null
+				null !== $row->final_grade ? (float) $row->final_grade : null
 			);
 		}
 
@@ -132,6 +132,10 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
 		$query .= " WHERE p.type = 'lesson'";
+		// Exclude lessons where a quiz exists but the student never submitted it
+		// and the lesson is already complete — there is nothing to grade.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " AND NOT ( pm.meta_value IS NOT NULL AND qs.id IS NULL AND p.status = 'complete' )";
 
 		$query .= $this->build_post_filter( $args );
 		$query .= $this->build_user_filter( $args );

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -120,17 +120,13 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 	private function build_base_query( string $table, string $submissions_table, array $args ): string {
 		$wpdb = $this->wpdb;
 
-		$query  = 'SELECT p.post_id, p.user_id, p.updated_at, COALESCE( q.status, p.status ) AS effective_status, qs.final_grade';
+		$query  = 'SELECT p.post_id, p.user_id, p.updated_at, COALESCE( CASE WHEN qs.id IS NOT NULL THEN q.status END, p.status ) AS effective_status, qs.final_grade';
 		$query .= " FROM {$table} p";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
-		// Only let quiz status override lesson status when a quiz submission exists,
-		// matching the pattern in count_lesson_statuses_with_quiz().
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " AND EXISTS ( SELECT 1 FROM {$submissions_table} qs2 WHERE qs2.quiz_id = q.post_id AND qs2.user_id = q.user_id )";
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
 		$query .= " WHERE p.type = 'lesson'";
 		// Exclude lessons where a quiz exists but the student never submitted it
 		// and the lesson is already complete — there is nothing to grade.
@@ -210,7 +206,7 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 
 		$placeholders = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-		return $wpdb->prepare( " AND COALESCE( q.status, p.status ) IN ( $placeholders )", $statuses );
+		return $wpdb->prepare( " AND COALESCE( CASE WHEN qs.id IS NOT NULL THEN q.status END, p.status ) IN ( $placeholders )", $statuses );
 	}
 
 	/**

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -96,7 +96,7 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 				$row->effective_status,
 				(int) $row->user_id,
 				(int) $row->post_id,
-				$row->updated_at,
+				get_date_from_gmt( $row->updated_at ),
 				null !== $row->final_grade ? (int) $row->final_grade : null
 			);
 		}

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -125,6 +125,10 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+		// Only let quiz status override lesson status when a quiz submission exists,
+		// matching the pattern in count_lesson_statuses_with_quiz().
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " AND EXISTS ( SELECT 1 FROM {$submissions_table} qs2 WHERE qs2.quiz_id = q.post_id AND qs2.user_id = q.user_id )";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
 		$query .= " WHERE p.type = 'lesson'";

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * File containing the Tables_Based_Grading_Listing_Service class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Tables_Based_Grading_Listing_Service.
+ *
+ * Tables-based (HPPS) implementation of the Grading_Listing_Service_Interface.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_Interface {
+
+	/**
+	 * WordPress database object.
+	 *
+	 * @var \wpdb
+	 */
+	private \wpdb $wpdb;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( \wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Get the progress table name.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private function get_progress_table_name(): string {
+		return $this->wpdb->prefix . 'sensei_lms_progress';
+	}
+
+	/**
+	 * Get lesson progress items for the grading listing.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Arguments for the query (see interface).
+	 * @return array{ items: Grading_Item[], total_count: int }
+	 */
+	public function get_lesson_progress_items( array $args ): array {
+		$wpdb              = $this->wpdb;
+		$table             = $this->get_progress_table_name();
+		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
+
+		// Build the base query with JOINs for quiz status coalescing and
+		// grade retrieval, plus any post/user/status filters.
+		$base_query = $this->build_base_query( $table, $submissions_table, $args );
+
+		// Get total count by wrapping the filtered base query in a COUNT(*).
+		$count_query = "SELECT COUNT(*) FROM ( $base_query ) AS counted";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared via build_base_query. Caching handled by callers.
+		$total_count = (int) $wpdb->get_var( $count_query );
+
+		// If the requested offset is beyond the total (e.g. in case a search
+		// threw off the pagination), snap back to the last valid page.
+		$offset = $args['offset'] ?? 0;
+		$number = $args['number'] ?? 10;
+		if ( $number > 0 && $total_count < $offset ) {
+			$new_paged = floor( $total_count / $number );
+			$offset    = $new_paged * $number;
+		}
+
+		// Append ordering and pagination to the base query for the items fetch.
+		$items_query  = $base_query;
+		$items_query .= $this->build_order_clause( $args );
+		$items_query .= $wpdb->prepare( ' LIMIT %d OFFSET %d', $number, $offset );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared via build_base_query. Caching handled by callers.
+		$rows = (array) $wpdb->get_results( $items_query );
+
+		$items = [];
+		foreach ( $rows as $row ) {
+			$items[] = new Grading_Item(
+				$row->effective_status,
+				(int) $row->user_id,
+				(int) $row->post_id,
+				$row->updated_at,
+				null !== $row->final_grade ? (int) $row->final_grade : null
+			);
+		}
+
+		return [
+			'items'       => $items,
+			'total_count' => $total_count,
+		];
+	}
+
+	/**
+	 * Build the base SELECT query.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $table             Progress table name.
+	 * @param string $submissions_table Quiz submissions table name.
+	 * @param array  $args              Query arguments.
+	 * @return string SQL query.
+	 */
+	private function build_base_query( string $table, string $submissions_table, array $args ): string {
+		$wpdb = $this->wpdb;
+
+		$query  = 'SELECT p.post_id, p.user_id, p.updated_at, COALESCE( q.status, p.status ) AS effective_status, qs.final_grade';
+		$query .= " FROM {$table} p";
+		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
+		$query .= " WHERE p.type = 'lesson'";
+
+		$query .= $this->build_post_filter( $args );
+		$query .= $this->build_user_filter( $args );
+		$query .= $this->build_status_filter( $args );
+
+		return $query;
+	}
+
+	/**
+	 * Build SQL clause for filtering by post ID(s).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_post_filter( array $args ): string {
+		$wpdb = $this->wpdb;
+
+		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			return $wpdb->prepare( " AND p.post_id IN ( $placeholders )", $args['post__in'] );
+		}
+
+		if ( ! empty( $args['post_id'] ) ) {
+			return $wpdb->prepare( ' AND p.post_id = %d', $args['post_id'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build SQL clause for filtering by user ID(s).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_user_filter( array $args ): string {
+		$wpdb = $this->wpdb;
+
+		if ( ! empty( $args['user_id'] ) && is_array( $args['user_id'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['user_id'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			return $wpdb->prepare( " AND p.user_id IN ( $placeholders )", $args['user_id'] );
+		}
+
+		if ( ! empty( $args['user_id'] ) ) {
+			return $wpdb->prepare( ' AND p.user_id = %d', $args['user_id'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build SQL clause for filtering by status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_status_filter( array $args ): string {
+		if ( empty( $args['status'] ) || 'any' === $args['status'] ) {
+			return '';
+		}
+
+		$wpdb     = $this->wpdb;
+		$statuses = (array) $args['status'];
+
+		$placeholders = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		return $wpdb->prepare( " AND COALESCE( q.status, p.status ) IN ( $placeholders )", $statuses );
+	}
+
+	/**
+	 * Build ORDER BY clause.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL ORDER BY clause.
+	 */
+	private function build_order_clause( array $args ): string {
+		$order   = isset( $args['order'] ) && 'ASC' === strtoupper( $args['order'] ) ? 'ASC' : 'DESC';
+		$orderby = $args['orderby'] ?? '';
+
+		// Title, course, and lesson columns map to post_id as a simplified
+		// approximation — actual title/course name ordering would require
+		// additional JOINs that are not worth the performance cost here.
+		$orderby_map = [
+			'title'       => 'p.post_id',
+			'course'      => 'p.post_id',
+			'lesson'      => 'p.post_id',
+			'updated'     => 'p.updated_at',
+			'user_status' => 'effective_status',
+			'user_grade'  => 'qs.final_grade',
+		];
+
+		$column = esc_sql( $orderby_map[ $orderby ] ?? 'p.updated_at' );
+
+		return " ORDER BY $column $order";
+	}
+}

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -42,6 +42,24 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
+	 * Get the site's UTC offset in '+HH:MM' / '-HH:MM' format for CONVERT_TZ.
+	 *
+	 * Uses a numeric offset so that MySQL timezone tables are not required.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string UTC offset string, e.g. '+05:00' or '-05:00'.
+	 */
+	private function get_utc_offset_string(): string {
+		$offset  = (float) get_option( 'gmt_offset' );
+		$hours   = (int) $offset;
+		$minutes = abs( (int) ( ( $offset - $hours ) * 60 ) );
+		$sign    = $offset < 0 ? '-' : '+';
+
+		return sprintf( '%s%02d:%02d', $sign, abs( $hours ), $minutes );
+	}
+
+	/**
 	 * Get the progress table name.
 	 *
 	 * @since $$next-version$$
@@ -118,6 +136,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$placeholders      = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
 		$completed         = "('" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "')";
 		$has_completion    = "('" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "')";
+		$utc_offset        = $this->get_utc_offset_string();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders and status list created dynamically.
 		$query = $wpdb->prepare(
@@ -125,7 +144,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			, COUNT(*) AS lesson_start_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $completed, 1, 0)) AS lesson_completed_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, 1, 0)) AS days_to_complete_count
-			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1, 0)) AS days_to_complete_sum
+			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1, 0)) AS days_to_complete_sum
 			FROM {$table} p
 			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
 			LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -245,14 +245,16 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	private function build_post_filter_clause( array $args ): string {
 		$wpdb = $this->wpdb;
 
+		// Prefer post_id (single lesson filter) over post__in (course lessons)
+		// so that counts reflect the specific lesson when both are set.
+		if ( ! empty( $args['post_id'] ) ) {
+			return $wpdb->prepare( ' AND p.post_id = %d', $args['post_id'] );
+		}
+
 		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
 			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
 			return $wpdb->prepare( " AND p.post_id IN ( $placeholders )", $args['post__in'] );
-		}
-
-		if ( ! empty( $args['post_id'] ) ) {
-			return $wpdb->prepare( ' AND p.post_id = %d', $args['post_id'] );
 		}
 
 		return '';

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -183,9 +183,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
 
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', 'lesson' );
-		// Exclude lessons where a quiz exists but the student never submitted it
-		// and the lesson is already complete — there is nothing to grade.
-		$query .= " AND NOT ( pm.meta_value IS NOT NULL AND qs.id IS NULL AND p.status = 'complete' )";
+		$query .= $this->build_unsubmitted_quiz_exclusion_clause( $args );
 
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
@@ -319,6 +317,28 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
 		return $wpdb->prepare( " AND p.user_id NOT IN ( $id_placeholders )", $excluded_user_ids );
+	}
+
+	/**
+	 * Build SQL clause for excluding completed lessons with no quiz submission.
+	 *
+	 * When enabled, excludes lessons where a quiz exists but the student never
+	 * submitted it and the lesson is already complete — there is nothing to grade.
+	 * Used by the Grading page; the Reports page passes false to include all students.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_unsubmitted_quiz_exclusion_clause( array $args ): string {
+		$exclude = $args['exclude_unsubmitted_quiz_completions'] ?? false;
+
+		if ( ! $exclude ) {
+			return '';
+		}
+
+		return " AND NOT ( pm.meta_value IS NOT NULL AND qs.id IS NULL AND p.status = 'complete' )";
 	}
 
 	/**

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -175,8 +175,13 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
 		$query .= " AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
 
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', 'lesson' );
+		// Exclude lessons where a quiz exists but the student never submitted it
+		// and the lesson is already complete — there is nothing to grade.
+		$query .= " AND NOT ( pm.meta_value IS NOT NULL AND qs.id IS NULL AND p.status = 'complete' )";
 
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -92,6 +92,62 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
+	 * Get aggregate totals for a set of lessons.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $lesson_ids Array of lesson post IDs.
+	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_sum.
+	 */
+	public function get_lesson_totals( array $lesson_ids ): array {
+		$defaults = [
+			'unique_student_count'   => 0,
+			'lesson_start_count'     => 0,
+			'lesson_completed_count' => 0,
+			'days_to_complete_sum'   => 0,
+		];
+
+		if ( empty( $lesson_ids ) ) {
+			return $defaults;
+		}
+
+		$wpdb              = $this->wpdb;
+		$table             = $this->get_progress_table_name();
+		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
+		$placeholders      = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+		$completed         = "('" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "')";
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders and status list created dynamically.
+		$query = $wpdb->prepare(
+			"SELECT COUNT(DISTINCT p.user_id) AS unique_student_count
+			, COUNT(*) AS lesson_start_count
+			, SUM(IF(COALESCE( q.status, p.status ) IN $completed, 1, 0)) AS lesson_completed_count
+			, SUM(IF(COALESCE( q.status, p.status ) IN $completed, ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1, 0)) AS days_to_complete_sum
+			FROM {$table} p
+			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
+			LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
+				AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )
+			WHERE p.type = 'lesson' AND p.post_id IN ( $placeholders )",
+			$lesson_ids
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$row = $wpdb->get_row( $query );
+
+		if ( ! $row ) {
+			return $defaults;
+		}
+
+		return [
+			'unique_student_count'   => (int) $row->unique_student_count,
+			'lesson_start_count'     => (int) $row->lesson_start_count,
+			'lesson_completed_count' => (int) $row->lesson_completed_count,
+			'days_to_complete_sum'   => (int) $row->days_to_complete_sum,
+		];
+	}
+
+	/**
 	 * Count lesson statuses using quiz status when a quiz exists.
 	 *
 	 * In HPPS, lesson progress rows only store 'in-progress' and 'complete',

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -42,24 +42,6 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
-	 * Get the site's UTC offset in '+HH:MM' / '-HH:MM' format for CONVERT_TZ.
-	 *
-	 * Uses a numeric offset so that MySQL timezone tables are not required.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return string UTC offset string, e.g. '+05:00' or '-05:00'.
-	 */
-	private function get_utc_offset_string(): string {
-		$offset  = (float) get_option( 'gmt_offset' );
-		$hours   = (int) $offset;
-		$minutes = abs( (int) ( ( $offset - $hours ) * 60 ) );
-		$sign    = $offset < 0 ? '-' : '+';
-
-		return sprintf( '%s%02d:%02d', $sign, abs( $hours ), $minutes );
-	}
-
-	/**
 	 * Get the progress table name.
 	 *
 	 * @since $$next-version$$
@@ -136,7 +118,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$placeholders      = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
 		$completed         = "('" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "')";
 		$has_completion    = "('" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "')";
-		$utc_offset        = $this->get_utc_offset_string();
+		$utc_offset        = Grading_Item::get_utc_offset_string();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders and status list created dynamically.
 		$query = $wpdb->prepare(

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -186,7 +186,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
-		$query .= $this->build_user_exclusion_clause( $args, "COALESCE( CASE WHEN qs.id IS NOT NULL THEN q.status END, p.status )" );
+		$query .= $this->build_user_exclusion_clause( $args, 'COALESCE( CASE WHEN qs.id IS NOT NULL THEN q.status END, p.status )' );
 
 		$query .= ' GROUP BY effective_status';
 

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -115,14 +115,13 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$table             = $this->get_progress_table_name();
 		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
 		$placeholders      = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-		$completed         = "('" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "')";
 		$has_completion    = "('" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "')";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders and status list created dynamically.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT p.user_id) AS unique_student_count
 			, COUNT(*) AS lesson_start_count
-			, SUM(IF(COALESCE( q.status, p.status ) IN $completed, 1, 0)) AS lesson_completed_count
+			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, 1, 0)) AS lesson_completed_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1, 0)) AS days_to_complete_sum
 			FROM {$table} p
 			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -174,21 +174,19 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query  = "SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status != 'trash'";
+		$query  = "SELECT COALESCE( CASE WHEN qs.id IS NOT NULL THEN q.status END, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
-		$query .= " AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )";
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
 
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', 'lesson' );
 		$query .= $this->build_unsubmitted_quiz_exclusion_clause( $args );
 
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
-		$query .= $this->build_user_exclusion_clause( $args, 'COALESCE( q.status, p.status )' );
+		$query .= $this->build_user_exclusion_clause( $args, "COALESCE( CASE WHEN qs.id IS NOT NULL THEN q.status END, p.status )" );
 
 		$query .= ' GROUP BY effective_status';
 

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -97,13 +97,14 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	 * @since $$next-version$$
 	 *
 	 * @param int[] $lesson_ids Array of lesson post IDs.
-	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_sum.
+	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_count, days_to_complete_sum.
 	 */
 	public function get_lesson_totals( array $lesson_ids ): array {
 		$defaults = [
 			'unique_student_count'   => 0,
 			'lesson_start_count'     => 0,
 			'lesson_completed_count' => 0,
+			'days_to_complete_count' => 0,
 			'days_to_complete_sum'   => 0,
 		];
 
@@ -115,13 +116,15 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$table             = $this->get_progress_table_name();
 		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
 		$placeholders      = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+		$completed         = "('" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "')";
 		$has_completion    = "('" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "')";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders and status list created dynamically.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT p.user_id) AS unique_student_count
 			, COUNT(*) AS lesson_start_count
-			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, 1, 0)) AS lesson_completed_count
+			, SUM(IF(COALESCE( q.status, p.status ) IN $completed, 1, 0)) AS lesson_completed_count
+			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, 1, 0)) AS days_to_complete_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1, 0)) AS days_to_complete_sum
 			FROM {$table} p
 			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
@@ -143,6 +146,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			'unique_student_count'   => (int) $row->unique_student_count,
 			'lesson_start_count'     => (int) $row->lesson_start_count,
 			'lesson_completed_count' => (int) $row->lesson_completed_count,
+			'days_to_complete_count' => (int) $row->days_to_complete_count,
 			'days_to_complete_sum'   => (int) $row->days_to_complete_sum,
 		];
 	}

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -116,13 +116,14 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$submissions_table = $wpdb->prefix . 'sensei_lms_quiz_submissions';
 		$placeholders      = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
 		$completed         = "('" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "')";
+		$has_completion    = "('" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "')";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders and status list created dynamically.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT p.user_id) AS unique_student_count
 			, COUNT(*) AS lesson_start_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $completed, 1, 0)) AS lesson_completed_count
-			, SUM(IF(COALESCE( q.status, p.status ) IN $completed, ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1, 0)) AS days_to_complete_sum
+			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1, 0)) AS days_to_complete_sum
 			FROM {$table} p
 			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
 			LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'

--- a/includes/internal/services/class-tables-based-progress-clauses-service.php
+++ b/includes/internal/services/class-tables-based-progress-clauses-service.php
@@ -190,8 +190,8 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 		$clauses['fields'] .= " AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )";
 		$clauses['fields'] .= " WHERE p.post_id = {$this->wpdb->posts}.ID";
 		$clauses['fields'] .= " AND p.type = 'lesson'";
-		$completed          = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
-		$clauses['fields'] .= " AND COALESCE( q.status, p.status ) IN ( $completed )";
+		$has_completion     = "'" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "'";
+		$clauses['fields'] .= " AND COALESCE( q.status, p.status ) IN ( $has_completion )";
 		$clauses['fields'] .= ') as days_to_complete';
 
 		return $clauses;

--- a/includes/internal/services/class-tables-based-progress-clauses-service.php
+++ b/includes/internal/services/class-tables-based-progress-clauses-service.php
@@ -42,24 +42,6 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	}
 
 	/**
-	 * Get the site's UTC offset in '+HH:MM' / '-HH:MM' format for CONVERT_TZ.
-	 *
-	 * Uses a numeric offset so that MySQL timezone tables are not required.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return string UTC offset string, e.g. '+05:00' or '-05:00'.
-	 */
-	private function get_utc_offset_string(): string {
-		$offset  = (float) get_option( 'gmt_offset' );
-		$hours   = (int) $offset;
-		$minutes = abs( (int) ( ( $offset - $hours ) * 60 ) );
-		$sign    = $offset < 0 ? '-' : '+';
-
-		return sprintf( '%s%02d:%02d', $sign, abs( $hours ), $minutes );
-	}
-
-	/**
 	 * Get the progress table name.
 	 *
 	 * @since $$next-version$$
@@ -122,7 +104,7 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	 */
 	public function add_days_to_completion_to_courses_clauses( array $clauses ): array {
 		$progress_table = $this->get_progress_table_name();
-		$utc_offset     = $this->get_utc_offset_string();
+		$utc_offset     = Grading_Item::get_utc_offset_string();
 
 		$clauses['fields']  .= ", SUM( ABS( DATEDIFF( CONVERT_TZ( cp.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( cp.started_at, '+00:00', '$utc_offset' ) ) ) + 1 ) AS days_to_completion";
 		$clauses['fields']  .= ', COUNT(cp.id) AS count_of_completions';
@@ -200,7 +182,7 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	public function add_days_to_completion_to_lessons_clauses( array $clauses ): array {
 		$progress_table    = $this->get_progress_table_name();
 		$submissions_table = $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
-		$utc_offset        = $this->get_utc_offset_string();
+		$utc_offset        = Grading_Item::get_utc_offset_string();
 
 		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1 )";
 		$clauses['fields'] .= " FROM {$progress_table} p";

--- a/includes/internal/services/class-tables-based-progress-clauses-service.php
+++ b/includes/internal/services/class-tables-based-progress-clauses-service.php
@@ -144,4 +144,56 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 
 		return $clauses;
 	}
+
+	/**
+	 * Modify WP_Query clauses to add last activity date to lesson posts.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_last_activity_to_lessons_clauses( array $clauses ): array {
+		$progress_table = $this->get_progress_table_name();
+
+		// In HPPS, lesson progress rows only store 'in-progress' and 'complete'.
+		// Quiz-derived statuses (passed, graded) live on separate quiz progress rows,
+		// so only lesson status 'complete' is needed here.
+		$clauses['fields'] .= ", (
+			SELECT MAX(p.completed_at)
+			FROM {$progress_table} p
+			WHERE p.post_id = {$this->wpdb->posts}.ID
+			AND p.type = 'lesson'
+			AND p.status = 'complete'
+		) AS last_activity_date";
+
+		return $clauses;
+	}
+
+	/**
+	 * Modify WP_Query clauses to add days-to-complete data to lesson posts.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_days_to_completion_to_lessons_clauses( array $clauses ): array {
+		$progress_table    = $this->get_progress_table_name();
+		$submissions_table = $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+
+		$clauses['fields'] .= ', (SELECT SUM( ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1 )';
+		$clauses['fields'] .= " FROM {$progress_table} p";
+		$clauses['fields'] .= " LEFT JOIN {$this->wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$clauses['fields'] .= " LEFT JOIN {$progress_table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+		$clauses['fields'] .= " AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )";
+		$clauses['fields'] .= " WHERE p.post_id = {$this->wpdb->posts}.ID";
+		$clauses['fields'] .= " AND p.type = 'lesson'";
+		$completed          = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
+		$clauses['fields'] .= " AND COALESCE( q.status, p.status ) IN ( $completed )";
+		$clauses['fields'] .= ') as days_to_complete';
+
+		return $clauses;
+	}
 }

--- a/includes/internal/services/class-tables-based-progress-clauses-service.php
+++ b/includes/internal/services/class-tables-based-progress-clauses-service.php
@@ -42,6 +42,24 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	}
 
 	/**
+	 * Get the site's UTC offset in '+HH:MM' / '-HH:MM' format for CONVERT_TZ.
+	 *
+	 * Uses a numeric offset so that MySQL timezone tables are not required.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string UTC offset string, e.g. '+05:00' or '-05:00'.
+	 */
+	private function get_utc_offset_string(): string {
+		$offset  = (float) get_option( 'gmt_offset' );
+		$hours   = (int) $offset;
+		$minutes = abs( (int) ( ( $offset - $hours ) * 60 ) );
+		$sign    = $offset < 0 ? '-' : '+';
+
+		return sprintf( '%s%02d:%02d', $sign, abs( $hours ), $minutes );
+	}
+
+	/**
 	 * Get the progress table name.
 	 *
 	 * @since $$next-version$$
@@ -104,8 +122,9 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	 */
 	public function add_days_to_completion_to_courses_clauses( array $clauses ): array {
 		$progress_table = $this->get_progress_table_name();
+		$utc_offset     = $this->get_utc_offset_string();
 
-		$clauses['fields']  .= ', SUM( ABS( DATEDIFF( cp.completed_at, cp.started_at ) ) + 1 ) AS days_to_completion';
+		$clauses['fields']  .= ", SUM( ABS( DATEDIFF( CONVERT_TZ( cp.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( cp.started_at, '+00:00', '$utc_offset' ) ) ) + 1 ) AS days_to_completion";
 		$clauses['fields']  .= ', COUNT(cp.id) AS count_of_completions';
 		$clauses['join']    .= " LEFT JOIN {$progress_table} cp ON cp.post_id = {$this->wpdb->posts}.ID";
 		$clauses['join']    .= " AND cp.type = 'course'";
@@ -181,8 +200,9 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	public function add_days_to_completion_to_lessons_clauses( array $clauses ): array {
 		$progress_table    = $this->get_progress_table_name();
 		$submissions_table = $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+		$utc_offset        = $this->get_utc_offset_string();
 
-		$clauses['fields'] .= ', (SELECT SUM( ABS( DATEDIFF( p.completed_at, p.started_at ) ) + 1 )';
+		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1 )";
 		$clauses['fields'] .= " FROM {$progress_table} p";
 		$clauses['fields'] .= " LEFT JOIN {$this->wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -5,6 +5,9 @@
  * @package sensei
  */
 
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+use Sensei\Internal\Services\Progress_Clauses_Service_Interface;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -29,12 +32,22 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 	private $course;
 
 	/**
-	 * Constructor
+	 * The progress clauses service.
 	 *
-	 * @param Sensei_Course $course Sensei course related services.
+	 * @var Progress_Clauses_Service_Interface
 	 */
-	public function __construct( Sensei_Course $course ) {
-		$this->course = $course;
+	private Progress_Clauses_Service_Interface $progress_clauses_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Sensei_Course                           $course                   Sensei course related services.
+	 * @param Progress_Clauses_Service_Interface|null $progress_clauses_service The progress clauses service.
+	 */
+	public function __construct( Sensei_Course $course, ?Progress_Clauses_Service_Interface $progress_clauses_service = null ) {
+		$this->course                   = $course;
+		$this->progress_clauses_service = $progress_clauses_service
+			?? ( new Progress_Query_Service_Factory() )->create_clauses_service();
 	}
 
 	/**
@@ -108,17 +121,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 	 * @return array Modified associative array of the clauses for the query.
 	 */
 	public function add_days_to_complete_to_lessons_query( array $clauses ): array {
-		global $wpdb;
-
-		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date )) + 1 ) as days_to_complete";
-		$clauses['fields'] .= " FROM {$wpdb->comments}";
-		$clauses['fields'] .= " INNER JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id";
-		$clauses['fields'] .= " WHERE {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
-		$clauses['fields'] .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
-		$clauses['fields'] .= " AND {$wpdb->comments}.comment_approved IN ( 'complete', 'graded', 'passed', 'failed', 'ungraded' )";
-		$clauses['fields'] .= " AND {$wpdb->commentmeta}.meta_key = 'start') as days_to_complete";
-
-		return $clauses;
+		return $this->progress_clauses_service->add_days_to_completion_to_lessons_clauses( $clauses );
 	}
 
 	/**
@@ -132,17 +135,6 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 	 * @return array Modified associative array of the clauses for the query.
 	 */
 	public function add_last_activity_to_lessons_query( array $clauses ): array {
-		global $wpdb;
-
-		$clauses['fields'] .= ", (
-			SELECT MAX({$wpdb->comments}.comment_date_gmt)
-			FROM {$wpdb->comments}
-			WHERE {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID
-			AND {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
-			AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
-			ORDER BY {$wpdb->comments}.comment_date_gmt DESC
-		) AS last_activity_date";
-
-		return $clauses;
+		return $this->progress_clauses_service->add_last_activity_to_lessons_clauses( $clauses );
 	}
 }

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -193,7 +193,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 
 		$lesson_students    = array_sum( $status_counts );
 		$lesson_completions = 0;
-		foreach ( Grading_Item::COMPLETED_STATUSES as $status ) {
+		foreach ( Grading_Item::STATUSES_WITH_COMPLETION_DATE as $status ) {
 			$lesson_completions += $status_counts[ $status ] ?? 0;
 		}
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -5,6 +5,10 @@
  * @package sensei
  */
 
+use Sensei\Internal\Services\Grading_Item;
+use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -23,15 +27,25 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 	private $course;
 
 	/**
-	 * Constructor
+	 * The progress aggregation service.
 	 *
-	 * @param Sensei_Course                                   $course Sensei course related services.
-	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider Report data provider.
+	 * @var Progress_Aggregation_Service_Interface
 	 */
-	public function __construct( Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider ) {
+	private Progress_Aggregation_Service_Interface $aggregation_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Sensei_Course                                   $course              Sensei course related services.
+	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider       Report data provider.
+	 * @param Progress_Aggregation_Service_Interface|null     $aggregation_service The progress aggregation service.
+	 */
+	public function __construct( Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider, ?Progress_Aggregation_Service_Interface $aggregation_service = null ) {
 		// Load Parent token into constructor.
 		parent::__construct( 'lessons', $data_provider );
-		$this->course = $course;
+		$this->course              = $course;
+		$this->aggregation_service = $aggregation_service
+			?? ( new Progress_Query_Service_Factory() )->create_aggregation_service();
 
 		add_filter( 'sensei_analysis_overview_columns', array( $this, 'add_totals_to_report_column_headers' ) );
 	}
@@ -161,41 +175,28 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 	 * @throws Exception If date-time conversion fails.
 	 */
 	protected function get_row_data( $item ) {
-		// Get Learners (i.e. those who have started).
-		$lesson_args = array(
-			'post_id' => $item->ID,
-			'type'    => 'sensei_lesson_status',
-			'status'  => 'any',
-		);
-		/**
-		 * Filter the lesson learners activity arguments for the Course Analysis list table.
-		 *
-		 * @hook sensei_analysis_lesson_learners
-		 *
-		 * @param {array}  $lesson_args The lesson learners activity arguments.
-		 * @param {object} $item The current item.
-		 * @return {array} The lesson learners activity arguments.
-		 */
-		$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
+		if ( has_filter( 'sensei_analysis_lesson_learners' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _deprecated_hook handles its own output.
+			_deprecated_hook( 'sensei_analysis_lesson_learners', '$$next-version$$', '', __( 'This filter is no longer used. Lesson counts now use the progress aggregation service.', 'sensei-lms' ) );
+		}
+		if ( has_filter( 'sensei_analysis_lesson_completions' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _deprecated_hook handles its own output.
+			_deprecated_hook( 'sensei_analysis_lesson_completions', '$$next-version$$', '', __( 'This filter is no longer used. Lesson counts now use the progress aggregation service.', 'sensei-lms' ) );
+		}
 
-		// Get Course Completions.
-		$lesson_args = array(
-			'post_id' => $item->ID,
-			'type'    => 'sensei_lesson_status',
-			'status'  => array( 'complete', 'graded', 'passed', 'failed', 'ungraded' ),
-			'count'   => true,
+		$status_counts = $this->aggregation_service->count_statuses(
+			[
+				'type'    => 'lesson',
+				'post_id' => $item->ID,
+			]
 		);
 
-		/**
-		 * Filter the lesson completions activity arguments.
-		 *
-		 * @hook sensei_analysis_lesson_completions
-		 *
-		 * @param {array}  $lesson_args The lesson completions activity arguments.
-		 * @param {object} $item The current item.
-		 * @return {array} The lesson completions activity arguments.
-		 */
-		$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
+		$lesson_students    = array_sum( $status_counts );
+		$lesson_completions = 0;
+		foreach ( Grading_Item::COMPLETED_STATUSES as $status ) {
+			$lesson_completions += $status_counts[ $status ] ?? 0;
+		}
+
 		// Taking the ceiling value for the average.
 		$average_completion_days = $lesson_completions > 0 ? ceil( $item->days_to_complete / $lesson_completions ) : __( 'N/A', 'sensei-lms' );
 
@@ -323,8 +324,6 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 	 * @return object Object containing the required totals for column header.
 	 */
 	private function get_totals_for_lesson_report_column_headers( int $course_id ) {
-		global $wpdb;
-
 		// Add search filter to query arguments.
 		$query_args = [];
 		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for searching.
@@ -332,34 +331,21 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$query_args['s'] = esc_html( $_GET['s'] );
 		}
-		$lessons    = $this->course->course_lessons( $course_id, array( 'publish', 'private' ), 'ids', $query_args );
-		$lesson_ids = '0';
+		$lessons = $this->course->course_lessons( $course_id, array( 'publish', 'private' ), 'ids', $query_args );
 
 		$lesson_count = count( $lessons );
-		if ( 0 < $lesson_count ) {
-			$lesson_ids = implode( ',', $lessons );
-		};
 
 		$default_args  = array(
 			'fields' => 'ids',
 		);
 		$modules       = wp_get_object_terms( $lessons, 'module', $default_args );
 		$modules_count = is_countable( $modules ) ? count( $modules ) : 0;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$lesson_completion_info                      = $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
-			, COUNT(lesson_students.comment_id) lesson_start_count
-			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), 1, 0)) lesson_completed_count
-			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
-			FROM $wpdb->comments lesson_students
-			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $lesson_ids )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				'%Y-%m-%d %H:%i:%s'
-			)
-		);
-		$lesson_completion_info->lesson_count        = $lesson_count;
-		$lesson_completion_info->unique_module_count = $modules_count;
-		return $lesson_completion_info;
+
+		$totals = $this->aggregation_service->get_lesson_totals( array_map( 'intval', $lessons ) );
+
+		$result                      = (object) $totals;
+		$result->lesson_count        = $lesson_count;
+		$result->unique_module_count = $modules_count;
+		return $result;
 	}
 }

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -117,8 +117,8 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 		$column_value_map['completions']        = $total_counts->lesson_completed_count > 0 && $total_counts->lesson_count > 0
 			? ceil( $total_counts->lesson_completed_count / $total_counts->lesson_count )
 			: 0;
-		$column_value_map['days_to_completion'] = $total_counts->lesson_completed_count > 0
-			? ceil( $total_counts->days_to_complete_sum / $total_counts->lesson_completed_count )
+		$column_value_map['days_to_completion'] = $total_counts->days_to_complete_count > 0
+			? ceil( $total_counts->days_to_complete_sum / $total_counts->days_to_complete_count )
 			: __( 'N/A', 'sensei-lms' );
 		$column_value_map['completion_rate']    = $total_counts->lesson_start_count > 0
 			? Sensei_Utils::quotient_as_absolute_rounded_percentage( $total_counts->lesson_completed_count, $total_counts->lesson_start_count ) . '%'
@@ -193,12 +193,19 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 
 		$lesson_students    = array_sum( $status_counts );
 		$lesson_completions = 0;
-		foreach ( Grading_Item::STATUSES_WITH_COMPLETION_DATE as $status ) {
+		foreach ( Grading_Item::COMPLETED_STATUSES as $status ) {
 			$lesson_completions += $status_counts[ $status ] ?? 0;
 		}
 
+		// Days-to-complete can only be averaged over statuses that have a
+		// completion date (excludes failed/ungraded).
+		$days_divisor = 0;
+		foreach ( Grading_Item::STATUSES_WITH_COMPLETION_DATE as $status ) {
+			$days_divisor += $status_counts[ $status ] ?? 0;
+		}
+
 		// Taking the ceiling value for the average.
-		$average_completion_days = $lesson_completions > 0 ? ceil( $item->days_to_complete / $lesson_completions ) : __( 'N/A', 'sensei-lms' );
+		$average_completion_days = $days_divisor > 0 ? ceil( $item->days_to_complete / $days_divisor ) : __( 'N/A', 'sensei-lms' );
 
 		// Output lesson data.
 		if ( $this->csv_output ) {

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -83,7 +83,7 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertSame( 85, $result['items'][0]->grade );
+		$this->assertSame( 85.0, $result['items'][0]->grade );
 	}
 
 	public function testGetLessonProgressItems_WithOffsetBeyondTotal_CorrectsPagination(): void {

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -56,12 +56,13 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertSame( 1, $result['total_count'] );
-		$this->assertCount( 1, $result['items'] );
-		$this->assertInstanceOf( Grading_Item::class, $result['items'][0] );
-		$this->assertSame( 'in-progress', $result['items'][0]->status );
-		$this->assertSame( $user_id, $result['items'][0]->user_id );
-		$this->assertSame( $lesson_id, $result['items'][0]->lesson_id );
+		$this->assertSame( 1, $result['total_count'], 'Expected exactly one result.' );
+		$this->assertCount( 1, $result['items'], 'Expected exactly one item.' );
+		$this->assertInstanceOf( Grading_Item::class, $result['items'][0], 'Expected a Grading_Item instance.' );
+		$this->assertSame( 'in-progress', $result['items'][0]->status, 'Expected in-progress status.' );
+		$this->assertSame( $user_id, $result['items'][0]->user_id, 'Expected matching user ID.' );
+		$this->assertSame( $lesson_id, $result['items'][0]->lesson_id, 'Expected matching lesson ID.' );
+		$this->assertNull( $result['items'][0]->grade, 'Expected null grade for non-graded item.' );
 	}
 
 	public function testGetLessonProgressItems_WithGradedStatus_ReturnsGradeValue(): void {
@@ -111,26 +112,6 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 1, $result['total_count'] );
 		$this->assertSame( 'ungraded', $result['items'][0]->status );
-	}
-
-	public function testGetLessonProgressItems_WithNoGrade_ReturnsNullGrade(): void {
-		/* Arrange. */
-		$user_id   = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
-
-		$service = new Comments_Based_Grading_Listing_Service();
-
-		/* Act. */
-		$result = $service->get_lesson_progress_items(
-			$this->get_default_args( [ 'post_id' => $lesson_id ] )
-		);
-
-		/* Assert. */
-		$this->assertNull( $result['items'][0]->grade, 'Expected null grade for non-graded item.' );
 	}
 
 	public function testGetLessonProgressItems_WithOffsetBeyondTotal_CorrectsPagination(): void {

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SenseiTest\Internal\Services;
+
+use Sensei\Internal\Services\Comments_Based_Grading_Listing_Service;
+use Sensei\Internal\Services\Grading_Item;
+
+/**
+ * @covers \Sensei\Internal\Services\Comments_Based_Grading_Listing_Service
+ */
+class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
+
+	private $sensei_factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->sensei_factory = new \Sensei_Factory();
+	}
+
+	public function testGetLessonProgressItems_WithLessonStatus_ReturnsGradingItems(): void {
+		/* Arrange. */
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'] );
+		$this->assertCount( 1, $result['items'] );
+		$this->assertInstanceOf( Grading_Item::class, $result['items'][0] );
+		$this->assertSame( 'in-progress', $result['items'][0]->status );
+		$this->assertSame( $user_id, $result['items'][0]->user_id );
+		$this->assertSame( $lesson_id, $result['items'][0]->lesson_id );
+	}
+
+	public function testGetLessonProgressItems_WithGradedStatus_ReturnsGradeValue(): void {
+		/* Arrange. */
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$comment_id = \Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'graded' );
+		update_comment_meta( $comment_id, 'grade', 85 );
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 85, $result['items'][0]->grade );
+	}
+
+	public function testGetLessonProgressItems_WithStatusFilter_FiltersResults(): void {
+		/* Arrange. */
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'in-progress' );
+		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'ungraded' );
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'ungraded', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'] );
+		$this->assertSame( 'ungraded', $result['items'][0]->status );
+	}
+
+	public function testGetLessonProgressItems_WithNoGrade_ReturnsNullGrade(): void {
+		/* Arrange. */
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertNull( $result['items'][0]->grade, 'Expected null grade for non-graded item.' );
+	}
+
+	public function testGetLessonProgressItems_WithOffsetBeyondTotal_CorrectsPagination(): void {
+		/* Arrange. */
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 100, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'], 'Expected one total item.' );
+		$this->assertCount( 1, $result['items'], 'Expected offset correction to return items.' );
+	}
+
+	public function testGetLessonProgressItems_WithPagination_RespectsLimitAndOffset(): void {
+		/* Arrange. */
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		for ( $i = 0; $i < 3; $i++ ) {
+			$user_id = $this->sensei_factory->user->create();
+			\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+		}
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 2, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 3, $result['total_count'] );
+		$this->assertCount( 2, $result['items'] );
+	}
+}

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -6,6 +6,8 @@ use Sensei\Internal\Services\Comments_Based_Grading_Listing_Service;
 use Sensei\Internal\Services\Grading_Item;
 
 /**
+ * Class Comments_Based_Grading_Listing_Service_Test.
+ *
  * @covers \Sensei\Internal\Services\Comments_Based_Grading_Listing_Service
  */
 class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
@@ -15,6 +17,26 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->sensei_factory = new \Sensei_Factory();
+	}
+
+	/**
+	 * Build default query args for get_lesson_progress_items.
+	 *
+	 * @param array $overrides Args to override.
+	 * @return array
+	 */
+	private function get_default_args( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'type'    => 'sensei_lesson_status',
+				'number'  => 10,
+				'offset'  => 0,
+				'orderby' => '',
+				'order'   => 'DESC',
+				'status'  => 'any',
+			],
+			$overrides
+		);
 	}
 
 	public function testGetLessonProgressItems_WithLessonStatus_ReturnsGradingItems(): void {
@@ -30,7 +52,7 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
 		);
 
 		/* Assert. */
@@ -44,9 +66,9 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 	public function testGetLessonProgressItems_WithGradedStatus_ReturnsGradeValue(): void {
 		/* Arrange. */
-		$user_id   = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
+		$user_id    = $this->sensei_factory->user->create();
+		$course_id  = $this->sensei_factory->course->create();
+		$lesson_id  = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$comment_id = \Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'graded' );
@@ -56,7 +78,7 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
 		);
 
 		/* Assert. */
@@ -78,7 +100,12 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'ungraded', 'post_id' => $lesson_id ]
+			$this->get_default_args(
+				[
+					'status'  => 'ungraded',
+					'post_id' => $lesson_id,
+				]
+			)
 		);
 
 		/* Assert. */
@@ -99,7 +126,7 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
 		);
 
 		/* Assert. */
@@ -119,7 +146,12 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 100, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args(
+				[
+					'offset'  => 100,
+					'post_id' => $lesson_id,
+				]
+			)
 		);
 
 		/* Assert. */
@@ -142,7 +174,12 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 2, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args(
+				[
+					'number'  => 2,
+					'post_id' => $lesson_id,
+				]
+			)
 		);
 
 		/* Assert. */

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -86,34 +86,6 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 85, $result['items'][0]->grade );
 	}
 
-	public function testGetLessonProgressItems_WithStatusFilter_FiltersResults(): void {
-		/* Arrange. */
-		$user1     = $this->sensei_factory->user->create();
-		$user2     = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'in-progress' );
-		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'ungraded' );
-
-		$service = new Comments_Based_Grading_Listing_Service();
-
-		/* Act. */
-		$result = $service->get_lesson_progress_items(
-			$this->get_default_args(
-				[
-					'status'  => 'ungraded',
-					'post_id' => $lesson_id,
-				]
-			)
-		);
-
-		/* Assert. */
-		$this->assertSame( 1, $result['total_count'] );
-		$this->assertSame( 'ungraded', $result['items'][0]->status );
-	}
-
 	public function testGetLessonProgressItems_WithOffsetBeyondTotal_CorrectsPagination(): void {
 		/* Arrange. */
 		$user_id   = $this->sensei_factory->user->create();
@@ -138,33 +110,5 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 1, $result['total_count'], 'Expected one total item.' );
 		$this->assertCount( 1, $result['items'], 'Expected offset correction to return items.' );
-	}
-
-	public function testGetLessonProgressItems_WithPagination_RespectsLimitAndOffset(): void {
-		/* Arrange. */
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		for ( $i = 0; $i < 3; $i++ ) {
-			$user_id = $this->sensei_factory->user->create();
-			\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
-		}
-
-		$service = new Comments_Based_Grading_Listing_Service();
-
-		/* Act. */
-		$result = $service->get_lesson_progress_items(
-			$this->get_default_args(
-				[
-					'number'  => 2,
-					'post_id' => $lesson_id,
-				]
-			)
-		);
-
-		/* Assert. */
-		$this->assertSame( 3, $result['total_count'] );
-		$this->assertCount( 2, $result['items'] );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -343,4 +343,102 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 1, $result['in-progress'], 'Regular user status should be counted.' );
 		$this->assertSame( 1, $result['ungraded'], 'Excluded user with override status should still be counted.' );
 	}
+
+	public function testCountStatuses_LessonWithQuizButNoAnswers_IncludedByDefault(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'complete' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses(
+			[
+				'type' => 'lesson',
+			]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['complete'], 'Completed lesson with quiz but no answers should be included by default.' );
+	}
+
+	public function testCountStatuses_LessonWithQuizButNoAnswers_ExcludedWhenFlagSet(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'complete' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses(
+			[
+				'type' => 'lesson',
+				'exclude_unsubmitted_quiz_completions' => true,
+			]
+		);
+
+		/* Assert. */
+		$this->assertArrayNotHasKey( 'complete', $result, 'Completed lesson with quiz but no answers should be excluded when flag is set.' );
+	}
+
+	public function testCountStatuses_InProgressWithQuizButNoAnswers_NotExcludedWhenFlagSet(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses(
+			[
+				'type' => 'lesson',
+				'exclude_unsubmitted_quiz_completions' => true,
+			]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['in-progress'], 'In-progress lesson should not be excluded even when flag is set.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -195,6 +195,49 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Excluded user status should not appear.' );
 	}
 
+	public function testGetLessonTotals_WithCompletedLessons_ReturnsCorrectAggregates(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$start_date = current_time( 'mysql' );
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', [ 'start' => $start_date ] );
+		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', [ 'start' => $start_date ] );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
+		$this->assertSame( 2, $result['lesson_start_count'], 'Expected two lesson starts.' );
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Expected one completed lesson.' );
+		$this->assertGreaterThanOrEqual( 1, $result['days_to_complete_sum'], 'Expected at least one day to complete.' );
+	}
+
+	public function testGetLessonTotals_WithEmptyLessonIds_ReturnsZeros(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [] );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['unique_student_count'] );
+		$this->assertSame( 0, $result['lesson_start_count'] );
+		$this->assertSame( 0, $result['lesson_completed_count'] );
+		$this->assertSame( 0, $result['days_to_complete_sum'] );
+	}
+
 	public function testCountStatuses_WithIncludeStatusesOverride_KeepsExcludedUsersForOverrideStatuses(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -400,7 +400,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Act. */
 		$result = $service->count_statuses(
 			[
-				'type' => 'lesson',
+				'type'                                 => 'lesson',
 				'exclude_unsubmitted_quiz_completions' => true,
 			]
 		);
@@ -433,7 +433,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Act. */
 		$result = $service->count_statuses(
 			[
-				'type' => 'lesson',
+				'type'                                 => 'lesson',
 				'exclude_unsubmitted_quiz_completions' => true,
 			]
 		);

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -206,7 +206,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$start_date = current_time( 'mysql' );
+		$start_date = gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
 		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', [ 'start' => $start_date ] );
 		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', [ 'start' => $start_date ] );
 
@@ -219,7 +219,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
 		$this->assertSame( 2, $result['lesson_start_count'], 'Expected two lesson starts.' );
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Expected one completed lesson.' );
-		$this->assertGreaterThanOrEqual( 1, $result['days_to_complete_sum'], 'Expected at least one day to complete.' );
+		$this->assertSame( 3, $result['days_to_complete_sum'], 'Expected 3 days (2 day difference + 1).' );
 	}
 
 	public function testGetLessonTotals_WithUngradedStatus_DoesNotCountAsCompleted(): void {

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -219,10 +219,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
 		$this->assertSame( 2, $result['lesson_start_count'], 'Expected two lesson starts.' );
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Expected one completed lesson.' );
+		$this->assertSame( 1, $result['days_to_complete_count'], 'Expected one lesson with completion date.' );
 		$this->assertSame( 3, $result['days_to_complete_sum'], 'Expected 3 days (2 day difference + 1).' );
 	}
 
-	public function testGetLessonTotals_WithUngradedStatus_DoesNotCountAsCompleted(): void {
+	public function testGetLessonTotals_WithUngradedStatus_CountsAsCompletedButNotDaysToComplete(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -241,11 +242,12 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
-		$this->assertSame( 0, $result['lesson_completed_count'], 'Ungraded status should NOT count as completed.' );
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Ungraded status should count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_count'], 'Ungraded status should not have a completion date.' );
 		$this->assertSame( 0, $result['days_to_complete_sum'], 'Ungraded status should not contribute to days to complete.' );
 	}
 
-	public function testGetLessonTotals_WithFailedStatus_DoesNotCountAsCompleted(): void {
+	public function testGetLessonTotals_WithFailedStatus_CountsAsCompletedButNotDaysToComplete(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -264,7 +266,8 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
-		$this->assertSame( 0, $result['lesson_completed_count'], 'Failed status should NOT count as completed.' );
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Failed status should count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_count'], 'Failed status should not have a completion date.' );
 		$this->assertSame( 0, $result['days_to_complete_sum'], 'Failed status should not contribute to days to complete.' );
 	}
 
@@ -288,6 +291,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed status should count as completed.' );
+		$this->assertSame( 1, $result['days_to_complete_count'], 'Passed status should have a completion date.' );
 		$this->assertSame( 4, $result['days_to_complete_sum'], 'Expected 4 days (3 day difference + 1).' );
 	}
 
@@ -304,6 +308,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 0, $result['unique_student_count'] );
 		$this->assertSame( 0, $result['lesson_start_count'] );
 		$this->assertSame( 0, $result['lesson_completed_count'] );
+		$this->assertSame( 0, $result['days_to_complete_count'] );
 		$this->assertSame( 0, $result['days_to_complete_sum'] );
 	}
 

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -222,6 +222,75 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertGreaterThanOrEqual( 1, $result['days_to_complete_sum'], 'Expected at least one day to complete.' );
 	}
 
+	public function testGetLessonTotals_WithUngradedStatus_DoesNotCountAsCompleted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$start_date = current_time( 'mysql' );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded', [ 'start' => $start_date ] );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['lesson_completed_count'], 'Ungraded status should NOT count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_sum'], 'Ungraded status should not contribute to days to complete.' );
+	}
+
+	public function testGetLessonTotals_WithFailedStatus_DoesNotCountAsCompleted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$start_date = current_time( 'mysql' );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'failed', [ 'start' => $start_date ] );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['lesson_completed_count'], 'Failed status should NOT count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_sum'], 'Failed status should not contribute to days to complete.' );
+	}
+
+	public function testGetLessonTotals_WithPassedStatus_IncludesDaysToComplete(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$start_date = gmdate( 'Y-m-d H:i:s', strtotime( '-3 days' ) );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed', [ 'start' => $start_date ] );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed status should count as completed.' );
+		$this->assertSame( 4, $result['days_to_complete_sum'], 'Expected 4 days (3 day difference + 1).' );
+	}
+
 	public function testGetLessonTotals_WithEmptyLessonIds_ReturnsZeros(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -206,7 +206,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$start_date = gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
+		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
 		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', [ 'start' => $start_date ] );
 		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', [ 'start' => $start_date ] );
 
@@ -278,7 +278,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$start_date = gmdate( 'Y-m-d H:i:s', strtotime( '-3 days' ) );
+		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-3 days' ) );
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed', [ 'start' => $start_date ] );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-clauses-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-clauses-service.php
@@ -134,7 +134,7 @@ class Comments_Based_Progress_Clauses_Service_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'sensei_lesson_status', $clauses['fields'], 'Expected lesson status comment type in fields clause.' );
 	}
 
-	public function testAddDaysToCompleteToLessonsClauses_WhenCalled_AddsDaysToCompleteField(): void {
+	public function testAddDaysToCompletionToLessonsClauses_WhenCalled_AddsDaysToCompleteField(): void {
 		/* Arrange. */
 		global $wpdb;
 

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-clauses-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-clauses-service.php
@@ -117,4 +117,36 @@ class Comments_Based_Progress_Clauses_Service_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( '', $clauses['where'] );
 	}
+
+	public function testAddLastActivityToLessonsClauses_WhenCalled_AddsLastActivityDateField(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Comments_Based_Progress_Clauses_Service( $wpdb );
+		$clauses = $this->get_empty_clauses();
+
+		/* Act. */
+		$clauses = $service->add_last_activity_to_lessons_clauses( $clauses );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'last_activity_date', $clauses['fields'], 'Expected last_activity_date in fields clause.' );
+		$this->assertStringContainsString( $wpdb->comments, $clauses['fields'], 'Expected comments table in fields clause.' );
+		$this->assertStringContainsString( 'sensei_lesson_status', $clauses['fields'], 'Expected lesson status comment type in fields clause.' );
+	}
+
+	public function testAddDaysToCompleteToLessonsClauses_WhenCalled_AddsDaysToCompleteField(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Comments_Based_Progress_Clauses_Service( $wpdb );
+		$clauses = $this->get_empty_clauses();
+
+		/* Act. */
+		$clauses = $service->add_days_to_completion_to_lessons_clauses( $clauses );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'days_to_complete', $clauses['fields'], 'Expected days_to_complete in fields clause.' );
+		$this->assertStringContainsString( $wpdb->comments, $clauses['fields'], 'Expected comments table in fields clause.' );
+		$this->assertStringContainsString( $wpdb->commentmeta, $clauses['fields'], 'Expected commentmeta table in fields clause.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-grading-item.php
+++ b/tests/unit-tests/internal/services/test-class-grading-item.php
@@ -19,6 +19,14 @@ class Grading_Item_Test extends \WP_UnitTestCase {
 		);
 	}
 
+	public function testStatusesWithCompletionDate_ContainsExpectedValues(): void {
+		/* Assert. */
+		$this->assertSame(
+			[ 'complete', 'graded', 'passed' ],
+			Grading_Item::STATUSES_WITH_COMPLETION_DATE
+		);
+	}
+
 	public function testGet_WithCommentApproved_ReturnsStatus(): void {
 		/* Arrange. */
 		$item = new Grading_Item( 'passed', 1, 100, '2026-01-01', 85 );

--- a/tests/unit-tests/internal/services/test-class-grading-item.php
+++ b/tests/unit-tests/internal/services/test-class-grading-item.php
@@ -11,6 +11,14 @@ use Sensei\Internal\Services\Grading_Item;
  */
 class Grading_Item_Test extends \WP_UnitTestCase {
 
+	public function testCompletedStatuses_ContainsExpectedValues(): void {
+		/* Assert. */
+		$this->assertSame(
+			[ 'complete', 'graded', 'passed', 'failed', 'ungraded' ],
+			Grading_Item::COMPLETED_STATUSES
+		);
+	}
+
 	public function testStatusesWithCompletionDate_ContainsExpectedValues(): void {
 		/* Assert. */
 		$this->assertSame(

--- a/tests/unit-tests/internal/services/test-class-grading-item.php
+++ b/tests/unit-tests/internal/services/test-class-grading-item.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SenseiTest\Internal\Services;
+
+use Sensei\Internal\Services\Grading_Item;
+
+/**
+ * @covers \Sensei\Internal\Services\Grading_Item
+ */
+class Grading_Item_Test extends \WP_UnitTestCase {
+
+	public function testCompletedStatuses_ContainsExpectedValues(): void {
+		/* Assert. */
+		$this->assertSame(
+			[ 'complete', 'graded', 'passed', 'failed', 'ungraded' ],
+			Grading_Item::COMPLETED_STATUSES
+		);
+	}
+
+	public function testGet_WithCommentApproved_ReturnsStatus(): void {
+		/* Arrange. */
+		$item = new Grading_Item( 'passed', 1, 100, '2026-01-01', 85 );
+		$this->setExpectedDeprecated( 'Grading_Item::$comment_approved' );
+
+		/* Act. */
+		$result = $item->comment_approved;
+
+		/* Assert. */
+		$this->assertSame( 'passed', $result );
+	}
+
+	public function testGet_WithCommentPostID_ReturnsLessonId(): void {
+		/* Arrange. */
+		$item = new Grading_Item( 'passed', 1, 100, '2026-01-01', 85 );
+		$this->setExpectedDeprecated( 'Grading_Item::$comment_post_ID' );
+
+		/* Act. */
+		$result = $item->comment_post_ID;
+
+		/* Assert. */
+		$this->assertSame( 100, $result );
+	}
+
+	public function testGet_WithCommentDate_ReturnsUpdatedAt(): void {
+		/* Arrange. */
+		$item = new Grading_Item( 'passed', 1, 100, '2026-01-01', 85 );
+		$this->setExpectedDeprecated( 'Grading_Item::$comment_date' );
+
+		/* Act. */
+		$result = $item->comment_date;
+
+		/* Assert. */
+		$this->assertSame( '2026-01-01', $result );
+	}
+
+	public function testGet_WithUnmappedProperty_ReturnsNull(): void {
+		/* Arrange. */
+		$item = new Grading_Item( 'passed', 1, 100, '2026-01-01', 85 );
+		$this->setExpectedIncorrectUsage( 'Grading_Item::$nonexistent' );
+
+		/* Act. */
+		$result = $item->nonexistent;
+
+		/* Assert. */
+		$this->assertNull( $result );
+	}
+}

--- a/tests/unit-tests/internal/services/test-class-grading-item.php
+++ b/tests/unit-tests/internal/services/test-class-grading-item.php
@@ -11,14 +11,6 @@ use Sensei\Internal\Services\Grading_Item;
  */
 class Grading_Item_Test extends \WP_UnitTestCase {
 
-	public function testCompletedStatuses_ContainsExpectedValues(): void {
-		/* Assert. */
-		$this->assertSame(
-			[ 'complete', 'graded', 'passed', 'failed', 'ungraded' ],
-			Grading_Item::COMPLETED_STATUSES
-		);
-	}
-
 	public function testStatusesWithCompletionDate_ContainsExpectedValues(): void {
 		/* Assert. */
 		$this->assertSame(

--- a/tests/unit-tests/internal/services/test-class-grading-item.php
+++ b/tests/unit-tests/internal/services/test-class-grading-item.php
@@ -5,6 +5,8 @@ namespace SenseiTest\Internal\Services;
 use Sensei\Internal\Services\Grading_Item;
 
 /**
+ * Class Grading_Item_Test.
+ *
  * @covers \Sensei\Internal\Services\Grading_Item
  */
 class Grading_Item_Test extends \WP_UnitTestCase {

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace SenseiTest\Internal\Services;
+
+use Sensei\Internal\Services\Tables_Based_Grading_Listing_Service;
+use Sensei\Internal\Services\Grading_Item;
+
+/**
+ * @covers \Sensei\Internal\Services\Tables_Based_Grading_Listing_Service
+ */
+class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
+
+	private $sensei_factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->sensei_factory = new \Sensei_Factory();
+	}
+
+	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null ): void {
+		$wpdb   = $GLOBALS['wpdb'];
+		$table  = $wpdb->prefix . 'sensei_lms_progress';
+		$now    = current_time( 'mysql' );
+		$data   = [ 'post_id' => $post_id, 'user_id' => $user_id, 'type' => $type, 'status' => $status, 'started_at' => $now, 'created_at' => $now, 'updated_at' => $now ];
+		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
+		if ( null !== $parent_post_id ) {
+			$data['parent_post_id'] = $parent_post_id;
+			$format[]               = '%d';
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert( $table, $data, $format );
+	}
+
+	private function insert_quiz_submission( int $quiz_id, int $user_id, ?int $final_grade = null ): void {
+		$wpdb   = $GLOBALS['wpdb'];
+		$table  = $wpdb->prefix . 'sensei_lms_quiz_submissions';
+		$now    = current_time( 'mysql' );
+		$data   = [ 'quiz_id' => $quiz_id, 'user_id' => $user_id, 'created_at' => $now, 'updated_at' => $now ];
+		$format = [ '%d', '%d', '%s', '%s' ];
+		if ( null !== $final_grade ) {
+			$data['final_grade'] = $final_grade;
+			$format[]            = '%d';
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert( $table, $data, $format );
+	}
+
+	public function testGetLessonProgressItems_WithLessonStatus_ReturnsGradingItems(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'] );
+		$this->assertCount( 1, $result['items'] );
+		$this->assertInstanceOf( Grading_Item::class, $result['items'][0] );
+		$this->assertSame( 'in-progress', $result['items'][0]->status );
+		$this->assertSame( $user_id, $result['items'][0]->user_id );
+		$this->assertSame( $lesson_id, $result['items'][0]->lesson_id );
+	}
+
+	public function testGetLessonProgressItems_WithQuizStatus_UsesCoalescedStatus(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$quiz_id   = $this->sensei_factory->quiz->create( [ 'post_parent' => $lesson_id, 'meta_input' => [ '_quiz_lesson' => $lesson_id ] ] );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id, 90 );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 'passed', $result['items'][0]->status, 'Quiz status should override lesson status.' );
+		$this->assertSame( 90, $result['items'][0]->grade, 'Expected grade from quiz submission.' );
+	}
+
+	public function testGetLessonProgressItems_WithNoGrade_ReturnsNullGrade(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertNull( $result['items'][0]->grade, 'Expected null grade for non-graded item.' );
+	}
+
+	public function testGetLessonProgressItems_WithPostInFilter_ReturnsMatchingLessons(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson1   = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson2   = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson3   = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson2, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson3, $user_id, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post__in' => [ $lesson1, $lesson2 ] ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 2, $result['total_count'], 'Expected two items for the two filtered lessons.' );
+		$returned_lesson_ids = array_map( function ( $item ) { return $item->lesson_id; }, $result['items'] );
+		$this->assertContains( $lesson1, $returned_lesson_ids, 'Expected lesson1 in results.' );
+		$this->assertContains( $lesson2, $returned_lesson_ids, 'Expected lesson2 in results.' );
+		$this->assertNotContains( $lesson3, $returned_lesson_ids, 'Expected lesson3 excluded from results.' );
+	}
+
+	public function testGetLessonProgressItems_WithOffsetBeyondTotal_CorrectsPagination(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 100, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'], 'Expected one total item.' );
+		$this->assertCount( 1, $result['items'], 'Expected offset correction to return items.' );
+	}
+
+	public function testGetLessonProgressItems_WithMultipleStatusArray_FiltersCorrectly(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$user3     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+
+		$quiz_id = $this->sensei_factory->quiz->create( [ 'post_parent' => $lesson_id, 'meta_input' => [ '_quiz_lesson' => $lesson_id ] ] );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		$this->insert_progress( $lesson_id, $user3, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user3, 'quiz', 'graded', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user3 );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => [ 'in-progress', 'complete' ], 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 2, $result['total_count'], 'Expected two items matching in-progress or complete.' );
+		$statuses = array_map( function ( $item ) { return $item->status; }, $result['items'] );
+		$this->assertNotContains( 'graded', $statuses, 'Graded status should be excluded.' );
+	}
+
+	public function testGetLessonProgressItems_WithStatusFilter_FiltersResults(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'in-progress', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'] );
+		$this->assertSame( 'in-progress', $result['items'][0]->status );
+	}
+
+	public function testGetLessonProgressItems_WithPagination_RespectsLimitAndOffset(): void {
+		/* Arrange. */
+		global $wpdb;
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		for ( $i = 0; $i < 3; $i++ ) {
+			$user_id = $this->sensei_factory->user->create();
+			$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		}
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 2, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 3, $result['total_count'] );
+		$this->assertCount( 2, $result['items'] );
+	}
+
+	public function testGetLessonProgressItems_WithUserIdFilter_RestrictsToUser(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'user_id' => $user1 ]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'] );
+		$this->assertSame( $user1, $result['items'][0]->user_id );
+	}
+}

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -153,6 +153,37 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 90, $result['items'][0]->grade, 'Expected grade from quiz submission.' );
 	}
 
+	public function testGetLessonProgressItems_WithQuizProgressButNoSubmission_UsesLessonStatus(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		// Quiz progress exists but no quiz submission.
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
+		);
+
+		/* Assert. */
+		$this->assertSame( 'complete', $result['items'][0]->status, 'Quiz progress without submission should fall back to lesson status.' );
+	}
+
 	public function testGetLessonProgressItems_WithNoGrade_ReturnsNullGrade(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -114,12 +114,13 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertSame( 1, $result['total_count'] );
-		$this->assertCount( 1, $result['items'] );
-		$this->assertInstanceOf( Grading_Item::class, $result['items'][0] );
-		$this->assertSame( 'in-progress', $result['items'][0]->status );
-		$this->assertSame( $user_id, $result['items'][0]->user_id );
-		$this->assertSame( $lesson_id, $result['items'][0]->lesson_id );
+		$this->assertSame( 1, $result['total_count'], 'Expected exactly one result.' );
+		$this->assertCount( 1, $result['items'], 'Expected exactly one item.' );
+		$this->assertInstanceOf( Grading_Item::class, $result['items'][0], 'Expected a Grading_Item instance.' );
+		$this->assertSame( 'in-progress', $result['items'][0]->status, 'Expected in-progress status.' );
+		$this->assertSame( $user_id, $result['items'][0]->user_id, 'Expected matching user ID.' );
+		$this->assertSame( $lesson_id, $result['items'][0]->lesson_id, 'Expected matching lesson ID.' );
+		$this->assertNull( $result['items'][0]->grade, 'Expected null grade for non-graded item.' );
 	}
 
 	public function testGetLessonProgressItems_WithQuizStatus_UsesCoalescedStatus(): void {
@@ -182,27 +183,6 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertSame( 'complete', $result['items'][0]->status, 'Quiz progress without submission should fall back to lesson status.' );
-	}
-
-	public function testGetLessonProgressItems_WithNoGrade_ReturnsNullGrade(): void {
-		/* Arrange. */
-		global $wpdb;
-		$user_id   = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
-
-		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->get_lesson_progress_items(
-			$this->get_default_args( [ 'post_id' => $lesson_id ] )
-		);
-
-		/* Assert. */
-		$this->assertNull( $result['items'][0]->grade, 'Expected null grade for non-graded item.' );
 	}
 
 	public function testGetLessonProgressItems_WithPostInFilter_ReturnsMatchingLessons(): void {

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -383,4 +383,82 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['total_count'] );
 		$this->assertSame( $user1, $result['items'][0]->user_id );
 	}
+
+	public function testGetStatusCounts_AfterGetLessonProgressItems_ReturnsPerStatusCounts(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		// User1: in-progress lesson (no quiz interaction).
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+
+		// User2: completed lesson with passed quiz.
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user2, 'quiz', 'passed', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user2, 85 );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$service->get_lesson_progress_items(
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
+		);
+		$counts = $service->get_status_counts();
+
+		/* Assert. */
+		$this->assertIsArray( $counts, 'Expected an array of status counts.' );
+		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Expected 1 in-progress.' );
+		$this->assertSame( 1, $counts['passed'] ?? 0, 'Expected 1 passed (coalesced from quiz).' );
+	}
+
+	public function testGetStatusCounts_BeforeGetLessonProgressItems_ReturnsNull(): void {
+		/* Arrange. */
+		global $wpdb;
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act & Assert. */
+		$this->assertNull( $service->get_status_counts(), 'Expected null before any query.' );
+	}
+
+	public function testGetStatusCounts_WithStatusFilter_ReturnsAllStatuses(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act -- query with status filter for in-progress only. */
+		$service->get_lesson_progress_items(
+			$this->get_default_args(
+				[
+					'status'  => 'in-progress',
+					'post_id' => $lesson_id,
+				]
+			)
+		);
+		$counts = $service->get_status_counts();
+
+		/* Assert -- counts should include ALL statuses, not just in-progress. */
+		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Expected 1 in-progress.' );
+		$this->assertSame( 1, $counts['complete'] ?? 0, 'Expected 1 complete even though status filter was in-progress.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -6,6 +6,8 @@ use Sensei\Internal\Services\Tables_Based_Grading_Listing_Service;
 use Sensei\Internal\Services\Grading_Item;
 
 /**
+ * Class Tables_Based_Grading_Listing_Service_Test.
+ *
  * @covers \Sensei\Internal\Services\Tables_Based_Grading_Listing_Service
  */
 class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
@@ -17,32 +19,81 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->sensei_factory = new \Sensei_Factory();
 	}
 
+	/**
+	 * Insert a progress row directly into the HPPS progress table.
+	 *
+	 * @param int      $post_id        The post ID.
+	 * @param int      $user_id        The user ID.
+	 * @param string   $type           The progress type.
+	 * @param string   $status         The progress status.
+	 * @param int|null $parent_post_id The parent post ID.
+	 */
 	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
-		$data   = [ 'post_id' => $post_id, 'user_id' => $user_id, 'type' => $type, 'status' => $status, 'started_at' => $now, 'created_at' => $now, 'updated_at' => $now ];
+		$data   = [
+			'post_id'    => $post_id,
+			'user_id'    => $user_id,
+			'type'       => $type,
+			'status'     => $status,
+			'started_at' => $now,
+			'created_at' => $now,
+			'updated_at' => $now,
+		];
 		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
 		if ( null !== $parent_post_id ) {
 			$data['parent_post_id'] = $parent_post_id;
 			$format[]               = '%d';
 		}
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
 		$wpdb->insert( $table, $data, $format );
 	}
 
+	/**
+	 * Insert a quiz submission row.
+	 *
+	 * @param int      $quiz_id     The quiz post ID.
+	 * @param int      $user_id     The user ID.
+	 * @param int|null $final_grade The final grade.
+	 */
 	private function insert_quiz_submission( int $quiz_id, int $user_id, ?int $final_grade = null ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_quiz_submissions';
 		$now    = current_time( 'mysql' );
-		$data   = [ 'quiz_id' => $quiz_id, 'user_id' => $user_id, 'created_at' => $now, 'updated_at' => $now ];
+		$data   = [
+			'quiz_id'    => $quiz_id,
+			'user_id'    => $user_id,
+			'created_at' => $now,
+			'updated_at' => $now,
+		];
 		$format = [ '%d', '%d', '%s', '%s' ];
 		if ( null !== $final_grade ) {
 			$data['final_grade'] = $final_grade;
 			$format[]            = '%d';
 		}
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
 		$wpdb->insert( $table, $data, $format );
+	}
+
+	/**
+	 * Build default query args for get_lesson_progress_items.
+	 *
+	 * @param array $overrides Args to override.
+	 * @return array
+	 */
+	private function get_default_args( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'type'    => 'sensei_lesson_status',
+				'number'  => 10,
+				'offset'  => 0,
+				'orderby' => '',
+				'order'   => 'DESC',
+				'status'  => 'any',
+			],
+			$overrides
+		);
 	}
 
 	public function testGetLessonProgressItems_WithLessonStatus_ReturnsGradingItems(): void {
@@ -50,14 +101,16 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
 		);
 
 		/* Assert. */
@@ -74,8 +127,15 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
-		$quiz_id   = $this->sensei_factory->quiz->create( [ 'post_parent' => $lesson_id, 'meta_input' => [ '_quiz_lesson' => $lesson_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
@@ -85,7 +145,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
 		);
 
 		/* Assert. */
@@ -98,14 +158,16 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
 		);
 
 		/* Assert. */
@@ -117,9 +179,15 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson1   = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
-		$lesson2   = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
-		$lesson3   = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson1   = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson2   = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson3   = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress', $course_id );
 		$this->insert_progress( $lesson2, $user_id, 'lesson', 'complete', $course_id );
 		$this->insert_progress( $lesson3, $user_id, 'lesson', 'in-progress', $course_id );
@@ -128,12 +196,17 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post__in' => [ $lesson1, $lesson2 ] ]
+			$this->get_default_args( [ 'post__in' => [ $lesson1, $lesson2 ] ] )
 		);
 
 		/* Assert. */
 		$this->assertSame( 2, $result['total_count'], 'Expected two items for the two filtered lessons.' );
-		$returned_lesson_ids = array_map( function ( $item ) { return $item->lesson_id; }, $result['items'] );
+		$returned_lesson_ids = array_map(
+			function ( $item ) {
+				return $item->lesson_id;
+			},
+			$result['items']
+		);
 		$this->assertContains( $lesson1, $returned_lesson_ids, 'Expected lesson1 in results.' );
 		$this->assertContains( $lesson2, $returned_lesson_ids, 'Expected lesson2 in results.' );
 		$this->assertNotContains( $lesson3, $returned_lesson_ids, 'Expected lesson3 excluded from results.' );
@@ -144,14 +217,21 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 100, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args(
+				[
+					'offset'  => 100,
+					'post_id' => $lesson_id,
+				]
+			)
 		);
 
 		/* Assert. */
@@ -166,11 +246,18 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$user2     = $this->sensei_factory->user->create();
 		$user3     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
 		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
 
-		$quiz_id = $this->sensei_factory->quiz->create( [ 'post_parent' => $lesson_id, 'meta_input' => [ '_quiz_lesson' => $lesson_id ] ] );
+		$quiz_id = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		$this->insert_progress( $lesson_id, $user3, 'lesson', 'complete', $course_id );
 		$this->insert_progress( $quiz_id, $user3, 'quiz', 'graded', $lesson_id );
@@ -180,12 +267,22 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => [ 'in-progress', 'complete' ], 'post_id' => $lesson_id ]
+			$this->get_default_args(
+				[
+					'status'  => [ 'in-progress', 'complete' ],
+					'post_id' => $lesson_id,
+				]
+			)
 		);
 
 		/* Assert. */
 		$this->assertSame( 2, $result['total_count'], 'Expected two items matching in-progress or complete.' );
-		$statuses = array_map( function ( $item ) { return $item->status; }, $result['items'] );
+		$statuses = array_map(
+			function ( $item ) {
+				return $item->status;
+			},
+			$result['items']
+		);
 		$this->assertNotContains( 'graded', $statuses, 'Graded status should be excluded.' );
 	}
 
@@ -195,7 +292,9 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$user1     = $this->sensei_factory->user->create();
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
 		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
 
@@ -203,7 +302,12 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'in-progress', 'post_id' => $lesson_id ]
+			$this->get_default_args(
+				[
+					'status'  => 'in-progress',
+					'post_id' => $lesson_id,
+				]
+			)
 		);
 
 		/* Assert. */
@@ -215,7 +319,9 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		global $wpdb;
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		for ( $i = 0; $i < 3; $i++ ) {
 			$user_id = $this->sensei_factory->user->create();
 			$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
@@ -225,7 +331,12 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 2, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'post_id' => $lesson_id ]
+			$this->get_default_args(
+				[
+					'number'  => 2,
+					'post_id' => $lesson_id,
+				]
+			)
 		);
 
 		/* Assert. */
@@ -239,7 +350,9 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$user1     = $this->sensei_factory->user->create();
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
 		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
 		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
 
@@ -247,7 +360,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->get_lesson_progress_items(
-			[ 'type' => 'sensei_lesson_status', 'number' => 10, 'offset' => 0, 'orderby' => '', 'order' => 'DESC', 'status' => 'any', 'user_id' => $user1 ]
+			$this->get_default_args( [ 'user_id' => $user1 ] )
 		);
 
 		/* Assert. */

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -151,10 +151,10 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertSame( 'passed', $result['items'][0]->status, 'Quiz status should override lesson status.' );
-		$this->assertSame( 90, $result['items'][0]->grade, 'Expected grade from quiz submission.' );
+		$this->assertSame( 90.0, $result['items'][0]->grade, 'Expected grade from quiz submission.' );
 	}
 
-	public function testGetLessonProgressItems_WithQuizProgressButNoSubmission_UsesLessonStatus(): void {
+	public function testGetLessonProgressItems_WithQuizProgressButNoSubmission_ExcludedFromResults(): void {
 		/* Arrange. */
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -170,7 +170,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
-		// Quiz progress exists but no quiz submission.
+		// Quiz progress exists but no quiz submission — nothing to grade.
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
 
@@ -182,7 +182,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertSame( 'complete', $result['items'][0]->status, 'Quiz progress without submission should fall back to lesson status.' );
+		$this->assertSame( 0, $result['total_count'], 'Completed lesson with quiz but no submission should be excluded.' );
+		$this->assertEmpty( $result['items'], 'No items should be returned.' );
 	}
 
 	public function testGetLessonProgressItems_WithPostInFilter_ReturnsMatchingLessons(): void {
@@ -260,16 +261,20 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
-
-		$quiz_id = $this->sensei_factory->quiz->create(
+		$quiz_id   = $this->sensei_factory->quiz->create(
 			[
 				'post_parent' => $lesson_id,
 				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
 			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		// User2 completed and submitted the quiz so is not excluded.
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user2, 'quiz', 'complete', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user2 );
+
 		$this->insert_progress( $lesson_id, $user3, 'lesson', 'complete', $course_id );
 		$this->insert_progress( $quiz_id, $user3, 'quiz', 'graded', $lesson_id );
 		$this->insert_quiz_submission( $quiz_id, $user3 );

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -549,6 +549,41 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result['days_to_complete_sum'] );
 	}
 
+	public function testGetLessonTotals_WithUtcDatesNearMidnight_ConvertsToLocalTimeBeforeDatediff(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		// Set site timezone to UTC-5 (e.g. America/New_York EST).
+		$original_offset   = get_option( 'gmt_offset' );
+		$original_timezone = get_option( 'timezone_string' );
+		update_option( 'gmt_offset', -5 );
+		update_option( 'timezone_string', '' );
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		// UTC dates span two days (Jan 1 05:00 → Jan 2 04:00),
+		// but in UTC-5 they're same day (Jan 1 00:00 → Jan 1 23:00).
+		$started_at   = '2024-01-01 05:00:00';
+		$completed_at = '2024-01-02 04:00:00';
+		$this->insert_progress_with_dates( $lesson_id, $user_id, 'lesson', 'complete', $course_id, $started_at, $completed_at );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['days_to_complete_sum'], 'UTC dates spanning midnight should be 1 day in local time (UTC-5).' );
+
+		/* Cleanup. */
+		update_option( 'gmt_offset', $original_offset );
+		update_option( 'timezone_string', $original_timezone );
+	}
+
 	public function testCountStatuses_WithIncludeStatusesOverride_KeepsExcludedUsersForOverrideStatuses(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -32,6 +32,32 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 	 * @param string      $status         The progress status.
 	 * @param int|null    $parent_post_id The parent post ID.
 	 */
+	private function insert_progress_with_dates( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id, string $started_at, string $completed_at ): void {
+		$wpdb  = $GLOBALS['wpdb'];
+		$table = $wpdb->prefix . 'sensei_lms_progress';
+		$now   = current_time( 'mysql' );
+		$data  = [
+			'post_id'      => $post_id,
+			'user_id'      => $user_id,
+			'type'         => $type,
+			'status'       => $status,
+			'started_at'   => $started_at,
+			'completed_at' => $completed_at,
+			'created_at'   => $now,
+			'updated_at'   => $now,
+		];
+
+		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' ];
+
+		if ( null !== $parent_post_id ) {
+			$data['parent_post_id'] = $parent_post_id;
+			$format[]               = '%d';
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper inserting directly into custom table.
+		$wpdb->insert( $table, $data, $format );
+	}
+
 	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null, ?string $completed_at = null ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
@@ -434,6 +460,104 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['unique_student_count'], 'Expected one student.' );
 		$this->assertSame( 1, $result['lesson_start_count'], 'Expected one lesson start.' );
 		$this->assertSame( 0, $result['lesson_completed_count'], 'In-progress quiz status should NOT count as completed.' );
+	}
+
+	public function testGetLessonTotals_WithUngradedQuizStatus_DoesNotCountAsCompleted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		// Lesson is in-progress, quiz is ungraded (submitted but not yet graded).
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['lesson_completed_count'], 'Ungraded quiz status should NOT count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_sum'], 'Ungraded quiz should not contribute to days to complete.' );
+	}
+
+	public function testGetLessonTotals_WithFailedQuizStatus_DoesNotCountAsCompleted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		// Lesson is in-progress, quiz is failed (pass required, student didn't pass).
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'failed', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['lesson_completed_count'], 'Failed quiz status should NOT count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_sum'], 'Failed quiz should not contribute to days to complete.' );
+	}
+
+	public function testGetLessonTotals_WithPassedQuiz_IncludesDaysToComplete(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		// Started 3 days ago, completed today.
+		$started_at   = gmdate( 'Y-m-d H:i:s', strtotime( '-3 days' ) );
+		$completed_at = current_time( 'mysql' );
+		$this->insert_progress_with_dates( $lesson_id, $user_id, 'lesson', 'complete', $course_id, $started_at, $completed_at );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed quiz should count as completed.' );
+		$this->assertSame( 4, $result['days_to_complete_sum'], 'Expected 4 days (3 day difference + 1).' );
 	}
 
 	public function testGetLessonTotals_WithEmptyLessonIds_ReturnsZeros(): void {

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -32,7 +32,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 	 * @param string      $status         The progress status.
 	 * @param int|null    $parent_post_id The parent post ID.
 	 */
-	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null ): void {
+	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null, ?string $completed_at = null ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
@@ -50,6 +50,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		if ( null !== $parent_post_id ) {
 			$data['parent_post_id'] = $parent_post_id;
 			$format[]               = '%d';
+		}
+
+		if ( null !== $completed_at ) {
+			$data['completed_at'] = $completed_at;
+			$format[]             = '%s';
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper inserting directly into custom table.
@@ -335,6 +340,116 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['ungraded'], 'Expected one ungraded quiz status.' );
 		$this->assertArrayNotHasKey( 'complete', $result, 'Raw lesson status should not appear when quiz status exists.' );
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Raw lesson status should not appear when quiz status exists.' );
+	}
+
+	public function testGetLessonTotals_WithCompletedLessons_ReturnsCorrectAggregates(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete', $course_id, current_time( 'mysql' ) );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
+		$this->assertSame( 2, $result['lesson_start_count'], 'Expected two lesson starts.' );
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Expected one completed lesson.' );
+		$this->assertGreaterThanOrEqual( 1, $result['days_to_complete_sum'], 'Expected at least one day to complete.' );
+	}
+
+	public function testGetLessonTotals_WithQuizStatus_UsesCoalesced(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
+
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id, current_time( 'mysql' ) );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['unique_student_count'], 'Expected one student.' );
+		$this->assertSame( 1, $result['lesson_start_count'], 'Expected one lesson start.' );
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed quiz status should count as completed.' );
+	}
+
+	public function testGetLessonTotals_WithInProgressQuizStatus_DoesNotCountAsCompleted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
+
+		// Lesson is complete but quiz is still in-progress — COALESCE should
+		// produce 'in-progress' which is NOT in the completed statuses list.
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id, current_time( 'mysql' ) );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'in-progress', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['unique_student_count'], 'Expected one student.' );
+		$this->assertSame( 1, $result['lesson_start_count'], 'Expected one lesson start.' );
+		$this->assertSame( 0, $result['lesson_completed_count'], 'In-progress quiz status should NOT count as completed.' );
+	}
+
+	public function testGetLessonTotals_WithEmptyLessonIds_ReturnsZeros(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( [] );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['unique_student_count'] );
+		$this->assertSame( 0, $result['lesson_start_count'] );
+		$this->assertSame( 0, $result['lesson_completed_count'] );
+		$this->assertSame( 0, $result['days_to_complete_sum'] );
 	}
 
 	public function testCountStatuses_WithIncludeStatusesOverride_KeepsExcludedUsersForOverrideStatuses(): void {

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -762,5 +762,4 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['complete'], 'Non-trashed course should be counted.' );
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Trashed course status should not appear.' );
 	}
-
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -379,8 +379,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$started_at   = gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
-		$completed_at = current_time( 'mysql' );
+		$started_at   = '2024-01-01 10:00:00';
+		$completed_at = '2024-01-03 10:00:00';
 		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
 		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
 
@@ -512,9 +512,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
-		// Started 3 days ago, completed today.
-		$started_at   = gmdate( 'Y-m-d H:i:s', strtotime( '-3 days' ) );
-		$completed_at = current_time( 'mysql' );
+		$started_at   = '2024-01-01 10:00:00';
+		$completed_at = '2024-01-04 10:00:00';
 		$this->insert_progress_with_dates( $lesson_id, $user_id, 'lesson', 'complete', $course_id, $started_at, $completed_at );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
 		$this->insert_quiz_submission( $quiz_id, $user_id );

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -763,35 +763,4 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Trashed course status should not appear.' );
 	}
 
-	public function testCountStatuses_TrashedLesson_ExcludedFromCounts(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id   = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson1   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$lesson2   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-
-		$this->insert_progress( $lesson1, $user_id, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $lesson2, $user_id, 'lesson', 'in-progress', $course_id );
-
-		wp_trash_post( $lesson2 );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses(
-			[
-				'type' => 'lesson',
-			]
-		);
-
-		/* Assert. */
-		$this->assertSame( 1, $result['complete'], 'Non-trashed lesson should be counted.' );
-		$this->assertArrayNotHasKey( 'in-progress', $result, 'Trashed lesson status should not appear.' );
-	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -679,7 +679,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Act. */
 		$result = $service->count_statuses(
 			[
-				'type' => 'lesson',
+				'type'                                 => 'lesson',
 				'exclude_unsubmitted_quiz_completions' => true,
 			]
 		);

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -581,7 +581,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['ungraded'], 'Excluded user with override status should still be counted.' );
 	}
 
-	public function testCountStatuses_LessonWithQuizButNoSubmission_UsesLessonStatus(): void {
+	public function testCountStatuses_LessonWithQuizButNoSubmission_IncludedByDefault(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -613,7 +613,44 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertArrayNotHasKey( 'complete', $result, 'Completed lesson with quiz but no submission should be excluded.' );
+		$this->assertSame( 1, $result['complete'], 'Completed lesson with quiz but no submission should be included by default.' );
+		$this->assertArrayNotHasKey( 'passed', $result, 'Quiz progress without submission should not count as graded.' );
+	}
+
+	public function testCountStatuses_LessonWithQuizButNoSubmission_ExcludedWhenFlagSet(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
+
+		// Quiz progress exists but no quiz submission (e.g. migration phantom or lost data).
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses(
+			[
+				'type' => 'lesson',
+				'exclude_unsubmitted_quiz_completions' => true,
+			]
+		);
+
+		/* Assert. */
+		$this->assertArrayNotHasKey( 'complete', $result, 'Completed lesson with quiz but no submission should be excluded when flag is set.' );
 		$this->assertArrayNotHasKey( 'passed', $result, 'Quiz progress without submission should not count as graded.' );
 	}
 

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -393,6 +393,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
 		$this->assertSame( 2, $result['lesson_start_count'], 'Expected two lesson starts.' );
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Expected one completed lesson.' );
+		$this->assertSame( 1, $result['days_to_complete_count'], 'Expected one lesson with completion date.' );
 		$this->assertSame( 3, $result['days_to_complete_sum'], 'Expected 3 days (2 day difference + 1).' );
 	}
 
@@ -431,7 +432,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result['lesson_completed_count'], 'In-progress quiz status should NOT count as completed.' );
 	}
 
-	public function testGetLessonTotals_WithUngradedQuizStatus_DoesNotCountAsCompleted(): void {
+	public function testGetLessonTotals_WithUngradedQuizStatus_CountsAsCompletedButNotDaysToComplete(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -459,11 +460,12 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
-		$this->assertSame( 0, $result['lesson_completed_count'], 'Ungraded quiz status should NOT count as completed.' );
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Ungraded quiz status should count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_count'], 'Ungraded quiz should not have a completion date.' );
 		$this->assertSame( 0, $result['days_to_complete_sum'], 'Ungraded quiz should not contribute to days to complete.' );
 	}
 
-	public function testGetLessonTotals_WithFailedQuizStatus_DoesNotCountAsCompleted(): void {
+	public function testGetLessonTotals_WithFailedQuizStatus_CountsAsCompletedButNotDaysToComplete(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -491,7 +493,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
-		$this->assertSame( 0, $result['lesson_completed_count'], 'Failed quiz status should NOT count as completed.' );
+		$this->assertSame( 1, $result['lesson_completed_count'], 'Failed quiz status should count as completed.' );
+		$this->assertSame( 0, $result['days_to_complete_count'], 'Failed quiz should not have a completion date.' );
 		$this->assertSame( 0, $result['days_to_complete_sum'], 'Failed quiz should not contribute to days to complete.' );
 	}
 
@@ -525,6 +528,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed quiz should count as completed.' );
+		$this->assertSame( 1, $result['days_to_complete_count'], 'Passed quiz should have a completion date.' );
 		$this->assertSame( 4, $result['days_to_complete_sum'], 'Expected 4 days (3 day difference + 1).' );
 	}
 
@@ -541,6 +545,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result['unique_student_count'] );
 		$this->assertSame( 0, $result['lesson_start_count'] );
 		$this->assertSame( 0, $result['lesson_completed_count'] );
+		$this->assertSame( 0, $result['days_to_complete_count'] );
 		$this->assertSame( 0, $result['days_to_complete_sum'] );
 	}
 
@@ -608,7 +613,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertSame( 1, $result['complete'], 'Quiz progress without submission should fall back to lesson status.' );
+		$this->assertArrayNotHasKey( 'complete', $result, 'Completed lesson with quiz but no submission should be excluded.' );
 		$this->assertArrayNotHasKey( 'passed', $result, 'Quiz progress without submission should not count as graded.' );
 	}
 

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -379,7 +379,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete', $course_id, current_time( 'mysql' ) );
+		$started_at   = gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
+		$completed_at = current_time( 'mysql' );
+		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
 		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -391,40 +393,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
 		$this->assertSame( 2, $result['lesson_start_count'], 'Expected two lesson starts.' );
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Expected one completed lesson.' );
-		$this->assertGreaterThanOrEqual( 1, $result['days_to_complete_sum'], 'Expected at least one day to complete.' );
-	}
-
-	public function testGetLessonTotals_WithQuizStatus_UsesCoalesced(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id   = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
-				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
-		);
-		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
-
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id, current_time( 'mysql' ) );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
-		$this->insert_quiz_submission( $quiz_id, $user_id );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
-
-		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], 'Expected one student.' );
-		$this->assertSame( 1, $result['lesson_start_count'], 'Expected one lesson start.' );
-		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed quiz status should count as completed.' );
+		$this->assertSame( 3, $result['days_to_complete_sum'], 'Expected 3 days (2 day difference + 1).' );
 	}
 
 	public function testGetLessonTotals_WithInProgressQuizStatus_DoesNotCountAsCompleted(): void {

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-clauses-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-clauses-service.php
@@ -116,4 +116,35 @@ class Tables_Based_Progress_Clauses_Service_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( '', $clauses['where'] );
 	}
+
+	public function testAddLastActivityToLessonsClauses_WhenCalled_AddsLastActivityDateField(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Clauses_Service( $wpdb );
+		$clauses = $this->get_empty_clauses();
+
+		/* Act. */
+		$clauses = $service->add_last_activity_to_lessons_clauses( $clauses );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'last_activity_date', $clauses['fields'], 'Expected last_activity_date in fields clause.' );
+		$this->assertStringContainsString( $wpdb->prefix . 'sensei_lms_progress', $clauses['fields'], 'Expected progress table in fields clause.' );
+	}
+
+	public function testAddDaysToCompleteToLessonsClauses_WhenCalled_AddsDaysToCompleteField(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Clauses_Service( $wpdb );
+		$clauses = $this->get_empty_clauses();
+
+		/* Act. */
+		$clauses = $service->add_days_to_completion_to_lessons_clauses( $clauses );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'days_to_complete', $clauses['fields'], 'Expected days_to_complete in fields clause.' );
+		$this->assertStringContainsString( $wpdb->prefix . 'sensei_lms_progress', $clauses['fields'], 'Expected progress table in fields clause.' );
+		$this->assertStringContainsString( 'COALESCE', $clauses['fields'], 'Expected COALESCE for quiz status in fields clause.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-clauses-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-clauses-service.php
@@ -147,4 +147,32 @@ class Tables_Based_Progress_Clauses_Service_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( $wpdb->prefix . 'sensei_lms_progress', $clauses['fields'], 'Expected progress table in fields clause.' );
 		$this->assertStringContainsString( 'COALESCE', $clauses['fields'], 'Expected COALESCE for quiz status in fields clause.' );
 	}
+
+	public function testAddDaysToCompletionToLessonsClauses_WhenCalled_ConvertsUtcToLocalTime(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Clauses_Service( $wpdb );
+		$clauses = $this->get_empty_clauses();
+
+		/* Act. */
+		$clauses = $service->add_days_to_completion_to_lessons_clauses( $clauses );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'CONVERT_TZ', $clauses['fields'], 'Expected CONVERT_TZ for UTC to local time conversion.' );
+	}
+
+	public function testAddDaysToCompletionToCoursesClauses_WhenCalled_ConvertsUtcToLocalTime(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Clauses_Service( $wpdb );
+		$clauses = $this->get_empty_clauses();
+
+		/* Act. */
+		$clauses = $service->add_days_to_completion_to_courses_clauses( $clauses );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'CONVERT_TZ', $clauses['fields'], 'Expected CONVERT_TZ for UTC to local time conversion.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-clauses-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-clauses-service.php
@@ -132,7 +132,7 @@ class Tables_Based_Progress_Clauses_Service_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( $wpdb->prefix . 'sensei_lms_progress', $clauses['fields'], 'Expected progress table in fields clause.' );
 	}
 
-	public function testAddDaysToCompleteToLessonsClauses_WhenCalled_AddsDaysToCompleteField(): void {
+	public function testAddDaysToCompletionToLessonsClauses_WhenCalled_AddsDaysToCompleteField(): void {
 		/* Arrange. */
 		global $wpdb;
 


### PR DESCRIPTION
## Summary
- Adds a composite index `(type, post_id)` to `sensei_lms_progress` to speed up queries that filter by `type` (e.g. `WHERE type = 'lesson'`)
- The existing unique key `(post_id, user_id, type)` has `type` last, so MySQL can't use it for type-filtered queries and does a full table scan instead
- `dbDelta` handles both new installs (index created with table) and existing installs (index added on next plugin update)

## Test plan
- On a site with HPPS enabled, verify the index exists after plugin update: `SHOW INDEX FROM wp_sensei_lms_progress;`
- Check Query Monitor on the Grading page — the GROUP BY and LIMIT queries should be faster
- Check Query Monitor on any admin page — the menu badge `count_lesson_statuses_with_quiz` query should be faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)