### PR TITLE
Use parent_post_id instead of postmeta joins in HPPS services

### DIFF
--- a/changelog/use-parent-post-id-in-hpps-services
+++ b/changelog/use-parent-post-id-in-hpps-services
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Internal: Use parent_post_id column instead of postmeta joins in HPPS tables-based services.

--- a/changelog/use-parent-post-id-in-hpps-services
+++ b/changelog/use-parent-post-id-in-hpps-services
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Internal: Use parent_post_id column instead of postmeta joins in HPPS tables-based services.

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -144,18 +144,15 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 	 * @return string SQL query.
 	 */
 	private function build_base_query( string $table, string $submissions_table, array $args ): string {
-		$wpdb = $this->wpdb;
-
 		$query  = 'SELECT p.post_id, p.user_id, p.updated_at, COALESCE( q.status, p.status ) AS effective_status, qs.final_grade';
 		$query .= " FROM {$table} p";
-		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
 		// Quiz progress is joined without requiring a submission to exist,
 		// so that the effective_status reflects the quiz result even when
 		// the quiz_submissions row is missing (e.g. migrated data).
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+		$query .= " LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id";
 		$query .= " WHERE p.type = 'lesson'";
 
 		$query .= $this->build_post_filter( $args );
@@ -177,15 +174,12 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 	 * @return string SQL query.
 	 */
 	private function build_count_query( string $table, string $submissions_table, array $args ): string {
-		$wpdb = $this->wpdb;
-
 		$query  = 'SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT(*) AS total';
 		$query .= " FROM {$table} p";
-		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
+		$query .= " LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id";
 		$query .= " WHERE p.type = 'lesson'";
 
 		$query .= $this->build_post_filter( $args );

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -134,8 +134,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, 1, 0)) AS days_to_complete_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1, 0)) AS days_to_complete_sum
 			FROM {$table} p
-			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
-			LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
+			LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
 				AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )
 			WHERE p.type = 'lesson' AND p.post_id IN ( $placeholders )",
 			$lesson_ids
@@ -181,9 +180,8 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query  = "SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
-		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+		$query .= " LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'";
 
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', 'lesson' );
 

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -179,7 +179,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$table = $this->get_progress_table_name();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$query  = "SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
+		$query = "SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'";
 

--- a/includes/internal/services/class-tables-based-progress-clauses-service.php
+++ b/includes/internal/services/class-tables-based-progress-clauses-service.php
@@ -69,9 +69,7 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	public function add_last_activity_to_courses_clauses( array $clauses ): array {
 		$progress_table = $this->get_progress_table_name();
 
-		$wpdb = $this->wpdb;
-
-		// For each lesson, find the most recent activity date across all students.
+		// For each course, find the most recent lesson activity date across all students.
 		// Uses updated_at (not completed_at) because it captures the latest
 		// modification to the progress row, which better represents "last activity"
 		// at the course level. The lesson-level query uses completed_at because
@@ -80,21 +78,14 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 		// rows, so only lesson status 'complete' is needed here.
 		$complete = Lesson_Progress_Interface::STATUS_COMPLETE;
 
-		$lessons_query = "SELECT p.post_id AS lesson_id, MAX(p.updated_at) AS last_activity_date
+		$course_query = "SELECT p.parent_post_id AS course_id, MAX(p.updated_at) AS last_activity_date
 			FROM {$progress_table} p
 			WHERE p.type = 'lesson'
 			AND p.status = '{$complete}'
-			GROUP BY p.post_id";
-
-		// Map lessons to courses via postmeta, then take the most recent activity date across all lessons per course.
-		$course_query = "SELECT pm.meta_value AS course_id, MAX(lq.last_activity_date) AS last_activity_date
-			FROM {$wpdb->postmeta} pm
-			JOIN ({$lessons_query}) lq ON lq.lesson_id = pm.post_id
-			AND pm.meta_key = '_lesson_course'
-			GROUP BY pm.meta_value";
+			GROUP BY p.parent_post_id";
 
 		$clauses['fields'] .= ', la.last_activity_date AS last_activity_date';
-		$clauses['join']   .= " LEFT JOIN ({$course_query}) AS la ON la.course_id = {$wpdb->posts}.ID";
+		$clauses['join']   .= " LEFT JOIN ({$course_query}) AS la ON la.course_id = {$this->wpdb->posts}.ID";
 
 		return $clauses;
 	}
@@ -198,9 +189,7 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 
 		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1 )";
 		$clauses['fields'] .= " FROM {$progress_table} p";
