### PR TITLE
Use quiz submission repository on grading detail page

### DIFF
--- a/changelog/add-quiz-grading-hpps-integration
+++ b/changelog/add-quiz-grading-hpps-integration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use quiz submission repository on grading detail page for HPPS compatibility.

--- a/changelog/add-quiz-grading-hpps-integration
+++ b/changelog/add-quiz-grading-hpps-integration
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: fixed
 
 Use quiz submission repository on grading detail page for HPPS compatibility.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -115,15 +115,8 @@ class Sensei_Grading_User_Quiz {
 			<div class="clear"></div><br/>
 			<?php
 
-			$lesson_status_id = Sensei_Utils::sensei_get_activity_value(
-				array(
-					'post_id' => $this->lesson_id,
-					'user_id' => $this->user_id,
-					'type'    => 'sensei_lesson_status',
-					'field'   => 'comment_ID',
-				)
-			);
-			$user_quiz_grade  = get_comment_meta( $lesson_status_id, 'grade', true );
+			$submission      = Sensei()->quiz_submission_repository->get( $this->quiz_id, $this->user_id );
+			$user_quiz_grade = $submission ? $submission->get_final_grade() : '';
 
 			foreach ( $questions as $question ) {
 				$question_id = $question->ID;

--- a/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-tables-based-submission-repository.php
@@ -243,7 +243,7 @@ class Tables_Based_Submission_Repository implements Submission_Repository_Interf
 
 		$query = $this->wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT question_id FROM {$quiz_answers_table} WHERE submission_id = %d",
+			"SELECT question_id FROM {$quiz_answers_table} WHERE submission_id = %d ORDER BY id ASC",
 			$submission_id
 		);
 


### PR DESCRIPTION
## Summary
- Replace direct comment meta query with `quiz_submission_repository->get()` on the quiz grading detail page (`admin.php?page=sensei_grading&user=X&quiz_id=Y`)
- This ensures the page works with both comments-based and tables-based (HPPS) storage, matching the pattern established in #7923

🤖 Generated with [Claude Code](https://claude.com/claude-code)