-		$clauses['fields'] .= " LEFT JOIN {$this->wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
-		$clauses['fields'] .= " LEFT JOIN {$progress_table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+		$clauses['fields'] .= " LEFT JOIN {$progress_table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'";
 		$clauses['fields'] .= " AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )";
 		$clauses['fields'] .= " WHERE p.post_id = {$this->wpdb->posts}.ID";
 		$clauses['fields'] .= " AND p.type = 'lesson'";

--- a/includes/internal/services/class-tables-based-progress-clauses-service.php
+++ b/includes/internal/services/class-tables-based-progress-clauses-service.php
@@ -72,8 +72,7 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 		// For each course, find the most recent lesson activity date across all students.
 		// Uses updated_at (not completed_at) because it captures the latest
 		// modification to the progress row, which better represents "last activity"
-		// at the course level. The lesson-level query uses completed_at because
-		// it specifically tracks completion dates for individual lessons.
+		// at the course level.
 		// In HPPS, quiz-derived statuses (passed, graded) live on separate quiz progress
 		// rows, so only lesson status 'complete' is needed here.
 		$complete = Lesson_Progress_Interface::STATUS_COMPLETE;
@@ -159,6 +158,9 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 	public function add_last_activity_to_lessons_clauses( array $clauses ): array {
 		$progress_table = $this->get_progress_table_name();
 
+		// Uses completed_at (not updated_at) because it specifically tracks completion
+		// dates for individual lessons. The course-level query uses updated_at instead
+		// because it better represents "last activity" across all lessons.
 		// In HPPS, lesson progress rows only store 'in-progress' and 'complete'.
 		// Quiz-derived statuses (passed, graded) live on separate quiz progress rows,
 		// so only lesson status 'complete' is needed here.

--- a/includes/internal/services/class-tables-based-progress-clauses-service.php
+++ b/includes/internal/services/class-tables-based-progress-clauses-service.php
@@ -82,6 +82,7 @@ class Tables_Based_Progress_Clauses_Service implements Progress_Clauses_Service_
 			FROM {$progress_table} p
 			WHERE p.type = 'lesson'
 			AND p.status = '{$complete}'
+			AND p.parent_post_id IS NOT NULL
 			GROUP BY p.parent_post_id";
 
 		$clauses['fields'] .= ', la.last_activity_date AS last_activity_date';

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -537,4 +537,35 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Expected 1 in-progress.' );
 		$this->assertSame( 1, $counts['complete'] ?? 0, 'Expected 1 complete even though status filter was in-progress.' );
 	}
+
+	public function testGetLessonProgressItems_WithoutLessonQuizMeta_UsesParentPostId(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		// Deliberately NOT setting _lesson_quiz postmeta.
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id, 85 );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items(
+			$this->get_default_args( [ 'post_id' => $lesson_id ] )
+		);
+
+		/* Assert. */
+		$this->assertSame( 'passed', $result['items'][0]->status, 'Quiz status should be used via parent_post_id without _lesson_quiz meta.' );
+		$this->assertSame( 85.0, $result['items'][0]->grade, 'Grade should be available via parent_post_id join.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -725,4 +725,39 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['complete'], 'Non-trashed course should be counted.' );
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Trashed course status should not appear.' );
 	}
+
+	public function testCountStatuses_LessonWithQuizWithoutMeta_UsesParentPostId(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[
+				'post_parent' => $lesson_id,
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
+		);
+		// Deliberately NOT setting _lesson_quiz postmeta.
+
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses(
+			[
+				'type' => 'lesson',
+			]
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result['graded'], 'Quiz status should be used via parent_post_id without _lesson_quiz meta.' );
+		$this->assertArrayNotHasKey( 'complete', $result, 'Lesson status should not appear when quiz progress exists.' );
+	}
 }

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -116,16 +116,16 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		foreach ( $lessons_with_quizzes as $lesson_id => $status ) {
 			$quiz_id = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
 			update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-			Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, $course_id );
 			Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
-			$qp = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id );
+			$qp = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id, $lesson_id );
 			$qp->{$status}();
 			Sensei()->quiz_progress_repository->save( $qp );
 		}
 
 		// Lessons without quizzes: in-progress, complete.
-		Sensei()->lesson_progress_repository->create( $lesson_ids[1], $user_id );
-		$lp = Sensei()->lesson_progress_repository->create( $lesson_ids[3], $user_id );
+		Sensei()->lesson_progress_repository->create( $lesson_ids[1], $user_id, $course_id );
+		$lp = Sensei()->lesson_progress_repository->create( $lesson_ids[3], $user_id, $course_id );
 		$lp->complete();
 		Sensei()->lesson_progress_repository->save( $lp );
 
@@ -166,9 +166,9 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		foreach ( $lesson_ids as $index => $lesson_id ) {
 			$quiz_id = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
 			update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-			Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			Sensei()->lesson_progress_repository->create( $lesson_id, $user_id, $course_id );
 			Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id );
-			$qp = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id );
+			$qp = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id, $lesson_id );
 			$qp->{$statuses[ $index ]}();
 			Sensei()->quiz_progress_repository->save( $qp );
 		}


### PR DESCRIPTION
## Summary

- Replace `_lesson_course` and `_lesson_quiz` postmeta joins with `parent_post_id` column in three HPPS tables-based services: progress clauses, grading listing, and progress aggregation
- For lesson-to-course mapping, the two nested subqueries are collapsed into a single `GROUP BY parent_post_id` query
- For lesson-to-quiz mapping, quiz progress rows are joined via `q.parent_post_id = p.post_id` instead of going through `wp_postmeta`
- Adds two new tests verifying the services work without `_lesson_quiz` postmeta set

## Test plan

- [x] Verify the Courses report page loads correctly with last activity dates and days-to-completion data
- [x] Verify the Lessons report page loads correctly with days-to-completion data and lesson status counts
- [x] Verify the Grading listing page shows correct statuses (in-progress, passed, graded, etc.) and grades
- [x] Verify the Grading listing status tabs (All/Ungraded/Graded/In Progress) show correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)