### PR TITLE
Add grading stats service for HPPS integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,27 @@
-## Linting
-- **PHPCS**: Run `npm run lint-php`.
-- **Psalm**: Run `vendor/bin/psalm --no-cache --diff`.
-- **Before pushing**: The pre-commit hook only lints new files. CI lints all changed lines. Always run both PHPCS and Psalm on modified files before pushing to avoid CI failures.
+## Pre-commit checklist (MANDATORY)
+
+Before EVERY commit, you MUST run all three checks on the files you changed and fix any errors. No exceptions.
+
+1. **PHPCS** (auto-fix first, then verify):
+   ```bash
+   vendor/bin/phpcbf --standard=WordPress <changed-files>
+   vendor/bin/phpcs --standard=WordPress <changed-files>
+   ```
+2. **Psalm** (on changed source files, not tests):
+   ```bash
+   vendor/bin/psalm --no-cache <changed-source-files>
+   ```
+3. **PHPUnit** (run relevant test files):
+   ```bash
+   vendor/bin/phpunit <relevant-test-files>
+   ```
+
+If any check fails, fix the errors and re-run before committing. Do NOT commit with known lint, Psalm, or test failures.
+
+### Notes
+- CI lints ALL changed lines, not just new files. The pre-commit hook only lints new files, so it will miss issues in modified files.
+- CI uses the full `WordPress` standard (includes `-Docs` rules like missing docblocks and alignment). Always use `--standard=WordPress`, not `WordPress-Core`.
+- `vendor/bin/phpcs` is the correct binary path. `npm run lint-php` requires a script name argument and does not work for targeted file linting.
 
 ## Conventions
 - **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `npm run changelog` (entries stored in `changelog/`).

--- a/changelog/add-hpps-grading-stats-service
+++ b/changelog/add-hpps-grading-stats-service
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Internal: Add grading stats service for HPPS integration.
+Add grading stats service for HPPS integration.

--- a/changelog/add-hpps-grading-stats-service
+++ b/changelog/add-hpps-grading-stats-service
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Internal: Add grading stats service for HPPS integration.

--- a/changelog/fix-grade-averages-spurious-zero
+++ b/changelog/fix-grade-averages-spurious-zero
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix grade averages being dragged down by spurious grade=0 meta written on lesson start.

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -4667,7 +4667,9 @@
     </PossiblyInvalidIterator>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php">
-    <InvalidScalarArgument occurrences="2">
+    <InvalidScalarArgument occurrences="4">
+      <code>$lesson_id</code>
+      <code>$lesson_id</code>
       <code>$lesson_id</code>
       <code>$lesson_id</code>
     </InvalidScalarArgument>

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -170,15 +170,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/admin/class-sensei-learners-main.php">
-    <ArgumentTypeCoercion occurrences="4">
-      <code>$item</code>
+    <ArgumentTypeCoercion occurrences="3">
       <code>$item</code>
       <code>$user_activity</code>
-      <code>array(
-				'total_items' =&gt; $total_items,
-				'total_pages' =&gt; $total_pages,
-				'per_page'    =&gt; $per_page,
-			)</code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="3">
       <code>! $item</code>
@@ -1653,9 +1647,8 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="includes/class-sensei-grading-user-quiz.php">
-    <InvalidScalarArgument occurrences="9">
+    <InvalidScalarArgument occurrences="8">
       <code>$attachment_id</code>
-      <code>$lesson_status_id</code>
       <code>$question_grade_total</code>
       <code>$quiz_grade</code>
       <code>$quiz_grade</code>
@@ -2837,10 +2830,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>0</code>
     </DocblockTypeContradiction>
-    <DuplicateArrayKey occurrences="2">
-      <code>$published_quiz_ids</code>
-      <code>$published_quiz_ids</code>
-    </DuplicateArrayKey>
     <InvalidArgument occurrences="9">
       <code>$key</code>
       <code>$published_quiz_ids</code>
@@ -2850,8 +2839,6 @@
       <code>$published_quiz_ids</code>
       <code>$published_quiz_ids</code>
       <code>$published_quiz_ids</code>
-      <code>'module'</code>
-      <code>'module'</code>
       <code>'module'</code>
     </InvalidArgument>
     <InvalidArrayOffset occurrences="2">
@@ -4560,6 +4547,15 @@
       <code>$comment-&gt;comment_ID</code>
     </InvalidScalarArgument>
   </file>
+  <file src="includes/internal/services/class-comments-based-grading-stats-service.php">
+    <PossiblyInvalidPropertyFetch occurrences="5">
+      <code>$result-&gt;courses_average</code>
+      <code>$row-&gt;count</code>
+      <code>$row-&gt;grade_count</code>
+      <code>$row-&gt;grade_sum</code>
+      <code>$row-&gt;sum</code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
   <file src="includes/internal/services/class-comments-based-progress-aggregation-service.php">
     <PossiblyInvalidPropertyFetch occurrences="5">
       <code>$row-&gt;days_to_complete_count</code>
@@ -4587,6 +4583,15 @@
       <code>ARRAY_A</code>
     </UndefinedConstant>
   </file>
+  <file src="includes/internal/services/class-tables-based-grading-stats-service.php">
+    <PossiblyInvalidPropertyFetch occurrences="5">
+      <code>$result-&gt;courses_average</code>
+      <code>$row-&gt;count</code>
+      <code>$row-&gt;grade_count</code>
+      <code>$row-&gt;grade_sum</code>
+      <code>$row-&gt;sum</code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
   <file src="includes/internal/services/class-tables-based-progress-aggregation-service.php">
     <PossiblyInvalidPropertyFetch occurrences="5">
       <code>$row-&gt;days_to_complete_count</code>
@@ -4596,6 +4601,7 @@
       <code>$row-&gt;unique_student_count</code>
     </PossiblyInvalidPropertyFetch>
     <UndefinedConstant occurrences="2">
+      <code>ARRAY_A</code>
       <code>ARRAY_A</code>
     </UndefinedConstant>
   </file>
@@ -4661,9 +4667,7 @@
     </PossiblyInvalidIterator>
   </file>
   <file src="includes/internal/student-progress/quiz-progress/repositories/class-table-reading-aggregate-quiz-progress-repository.php">
-    <InvalidScalarArgument occurrences="4">
-      <code>$lesson_id</code>
-      <code>$lesson_id</code>
+    <InvalidScalarArgument occurrences="2">
       <code>$lesson_id</code>
       <code>$lesson_id</code>
     </InvalidScalarArgument>

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -33,7 +33,7 @@ class Sensei_Grading {
 	 */
 	public function __construct( $file ) {
 		$this->file      = $file;
-		$this->page_slug             = 'sensei_grading';
+		$this->page_slug = 'sensei_grading';
 
 		// Admin functions
 		if ( is_admin() ) {

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1,4 +1,5 @@
 <?php
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Models\Lesson_Progress_Interface;
@@ -31,17 +32,26 @@ class Sensei_Grading {
 	private ?Progress_Aggregation_Service_Interface $aggregation_service = null;
 
 	/**
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface|null
+	 */
+	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
 	 *
-	 * @param string                                      $file                The main plugin file path.
-	 * @param Progress_Aggregation_Service_Interface|null $aggregation_service The progress aggregation service.
+	 * @param string                                      $file                   The main plugin file path.
+	 * @param Progress_Aggregation_Service_Interface|null $aggregation_service    The progress aggregation service.
+	 * @param Grading_Stats_Service_Interface|null        $grading_stats_service  The grading stats service.
 	 */
-	public function __construct( $file, ?Progress_Aggregation_Service_Interface $aggregation_service = null ) {
-		$this->aggregation_service = $aggregation_service;
-		$this->file                = $file;
-		$this->page_slug           = 'sensei_grading';
+	public function __construct( $file, ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
+		$this->aggregation_service   = $aggregation_service;
+		$this->grading_stats_service = $grading_stats_service;
+		$this->file                  = $file;
+		$this->page_slug             = 'sensei_grading';
 
 		// Admin functions
 		if ( is_admin() ) {
@@ -97,7 +107,7 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		$indicator_html = '';
-		$grading_counts = Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] );
+		$grading_counts = Sensei()->grading->count_statuses( array( 'type' => 'lesson' ) );
 
 		if ( intval( $grading_counts['ungraded'] ) > 0 ) {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
@@ -126,8 +136,7 @@ class Sensei_Grading {
 	public function enqueue_scripts() {
 
 		// Load Grading JS
-		Sensei()->assets->enqueue( 'sensei-grading-general', 'js/grading-general.js', [ 'jquery', 'sensei-core-select2' ] );
-
+		Sensei()->assets->enqueue( 'sensei-grading-general', 'js/grading-general.js', array( 'jquery', 'sensei-core-select2' ) );
 	}
 
 	/**
@@ -143,7 +152,6 @@ class Sensei_Grading {
 		wp_enqueue_style( Sensei()->token . '-admin' );
 
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css' );
-
 	}
 
 	/**
@@ -278,7 +286,7 @@ class Sensei_Grading {
 		?>
 		<form id="grading-filters" method="get">
 			<?php
-			Sensei_Utils::output_query_params_as_inputs( [ 'course_id', 'lesson_id', 's' ] );
+			Sensei_Utils::output_query_params_as_inputs( array( 'course_id', 'lesson_id', 's' ) );
 			$sensei_grading_overview->table_search_form();
 			$sensei_grading_overview->display();
 			?>
@@ -832,7 +840,7 @@ class Sensei_Grading {
 			return false;
 		}
 
-		$lesson_metadata = [];
+		$lesson_metadata = array();
 		$quiz_progress->ungrade();
 
 		// $_POST['all_questions_graded'] is set when all questions have been graded
@@ -908,7 +916,6 @@ class Sensei_Grading {
 
 		wp_safe_redirect( esc_url_raw( $load_url ) );
 		exit;
-
 	}
 
 	public function get_redirect_url() {
@@ -1097,7 +1104,6 @@ class Sensei_Grading {
 		Sensei()->quiz->set_user_grades( $all_question_grades, $lesson_id, $user_id );
 
 		return $grade;
-
 	}
 
 	/**
@@ -1258,15 +1264,12 @@ class Sensei_Grading {
 	 * @return int $number_of_graded_lessons
 	 */
 	public static function get_graded_lessons_count() {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$number_of_graded_lessons = (int) $wpdb->get_var(
-			"SELECT COUNT(*) AS total
-			FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')"
-		);
-
-		return $number_of_graded_lessons;
+		return $service->get_grade_totals()['count'];
 	}
 
 	/**
@@ -1276,15 +1279,12 @@ class Sensei_Grading {
 	 * @return int $sum_of_all_grades
 	 */
 	public static function get_graded_lessons_sum() {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-			FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')"
-		);
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals()['sum'];
 	}
 
 	/**
@@ -1295,21 +1295,15 @@ class Sensei_Grading {
 	 * @return double $graded_lesson_average_grade Average value of all the graded lessons in all the courses.
 	 */
 	public function get_graded_lessons_average_grade() {
-		global $wpdb;
+		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
 
-		// Fetching all the grades of all the lessons that are graded.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$sum_result          = $wpdb->get_row(
-			"SELECT SUM( {$wpdb->commentmeta}.meta_value ) AS grade_sum,COUNT( * ) as grade_count FROM {$wpdb->comments}
-             INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			 WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')"
-		);
-		$average_grade_value = 0;
-		if ( '0' === $sum_result->grade_count ) {
-			return $average_grade_value;
+		$totals = $this->grading_stats_service->get_grade_totals();
+
+		if ( 0 === $totals['count'] ) {
+			return 0;
 		}
-		$average_grade_value = $sum_result->grade_sum / $sum_result->grade_count;
-		return $average_grade_value;
+
+		return $totals['sum'] / $totals['count'];
 	}
 
 	/**
@@ -1320,18 +1314,12 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_user_graded_lessons_sum( $user_id ) {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade') AND {$wpdb->comments}.user_id = %d ",
-				$user_id
-			)
-		);
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals( array( 'user_id' => $user_id ) )['sum'];
 	}
 
 	/**
@@ -1343,18 +1331,12 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_lessons_users_grades_sum( $lesson_id ) {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade') AND {$wpdb->comments}.comment_post_ID = %d ",
-				$lesson_id
-			)
-		);
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals( array( 'lesson_id' => $lesson_id ) )['sum'];
 	}
 
 	/**
@@ -1366,28 +1348,17 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_course_users_grades_sum( $course_id ) {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
 		$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
 		if ( ! $lesson_ids ) {
 			return 0;
 		}
 
-		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND {$wpdb->comments}.comment_approved IN ('graded', 'passed', 'failed') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
-				AND {$wpdb->comments}.comment_post_ID IN ({$lesson_ids_placeholder}) ",
-				$lesson_ids
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals( array( 'post__in' => $lesson_ids ) )['sum'];
 	}
 
 	/**
@@ -1399,38 +1370,9 @@ class Sensei_Grading {
 	 * @return double Average grade of all courses.
 	 */
 	public function get_courses_average_grade() {
-		global $wpdb;
+		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
 
-		/**
-		 * The subquery calculates the average grade per course, and the outer query then calculates the
-		 * average grade of all courses. To be included in the calculation, a lesson must:
-		 *   Have a status of 'graded', 'passed' or 'failed'.
-		 *   Have grade data.
-		 *   Be associated with a course.
-		 *   Have quiz questions (checking for the existence of '_quiz_has_questions' meta is sufficient;
-		 *   if it exists its value will be 1).
-		 */
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$result = $wpdb->get_row(
-			"SELECT AVG(course_average) as courses_average
-			FROM (
-				SELECT AVG(cm.meta_value) as course_average
-				FROM {$wpdb->comments} c
-				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
-				INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
-				INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
-				INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
-				WHERE c.comment_type = 'sensei_lesson_status'
-					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
-					AND cm.meta_key = 'grade'
-					AND course.meta_key = '_lesson_course'
-					AND course.meta_value <> ''
-					AND has_questions.meta_key = '_quiz_has_questions'
-				GROUP BY course.meta_value
-			) averages_by_course"
-		);
-
-		return floatval( isset( $result->courses_average ) ? $result->courses_average : 0 );
+		return $this->grading_stats_service->get_courses_average_grade();
 	}
 }
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -25,32 +25,14 @@ class Sensei_Grading {
 	public $page_slug;
 
 	/**
-	 * The progress aggregation service.
-	 *
-	 * @var Progress_Aggregation_Service_Interface|null
-	 */
-	private ?Progress_Aggregation_Service_Interface $aggregation_service = null;
-
-	/**
-	 * The grading stats service.
-	 *
-	 * @var Grading_Stats_Service_Interface|null
-	 */
-	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
-
-	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
 	 *
-	 * @param string                                      $file                   The main plugin file path.
-	 * @param Progress_Aggregation_Service_Interface|null $aggregation_service    The progress aggregation service.
-	 * @param Grading_Stats_Service_Interface|null        $grading_stats_service  The grading stats service.
+	 * @param string $file The main plugin file path.
 	 */
-	public function __construct( $file, ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
-		$this->aggregation_service   = $aggregation_service;
-		$this->grading_stats_service = $grading_stats_service;
-		$this->file                  = $file;
+	public function __construct( $file ) {
+		$this->file      = $file;
 		$this->page_slug             = 'sensei_grading';
 
 		// Admin functions
@@ -97,6 +79,36 @@ class Sensei_Grading {
 	 */
 	public function get_name() {
 		return __( 'Grading', 'sensei-lms' );
+	}
+
+	/**
+	 * Get the shared progress aggregation service instance.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return Progress_Aggregation_Service_Interface
+	 */
+	private static function get_aggregation_service(): Progress_Aggregation_Service_Interface {
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+		}
+		return $service;
+	}
+
+	/**
+	 * Get the shared grading stats service instance.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return Grading_Stats_Service_Interface
+	 */
+	private static function get_grading_stats_service(): Grading_Stats_Service_Interface {
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
+		return $service;
 	}
 
 	/**
@@ -585,10 +597,7 @@ class Sensei_Grading {
 		$counts    = wp_cache_get( $cache_key, 'counts' );
 
 		if ( false === $counts ) {
-			if ( null === $this->aggregation_service ) {
-				$this->aggregation_service = ( new Progress_Query_Service_Factory() )->create_aggregation_service();
-			}
-			$counts = $this->aggregation_service->count_statuses( $args );
+			$counts = self::get_aggregation_service()->count_statuses( $args );
 			wp_cache_set( $cache_key, $counts, 'counts' );
 		}
 
@@ -1264,12 +1273,7 @@ class Sensei_Grading {
 	 * @return int $number_of_graded_lessons
 	 */
 	public static function get_graded_lessons_count() {
-		static $service = null;
-		if ( null === $service ) {
-			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-
-		return $service->get_grade_totals()['count'];
+		return self::get_grading_stats_service()->get_grade_totals()['count'];
 	}
 
 	/**
@@ -1279,12 +1283,7 @@ class Sensei_Grading {
 	 * @return int $sum_of_all_grades
 	 */
 	public static function get_graded_lessons_sum() {
-		static $service = null;
-		if ( null === $service ) {
-			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-
-		return (int) $service->get_grade_totals()['sum'];
+		return (int) self::get_grading_stats_service()->get_grade_totals()['sum'];
 	}
 
 	/**
@@ -1295,9 +1294,7 @@ class Sensei_Grading {
 	 * @return double $graded_lesson_average_grade Average value of all the graded lessons in all the courses.
 	 */
 	public function get_graded_lessons_average_grade() {
-		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-
-		$totals = $this->grading_stats_service->get_grade_totals();
+		$totals = self::get_grading_stats_service()->get_grade_totals();
 
 		if ( 0 === $totals['count'] ) {
 			return 0;
@@ -1314,12 +1311,7 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_user_graded_lessons_sum( $user_id ) {
-		static $service = null;
-		if ( null === $service ) {
-			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-
-		return (int) $service->get_grade_totals( array( 'user_id' => $user_id ) )['sum'];
+		return (int) self::get_grading_stats_service()->get_grade_totals( array( 'user_id' => $user_id ) )['sum'];
 	}
 
 	/**
@@ -1331,12 +1323,7 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_lessons_users_grades_sum( $lesson_id ) {
-		static $service = null;
-		if ( null === $service ) {
-			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-
-		return (int) $service->get_grade_totals( array( 'lesson_id' => $lesson_id ) )['sum'];
+		return (int) self::get_grading_stats_service()->get_grade_totals( array( 'lesson_id' => $lesson_id ) )['sum'];
 	}
 
 	/**
@@ -1348,17 +1335,12 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_course_users_grades_sum( $course_id ) {
-		static $service = null;
-		if ( null === $service ) {
-			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-
 		$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
 		if ( ! $lesson_ids ) {
 			return 0;
 		}
 
-		return (int) $service->get_grade_totals( array( 'post__in' => $lesson_ids ) )['sum'];
+		return (int) self::get_grading_stats_service()->get_grade_totals( array( 'post__in' => $lesson_ids ) )['sum'];
 	}
 
 	/**
@@ -1370,9 +1352,7 @@ class Sensei_Grading {
 	 * @return double Average grade of all courses.
 	 */
 	public function get_courses_average_grade() {
-		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-
-		return $this->grading_stats_service->get_courses_average_grade();
+		return self::get_grading_stats_service()->get_courses_average_grade();
 	}
 }
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -82,33 +82,25 @@ class Sensei_Grading {
 	}
 
 	/**
-	 * Get the shared progress aggregation service instance.
+	 * Get the progress aggregation service instance.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @return Progress_Aggregation_Service_Interface
 	 */
 	private static function get_aggregation_service(): Progress_Aggregation_Service_Interface {
-		static $service = null;
-		if ( null === $service ) {
-			$service = ( new Progress_Query_Service_Factory() )->create_aggregation_service();
-		}
-		return $service;
+		return ( new Progress_Query_Service_Factory() )->create_aggregation_service();
 	}
 
 	/**
-	 * Get the shared grading stats service instance.
+	 * Get the grading stats service instance.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @return Grading_Stats_Service_Interface
 	 */
 	private static function get_grading_stats_service(): Grading_Stats_Service_Interface {
-		static $service = null;
-		if ( null === $service ) {
-			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-		return $service;
+		return ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1267,20 +1267,20 @@ class Sensei_Grading {
 	}
 
 	/**
-	 * Counts the lessons that have been graded manually and automatically
+	 * Counts the lessons that have been graded manually and automatically.
 	 *
 	 * @since 1.9.0
-	 * @return int $number_of_graded_lessons
+	 * @return int Number of graded lessons.
 	 */
 	public static function get_graded_lessons_count() {
 		return self::get_grading_stats_service()->get_grade_totals()['count'];
 	}
 
 	/**
-	 * Add together all the graded lesson grades
+	 * Add together all the graded lesson grades.
 	 *
 	 * @since 1.9.0
-	 * @return int $sum_of_all_grades
+	 * @return int Sum of all graded lesson grades.
 	 */
 	public static function get_graded_lessons_sum() {
 		return (int) self::get_grading_stats_service()->get_grade_totals()['sum'];
@@ -1291,13 +1291,13 @@ class Sensei_Grading {
 	 *
 	 * @since 4.2.0
 	 * @access public
-	 * @return double $graded_lesson_average_grade Average value of all the graded lessons in all the courses.
+	 * @return float Average value of all the graded lessons in all the courses.
 	 */
 	public function get_graded_lessons_average_grade() {
 		$totals = self::get_grading_stats_service()->get_grade_totals();
 
 		if ( 0 === $totals['count'] ) {
-			return 0;
+			return 0.0;
 		}
 
 		return $totals['sum'] / $totals['count'];

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1,4 +1,5 @@
 <?php
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Models\Lesson_Progress_Interface;
@@ -31,17 +32,26 @@ class Sensei_Grading {
 	private ?Progress_Aggregation_Service_Interface $aggregation_service = null;
 
 	/**
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface|null
+	 */
+	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
 	 *
-	 * @param string                                      $file                The main plugin file path.
-	 * @param Progress_Aggregation_Service_Interface|null $aggregation_service The progress aggregation service.
+	 * @param string                                      $file                   The main plugin file path.
+	 * @param Progress_Aggregation_Service_Interface|null $aggregation_service    The progress aggregation service.
+	 * @param Grading_Stats_Service_Interface|null        $grading_stats_service  The grading stats service.
 	 */
-	public function __construct( $file, ?Progress_Aggregation_Service_Interface $aggregation_service = null ) {
-		$this->aggregation_service = $aggregation_service;
-		$this->file                = $file;
-		$this->page_slug           = 'sensei_grading';
+	public function __construct( $file, ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
+		$this->aggregation_service   = $aggregation_service;
+		$this->grading_stats_service = $grading_stats_service;
+		$this->file                  = $file;
+		$this->page_slug             = 'sensei_grading';
 
 		// Admin functions
 		if ( is_admin() ) {
@@ -97,7 +107,7 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		$indicator_html = '';
-		$grading_counts = Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] );
+		$grading_counts = Sensei()->grading->count_statuses( array( 'type' => 'lesson' ) );
 
 		if ( intval( $grading_counts['ungraded'] ) > 0 ) {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
@@ -126,8 +136,7 @@ class Sensei_Grading {
 	public function enqueue_scripts() {
 
 		// Load Grading JS
-		Sensei()->assets->enqueue( 'sensei-grading-general', 'js/grading-general.js', [ 'jquery', 'sensei-core-select2' ] );
-
+		Sensei()->assets->enqueue( 'sensei-grading-general', 'js/grading-general.js', array( 'jquery', 'sensei-core-select2' ) );
 	}
 
 	/**
@@ -143,7 +152,6 @@ class Sensei_Grading {
 		wp_enqueue_style( Sensei()->token . '-admin' );
 
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css' );
-
 	}
 
 	/**
@@ -278,7 +286,7 @@ class Sensei_Grading {
 		?>
 		<form id="grading-filters" method="get">
 			<?php
-			Sensei_Utils::output_query_params_as_inputs( [ 'course_id', 'lesson_id', 's' ] );
+			Sensei_Utils::output_query_params_as_inputs( array( 'course_id', 'lesson_id', 's' ) );
 			$sensei_grading_overview->table_search_form();
 			$sensei_grading_overview->display();
 			?>
@@ -832,7 +840,7 @@ class Sensei_Grading {
 			return false;
 		}
 
-		$lesson_metadata = [];
+		$lesson_metadata = array();
 		$quiz_progress->ungrade();
 
 		// $_POST['all_questions_graded'] is set when all questions have been graded
@@ -908,7 +916,6 @@ class Sensei_Grading {
 
 		wp_safe_redirect( esc_url_raw( $load_url ) );
 		exit;
-
 	}
 
 	public function get_redirect_url() {
@@ -1097,7 +1104,6 @@ class Sensei_Grading {
 		Sensei()->quiz->set_user_grades( $all_question_grades, $lesson_id, $user_id );
 
 		return $grade;
-
 	}
 
 	/**
@@ -1258,15 +1264,12 @@ class Sensei_Grading {
 	 * @return int $number_of_graded_lessons
 	 */
 	public static function get_graded_lessons_count() {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$number_of_graded_lessons = (int) $wpdb->get_var(
-			"SELECT COUNT(*) AS total
-			FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')"
-		);
-
-		return $number_of_graded_lessons;
+		return $service->get_grade_totals()['count'];
 	}
 
 	/**
@@ -1276,15 +1279,12 @@ class Sensei_Grading {
 	 * @return int $sum_of_all_grades
 	 */
 	public static function get_graded_lessons_sum() {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-			FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')"
-		);
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals()['sum'];
 	}
 
 	/**
@@ -1295,21 +1295,15 @@ class Sensei_Grading {
 	 * @return double $graded_lesson_average_grade Average value of all the graded lessons in all the courses.
 	 */
 	public function get_graded_lessons_average_grade() {
-		global $wpdb;
+		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
 
-		// Fetching all the grades of all the lessons that are graded.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$sum_result          = $wpdb->get_row(
-			"SELECT SUM( {$wpdb->commentmeta}.meta_value ) AS grade_sum,COUNT( * ) as grade_count FROM {$wpdb->comments}
-             INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			 WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')"
-		);
-		$average_grade_value = 0;
-		if ( '0' === $sum_result->grade_count ) {
-			return $average_grade_value;
+		$totals = $this->grading_stats_service->get_grade_totals();
+
+		if ( 0 === $totals['count'] ) {
+			return 0;
 		}
-		$average_grade_value = $sum_result->grade_sum / $sum_result->grade_count;
-		return $average_grade_value;
+
+		return $totals['sum'] / $totals['count'];
 	}
 
 	/**
@@ -1320,18 +1314,12 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_user_graded_lessons_sum( $user_id ) {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade') AND {$wpdb->comments}.user_id = %d ",
-				$user_id
-			)
-		);
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals( array( 'user_id' => $user_id ) )['sum'];
 	}
 
 	/**
@@ -1343,18 +1331,12 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_lessons_users_grades_sum( $lesson_id ) {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade') AND {$wpdb->comments}.comment_post_ID = %d ",
-				$lesson_id
-			)
-		);
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals( array( 'lesson_id' => $lesson_id ) )['sum'];
 	}
 
 	/**
@@ -1366,28 +1348,17 @@ class Sensei_Grading {
 	 * @return int
 	 */
 	public static function get_course_users_grades_sum( $course_id ) {
-		global $wpdb;
+		static $service = null;
+		if ( null === $service ) {
+			$service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
 		$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
 		if ( ! $lesson_ids ) {
 			return 0;
 		}
 
-		$lesson_ids_placeholder = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-		$sum_of_all_grades = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT SUM({$wpdb->commentmeta}.meta_value) AS meta_sum
-				FROM {$wpdb->comments}  INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-				WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND {$wpdb->comments}.comment_approved IN ('graded', 'passed', 'failed') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
-				AND {$wpdb->comments}.comment_post_ID IN ({$lesson_ids_placeholder}) ",
-				$lesson_ids
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-
-		return $sum_of_all_grades;
+		return (int) $service->get_grade_totals( array( 'post__in' => $lesson_ids ) )['sum'];
 	}
 
 	/**
@@ -1399,38 +1370,9 @@ class Sensei_Grading {
 	 * @return double Average grade of all courses.
 	 */
 	public function get_courses_average_grade() {
-		global $wpdb;
+		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
 
-		/**
-		 * The subquery calculates the average grade per course, and the outer query then calculates the
-		 * average grade of all courses. To be included in the calculation, a lesson must:
-		 *   Have a status of 'graded', 'passed' or 'failed'.
-		 *   Have grade data.
-		 *   Be associated with a course.
-		 *   Have quiz questions (checking for the existence of '_quiz_has_questions' meta is sufficient;
-		 *   if it exists its value will be 1).
-		 */
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$result = $wpdb->get_row(
-			"SELECT AVG(course_average) as courses_average
-			FROM (
-				SELECT AVG(cm.meta_value) as course_average
-				FROM {$wpdb->comments} c
-				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
-				INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
-				INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
-				INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
-				WHERE c.comment_type = 'sensei_lesson_status'
-					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
-					AND cm.meta_key = 'grade'
-					AND course.meta_key = '_lesson_course'
-					AND course.meta_value <> ''
-					AND has_questions.meta_key = '_quiz_has_questions'
-				GROUP BY course.meta_value
-			) averages_by_course"
-		);
-
-		return floatval( $result->courses_average );
+		return $this->grading_stats_service->get_courses_average_grade();
 	}
 }
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -234,7 +234,7 @@ class Sensei_Usage_Tracking_Data {
 				AND `meta_key`=%s
 				AND `meta_value`!=''
 				AND `meta_value`!='0'",
-				[ ...$published_quiz_ids, $meta_key ]
+				array_merge( $published_quiz_ids, [ $meta_key ] )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
@@ -265,7 +265,7 @@ class Sensei_Usage_Tracking_Data {
 				IN ( $published_quiz_ids_placeholder )
 				AND `meta_key`=%s
 				AND `meta_value`=%s",
-				[ ...$published_quiz_ids, $meta_key, $meta_value ]
+				array_merge( $published_quiz_ids, [ $meta_key, $meta_value ] )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -234,7 +234,7 @@ class Sensei_Usage_Tracking_Data {
 				AND `meta_key`=%s
 				AND `meta_value`!=''
 				AND `meta_value`!='0'",
-				array_merge( $published_quiz_ids, [ $meta_key ] )
+				array_merge( $published_quiz_ids, array( $meta_key ) )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
@@ -265,7 +265,7 @@ class Sensei_Usage_Tracking_Data {
 				IN ( $published_quiz_ids_placeholder )
 				AND `meta_key`=%s
 				AND `meta_value`=%s",
-				array_merge( $published_quiz_ids, [ $meta_key, $meta_value ] )
+				array_merge( $published_quiz_ids, array( $meta_key, $meta_value ) )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -63,8 +63,8 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
 
+		/** Query result row. @var object|null $row */
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
-		/** @var object|null $row */
 		$row = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based grade totals' );
 
@@ -133,8 +133,8 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$query .= $course_filter;
 		$query .= ' GROUP BY course.meta_value ) averages_by_course';
 
+		/** Query result. @var object|null $result */
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
-		/** @var object|null $result */
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based courses average grade' );
 
@@ -162,7 +162,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$placeholders = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
-		/** @var object|null $row */
+		/** Query result row. @var object|null $row */
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( cm.meta_value ) AS grade_sum, COUNT( * ) AS grade_count

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -122,7 +122,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		 *   - Have a status of 'graded', 'passed' or 'failed'.
 		 *   - Have grade data.
 		 *   - Be associated with a course.
-		 *   - Have quiz questions.
+		 *   - Have quiz answers (excludes auto-passed students who never took the quiz).
 		 */
 		$query  = $wpdb->prepare(
 			"SELECT AVG(course_average) AS courses_average
@@ -131,22 +131,19 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 				FROM %i c
 				INNER JOIN %i cm ON c.comment_ID = cm.comment_id
 				INNER JOIN %i course ON c.comment_post_ID = course.post_id
-				INNER JOIN %i has_questions ON c.comment_post_ID = has_questions.post_id
 				INNER JOIN %i p ON p.ID = course.meta_value
 				WHERE c.comment_type = 'sensei_lesson_status'
 					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
 					AND cm.meta_key = 'grade'
 					AND course.meta_key = '_lesson_course'
 					AND course.meta_value <> ''
-					AND has_questions.meta_key = '_quiz_has_questions'
-						AND EXISTS (
-							SELECT 1 FROM %i cm2
-							WHERE cm2.comment_id = c.comment_ID
-								AND cm2.meta_key = 'quiz_answers'
-						)",
+					AND EXISTS (
+						SELECT 1 FROM %i cm2
+						WHERE cm2.comment_id = c.comment_ID
+							AND cm2.meta_key = 'quiz_answers'
+					)",
 			$wpdb->comments,
 			$wpdb->commentmeta,
-			$wpdb->postmeta,
 			$wpdb->postmeta,
 			$wpdb->posts,
 			$wpdb->commentmeta

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Services;
 
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -42,6 +44,22 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	}
 
 	/**
+	 * Get the SQL IN clause for graded quiz statuses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string SQL fragment like "( 'graded', 'passed', 'failed' )".
+	 */
+	private function get_graded_statuses_sql(): string {
+		return sprintf(
+			"( '%s', '%s', '%s' )",
+			Quiz_Progress_Interface::STATUS_GRADED,
+			Quiz_Progress_Interface::STATUS_PASSED,
+			Quiz_Progress_Interface::STATUS_FAILED
+		);
+	}
+
+	/**
 	 * Get grade count and sum, with optional filters.
 	 *
 	 * @since $$next-version$$
@@ -58,12 +76,13 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	public function get_grade_totals( array $args = array() ): array {
 		$wpdb = $this->wpdb;
 
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum
 			FROM %i c
 			INNER JOIN %i cm ON c.comment_ID = cm.comment_id
 			WHERE c.comment_type = 'sensei_lesson_status'
-				AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
+				AND c.comment_approved IN " . $this->get_graded_statuses_sql() . "
 				AND cm.meta_key = 'grade'
 				AND EXISTS (
 					SELECT 1 FROM %i cm2
@@ -74,6 +93,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 			$wpdb->commentmeta,
 			$wpdb->commentmeta
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
@@ -124,6 +144,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		 *   - Be associated with a course.
 		 *   - Have quiz answers (excludes auto-passed students who never took the quiz).
 		 */
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
 		$query  = $wpdb->prepare(
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
@@ -133,7 +154,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 				INNER JOIN %i course ON c.comment_post_ID = course.post_id
 				INNER JOIN %i p ON p.ID = course.meta_value
 				WHERE c.comment_type = 'sensei_lesson_status'
-					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
+					AND c.comment_approved IN " . $this->get_graded_statuses_sql() . "
 					AND cm.meta_key = 'grade'
 					AND course.meta_key = '_lesson_course'
 					AND course.meta_value <> ''
@@ -148,6 +169,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 			$wpdb->posts,
 			$wpdb->commentmeta
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		$query .= $course_filter;
 		$query .= ' GROUP BY course.meta_value ) averages_by_course';
 
@@ -179,7 +201,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$wpdb         = $this->wpdb;
 		$placeholders = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Statuses from constants. Placeholders created dynamically. Caching handled by callers.
 		/** Query result row. @var object|null $row */
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
@@ -187,7 +209,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 				FROM %i c
 				INNER JOIN %i cm ON c.comment_ID = cm.comment_id
 				WHERE c.comment_type = 'sensei_lesson_status'
-					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
+					AND c.comment_approved IN " . $this->get_graded_statuses_sql() . "
 					AND cm.meta_key = 'grade'
 					AND EXISTS (
 						SELECT 1 FROM %i cm2

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -64,6 +64,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$query .= $this->build_post_filter( $args );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		/** @var object|null $row */
 		$row = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based grade totals' );
 
@@ -133,6 +134,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$query .= ' GROUP BY course.meta_value ) averages_by_course';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
+		/** @var object|null $result */
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based courses average grade' );
 
@@ -156,6 +158,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$placeholders = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
+		/** @var object|null $row */
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( cm.meta_value ) AS grade_sum, COUNT( * ) AS grade_count

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -71,11 +71,14 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	 *     @type int   $lesson_id Filter by lesson (post_id).
 	 *     @type int[] $post__in  Filter by lesson IDs.
 	 * }
-	 * @return array { count: int, sum: float }
+	 * @return array{count: int, sum: float}
 	 */
 	public function get_grade_totals( array $args = array() ): array {
 		$wpdb = $this->wpdb;
 
+		// The quiz_answers EXISTS check restricts results to attempts where the
+		// student actually submitted answers. This excludes auto-passed students
+		// whose lesson was marked passed without ever taking the quiz.
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum
@@ -118,7 +121,8 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 
 	/**
 	 * Average grade across courses (AVG of per-course AVGs).
-	 * Only includes lessons with quizzes that have been graded.
+	 * Only includes student attempts where the quiz was actually submitted
+	 * (enforced via the quiz_answers EXISTS check).
 	 *
 	 * @since $$next-version$$
 	 *
@@ -201,6 +205,9 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$wpdb         = $this->wpdb;
 		$placeholders = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
+		// The quiz_answers EXISTS check restricts results to attempts where the
+		// student actually submitted answers. This excludes auto-passed students
+		// whose lesson was marked passed without ever taking the quiz.
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Statuses from constants. Placeholders created dynamically. Caching handled by callers.
 		/** Query result row. @var object|null $row */
 		$row = $wpdb->get_row(
@@ -223,7 +230,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		// phpcs:enable
 		Utils::log_query_error( $wpdb, 'Comments-based users average grade' );
 
-		if ( ! $row || ! $row->grade_count || '0' === $row->grade_count ) {
+		if ( ! $row || ! $row->grade_count ) {
 			return 0.0;
 		}
 

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -58,7 +58,22 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	public function get_grade_totals( array $args = array() ): array {
 		$wpdb = $this->wpdb;
 
-		$query = $wpdb->prepare( "SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum FROM %i c INNER JOIN %i cm ON c.comment_ID = cm.comment_id WHERE c.comment_type = 'sensei_lesson_status' AND c.comment_approved IN ( 'graded', 'passed', 'failed' ) AND cm.meta_key = 'grade'", $wpdb->comments, $wpdb->commentmeta );
+		$query = $wpdb->prepare(
+			"SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum
+			FROM %i c
+			INNER JOIN %i cm ON c.comment_ID = cm.comment_id
+			WHERE c.comment_type = 'sensei_lesson_status'
+				AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
+				AND cm.meta_key = 'grade'
+				AND EXISTS (
+					SELECT 1 FROM %i cm2
+					WHERE cm2.comment_id = c.comment_ID
+						AND cm2.meta_key = 'quiz_answers'
+				)",
+			$wpdb->comments,
+			$wpdb->commentmeta,
+			$wpdb->commentmeta
+		);
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
@@ -123,12 +138,18 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 					AND cm.meta_key = 'grade'
 					AND course.meta_key = '_lesson_course'
 					AND course.meta_value <> ''
-					AND has_questions.meta_key = '_quiz_has_questions'",
+					AND has_questions.meta_key = '_quiz_has_questions'
+						AND EXISTS (
+							SELECT 1 FROM %i cm2
+							WHERE cm2.comment_id = c.comment_ID
+								AND cm2.meta_key = 'quiz_answers'
+						)",
 			$wpdb->comments,
 			$wpdb->commentmeta,
 			$wpdb->postmeta,
 			$wpdb->postmeta,
-			$wpdb->posts
+			$wpdb->posts,
+			$wpdb->commentmeta
 		);
 		$query .= $course_filter;
 		$query .= ' GROUP BY course.meta_value ) averages_by_course';
@@ -171,8 +192,13 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 				WHERE c.comment_type = 'sensei_lesson_status'
 					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
 					AND cm.meta_key = 'grade'
+					AND EXISTS (
+						SELECT 1 FROM %i cm2
+						WHERE cm2.comment_id = c.comment_ID
+							AND cm2.meta_key = 'quiz_answers'
+					)
 					AND c.user_id IN ( $placeholders )",
-				array_merge( array( $wpdb->comments, $wpdb->commentmeta ), $user_ids )
+				array_merge( array( $wpdb->comments, $wpdb->commentmeta, $wpdb->commentmeta ), $user_ids )
 			)
 		);
 		// phpcs:enable

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -58,7 +58,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	public function get_grade_totals( array $args = array() ): array {
 		$wpdb = $this->wpdb;
 
-		$query = $wpdb->prepare( "SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum FROM %i c INNER JOIN %i cm ON c.comment_ID = cm.comment_id WHERE c.comment_type = 'sensei_lesson_status' AND cm.meta_key = 'grade'", $wpdb->comments, $wpdb->commentmeta );
+		$query = $wpdb->prepare( "SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum FROM %i c INNER JOIN %i cm ON c.comment_ID = cm.comment_id WHERE c.comment_type = 'sensei_lesson_status' AND c.comment_approved IN ( 'graded', 'passed', 'failed' ) AND cm.meta_key = 'grade'", $wpdb->comments, $wpdb->commentmeta );
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
@@ -162,6 +162,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 				FROM %i c
 				INNER JOIN %i cm ON c.comment_ID = cm.comment_id
 				WHERE c.comment_type = 'sensei_lesson_status'
+					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
 					AND cm.meta_key = 'grade'
 					AND c.user_id IN ( $placeholders )",
 				array_merge( array( $wpdb->comments, $wpdb->commentmeta ), $user_ids )

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -246,11 +246,11 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	 * @return string SQL clause.
 	 */
 	private function build_user_filter( array $args ): string {
-		if ( ! empty( $args['user_id'] ) ) {
-			return $this->wpdb->prepare( ' AND c.user_id = %d', $args['user_id'] );
+		if ( empty( $args['user_id'] ) ) {
+			return '';
 		}
 
-		return '';
+		return $this->wpdb->prepare( ' AND c.user_id = %d', $args['user_id'] );
 	}
 
 	/**

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * File containing the Comments_Based_Grading_Stats_Service class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Comments_Based_Grading_Stats_Service.
+ *
+ * Comments-based (legacy) implementation of grading statistics.
+ * Queries wp_comments joined with wp_commentmeta for grade data.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Interface {
+
+	/**
+	 * WordPress database object.
+	 *
+	 * @var \wpdb
+	 */
+	private \wpdb $wpdb;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( \wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Get grade count and sum, with optional filters.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args {
+	 *     Optional filters.
+	 *
+	 *     @type int   $user_id   Filter by user.
+	 *     @type int   $lesson_id Filter by lesson (post_id).
+	 *     @type int[] $post__in  Filter by lesson IDs.
+	 * }
+	 * @return array { count: int, sum: float }
+	 */
+	public function get_grade_totals( array $args = array() ): array {
+		$wpdb = $this->wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
+		$query = "SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum FROM {$wpdb->comments} c INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id WHERE c.comment_type = 'sensei_lesson_status' AND cm.meta_key = 'grade'";
+
+		$query .= $this->build_user_filter( $args );
+		$query .= $this->build_post_filter( $args );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$row = $wpdb->get_row( $query );
+		Utils::log_query_error( $wpdb, 'Comments-based grade totals' );
+
+		if ( ! $row ) {
+			return array(
+				'count' => 0,
+				'sum'   => 0.0,
+			);
+		}
+
+		return array(
+			'count' => (int) $row->count,
+			'sum'   => (float) $row->sum,
+		);
+	}
+
+	/**
+	 * Average grade across courses (AVG of per-course AVGs).
+	 * Only includes lessons with quizzes that have been graded.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Optional. Filter by courses. Empty = all.
+	 * @return float
+	 */
+	public function get_courses_average_grade( array $course_ids = array() ): float {
+		$wpdb = $this->wpdb;
+
+		$course_filter = '';
+		if ( ! empty( $course_ids ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$course_filter = $wpdb->prepare( " AND course.meta_value IN ( $placeholders )", $course_ids );
+		}
+
+		/**
+		 * The subquery calculates the average grade per course, and the outer query
+		 * then calculates the average grade of all courses. To be included in the
+		 * calculation, a lesson must:
+		 *   - Have a status of 'graded', 'passed' or 'failed'.
+		 *   - Have grade data.
+		 *   - Be associated with a course.
+		 *   - Have quiz questions.
+		 */
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names from wpdb. Dynamic filter prepared above. Caching handled by callers.
+		$result = $wpdb->get_row(
+			"SELECT AVG(course_average) AS courses_average
+			FROM (
+				SELECT AVG(cm.meta_value) AS course_average
+				FROM {$wpdb->comments} c
+				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+				INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
+				INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
+				INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
+				WHERE c.comment_type = 'sensei_lesson_status'
+					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
+					AND cm.meta_key = 'grade'
+					AND course.meta_key = '_lesson_course'
+					AND course.meta_value <> ''
+					AND has_questions.meta_key = '_quiz_has_questions'
+					{$course_filter}
+				GROUP BY course.meta_value
+			) averages_by_course"
+		);
+		// phpcs:enable
+		Utils::log_query_error( $wpdb, 'Comments-based courses average grade' );
+
+		return floatval( $result->courses_average ?? 0 );
+	}
+
+	/**
+	 * Average grade filtered by user IDs.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $user_ids User IDs to include.
+	 * @return float
+	 */
+	public function get_users_average_grade( array $user_ids ): float {
+		if ( empty( $user_ids ) ) {
+			return 0.0;
+		}
+
+		$wpdb         = $this->wpdb;
+		$placeholders = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM( cm.meta_value ) AS grade_sum, COUNT( * ) AS grade_count
+				FROM {$wpdb->comments} c
+				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+				WHERE c.comment_type = 'sensei_lesson_status'
+					AND cm.meta_key = 'grade'
+					AND c.user_id IN ( $placeholders )",
+				$user_ids
+			)
+		);
+		// phpcs:enable
+		Utils::log_query_error( $wpdb, 'Comments-based users average grade' );
+
+		if ( ! $row || ! $row->grade_count || '0' === $row->grade_count ) {
+			return 0.0;
+		}
+
+		return (float) ( $row->grade_sum / $row->grade_count );
+	}
+
+	/**
+	 * Build SQL clause for filtering by user ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_user_filter( array $args ): string {
+		if ( ! empty( $args['user_id'] ) ) {
+			return $this->wpdb->prepare( ' AND c.user_id = %d', $args['user_id'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build SQL clause for filtering by post ID(s).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_post_filter( array $args ): string {
+		$wpdb = $this->wpdb;
+
+		if ( ! empty( $args['lesson_id'] ) ) {
+			return $wpdb->prepare( ' AND c.comment_post_ID = %d', $args['lesson_id'] );
+		}
+
+		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			return $wpdb->prepare( " AND c.comment_post_ID IN ( $placeholders )", $args['post__in'] );
+		}
+
+		return '';
+	}
+}

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -58,8 +58,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	public function get_grade_totals( array $args = array() ): array {
 		$wpdb = $this->wpdb;
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
-		$query = "SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum FROM {$wpdb->comments} c INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id WHERE c.comment_type = 'sensei_lesson_status' AND cm.meta_key = 'grade'";
+		$query = $wpdb->prepare( "SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum FROM %i c INNER JOIN %i cm ON c.comment_ID = cm.comment_id WHERE c.comment_type = 'sensei_lesson_status' AND cm.meta_key = 'grade'", $wpdb->comments, $wpdb->commentmeta );
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
@@ -109,27 +108,32 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		 *   - Be associated with a course.
 		 *   - Have quiz questions.
 		 */
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names from wpdb. Dynamic filter prepared above. Caching handled by callers.
-		$result = $wpdb->get_row(
+		$query  = $wpdb->prepare(
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
 				SELECT AVG(cm.meta_value) AS course_average
-				FROM {$wpdb->comments} c
-				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
-				INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
-				INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
-				INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
+				FROM %i c
+				INNER JOIN %i cm ON c.comment_ID = cm.comment_id
+				INNER JOIN %i course ON c.comment_post_ID = course.post_id
+				INNER JOIN %i has_questions ON c.comment_post_ID = has_questions.post_id
+				INNER JOIN %i p ON p.ID = course.meta_value
 				WHERE c.comment_type = 'sensei_lesson_status'
 					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
 					AND cm.meta_key = 'grade'
 					AND course.meta_key = '_lesson_course'
 					AND course.meta_value <> ''
-					AND has_questions.meta_key = '_quiz_has_questions'
-					{$course_filter}
-				GROUP BY course.meta_value
-			) averages_by_course"
+					AND has_questions.meta_key = '_quiz_has_questions'",
+			$wpdb->comments,
+			$wpdb->commentmeta,
+			$wpdb->postmeta,
+			$wpdb->postmeta,
+			$wpdb->posts
 		);
-		// phpcs:enable
+		$query .= $course_filter;
+		$query .= ' GROUP BY course.meta_value ) averages_by_course';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
+		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based courses average grade' );
 
 		return floatval( $result->courses_average ?? 0 );
@@ -151,16 +155,16 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$wpdb         = $this->wpdb;
 		$placeholders = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( cm.meta_value ) AS grade_sum, COUNT( * ) AS grade_count
-				FROM {$wpdb->comments} c
-				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+				FROM %i c
+				INNER JOIN %i cm ON c.comment_ID = cm.comment_id
 				WHERE c.comment_type = 'sensei_lesson_status'
 					AND cm.meta_key = 'grade'
 					AND c.user_id IN ( $placeholders )",
-				$user_ids
+				array_merge( array( $wpdb->comments, $wpdb->commentmeta ), $user_ids )
 			)
 		);
 		// phpcs:enable

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -132,8 +132,9 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	public function get_courses_average_grade( array $course_ids = array() ): float {
 		$wpdb = $this->wpdb;
 
-		$course_filter = '';
-		if ( ! empty( $course_ids ) ) {
+		if ( empty( $course_ids ) ) {
+			$course_filter = '';
+		} else {
 			$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
 			$course_filter = $wpdb->prepare( " AND course.meta_value IN ( $placeholders )", $course_ids );
@@ -264,16 +265,16 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	private function build_post_filter( array $args ): string {
 		$wpdb = $this->wpdb;
 
+		if ( empty( $args['lesson_id'] ) && ( empty( $args['post__in'] ) || ! is_array( $args['post__in'] ) ) ) {
+			return '';
+		}
+
 		if ( ! empty( $args['lesson_id'] ) ) {
 			return $wpdb->prepare( ' AND c.comment_post_ID = %d', $args['lesson_id'] );
 		}
 
-		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
-			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-			return $wpdb->prepare( " AND c.comment_post_ID IN ( $placeholders )", $args['post__in'] );
-		}
-
-		return '';
+		$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+		return $wpdb->prepare( " AND c.comment_post_ID IN ( $placeholders )", $args['post__in'] );
 	}
 }

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -145,7 +145,7 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		 *   - Have quiz answers (excludes auto-passed students who never took the quiz).
 		 */
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
-		$query  = $wpdb->prepare(
+		$query = $wpdb->prepare(
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
 				SELECT AVG(cm.meta_value) AS course_average

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -138,7 +138,11 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based courses average grade' );
 
-		return floatval( $result->courses_average ?? 0 );
+		if ( ! $result ) {
+			return 0.0;
+		}
+
+		return floatval( $result->courses_average );
 	}
 
 	/**

--- a/includes/internal/services/class-grading-stats-service-interface.php
+++ b/includes/internal/services/class-grading-stats-service-interface.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * File containing the Grading_Stats_Service_Interface interface.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Interface Grading_Stats_Service_Interface.
+ *
+ * Provides methods to retrieve grade statistics such as
+ * totals, averages per course, and averages per user.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+interface Grading_Stats_Service_Interface {
+
+	/**
+	 * Get grade count and sum, with optional filters.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args {
+	 *     Optional filters.
+	 *
+	 *     @type int   $user_id   Filter by user.
+	 *     @type int   $lesson_id Filter by lesson (post_id).
+	 *     @type int[] $post__in  Filter by lesson IDs.
+	 * }
+	 * @return array { count: int, sum: float }
+	 */
+	public function get_grade_totals( array $args = array() ): array;
+
+	/**
+	 * Average grade across courses (AVG of per-course AVGs).
+	 * Only includes lessons with quizzes that have been graded.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Optional. Filter by courses. Empty = all.
+	 * @return float
+	 */
+	public function get_courses_average_grade( array $course_ids = array() ): float;
+
+	/**
+	 * Average grade filtered by user IDs.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $user_ids User IDs to include.
+	 * @return float
+	 */
+	public function get_users_average_grade( array $user_ids ): float;
+}

--- a/includes/internal/services/class-grading-stats-service-interface.php
+++ b/includes/internal/services/class-grading-stats-service-interface.php
@@ -35,13 +35,13 @@ interface Grading_Stats_Service_Interface {
 	 *     @type int   $lesson_id Filter by lesson (post_id).
 	 *     @type int[] $post__in  Filter by lesson IDs.
 	 * }
-	 * @return array { count: int, sum: float }
+	 * @return array{count: int, sum: float}
 	 */
 	public function get_grade_totals( array $args = array() ): array;
 
 	/**
 	 * Average grade across courses (AVG of per-course AVGs).
-	 * Only includes lessons with quizzes that have been graded.
+	 * Only includes student attempts where the quiz was actually submitted.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/internal/services/class-progress-query-service-factory.php
+++ b/includes/internal/services/class-progress-query-service-factory.php
@@ -61,6 +61,26 @@ class Progress_Query_Service_Factory {
 	}
 
 	/**
+	 * Create a Grading_Stats_Service_Interface instance.
+	 *
+	 * Returns a tables-based implementation when HPPS is enabled and the tables
+	 * repository is active, otherwise returns a comments-based implementation.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return Grading_Stats_Service_Interface The grading stats service.
+	 */
+	public function create_grading_stats_service(): Grading_Stats_Service_Interface {
+		global $wpdb;
+
+		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+			return new Tables_Based_Grading_Stats_Service( $wpdb );
+		}
+
+		return new Comments_Based_Grading_Stats_Service( $wpdb );
+	}
+
+	/**
 	 * Create a Progress_Aggregation_Service_Interface instance.
 	 *
 	 * Returns a tables-based implementation when HPPS is enabled and the tables

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -149,8 +149,9 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$table             = $this->get_progress_table_name();
 		$submissions_table = $this->get_submissions_table_name();
 
-		$course_filter = '';
-		if ( ! empty( $course_ids ) ) {
+		if ( empty( $course_ids ) ) {
+			$course_filter = '';
+		} else {
 			$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
 			$course_filter = $wpdb->prepare( " AND p.parent_post_id IN ( $placeholders )", $course_ids );
@@ -262,16 +263,16 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 	private function build_post_filter( array $args ): string {
 		$wpdb = $this->wpdb;
 
+		if ( empty( $args['lesson_id'] ) && ( empty( $args['post__in'] ) || ! is_array( $args['post__in'] ) ) ) {
+			return '';
+		}
+
 		if ( ! empty( $args['lesson_id'] ) ) {
 			return $wpdb->prepare( ' AND q.parent_post_id = %d', $args['lesson_id'] );
 		}
 
-		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
-			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-			return $wpdb->prepare( " AND q.parent_post_id IN ( $placeholders )", $args['post__in'] );
-		}
-
-		return '';
+		$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+		return $wpdb->prepare( " AND q.parent_post_id IN ( $placeholders )", $args['post__in'] );
 	}
 }

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -82,15 +82,13 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$table             = $this->get_progress_table_name();
 		$submissions_table = $this->get_submissions_table_name();
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query  = 'SELECT COUNT(*) AS count, COALESCE( SUM( qs.final_grade ), 0 ) AS sum';
-		$query .= " FROM {$table} p";
-		$query .= " LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'";
-		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id";
+		$query .= $wpdb->prepare( ' FROM %i p', $table );
+		$query .= $wpdb->prepare( " LEFT JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'", $table );
+		$query .= $wpdb->prepare( ' LEFT JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id', $submissions_table );
 		$query .= " WHERE p.type = 'lesson'";
 		$query .= " AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )";
 		$query .= ' AND qs.final_grade IS NOT NULL';
-		// phpcs:enable
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
@@ -138,22 +136,25 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		 * A quiz progress row existing (type='quiz') proves the lesson has a quiz.
 		 * The subquery computes AVG grade per course; the outer query averages those.
 		 */
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names from wpdb prefix. Dynamic filter prepared above. Caching handled by callers.
-		$result = $wpdb->get_row(
+		$query  = $wpdb->prepare(
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
 				SELECT AVG(qs.final_grade) AS course_average
-				FROM {$table} p
-				INNER JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
-				INNER JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
+				FROM %i p
+				INNER JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
+				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
 				WHERE p.type = 'lesson'
 					AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )
-					AND qs.final_grade IS NOT NULL
-					{$course_filter}
-				GROUP BY p.parent_post_id
-			) averages_by_course"
+					AND qs.final_grade IS NOT NULL",
+			$table,
+			$table,
+			$submissions_table
 		);
-		// phpcs:enable
+		$query .= $course_filter;
+		$query .= ' GROUP BY p.parent_post_id ) averages_by_course';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
+		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based courses average grade' );
 
 		return floatval( $result->courses_average ?? 0 );
@@ -177,18 +178,18 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$submissions_table = $this->get_submissions_table_name();
 		$placeholders      = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names from wpdb prefix. Placeholders created dynamically. Caching handled by callers.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( qs.final_grade ) AS grade_sum, COUNT( * ) AS grade_count
-				FROM {$table} p
-				LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
-				LEFT JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
+				FROM %i p
+				LEFT JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
+				LEFT JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
 				WHERE p.type = 'lesson'
 					AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )
 					AND qs.final_grade IS NOT NULL
 					AND p.user_id IN ( $placeholders )",
-				$user_ids
+				array_merge( array( $table, $table, $submissions_table ), $user_ids )
 			)
 		);
 		// phpcs:enable

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -244,11 +244,11 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 	 * @return string SQL clause.
 	 */
 	private function build_user_filter( array $args ): string {
-		if ( ! empty( $args['user_id'] ) ) {
-			return $this->wpdb->prepare( ' AND q.user_id = %d', $args['user_id'] );
+		if ( empty( $args['user_id'] ) ) {
+			return '';
 		}
 
-		return '';
+		return $this->wpdb->prepare( ' AND q.user_id = %d', $args['user_id'] );
 	}
 
 	/**

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -161,7 +161,11 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based courses average grade' );
 
-		return floatval( $result->courses_average ?? 0 );
+		if ( ! $result ) {
+			return 0.0;
+		}
+
+		return floatval( $result->courses_average );
 	}
 
 	/**

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * File containing the Tables_Based_Grading_Stats_Service class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Tables_Based_Grading_Stats_Service.
+ *
+ * Tables-based (HPPS) implementation of grading statistics.
+ * Queries sensei_lms_progress and sensei_lms_quiz_submissions for grade data.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interface {
+
+	/**
+	 * WordPress database object.
+	 *
+	 * @var \wpdb
+	 */
+	private \wpdb $wpdb;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( \wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Get the progress table name.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private function get_progress_table_name(): string {
+		return $this->wpdb->prefix . 'sensei_lms_progress';
+	}
+
+	/**
+	 * Get the quiz submissions table name.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private function get_submissions_table_name(): string {
+		return $this->wpdb->prefix . 'sensei_lms_quiz_submissions';
+	}
+
+	/**
+	 * Get grade count and sum, with optional filters.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args {
+	 *     Optional filters.
+	 *
+	 *     @type int   $user_id   Filter by user.
+	 *     @type int   $lesson_id Filter by lesson (post_id).
+	 *     @type int[] $post__in  Filter by lesson IDs.
+	 * }
+	 * @return array { count: int, sum: float }
+	 */
+	public function get_grade_totals( array $args = array() ): array {
+		$wpdb              = $this->wpdb;
+		$table             = $this->get_progress_table_name();
+		$submissions_table = $this->get_submissions_table_name();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query  = 'SELECT COUNT(*) AS count, COALESCE( SUM( qs.final_grade ), 0 ) AS sum';
+		$query .= " FROM {$table} p";
+		$query .= " LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'";
+		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id";
+		$query .= " WHERE p.type = 'lesson'";
+		$query .= " AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )";
+		$query .= ' AND qs.final_grade IS NOT NULL';
+		// phpcs:enable
+
+		$query .= $this->build_user_filter( $args );
+		$query .= $this->build_post_filter( $args );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$row = $wpdb->get_row( $query );
+		Utils::log_query_error( $wpdb, 'Tables-based grade totals' );
+
+		if ( ! $row ) {
+			return array(
+				'count' => 0,
+				'sum'   => 0.0,
+			);
+		}
+
+		return array(
+			'count' => (int) $row->count,
+			'sum'   => (float) $row->sum,
+		);
+	}
+
+	/**
+	 * Average grade across courses (AVG of per-course AVGs).
+	 * Only includes lessons with quizzes that have been graded.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Optional. Filter by courses. Empty = all.
+	 * @return float
+	 */
+	public function get_courses_average_grade( array $course_ids = array() ): float {
+		$wpdb              = $this->wpdb;
+		$table             = $this->get_progress_table_name();
+		$submissions_table = $this->get_submissions_table_name();
+
+		$course_filter = '';
+		if ( ! empty( $course_ids ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$course_filter = $wpdb->prepare( " AND p.parent_post_id IN ( $placeholders )", $course_ids );
+		}
+
+		/**
+		 * Uses parent_post_id on lesson progress rows as the course ID.
+		 * A quiz progress row existing (type='quiz') proves the lesson has a quiz.
+		 * The subquery computes AVG grade per course; the outer query averages those.
+		 */
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names from wpdb prefix. Dynamic filter prepared above. Caching handled by callers.
+		$result = $wpdb->get_row(
+			"SELECT AVG(course_average) AS courses_average
+			FROM (
+				SELECT AVG(qs.final_grade) AS course_average
+				FROM {$table} p
+				INNER JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
+				INNER JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
+				WHERE p.type = 'lesson'
+					AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )
+					AND qs.final_grade IS NOT NULL
+					{$course_filter}
+				GROUP BY p.parent_post_id
+			) averages_by_course"
+		);
+		// phpcs:enable
+		Utils::log_query_error( $wpdb, 'Tables-based courses average grade' );
+
+		return floatval( $result->courses_average ?? 0 );
+	}
+
+	/**
+	 * Average grade filtered by user IDs.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $user_ids User IDs to include.
+	 * @return float
+	 */
+	public function get_users_average_grade( array $user_ids ): float {
+		if ( empty( $user_ids ) ) {
+			return 0.0;
+		}
+
+		$wpdb              = $this->wpdb;
+		$table             = $this->get_progress_table_name();
+		$submissions_table = $this->get_submissions_table_name();
+		$placeholders      = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names from wpdb prefix. Placeholders created dynamically. Caching handled by callers.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM( qs.final_grade ) AS grade_sum, COUNT( * ) AS grade_count
+				FROM {$table} p
+				LEFT JOIN {$table} q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
+				LEFT JOIN {$submissions_table} qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
+				WHERE p.type = 'lesson'
+					AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )
+					AND qs.final_grade IS NOT NULL
+					AND p.user_id IN ( $placeholders )",
+				$user_ids
+			)
+		);
+		// phpcs:enable
+		Utils::log_query_error( $wpdb, 'Tables-based users average grade' );
+
+		if ( ! $row || ! $row->grade_count || '0' === $row->grade_count ) {
+			return 0.0;
+		}
+
+		return (float) ( $row->grade_sum / $row->grade_count );
+	}
+
+	/**
+	 * Build SQL clause for filtering by user ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_user_filter( array $args ): string {
+		if ( ! empty( $args['user_id'] ) ) {
+			return $this->wpdb->prepare( ' AND p.user_id = %d', $args['user_id'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build SQL clause for filtering by post ID(s).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments.
+	 * @return string SQL clause.
+	 */
+	private function build_post_filter( array $args ): string {
+		$wpdb = $this->wpdb;
+
+		if ( ! empty( $args['lesson_id'] ) ) {
+			return $wpdb->prepare( ' AND p.post_id = %d', $args['lesson_id'] );
+		}
+
+		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			return $wpdb->prepare( " AND p.post_id IN ( $placeholders )", $args['post__in'] );
+		}
+
+		return '';
+	}
+}

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -94,6 +94,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$query .= $this->build_post_filter( $args );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		/** @var object|null $row */
 		$row = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based grade totals' );
 
@@ -156,6 +157,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$query .= ' GROUP BY p.parent_post_id ) averages_by_course';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
+		/** @var object|null $result */
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based courses average grade' );
 
@@ -181,6 +183,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$placeholders      = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
+		/** @var object|null $row */
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( qs.final_grade ) AS grade_sum, COUNT( * ) AS grade_count

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -93,7 +93,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 	 *     @type int   $lesson_id Filter by lesson (post_id).
 	 *     @type int[] $post__in  Filter by lesson IDs.
 	 * }
-	 * @return array { count: int, sum: float }
+	 * @return array{count: int, sum: float}
 	 */
 	public function get_grade_totals( array $args = array() ): array {
 		$wpdb              = $this->wpdb;
@@ -130,7 +130,8 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 
 	/**
 	 * Average grade across courses (AVG of per-course AVGs).
-	 * Only includes lessons with quizzes that have been graded.
+	 * Only includes student attempts where the quiz was actually submitted
+	 * (enforced via INNER JOIN on the quiz submissions table and final_grade IS NOT NULL).
 	 *
 	 * @since $$next-version$$
 	 *
@@ -221,7 +222,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		// phpcs:enable
 		Utils::log_query_error( $wpdb, 'Tables-based users average grade' );
 
-		if ( ! $row || ! $row->grade_count || '0' === $row->grade_count ) {
+		if ( ! $row || ! $row->grade_count ) {
 			return 0.0;
 		}
 

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -83,11 +83,10 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$submissions_table = $this->get_submissions_table_name();
 
 		$query  = 'SELECT COUNT(*) AS count, COALESCE( SUM( qs.final_grade ), 0 ) AS sum';
-		$query .= $wpdb->prepare( ' FROM %i p', $table );
-		$query .= $wpdb->prepare( " LEFT JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'", $table );
-		$query .= $wpdb->prepare( ' LEFT JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id', $submissions_table );
-		$query .= " WHERE p.type = 'lesson'";
-		$query .= " AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )";
+		$query .= $wpdb->prepare( ' FROM %i q', $table );
+		$query .= $wpdb->prepare( ' INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id', $submissions_table );
+		$query .= " WHERE q.type = 'quiz'";
+		$query .= " AND q.status IN ( 'graded', 'passed', 'failed' )";
 		$query .= ' AND qs.final_grade IS NOT NULL';
 
 		$query .= $this->build_user_filter( $args );
@@ -221,7 +220,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 	 */
 	private function build_user_filter( array $args ): string {
 		if ( ! empty( $args['user_id'] ) ) {
-			return $this->wpdb->prepare( ' AND p.user_id = %d', $args['user_id'] );
+			return $this->wpdb->prepare( ' AND q.user_id = %d', $args['user_id'] );
 		}
 
 		return '';
@@ -239,13 +238,13 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$wpdb = $this->wpdb;
 
 		if ( ! empty( $args['lesson_id'] ) ) {
-			return $wpdb->prepare( ' AND p.post_id = %d', $args['lesson_id'] );
+			return $wpdb->prepare( ' AND q.parent_post_id = %d', $args['lesson_id'] );
 		}
 
 		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
 			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-			return $wpdb->prepare( " AND p.post_id IN ( $placeholders )", $args['post__in'] );
+			return $wpdb->prepare( " AND q.parent_post_id IN ( $placeholders )", $args['post__in'] );
 		}
 
 		return '';

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -145,7 +145,9 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
 				WHERE p.type = 'lesson'
 					AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )
-					AND qs.final_grade IS NOT NULL",
+					AND qs.final_grade IS NOT NULL
+					AND p.parent_post_id IS NOT NULL
+					AND p.parent_post_id != 0",
 			$table,
 			$table,
 			$submissions_table

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -100,12 +100,18 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$table             = $this->get_progress_table_name();
 		$submissions_table = $this->get_submissions_table_name();
 
-		$query  = 'SELECT COUNT(*) AS count, COALESCE( SUM( qs.final_grade ), 0 ) AS sum';
-		$query .= $wpdb->prepare( ' FROM %i q', $table );
-		$query .= $wpdb->prepare( ' INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id', $submissions_table );
-		$query .= " WHERE q.type = 'quiz'";
-		$query .= ' AND q.status IN ' . $this->get_graded_statuses_sql();
-		$query .= ' AND qs.final_grade IS NOT NULL';
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
+		$query = $wpdb->prepare(
+			"SELECT COUNT(*) AS count, COALESCE( SUM( qs.final_grade ), 0 ) AS sum
+			FROM %i q
+			INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
+			WHERE q.type = 'quiz'
+				AND q.status IN " . $this->get_graded_statuses_sql() . '
+				AND qs.final_grade IS NOT NULL',
+			$table,
+			$submissions_table
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -93,8 +93,8 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
 
+		/** Query result row. @var object|null $row */
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
-		/** @var object|null $row */
 		$row = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based grade totals' );
 
@@ -156,8 +156,8 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$query .= $course_filter;
 		$query .= ' GROUP BY p.parent_post_id ) averages_by_course';
 
+		/** Query result. @var object|null $result */
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
-		/** @var object|null $result */
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based courses average grade' );
 
@@ -187,7 +187,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$placeholders      = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
-		/** @var object|null $row */
+		/** Query result row. @var object|null $row */
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( qs.final_grade ) AS grade_sum, COUNT( * ) AS grade_count

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Services;
 
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -64,6 +66,22 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 	}
 
 	/**
+	 * Get the SQL IN clause for graded quiz statuses.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string SQL fragment like "( 'graded', 'passed', 'failed' )".
+	 */
+	private function get_graded_statuses_sql(): string {
+		return sprintf(
+			"( '%s', '%s', '%s' )",
+			Quiz_Progress_Interface::STATUS_GRADED,
+			Quiz_Progress_Interface::STATUS_PASSED,
+			Quiz_Progress_Interface::STATUS_FAILED
+		);
+	}
+
+	/**
 	 * Get grade count and sum, with optional filters.
 	 *
 	 * @since $$next-version$$
@@ -86,7 +104,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$query .= $wpdb->prepare( ' FROM %i q', $table );
 		$query .= $wpdb->prepare( ' INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id', $submissions_table );
 		$query .= " WHERE q.type = 'quiz'";
-		$query .= " AND q.status IN ( 'graded', 'passed', 'failed' )";
+		$query .= ' AND q.status IN ' . $this->get_graded_statuses_sql();
 		$query .= ' AND qs.final_grade IS NOT NULL';
 
 		$query .= $this->build_user_filter( $args );
@@ -135,7 +153,8 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		 * Uses parent_post_id on lesson progress rows as the course ID.
 		 * The subquery computes AVG grade per course; the outer query averages those.
 		 */
-		$query  = $wpdb->prepare(
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
+		$query = $wpdb->prepare(
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
 				SELECT AVG(qs.final_grade) AS course_average
@@ -143,14 +162,15 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 				INNER JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
 				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
 				WHERE p.type = 'lesson'
-					AND q.status IN ( 'graded', 'passed', 'failed' )
+					AND q.status IN " . $this->get_graded_statuses_sql() . '
 					AND qs.final_grade IS NOT NULL
 					AND p.parent_post_id IS NOT NULL
-					AND p.parent_post_id != 0",
+					AND p.parent_post_id != 0',
 			$table,
 			$table,
 			$submissions_table
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		$query .= $course_filter;
 		$query .= ' GROUP BY p.parent_post_id ) averages_by_course';
 
@@ -184,7 +204,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$submissions_table = $this->get_submissions_table_name();
 		$placeholders      = implode( ', ', array_fill( 0, count( $user_ids ), '%d' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Placeholders created dynamically. Caching handled by callers.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Statuses from constants. Placeholders created dynamically. Caching handled by callers.
 		/** Query result row. @var object|null $row */
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
@@ -192,7 +212,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 				FROM %i q
 				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
 				WHERE q.type = 'quiz'
-					AND q.status IN ( 'graded', 'passed', 'failed' )
+					AND q.status IN " . $this->get_graded_statuses_sql() . "
 					AND qs.final_grade IS NOT NULL
 					AND q.user_id IN ( $placeholders )",
 				array_merge( array( $table, $submissions_table ), $user_ids )

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -133,7 +133,6 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 
 		/**
 		 * Uses parent_post_id on lesson progress rows as the course ID.
-		 * A quiz progress row existing (type='quiz') proves the lesson has a quiz.
 		 * The subquery computes AVG grade per course; the outer query averages those.
 		 */
 		$query  = $wpdb->prepare(
@@ -144,7 +143,7 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 				INNER JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
 				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
 				WHERE p.type = 'lesson'
-					AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )
+					AND q.status IN ( 'graded', 'passed', 'failed' )
 					AND qs.final_grade IS NOT NULL
 					AND p.parent_post_id IS NOT NULL
 					AND p.parent_post_id != 0",
@@ -190,14 +189,13 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( qs.final_grade ) AS grade_sum, COUNT( * ) AS grade_count
-				FROM %i p
-				LEFT JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
-				LEFT JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
-				WHERE p.type = 'lesson'
-					AND COALESCE( q.status, p.status ) IN ( 'graded', 'passed', 'failed' )
+				FROM %i q
+				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
+				WHERE q.type = 'quiz'
+					AND q.status IN ( 'graded', 'passed', 'failed' )
 					AND qs.final_grade IS NOT NULL
-					AND p.user_id IN ( $placeholders )",
-				array_merge( array( $table, $table, $submissions_table ), $user_ids )
+					AND q.user_id IN ( $placeholders )",
+				array_merge( array( $table, $submissions_table ), $user_ids )
 			)
 		);
 		// phpcs:enable

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -108,7 +108,9 @@ class Sensei_Reports_Overview_Service_Courses {
 			return 0;
 		}
 
-		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		if ( null === $this->grading_stats_service ) {
+			$this->grading_stats_service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
 		return $this->grading_stats_service->get_courses_average_grade( $course_ids );
 	}

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -5,7 +5,6 @@
  * @package sensei
  */
 
-use Sensei\Internal\Services\Grading_Stats_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -18,22 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.4.1
  */
 class Sensei_Reports_Overview_Service_Courses {
-
-	/**
-	 * The grading stats service.
-	 *
-	 * @var Grading_Stats_Service_Interface|null
-	 */
-	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
-
-	/**
-	 * Constructor
-	 *
-	 * @param Grading_Stats_Service_Interface|null $grading_stats_service The grading stats service.
-	 */
-	public function __construct( ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
-		$this->grading_stats_service = $grading_stats_service;
-	}
 
 	/**
 	 * Get total average progress value for courses.
@@ -108,11 +91,7 @@ class Sensei_Reports_Overview_Service_Courses {
 			return 0;
 		}
 
-		if ( null === $this->grading_stats_service ) {
-			$this->grading_stats_service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-
-		return $this->grading_stats_service->get_courses_average_grade( $course_ids );
+		return ( new Progress_Query_Service_Factory() )->create_grading_stats_service()->get_courses_average_grade( $course_ids );
 	}
 
 	/**

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -5,6 +5,9 @@
  * @package sensei
  */
 
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -17,9 +20,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Reports_Overview_Service_Courses {
 
 	/**
-	 * Constructor
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface|null
 	 */
-	public function __construct() {
+	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Grading_Stats_Service_Interface|null $grading_stats_service The grading stats service.
+	 */
+	public function __construct( ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
+		$this->grading_stats_service = $grading_stats_service;
 	}
 
 	/**
@@ -94,38 +107,10 @@ class Sensei_Reports_Overview_Service_Courses {
 		if ( empty( $course_ids ) ) {
 			return 0;
 		}
-		global $wpdb;
-		/**
-		 * The subquery calculates the average grade per course, and the outer query then calculates the
-		 * average grade of all courses. To be included in the calculation, a lesson must:
-		 *   Have a status of 'graded', 'passed' or 'failed'.
-		 *   Have grade data.
-		 *   Be associated with a course.
-		 *   Have quiz questions (checking for the existence of '_quiz_has_questions' meta is sufficient;
-		 *   if it exists its value will be 1).
-		 */
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$result = $wpdb->get_row(
-			"SELECT AVG(course_average) as courses_average
-		FROM (
-			SELECT AVG(cm.meta_value) as course_average
-			FROM {$wpdb->comments} c
-			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
-			INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
-			INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
-			INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
-			WHERE c.comment_type = 'sensei_lesson_status'
-				AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
-				AND cm.meta_key = 'grade'
-				AND course.meta_key = '_lesson_course'
-				AND course.meta_value <> ''
-				AND has_questions.meta_key = '_quiz_has_questions'
-				AND course.meta_value IN ( " . implode( ',', $course_ids ) . ' ) ' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			. ' GROUP BY course.meta_value
-		) averages_by_course'
-		);
 
-		return floatval( isset( $result->courses_average ) ? $result->courses_average : 0 );
+		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+
+		return $this->grading_stats_service->get_courses_average_grade( $course_ids );
 	}
 
 	/**
@@ -137,7 +122,7 @@ class Sensei_Reports_Overview_Service_Courses {
 	 * @param array $course_ids Courses ids to filter by.
 	 * @return float Average days to completion, rounded to the highest integer.
 	 */
-	public function get_average_days_to_completion( array $course_ids ) : float {
+	public function get_average_days_to_completion( array $course_ids ): float {
 		if ( empty( $course_ids ) ) {
 			return 0;
 		}
@@ -170,7 +155,7 @@ class Sensei_Reports_Overview_Service_Courses {
 	 *
 	 * @return int total of enrollments
 	 */
-	public function get_total_enrollments( $course_ids ):int {
+	public function get_total_enrollments( $course_ids ): int {
 		if ( empty( $course_ids ) ) {
 			return 0;
 		}
@@ -259,5 +244,4 @@ class Sensei_Reports_Overview_Service_Courses {
 			'OBJECT_K'
 		);
 	}
-
 }

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -5,6 +5,9 @@
  * @package sensei
  */
 
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -17,9 +20,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Reports_Overview_Service_Courses {
 
 	/**
-	 * Constructor
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface|null
 	 */
-	public function __construct() {
+	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Grading_Stats_Service_Interface|null $grading_stats_service The grading stats service.
+	 */
+	public function __construct( ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
+		$this->grading_stats_service = $grading_stats_service;
 	}
 
 	/**
@@ -94,38 +107,10 @@ class Sensei_Reports_Overview_Service_Courses {
 		if ( empty( $course_ids ) ) {
 			return 0;
 		}
-		global $wpdb;
-		/**
-		 * The subquery calculates the average grade per course, and the outer query then calculates the
-		 * average grade of all courses. To be included in the calculation, a lesson must:
-		 *   Have a status of 'graded', 'passed' or 'failed'.
-		 *   Have grade data.
-		 *   Be associated with a course.
-		 *   Have quiz questions (checking for the existence of '_quiz_has_questions' meta is sufficient;
-		 *   if it exists its value will be 1).
-		 */
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$result = $wpdb->get_row(
-			"SELECT AVG(course_average) as courses_average
-		FROM (
-			SELECT AVG(cm.meta_value) as course_average
-			FROM {$wpdb->comments} c
-			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
-			INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
-			INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
-			INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
-			WHERE c.comment_type = 'sensei_lesson_status'
-				AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
-				AND cm.meta_key = 'grade'
-				AND course.meta_key = '_lesson_course'
-				AND course.meta_value <> ''
-				AND has_questions.meta_key = '_quiz_has_questions'
-				AND course.meta_value IN ( " . implode( ',', $course_ids ) . ' ) ' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			. ' GROUP BY course.meta_value
-		) averages_by_course'
-		);
 
-		return floatval( $result->courses_average );
+		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+
+		return $this->grading_stats_service->get_courses_average_grade( $course_ids );
 	}
 
 	/**
@@ -137,7 +122,7 @@ class Sensei_Reports_Overview_Service_Courses {
 	 * @param array $course_ids Courses ids to filter by.
 	 * @return float Average days to completion, rounded to the highest integer.
 	 */
-	public function get_average_days_to_completion( array $course_ids ) : float {
+	public function get_average_days_to_completion( array $course_ids ): float {
 		if ( empty( $course_ids ) ) {
 			return 0;
 		}
@@ -170,7 +155,7 @@ class Sensei_Reports_Overview_Service_Courses {
 	 *
 	 * @return int total of enrollments
 	 */
-	public function get_total_enrollments( $course_ids ):int {
+	public function get_total_enrollments( $course_ids ): int {
 		if ( empty( $course_ids ) ) {
 			return 0;
 		}
@@ -259,5 +244,4 @@ class Sensei_Reports_Overview_Service_Courses {
 			'OBJECT_K'
 		);
 	}
-
 }

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -5,7 +5,6 @@
  * @package sensei
  */
 
-use Sensei\Internal\Services\Grading_Stats_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,27 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Courses overview service class.
+ * Students overview service class.
  *
  * @since 4.4.1
  */
 class Sensei_Reports_Overview_Service_Students {
-
-	/**
-	 * The grading stats service.
-	 *
-	 * @var Grading_Stats_Service_Interface|null
-	 */
-	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
-
-	/**
-	 * Constructor
-	 *
-	 * @param Grading_Stats_Service_Interface|null $grading_stats_service The grading stats service.
-	 */
-	public function __construct( ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
-		$this->grading_stats_service = $grading_stats_service;
-	}
 
 	/**
 	 * Get average grade of all lessons graded in all the courses filtered by students.
@@ -49,10 +32,6 @@ class Sensei_Reports_Overview_Service_Students {
 			return 0;
 		}
 
-		if ( null === $this->grading_stats_service ) {
-			$this->grading_stats_service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
-		}
-
-		return ceil( $this->grading_stats_service->get_users_average_grade( $user_ids ) );
+		return ceil( ( new Progress_Query_Service_Factory() )->create_grading_stats_service()->get_users_average_grade( $user_ids ) );
 	}
 }

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -5,6 +5,9 @@
  * @package sensei
  */
 
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -17,9 +20,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Reports_Overview_Service_Students {
 
 	/**
-	 * Constructor
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface|null
 	 */
-	public function __construct() {     }
+	private ?Grading_Stats_Service_Interface $grading_stats_service = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Grading_Stats_Service_Interface|null $grading_stats_service The grading stats service.
+	 */
+	public function __construct( ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
+		$this->grading_stats_service = $grading_stats_service;
+	}
 
 	/**
 	 * Get average grade of all lessons graded in all the courses filtered by students.
@@ -34,21 +48,9 @@ class Sensei_Reports_Overview_Service_Students {
 		if ( empty( $user_ids ) ) {
 			return 0;
 		}
-		global $wpdb;
 
-		// Fetching all the grades of all the lessons that are graded.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$sum_result          = $wpdb->get_row(
-			"SELECT SUM( {$wpdb->commentmeta}.meta_value ) AS grade_sum,COUNT( * ) as grade_count FROM {$wpdb->comments}
-			INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
-			AND {$wpdb->comments}.user_id IN ( " . implode( ',', $user_ids ) . ' )' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		);
-		$average_grade_value = 0;
-		if ( ! $sum_result->grade_count || '0' === $sum_result->grade_count ) {
-			return $average_grade_value;
-		}
-		$average_grade_value = ceil( $sum_result->grade_sum / $sum_result->grade_count );
-		return $average_grade_value;
+		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+
+		return ceil( $this->grading_stats_service->get_users_average_grade( $user_ids ) );
 	}
 }

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -49,7 +49,9 @@ class Sensei_Reports_Overview_Service_Students {
 			return 0;
 		}
 
-		$this->grading_stats_service ??= ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		if ( null === $this->grading_stats_service ) {
+			$this->grading_stats_service = ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		}
 
 		return ceil( $this->grading_stats_service->get_users_average_grade( $user_ids ) );
 	}

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -890,6 +890,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 			$comment_id   = $this->comment->create( $comment_args );
 
 			add_comment_meta( $comment_id, 'grade', $grade );
+			add_comment_meta( $comment_id, 'quiz_answers', 'a:1:{i:0;s:1:"1";}' );
 		}
 	}
 

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -50,6 +50,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			)
 		);
 		update_comment_meta( $comment_id, 'grade', $grade );
+		update_comment_meta( $comment_id, 'quiz_answers', 'a:1:{i:0;s:1:"1";}' );
 	}
 
 	/**

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -146,6 +146,35 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test testGetGradeTotals_WithCombinedFilters_AppliesAllFilters.
+	 */
+	public function testGetGradeTotals_WithCombinedFilters_AppliesAllFilters(): void {
+		global $wpdb;
+		$user_1   = $this->sensei_factory->user->create();
+		$user_2   = $this->sensei_factory->user->create();
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
+
+		// User 1: grade 80 on lesson 1, grade 70 on lesson 2.
+		$this->create_lesson_status_with_grade( $lesson_1, $user_1, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_1, 'graded', 70 );
+		// User 2: grade 60 on lesson 1.
+		$this->create_lesson_status_with_grade( $lesson_1, $user_2, 'graded', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals(
+			array(
+				'user_id'   => $user_1,
+				'lesson_id' => $lesson_1,
+			)
+		);
+
+		// Only user 1's grade on lesson 1 should match.
+		$this->assertSame( 1, $result['count'], 'Combined user_id and lesson_id filter should match exactly one row.' );
+		$this->assertSame( 80.0, $result['sum'], 'Combined user_id and lesson_id filter should sum only user 1 on lesson 1.' );
+	}
+
+	/**
 	 * Test testGetCoursesAverageGrade_WithNoData_ReturnsZero.
 	 */
 	public function testGetCoursesAverageGrade_WithNoData_ReturnsZero(): void {

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -37,7 +37,8 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	 * @param int    $lesson_id Lesson post ID.
 	 * @param int    $user_id   User ID.
 	 * @param string $status    Comment status (e.g. 'graded', 'passed', 'failed').
-	 * @param int    $grade     The grade value.
+	 * @param int    $grade            The grade value.
+	 * @param bool   $has_quiz_answers Whether to add quiz_answers meta.
 	 */
 	private function create_lesson_status_with_grade( int $lesson_id, int $user_id, string $status, int $grade, bool $has_quiz_answers = true ): void {
 		$comment_id = wp_insert_comment(
@@ -166,7 +167,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
-					'_lesson_course'      => $course_id,
+					'_lesson_course' => $course_id,
 
 				),
 			)
@@ -191,7 +192,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$lesson_1 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
-					'_lesson_course'      => $course_1,
+					'_lesson_course' => $course_1,
 
 				),
 			)
@@ -199,7 +200,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$lesson_2 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
-					'_lesson_course'      => $course_2,
+					'_lesson_course' => $course_2,
 
 				),
 			)
@@ -260,7 +261,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$lesson_1 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
-					'_lesson_course'      => $course_1,
+					'_lesson_course' => $course_1,
 
 				),
 			)
@@ -268,7 +269,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$lesson_2 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
-					'_lesson_course'      => $course_1,
+					'_lesson_course' => $course_1,
 
 				),
 			)
@@ -276,7 +277,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$lesson_3 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
-					'_lesson_course'      => $course_2,
+					'_lesson_course' => $course_2,
 
 				),
 			)
@@ -296,25 +297,24 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_courses_average_grade excludes lessons without quizzes.
+	 * Tests that get_courses_average_grade excludes auto-passed students with no quiz answers.
 	 */
-	public function testGetCoursesAverageGrade_WithLessonWithoutQuiz_ExcludesFromAverage(): void {
+	public function testGetCoursesAverageGrade_WithNoQuizAnswers_ExcludesFromAverage(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 
-		// Lesson with quiz.
+		// Lesson with quiz answers.
 		$lesson_1 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
-					'_lesson_course'      => $course_id,
-
+					'_lesson_course' => $course_id,
 				),
 			)
 		);
 		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
 
-		// Lesson without quiz (no quiz answers).
+		// Lesson with grade but no quiz_answers meta (auto-passed).
 		$lesson_2 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
@@ -327,7 +327,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_courses_average_grade();
 
-		// Only the lesson with quiz should be included.
+		// Only the lesson with quiz answers should be included.
 		$this->assertSame( 80.0, $result );
 	}
 

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace SenseiTest\Internal\Services;
+
+use Sensei\Internal\Services\Comments_Based_Grading_Stats_Service;
+
+/**
+ * Class Comments_Based_Grading_Stats_Service_Test.
+ *
+ * @covers \Sensei\Internal\Services\Comments_Based_Grading_Stats_Service
+ */
+class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
+
+	private $sensei_factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->sensei_factory = new \Sensei_Factory();
+	}
+
+	/**
+	 * Helper: create a lesson status comment with a grade.
+	 *
+	 * @param int    $lesson_id Lesson post ID.
+	 * @param int    $user_id   User ID.
+	 * @param string $status    Comment status (e.g. 'graded', 'passed', 'failed').
+	 * @param int    $grade     The grade value.
+	 */
+	private function create_lesson_status_with_grade( int $lesson_id, int $user_id, string $status, int $grade ): void {
+		$comment_id = wp_insert_comment(
+			[
+				'comment_post_ID'  => $lesson_id,
+				'user_id'          => $user_id,
+				'comment_type'     => 'sensei_lesson_status',
+				'comment_approved' => $status,
+				'comment_content'  => '',
+			]
+		);
+		update_comment_meta( $comment_id, 'grade', $grade );
+	}
+
+	public function testGetGradeTotals_WithNoData_ReturnsZeros(): void {
+		global $wpdb;
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_grade_totals();
+
+		$this->assertSame( 0, $result['count'] );
+		$this->assertSame( 0.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithGradedLessons_ReturnsCountAndSum(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
+
+		$this->create_lesson_status_with_grade( $lesson_id, $user_id, 'graded', 80 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals();
+
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 80.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithUserIdFilter_ReturnsFilteredResults(): void {
+		global $wpdb;
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
+
+		$this->create_lesson_status_with_grade( $lesson_id, $user_1, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_id, $user_2, 'graded', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals( [ 'user_id' => $user_1 ] );
+
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 80.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithLessonIdFilter_ReturnsFilteredResults(): void {
+		global $wpdb;
+		$user_id    = $this->sensei_factory->user->create();
+		$lesson_1   = $this->sensei_factory->lesson->create();
+		$lesson_2   = $this->sensei_factory->lesson->create();
+
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals( [ 'lesson_id' => $lesson_1 ] );
+
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 80.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithPostInFilter_ReturnsFilteredResults(): void {
+		global $wpdb;
+		$user_id    = $this->sensei_factory->user->create();
+		$lesson_1   = $this->sensei_factory->lesson->create();
+		$lesson_2   = $this->sensei_factory->lesson->create();
+		$lesson_3   = $this->sensei_factory->lesson->create();
+
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 60 );
+		$this->create_lesson_status_with_grade( $lesson_3, $user_id, 'graded', 40 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals( [ 'post__in' => [ $lesson_1, $lesson_2 ] ] );
+
+		$this->assertSame( 2, $result['count'] );
+		$this->assertSame( 140.0, $result['sum'] );
+	}
+
+	public function testGetCoursesAverageGrade_WithNoData_ReturnsZero(): void {
+		global $wpdb;
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_courses_average_grade();
+
+		$this->assertSame( 0.0, $result );
+	}
+
+	public function testGetCoursesAverageGrade_WithGradedLessons_ReturnsAverage(): void {
+		global $wpdb;
+		$user_id    = $this->sensei_factory->user->create();
+		$course_id  = $this->sensei_factory->course->create();
+		$lesson_id  = $this->sensei_factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+
+		$this->create_lesson_status_with_grade( $lesson_id, $user_id, 'graded', 80 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade();
+
+		$this->assertSame( 80.0, $result );
+	}
+
+	public function testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage(): void {
+		global $wpdb;
+		$user_id     = $this->sensei_factory->user->create();
+		$course_1    = $this->sensei_factory->course->create();
+		$course_2    = $this->sensei_factory->course->create();
+		$lesson_1    = $this->sensei_factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_1,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$lesson_2    = $this->sensei_factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_2,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade( [ $course_1 ] );
+
+		$this->assertSame( 80.0, $result );
+	}
+
+	public function testGetUsersAverageGrade_WithNoUserIds_ReturnsZero(): void {
+		global $wpdb;
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_users_average_grade( [] );
+
+		$this->assertSame( 0.0, $result );
+	}
+
+	public function testGetUsersAverageGrade_WithUserIds_ReturnsAverage(): void {
+		global $wpdb;
+		$user_1     = $this->sensei_factory->user->create();
+		$user_2     = $this->sensei_factory->user->create();
+		$lesson_id  = $this->sensei_factory->lesson->create();
+
+		$this->create_lesson_status_with_grade( $lesson_id, $user_1, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_id, $user_2, 'graded', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_users_average_grade( [ $user_1, $user_2 ] );
+
+		$this->assertSame( 70.0, $result );
+	}
+
+	public function testGetUsersAverageGrade_FilteredBySpecificUser_ReturnsUserAverage(): void {
+		global $wpdb;
+		$user_1     = $this->sensei_factory->user->create();
+		$user_2     = $this->sensei_factory->user->create();
+		$lesson_id  = $this->sensei_factory->lesson->create();
+
+		$this->create_lesson_status_with_grade( $lesson_id, $user_1, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_id, $user_2, 'graded', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_users_average_grade( [ $user_1 ] );
+
+		$this->assertSame( 80.0, $result );
+	}
+}

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -28,13 +28,13 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	 */
 	private function create_lesson_status_with_grade( int $lesson_id, int $user_id, string $status, int $grade ): void {
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_post_ID'  => $lesson_id,
 				'user_id'          => $user_id,
 				'comment_type'     => 'sensei_lesson_status',
 				'comment_approved' => $status,
 				'comment_content'  => '',
-			]
+			)
 		);
 		update_comment_meta( $comment_id, 'grade', $grade );
 	}
@@ -73,7 +73,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->create_lesson_status_with_grade( $lesson_id, $user_2, 'graded', 60 );
 
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_grade_totals( [ 'user_id' => $user_1 ] );
+		$result  = $service->get_grade_totals( array( 'user_id' => $user_1 ) );
 
 		$this->assertSame( 1, $result['count'] );
 		$this->assertSame( 80.0, $result['sum'] );
@@ -81,15 +81,15 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 	public function testGetGradeTotals_WithLessonIdFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
-		$user_id    = $this->sensei_factory->user->create();
-		$lesson_1   = $this->sensei_factory->lesson->create();
-		$lesson_2   = $this->sensei_factory->lesson->create();
+		$user_id  = $this->sensei_factory->user->create();
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
 
 		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
 		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 60 );
 
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_grade_totals( [ 'lesson_id' => $lesson_1 ] );
+		$result  = $service->get_grade_totals( array( 'lesson_id' => $lesson_1 ) );
 
 		$this->assertSame( 1, $result['count'] );
 		$this->assertSame( 80.0, $result['sum'] );
@@ -97,17 +97,17 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 	public function testGetGradeTotals_WithPostInFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
-		$user_id    = $this->sensei_factory->user->create();
-		$lesson_1   = $this->sensei_factory->lesson->create();
-		$lesson_2   = $this->sensei_factory->lesson->create();
-		$lesson_3   = $this->sensei_factory->lesson->create();
+		$user_id  = $this->sensei_factory->user->create();
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$lesson_3 = $this->sensei_factory->lesson->create();
 
 		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
 		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 60 );
 		$this->create_lesson_status_with_grade( $lesson_3, $user_id, 'graded', 40 );
 
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_grade_totals( [ 'post__in' => [ $lesson_1, $lesson_2 ] ] );
+		$result  = $service->get_grade_totals( array( 'post__in' => array( $lesson_1, $lesson_2 ) ) );
 
 		$this->assertSame( 2, $result['count'] );
 		$this->assertSame( 140.0, $result['sum'] );
@@ -124,15 +124,15 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 	public function testGetCoursesAverageGrade_WithGradedLessons_ReturnsAverage(): void {
 		global $wpdb;
-		$user_id    = $this->sensei_factory->user->create();
-		$course_id  = $this->sensei_factory->course->create();
-		$lesson_id  = $this->sensei_factory->lesson->create(
-			[
-				'meta_input' => [
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
 					'_lesson_course'      => $course_id,
 					'_quiz_has_questions' => 1,
-				],
-			]
+				),
+			)
 		);
 
 		$this->create_lesson_status_with_grade( $lesson_id, $user_id, 'graded', 80 );
@@ -145,31 +145,31 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 	public function testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage(): void {
 		global $wpdb;
-		$user_id     = $this->sensei_factory->user->create();
-		$course_1    = $this->sensei_factory->course->create();
-		$course_2    = $this->sensei_factory->course->create();
-		$lesson_1    = $this->sensei_factory->lesson->create(
-			[
-				'meta_input' => [
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
 					'_lesson_course'      => $course_1,
 					'_quiz_has_questions' => 1,
-				],
-			]
+				),
+			)
 		);
-		$lesson_2    = $this->sensei_factory->lesson->create(
-			[
-				'meta_input' => [
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
 					'_lesson_course'      => $course_2,
 					'_quiz_has_questions' => 1,
-				],
-			]
+				),
+			)
 		);
 
 		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
 		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 60 );
 
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_courses_average_grade( [ $course_1 ] );
+		$result  = $service->get_courses_average_grade( array( $course_1 ) );
 
 		$this->assertSame( 80.0, $result );
 	}
@@ -178,37 +178,37 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 
-		$result = $service->get_users_average_grade( [] );
+		$result = $service->get_users_average_grade( array() );
 
 		$this->assertSame( 0.0, $result );
 	}
 
 	public function testGetUsersAverageGrade_WithUserIds_ReturnsAverage(): void {
 		global $wpdb;
-		$user_1     = $this->sensei_factory->user->create();
-		$user_2     = $this->sensei_factory->user->create();
-		$lesson_id  = $this->sensei_factory->lesson->create();
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
 
 		$this->create_lesson_status_with_grade( $lesson_id, $user_1, 'graded', 80 );
 		$this->create_lesson_status_with_grade( $lesson_id, $user_2, 'graded', 60 );
 
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_users_average_grade( [ $user_1, $user_2 ] );
+		$result  = $service->get_users_average_grade( array( $user_1, $user_2 ) );
 
 		$this->assertSame( 70.0, $result );
 	}
 
 	public function testGetUsersAverageGrade_FilteredBySpecificUser_ReturnsUserAverage(): void {
 		global $wpdb;
-		$user_1     = $this->sensei_factory->user->create();
-		$user_2     = $this->sensei_factory->user->create();
-		$lesson_id  = $this->sensei_factory->lesson->create();
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
 
 		$this->create_lesson_status_with_grade( $lesson_id, $user_1, 'graded', 80 );
 		$this->create_lesson_status_with_grade( $lesson_id, $user_2, 'graded', 60 );
 
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_users_average_grade( [ $user_1 ] );
+		$result  = $service->get_users_average_grade( array( $user_1 ) );
 
 		$this->assertSame( 80.0, $result );
 	}

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -174,6 +174,123 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result );
 	}
 
+	/**
+	 * Tests that get_grade_totals only includes graded, passed, and failed statuses.
+	 */
+	public function testGetGradeTotals_WithMixedStatuses_OnlyCountsGradedPassedFailed(): void {
+		global $wpdb;
+		$user_id = $this->sensei_factory->user->create();
+
+		// These should be included.
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$lesson_3 = $this->sensei_factory->lesson->create();
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'passed', 90 );
+		$this->create_lesson_status_with_grade( $lesson_3, $user_id, 'failed', 40 );
+
+		// This should be excluded: 'complete' status with grade meta.
+		$lesson_4   = $this->sensei_factory->lesson->create();
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $lesson_4,
+				'user_id'          => $user_id,
+				'comment_type'     => 'sensei_lesson_status',
+				'comment_approved' => 'complete',
+				'comment_content'  => '',
+			)
+		);
+		update_comment_meta( $comment_id, 'grade', 100 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals();
+
+		$this->assertSame( 3, $result['count'] );
+		$this->assertSame( 210.0, $result['sum'] ); // 80 + 90 + 40.
+	}
+
+	/**
+	 * Tests that get_courses_average_grade returns the average of per-course averages.
+	 */
+	public function testGetCoursesAverageGrade_WithMultipleCourses_ReturnsAverageOfAverages(): void {
+		global $wpdb;
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course'      => $course_1,
+					'_quiz_has_questions' => 1,
+				),
+			)
+		);
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course'      => $course_1,
+					'_quiz_has_questions' => 1,
+				),
+			)
+		);
+		$lesson_3 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course'      => $course_2,
+					'_quiz_has_questions' => 1,
+				),
+			)
+		);
+
+		// Course 1: grades 80, 60 -> avg 70.
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'passed', 60 );
+		// Course 2: grade 90 -> avg 90.
+		$this->create_lesson_status_with_grade( $lesson_3, $user_id, 'failed', 90 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade();
+
+		// Average of averages: (70 + 90) / 2 = 80.
+		$this->assertSame( 80.0, $result );
+	}
+
+	/**
+	 * Tests that get_courses_average_grade excludes lessons without quizzes.
+	 */
+	public function testGetCoursesAverageGrade_WithLessonWithoutQuiz_ExcludesFromAverage(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+
+		// Lesson with quiz.
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				),
+			)
+		);
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+
+		// Lesson without quiz (no _quiz_has_questions meta).
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 40 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade();
+
+		// Only the lesson with quiz should be included.
+		$this->assertSame( 80.0, $result );
+	}
+
 	public function testGetUsersAverageGrade_WithNoUserIds_ReturnsZero(): void {
 		global $wpdb;
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -65,8 +65,8 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 		$result = $service->get_grade_totals();
 
-		$this->assertSame( 0, $result['count'] );
-		$this->assertSame( 0.0, $result['sum'] );
+		$this->assertSame( 0, $result['count'], 'Count should be 0 when no data exists.' );
+		$this->assertSame( 0.0, $result['sum'], 'Sum should be 0.0 when no data exists.' );
 	}
 
 	/**
@@ -82,8 +82,8 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals();
 
-		$this->assertSame( 1, $result['count'] );
-		$this->assertSame( 80.0, $result['sum'] );
+		$this->assertSame( 1, $result['count'], 'Count should be 1 for a single graded lesson.' );
+		$this->assertSame( 80.0, $result['sum'], 'Sum should equal the single grade value.' );
 	}
 
 	/**
@@ -101,8 +101,8 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals( array( 'user_id' => $user_1 ) );
 
-		$this->assertSame( 1, $result['count'] );
-		$this->assertSame( 80.0, $result['sum'] );
+		$this->assertSame( 1, $result['count'], 'user_id filter should match exactly user 1.' );
+		$this->assertSame( 80.0, $result['sum'], 'user_id filter should sum only user 1 grades.' );
 	}
 
 	/**
@@ -120,8 +120,8 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals( array( 'lesson_id' => $lesson_1 ) );
 
-		$this->assertSame( 1, $result['count'] );
-		$this->assertSame( 80.0, $result['sum'] );
+		$this->assertSame( 1, $result['count'], 'lesson_id filter should match exactly lesson 1.' );
+		$this->assertSame( 80.0, $result['sum'], 'lesson_id filter should sum only lesson 1 grades.' );
 	}
 
 	/**
@@ -141,8 +141,8 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals( array( 'post__in' => array( $lesson_1, $lesson_2 ) ) );
 
-		$this->assertSame( 2, $result['count'] );
-		$this->assertSame( 140.0, $result['sum'] );
+		$this->assertSame( 2, $result['count'], 'post__in filter should match the two specified lessons.' );
+		$this->assertSame( 140.0, $result['sum'], 'post__in filter should sum only the specified lessons.' );
 	}
 
 	/**
@@ -275,8 +275,8 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals();
 
-		$this->assertSame( 3, $result['count'] );
-		$this->assertSame( 210.0, $result['sum'] ); // 80 + 90 + 40.
+		$this->assertSame( 3, $result['count'], 'Only graded/passed/failed statuses should be counted.' );
+		$this->assertSame( 210.0, $result['sum'], 'Sum should only include graded/passed/failed grades (80 + 90 + 40).' );
 	}
 
 	/**

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Tests for grading stats service.
+ *
+ * @package sensei-tests
+ */
 
 namespace SenseiTest\Internal\Services;
 
@@ -11,8 +16,16 @@ use Sensei\Internal\Services\Comments_Based_Grading_Stats_Service;
  */
 class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
+	/**
+	 * Service instance.
+	 *
+	 * @var mixed
+	 */
 	private $sensei_factory;
 
+	/**
+	 * Test setUp.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->sensei_factory = new \Sensei_Factory();
@@ -39,6 +52,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		update_comment_meta( $comment_id, 'grade', $grade );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithNoData_ReturnsZeros.
+	 */
 	public function testGetGradeTotals_WithNoData_ReturnsZeros(): void {
 		global $wpdb;
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
@@ -49,6 +65,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithGradedLessons_ReturnsCountAndSum.
+	 */
 	public function testGetGradeTotals_WithGradedLessons_ReturnsCountAndSum(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -63,6 +82,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithUserIdFilter_ReturnsFilteredResults.
+	 */
 	public function testGetGradeTotals_WithUserIdFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
 		$user_1    = $this->sensei_factory->user->create();
@@ -79,6 +101,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithLessonIdFilter_ReturnsFilteredResults.
+	 */
 	public function testGetGradeTotals_WithLessonIdFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
 		$user_id  = $this->sensei_factory->user->create();
@@ -95,6 +120,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithPostInFilter_ReturnsFilteredResults.
+	 */
 	public function testGetGradeTotals_WithPostInFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
 		$user_id  = $this->sensei_factory->user->create();
@@ -113,6 +141,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 140.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetCoursesAverageGrade_WithNoData_ReturnsZero.
+	 */
 	public function testGetCoursesAverageGrade_WithNoData_ReturnsZero(): void {
 		global $wpdb;
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
@@ -122,6 +153,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0.0, $result );
 	}
 
+	/**
+	 * Test testGetCoursesAverageGrade_WithGradedLessons_ReturnsAverage.
+	 */
 	public function testGetCoursesAverageGrade_WithGradedLessons_ReturnsAverage(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -143,6 +177,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result );
 	}
 
+	/**
+	 * Test testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage.
+	 */
 	public function testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage(): void {
 		global $wpdb;
 		$user_id  = $this->sensei_factory->user->create();
@@ -291,6 +328,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result );
 	}
 
+	/**
+	 * Test testGetUsersAverageGrade_WithNoUserIds_ReturnsZero.
+	 */
 	public function testGetUsersAverageGrade_WithNoUserIds_ReturnsZero(): void {
 		global $wpdb;
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
@@ -300,6 +340,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0.0, $result );
 	}
 
+	/**
+	 * Test testGetUsersAverageGrade_WithUserIds_ReturnsAverage.
+	 */
 	public function testGetUsersAverageGrade_WithUserIds_ReturnsAverage(): void {
 		global $wpdb;
 		$user_1    = $this->sensei_factory->user->create();
@@ -315,6 +358,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 70.0, $result );
 	}
 
+	/**
+	 * Test testGetUsersAverageGrade_FilteredBySpecificUser_ReturnsUserAverage.
+	 */
 	public function testGetUsersAverageGrade_FilteredBySpecificUser_ReturnsUserAverage(): void {
 		global $wpdb;
 		$user_1    = $this->sensei_factory->user->create();

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -167,7 +167,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			array(
 				'meta_input' => array(
 					'_lesson_course'      => $course_id,
-					'_quiz_has_questions' => 1,
+
 				),
 			)
 		);
@@ -192,7 +192,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			array(
 				'meta_input' => array(
 					'_lesson_course'      => $course_1,
-					'_quiz_has_questions' => 1,
+
 				),
 			)
 		);
@@ -200,7 +200,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			array(
 				'meta_input' => array(
 					'_lesson_course'      => $course_2,
-					'_quiz_has_questions' => 1,
+
 				),
 			)
 		);
@@ -261,7 +261,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			array(
 				'meta_input' => array(
 					'_lesson_course'      => $course_1,
-					'_quiz_has_questions' => 1,
+
 				),
 			)
 		);
@@ -269,7 +269,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			array(
 				'meta_input' => array(
 					'_lesson_course'      => $course_1,
-					'_quiz_has_questions' => 1,
+
 				),
 			)
 		);
@@ -277,7 +277,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			array(
 				'meta_input' => array(
 					'_lesson_course'      => $course_2,
-					'_quiz_has_questions' => 1,
+
 				),
 			)
 		);
@@ -308,7 +308,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			array(
 				'meta_input' => array(
 					'_lesson_course'      => $course_id,
-					'_quiz_has_questions' => 1,
+
 				),
 			)
 		);

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -39,7 +39,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	 * @param string $status    Comment status (e.g. 'graded', 'passed', 'failed').
 	 * @param int    $grade     The grade value.
 	 */
-	private function create_lesson_status_with_grade( int $lesson_id, int $user_id, string $status, int $grade ): void {
+	private function create_lesson_status_with_grade( int $lesson_id, int $user_id, string $status, int $grade, bool $has_quiz_answers = true ): void {
 		$comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID'  => $lesson_id,
@@ -50,7 +50,9 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			)
 		);
 		update_comment_meta( $comment_id, 'grade', $grade );
-		update_comment_meta( $comment_id, 'quiz_answers', 'a:1:{i:0;s:1:"1";}' );
+		if ( $has_quiz_answers ) {
+			update_comment_meta( $comment_id, 'quiz_answers', 'a:1:{i:0;s:1:"1";}' );
+		}
 	}
 
 	/**
@@ -312,7 +314,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		);
 		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
 
-		// Lesson without quiz (no _quiz_has_questions meta).
+		// Lesson without quiz (no quiz answers).
 		$lesson_2 = $this->sensei_factory->lesson->create(
 			array(
 				'meta_input' => array(
@@ -320,7 +322,7 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 				),
 			)
 		);
-		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 40 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 40, false );
 
 		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_courses_average_grade();

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace SenseiTest\Internal\Services;
+
+use Sensei\Internal\Services\Tables_Based_Grading_Stats_Service;
+
+/**
+ * Class Tables_Based_Grading_Stats_Service_Test.
+ *
+ * @covers \Sensei\Internal\Services\Tables_Based_Grading_Stats_Service
+ */
+class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
+
+	private $sensei_factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->sensei_factory = new \Sensei_Factory();
+	}
+
+	/**
+	 * Insert a progress row directly into the HPPS progress table.
+	 *
+	 * @param int      $post_id        The post ID.
+	 * @param int      $user_id        The user ID.
+	 * @param string   $type           The progress type.
+	 * @param string   $status         The progress status.
+	 * @param int|null $parent_post_id The parent post ID.
+	 */
+	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null ): void {
+		$wpdb   = $GLOBALS['wpdb'];
+		$table  = $wpdb->prefix . 'sensei_lms_progress';
+		$now    = current_time( 'mysql' );
+		$data   = [
+			'post_id'    => $post_id,
+			'user_id'    => $user_id,
+			'type'       => $type,
+			'status'     => $status,
+			'started_at' => $now,
+			'created_at' => $now,
+			'updated_at' => $now,
+		];
+		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
+		if ( null !== $parent_post_id ) {
+			$data['parent_post_id'] = $parent_post_id;
+			$format[]               = '%d';
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
+		$wpdb->insert( $table, $data, $format );
+	}
+
+	/**
+	 * Insert a quiz submission row.
+	 *
+	 * @param int      $quiz_id     The quiz post ID.
+	 * @param int      $user_id     The user ID.
+	 * @param int|null $final_grade The final grade.
+	 */
+	private function insert_quiz_submission( int $quiz_id, int $user_id, ?int $final_grade = null ): void {
+		$wpdb   = $GLOBALS['wpdb'];
+		$table  = $wpdb->prefix . 'sensei_lms_quiz_submissions';
+		$now    = current_time( 'mysql' );
+		$data   = [
+			'quiz_id'    => $quiz_id,
+			'user_id'    => $user_id,
+			'created_at' => $now,
+			'updated_at' => $now,
+		];
+		$format = [ '%d', '%d', '%s', '%s' ];
+		if ( null !== $final_grade ) {
+			$data['final_grade'] = $final_grade;
+			$format[]            = '%d';
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
+		$wpdb->insert( $table, $data, $format );
+	}
+
+	/**
+	 * Helper to set up a graded lesson with quiz in HPPS tables.
+	 *
+	 * @param int    $lesson_id  The lesson ID.
+	 * @param int    $quiz_id    The quiz ID.
+	 * @param int    $user_id    The user ID.
+	 * @param int    $course_id  The course ID.
+	 * @param string $status     The quiz status.
+	 * @param int    $grade      The grade value.
+	 */
+	private function create_graded_lesson( int $lesson_id, int $quiz_id, int $user_id, int $course_id, string $status, int $grade ): void {
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', $status, $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', $status, $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id, $grade );
+	}
+
+	public function testGetGradeTotals_WithNoData_ReturnsZeros(): void {
+		global $wpdb;
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_grade_totals();
+
+		$this->assertSame( 0, $result['count'] );
+		$this->assertSame( 0.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithGradedLesson_ReturnsCountAndSum(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_id ]
+		);
+
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_id, $course_id, 'graded', 80 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals();
+
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 80.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithUserIdFilter_ReturnsFilteredResults(): void {
+		global $wpdb;
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_id ]
+		);
+
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals( [ 'user_id' => $user_1 ] );
+
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 80.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithLessonIdFilter_ReturnsFilteredResults(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_1  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_1    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_1 ]
+		);
+		$lesson_2  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_2    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_2 ]
+		);
+
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_id, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals( [ 'lesson_id' => $lesson_1 ] );
+
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 80.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithPostInFilter_ReturnsFilteredResults(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_1  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_1    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_1 ]
+		);
+		$lesson_2  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_2    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_2 ]
+		);
+		$lesson_3  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_3    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_3 ]
+		);
+
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_id, 'graded', 60 );
+		$this->create_graded_lesson( $lesson_3, $quiz_3, $user_id, $course_id, 'graded', 40 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals( [ 'post__in' => [ $lesson_1, $lesson_2 ] ] );
+
+		$this->assertSame( 2, $result['count'] );
+		$this->assertSame( 140.0, $result['sum'] );
+	}
+
+	public function testGetGradeTotals_WithNullFinalGrade_ExcludesFromResults(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_id ]
+		);
+
+		// Lesson progress exists but quiz submission has no grade.
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'graded', $course_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded', $lesson_id );
+		$this->insert_quiz_submission( $quiz_id, $user_id, null );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals();
+
+		$this->assertSame( 0, $result['count'] );
+	}
+
+	public function testGetCoursesAverageGrade_WithNoData_ReturnsZero(): void {
+		global $wpdb;
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_courses_average_grade();
+
+		$this->assertSame( 0.0, $result );
+	}
+
+	public function testGetCoursesAverageGrade_WithGradedLessons_ReturnsAverage(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_id ]
+		);
+
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_id, $course_id, 'graded', 80 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade();
+
+		$this->assertSame( 80.0, $result );
+	}
+
+	public function testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_1  = $this->sensei_factory->course->create();
+		$course_2  = $this->sensei_factory->course->create();
+		$lesson_1  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_1 ] ]
+		);
+		$quiz_1    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_1 ]
+		);
+		$lesson_2  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_2 ] ]
+		);
+		$quiz_2    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_2 ]
+		);
+
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_1, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_2, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade( [ $course_1 ] );
+
+		$this->assertSame( 80.0, $result );
+	}
+
+	public function testGetCoursesAverageGrade_WithMultipleCourses_ReturnsAverageOfAverages(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_1  = $this->sensei_factory->course->create();
+		$course_2  = $this->sensei_factory->course->create();
+		$lesson_1  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_1 ] ]
+		);
+		$quiz_1    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_1 ]
+		);
+		$lesson_2  = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_2 ] ]
+		);
+		$quiz_2    = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_2 ]
+		);
+
+		// Course 1: grade 80, Course 2: grade 60. Average of averages = (80 + 60) / 2 = 70.
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_1, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_2, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade();
+
+		$this->assertSame( 70.0, $result );
+	}
+
+	public function testGetUsersAverageGrade_WithNoUserIds_ReturnsZero(): void {
+		global $wpdb;
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_users_average_grade( [] );
+
+		$this->assertSame( 0.0, $result );
+	}
+
+	public function testGetUsersAverageGrade_WithUserIds_ReturnsAverage(): void {
+		global $wpdb;
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_id ]
+		);
+
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_users_average_grade( [ $user_1, $user_2 ] );
+
+		$this->assertSame( 70.0, $result );
+	}
+
+	public function testGetUsersAverageGrade_FilteredBySpecificUser_ReturnsUserAverage(): void {
+		global $wpdb;
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			[ 'post_parent' => $lesson_id ]
+		);
+
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_users_average_grade( [ $user_1 ] );
+
+		$this->assertSame( 80.0, $result );
+	}
+}

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -31,7 +31,7 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
-		$data   = [
+		$data   = array(
 			'post_id'    => $post_id,
 			'user_id'    => $user_id,
 			'type'       => $type,
@@ -39,8 +39,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			'started_at' => $now,
 			'created_at' => $now,
 			'updated_at' => $now,
-		];
-		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
+		);
+		$format = array( '%d', '%d', '%s', '%s', '%s', '%s', '%s' );
 		if ( null !== $parent_post_id ) {
 			$data['parent_post_id'] = $parent_post_id;
 			$format[]               = '%d';
@@ -60,13 +60,13 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_quiz_submissions';
 		$now    = current_time( 'mysql' );
-		$data   = [
+		$data   = array(
 			'quiz_id'    => $quiz_id,
 			'user_id'    => $user_id,
 			'created_at' => $now,
 			'updated_at' => $now,
-		];
-		$format = [ '%d', '%d', '%s', '%s' ];
+		);
+		$format = array( '%d', '%d', '%s', '%s' );
 		if ( null !== $final_grade ) {
 			$data['final_grade'] = $final_grade;
 			$format[]            = '%d';
@@ -106,10 +106,10 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_id ]
+			array( 'post_parent' => $lesson_id )
 		);
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_id, $course_id, 'graded', 80 );
@@ -127,17 +127,17 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_2    = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_id ]
+			array( 'post_parent' => $lesson_id )
 		);
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_grade_totals( [ 'user_id' => $user_1 ] );
+		$result  = $service->get_grade_totals( array( 'user_id' => $user_1 ) );
 
 		$this->assertSame( 1, $result['count'] );
 		$this->assertSame( 80.0, $result['sum'] );
@@ -148,23 +148,23 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_1  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_1    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_1 ]
+			array( 'post_parent' => $lesson_1 )
 		);
 		$lesson_2  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_2    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_2 ]
+			array( 'post_parent' => $lesson_2 )
 		);
 
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_id, 'graded', 60 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_grade_totals( [ 'lesson_id' => $lesson_1 ] );
+		$result  = $service->get_grade_totals( array( 'lesson_id' => $lesson_1 ) );
 
 		$this->assertSame( 1, $result['count'] );
 		$this->assertSame( 80.0, $result['sum'] );
@@ -175,22 +175,22 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_1  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_1    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_1 ]
+			array( 'post_parent' => $lesson_1 )
 		);
 		$lesson_2  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_2    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_2 ]
+			array( 'post_parent' => $lesson_2 )
 		);
 		$lesson_3  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_3    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_3 ]
+			array( 'post_parent' => $lesson_3 )
 		);
 
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
@@ -198,7 +198,7 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->create_graded_lesson( $lesson_3, $quiz_3, $user_id, $course_id, 'graded', 40 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_grade_totals( [ 'post__in' => [ $lesson_1, $lesson_2 ] ] );
+		$result  = $service->get_grade_totals( array( 'post__in' => array( $lesson_1, $lesson_2 ) ) );
 
 		$this->assertSame( 2, $result['count'] );
 		$this->assertSame( 140.0, $result['sum'] );
@@ -209,10 +209,10 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_id ]
+			array( 'post_parent' => $lesson_id )
 		);
 
 		// Lesson progress exists but quiz submission has no grade.
@@ -240,10 +240,10 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_id ]
+			array( 'post_parent' => $lesson_id )
 		);
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_id, $course_id, 'graded', 80 );
@@ -256,47 +256,47 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 	public function testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage(): void {
 		global $wpdb;
-		$user_id   = $this->sensei_factory->user->create();
-		$course_1  = $this->sensei_factory->course->create();
-		$course_2  = $this->sensei_factory->course->create();
-		$lesson_1  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_1 ] ]
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_1 ) )
 		);
-		$quiz_1    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_1 ]
+		$quiz_1   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_1 )
 		);
-		$lesson_2  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_2 ] ]
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_2 ) )
 		);
-		$quiz_2    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_2 ]
+		$quiz_2   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_2 )
 		);
 
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_1, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_2, 'graded', 60 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_courses_average_grade( [ $course_1 ] );
+		$result  = $service->get_courses_average_grade( array( $course_1 ) );
 
 		$this->assertSame( 80.0, $result );
 	}
 
 	public function testGetCoursesAverageGrade_WithMultipleCourses_ReturnsAverageOfAverages(): void {
 		global $wpdb;
-		$user_id   = $this->sensei_factory->user->create();
-		$course_1  = $this->sensei_factory->course->create();
-		$course_2  = $this->sensei_factory->course->create();
-		$lesson_1  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_1 ] ]
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_1 ) )
 		);
-		$quiz_1    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_1 ]
+		$quiz_1   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_1 )
 		);
-		$lesson_2  = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_2 ] ]
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_2 ) )
 		);
-		$quiz_2    = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_2 ]
+		$quiz_2   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_2 )
 		);
 
 		// Course 1: grade 80, Course 2: grade 60. Average of averages = (80 + 60) / 2 = 70.
@@ -313,7 +313,7 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 
-		$result = $service->get_users_average_grade( [] );
+		$result = $service->get_users_average_grade( array() );
 
 		$this->assertSame( 0.0, $result );
 	}
@@ -324,17 +324,17 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_2    = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_id ]
+			array( 'post_parent' => $lesson_id )
 		);
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_users_average_grade( [ $user_1, $user_2 ] );
+		$result  = $service->get_users_average_grade( array( $user_1, $user_2 ) );
 
 		$this->assertSame( 70.0, $result );
 	}
@@ -345,17 +345,17 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_2    = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[ 'post_parent' => $lesson_id ]
+			array( 'post_parent' => $lesson_id )
 		);
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
-		$result  = $service->get_users_average_grade( [ $user_1 ] );
+		$result  = $service->get_users_average_grade( array( $user_1 ) );
 
 		$this->assertSame( 80.0, $result );
 	}

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -309,6 +309,87 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 70.0, $result );
 	}
 
+	/**
+	 * Tests that get_grade_totals only includes graded, passed, and failed statuses.
+	 */
+	public function testGetGradeTotals_WithMixedStatuses_OnlyCountsGradedPassedFailed(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+
+		// These should be included.
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_1   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_1 )
+		);
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
+
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_2   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_2 )
+		);
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_id, 'passed', 90 );
+
+		$lesson_3 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_3   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_3 )
+		);
+		$this->create_graded_lesson( $lesson_3, $quiz_3, $user_id, $course_id, 'failed', 40 );
+
+		// This should be excluded: 'in-progress' status with a grade.
+		$lesson_4 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_4   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_4 )
+		);
+		$this->insert_progress( $lesson_4, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $quiz_4, $user_id, 'quiz', 'in-progress', $lesson_4 );
+		$this->insert_quiz_submission( $quiz_4, $user_id, 100 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals();
+
+		$this->assertSame( 3, $result['count'] );
+		$this->assertSame( 210.0, $result['sum'] ); // 80 + 90 + 40.
+	}
+
+	/**
+	 * Tests that get_courses_average_grade excludes lessons without quizzes.
+	 */
+	public function testGetCoursesAverageGrade_WithLessonWithoutQuiz_ExcludesFromAverage(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+
+		// Lesson with quiz.
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_1   = $this->sensei_factory->quiz->create(
+			array( 'post_parent' => $lesson_1 )
+		);
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
+
+		// Lesson without quiz: only lesson progress, no quiz progress or submission.
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$this->insert_progress( $lesson_2, $user_id, 'lesson', 'complete', $course_id );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_courses_average_grade();
+
+		// Only the lesson with quiz should be included.
+		$this->assertSame( 80.0, $result );
+	}
+
 	public function testGetUsersAverageGrade_WithNoUserIds_ReturnsZero(): void {
 		global $wpdb;
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Tests for grading stats service.
+ *
+ * @package sensei-tests
+ */
 
 namespace SenseiTest\Internal\Services;
 
@@ -11,8 +16,16 @@ use Sensei\Internal\Services\Tables_Based_Grading_Stats_Service;
  */
 class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
+	/**
+	 * Service instance.
+	 *
+	 * @var mixed
+	 */
 	private $sensei_factory;
 
+	/**
+	 * Test setUp.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->sensei_factory = new \Sensei_Factory();
@@ -91,6 +104,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->insert_quiz_submission( $quiz_id, $user_id, $grade );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithNoData_ReturnsZeros.
+	 */
 	public function testGetGradeTotals_WithNoData_ReturnsZeros(): void {
 		global $wpdb;
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
@@ -101,6 +117,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithGradedLesson_ReturnsCountAndSum.
+	 */
 	public function testGetGradeTotals_WithGradedLesson_ReturnsCountAndSum(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -121,6 +140,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithUserIdFilter_ReturnsFilteredResults.
+	 */
 	public function testGetGradeTotals_WithUserIdFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
 		$user_1    = $this->sensei_factory->user->create();
@@ -143,6 +165,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithLessonIdFilter_ReturnsFilteredResults.
+	 */
 	public function testGetGradeTotals_WithLessonIdFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -170,6 +195,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithPostInFilter_ReturnsFilteredResults.
+	 */
 	public function testGetGradeTotals_WithPostInFilter_ReturnsFilteredResults(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -204,6 +232,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 140.0, $result['sum'] );
 	}
 
+	/**
+	 * Test testGetGradeTotals_WithNullFinalGrade_ExcludesFromResults.
+	 */
 	public function testGetGradeTotals_WithNullFinalGrade_ExcludesFromResults(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -226,6 +257,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result['count'] );
 	}
 
+	/**
+	 * Test testGetCoursesAverageGrade_WithNoData_ReturnsZero.
+	 */
 	public function testGetCoursesAverageGrade_WithNoData_ReturnsZero(): void {
 		global $wpdb;
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
@@ -235,6 +269,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0.0, $result );
 	}
 
+	/**
+	 * Test testGetCoursesAverageGrade_WithGradedLessons_ReturnsAverage.
+	 */
 	public function testGetCoursesAverageGrade_WithGradedLessons_ReturnsAverage(): void {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
@@ -254,6 +291,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result );
 	}
 
+	/**
+	 * Test testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage.
+	 */
 	public function testGetCoursesAverageGrade_WithCourseIdsFilter_ReturnsFilteredAverage(): void {
 		global $wpdb;
 		$user_id  = $this->sensei_factory->user->create();
@@ -281,6 +321,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result );
 	}
 
+	/**
+	 * Test testGetCoursesAverageGrade_WithMultipleCourses_ReturnsAverageOfAverages.
+	 */
 	public function testGetCoursesAverageGrade_WithMultipleCourses_ReturnsAverageOfAverages(): void {
 		global $wpdb;
 		$user_id  = $this->sensei_factory->user->create();
@@ -390,6 +433,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 80.0, $result );
 	}
 
+	/**
+	 * Test testGetUsersAverageGrade_WithNoUserIds_ReturnsZero.
+	 */
 	public function testGetUsersAverageGrade_WithNoUserIds_ReturnsZero(): void {
 		global $wpdb;
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
@@ -399,6 +445,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0.0, $result );
 	}
 
+	/**
+	 * Test testGetUsersAverageGrade_WithUserIds_ReturnsAverage.
+	 */
 	public function testGetUsersAverageGrade_WithUserIds_ReturnsAverage(): void {
 		global $wpdb;
 		$user_1    = $this->sensei_factory->user->create();
@@ -420,6 +469,9 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 70.0, $result );
 	}
 
+	/**
+	 * Test testGetUsersAverageGrade_FilteredBySpecificUser_ReturnsUserAverage.
+	 */
 	public function testGetUsersAverageGrade_FilteredBySpecificUser_ReturnsUserAverage(): void {
 		global $wpdb;
 		$user_1    = $this->sensei_factory->user->create();

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -124,12 +124,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_id )
-		);
+		$lesson_id = $this->sensei_factory->lesson->create();
+		$quiz_id   = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_id, $course_id, 'graded', 80 );
 
@@ -148,12 +144,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_1    = $this->sensei_factory->user->create();
 		$user_2    = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_id )
-		);
+		$lesson_id = $this->sensei_factory->lesson->create();
+		$quiz_id   = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
@@ -172,18 +164,10 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_1  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_1    = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_1 )
-		);
-		$lesson_2  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_2    = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_2 )
-		);
+		$lesson_1  = $this->sensei_factory->lesson->create();
+		$quiz_1    = $this->sensei_factory->quiz->create();
+		$lesson_2  = $this->sensei_factory->lesson->create();
+		$quiz_2    = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_id, 'graded', 60 );
@@ -202,24 +186,12 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_1  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_1    = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_1 )
-		);
-		$lesson_2  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_2    = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_2 )
-		);
-		$lesson_3  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_3    = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_3 )
-		);
+		$lesson_1  = $this->sensei_factory->lesson->create();
+		$quiz_1    = $this->sensei_factory->quiz->create();
+		$lesson_2  = $this->sensei_factory->lesson->create();
+		$quiz_2    = $this->sensei_factory->quiz->create();
+		$lesson_3  = $this->sensei_factory->lesson->create();
+		$quiz_3    = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_id, 'graded', 60 );
@@ -239,12 +211,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_id )
-		);
+		$lesson_id = $this->sensei_factory->lesson->create();
+		$quiz_id   = $this->sensei_factory->quiz->create();
 
 		// Lesson progress exists but quiz submission has no grade.
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'graded', $course_id );
@@ -276,12 +244,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		global $wpdb;
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_id )
-		);
+		$lesson_id = $this->sensei_factory->lesson->create();
+		$quiz_id   = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_id, $course_id, 'graded', 80 );
 
@@ -299,18 +263,10 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_id  = $this->sensei_factory->user->create();
 		$course_1 = $this->sensei_factory->course->create();
 		$course_2 = $this->sensei_factory->course->create();
-		$lesson_1 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_1 ) )
-		);
-		$quiz_1   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_1 )
-		);
-		$lesson_2 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_2 ) )
-		);
-		$quiz_2   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_2 )
-		);
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$quiz_1   = $this->sensei_factory->quiz->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$quiz_2   = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_1, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_2, 'graded', 60 );
@@ -329,27 +285,24 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_id  = $this->sensei_factory->user->create();
 		$course_1 = $this->sensei_factory->course->create();
 		$course_2 = $this->sensei_factory->course->create();
-		$lesson_1 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_1 ) )
-		);
-		$quiz_1   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_1 )
-		);
-		$lesson_2 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_2 ) )
-		);
-		$quiz_2   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_2 )
-		);
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$quiz_1   = $this->sensei_factory->quiz->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$quiz_2   = $this->sensei_factory->quiz->create();
+		$lesson_3 = $this->sensei_factory->lesson->create();
+		$quiz_3   = $this->sensei_factory->quiz->create();
 
-		// Course 1: grade 80, Course 2: grade 60. Average of averages = (80 + 60) / 2 = 70.
+		// Course 1: grades 80, 60 -> avg 70.
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_1, 'graded', 80 );
-		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_2, 'graded', 60 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_1, 'passed', 60 );
+		// Course 2: grade 90 -> avg 90.
+		$this->create_graded_lesson( $lesson_3, $quiz_3, $user_id, $course_2, 'failed', 90 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_courses_average_grade();
 
-		$this->assertSame( 70.0, $result );
+		// Average of averages: (70 + 90) / 2 = 80.
+		$this->assertSame( 80.0, $result );
 	}
 
 	/**
@@ -361,37 +314,21 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$course_id = $this->sensei_factory->course->create();
 
 		// These should be included.
-		$lesson_1 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_1   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_1 )
-		);
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$quiz_1   = $this->sensei_factory->quiz->create();
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
 
-		$lesson_2 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_2   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_2 )
-		);
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$quiz_2   = $this->sensei_factory->quiz->create();
 		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_id, 'passed', 90 );
 
-		$lesson_3 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_3   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_3 )
-		);
+		$lesson_3 = $this->sensei_factory->lesson->create();
+		$quiz_3   = $this->sensei_factory->quiz->create();
 		$this->create_graded_lesson( $lesson_3, $quiz_3, $user_id, $course_id, 'failed', 40 );
 
 		// This should be excluded: 'in-progress' status with a grade.
-		$lesson_4 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_4   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_4 )
-		);
+		$lesson_4 = $this->sensei_factory->lesson->create();
+		$quiz_4   = $this->sensei_factory->quiz->create();
 		$this->insert_progress( $lesson_4, $user_id, 'lesson', 'in-progress', $course_id );
 		$this->insert_progress( $quiz_4, $user_id, 'quiz', 'in-progress', $lesson_4 );
 		$this->insert_quiz_submission( $quiz_4, $user_id, 100 );
@@ -412,18 +349,12 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$course_id = $this->sensei_factory->course->create();
 
 		// Lesson with quiz.
-		$lesson_1 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_1   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_1 )
-		);
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$quiz_1   = $this->sensei_factory->quiz->create();
 		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_id, 'graded', 80 );
 
 		// Lesson without quiz: only lesson progress, no quiz progress or submission.
-		$lesson_2 = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
+		$lesson_2 = $this->sensei_factory->lesson->create();
 		$this->insert_progress( $lesson_2, $user_id, 'lesson', 'complete', $course_id );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
@@ -453,12 +384,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_1    = $this->sensei_factory->user->create();
 		$user_2    = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_id )
-		);
+		$lesson_id = $this->sensei_factory->lesson->create();
+		$quiz_id   = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );
@@ -477,12 +404,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$user_1    = $this->sensei_factory->user->create();
 		$user_2    = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array( 'post_parent' => $lesson_id )
-		);
+		$lesson_id = $this->sensei_factory->lesson->create();
+		$quiz_id   = $this->sensei_factory->quiz->create();
 
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
 		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'graded', 60 );

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -226,6 +226,38 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test testGetGradeTotals_WithCombinedFilters_AppliesAllFilters.
+	 */
+	public function testGetGradeTotals_WithCombinedFilters_AppliesAllFilters(): void {
+		global $wpdb;
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_1  = $this->sensei_factory->lesson->create();
+		$quiz_1    = $this->sensei_factory->quiz->create();
+		$lesson_2  = $this->sensei_factory->lesson->create();
+		$quiz_2    = $this->sensei_factory->quiz->create();
+
+		// User 1: grade 80 on lesson 1, grade 70 on lesson 2.
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_1, $course_id, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_1, $course_id, 'graded', 70 );
+		// User 2: grade 60 on lesson 1.
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_2, $course_id, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals(
+			array(
+				'user_id'   => $user_1,
+				'lesson_id' => $lesson_1,
+			)
+		);
+
+		// Only user 1's grade on lesson 1 should match.
+		$this->assertSame( 1, $result['count'], 'Combined user_id and lesson_id filter should match exactly one row.' );
+		$this->assertSame( 80.0, $result['sum'], 'Combined user_id and lesson_id filter should sum only user 1 on lesson 1.' );
+	}
+
+	/**
 	 * Test testGetCoursesAverageGrade_WithNoData_ReturnsZero.
 	 */
 	public function testGetCoursesAverageGrade_WithNoData_ReturnsZero(): void {

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -113,8 +113,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 		$result = $service->get_grade_totals();
 
-		$this->assertSame( 0, $result['count'] );
-		$this->assertSame( 0.0, $result['sum'] );
+		$this->assertSame( 0, $result['count'], 'Count should be 0 when no data exists.' );
+		$this->assertSame( 0.0, $result['sum'], 'Sum should be 0.0 when no data exists.' );
 	}
 
 	/**
@@ -132,8 +132,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals();
 
-		$this->assertSame( 1, $result['count'] );
-		$this->assertSame( 80.0, $result['sum'] );
+		$this->assertSame( 1, $result['count'], 'Count should be 1 for a single graded lesson.' );
+		$this->assertSame( 80.0, $result['sum'], 'Sum should equal the single grade value.' );
 	}
 
 	/**
@@ -153,8 +153,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals( array( 'user_id' => $user_1 ) );
 
-		$this->assertSame( 1, $result['count'] );
-		$this->assertSame( 80.0, $result['sum'] );
+		$this->assertSame( 1, $result['count'], 'user_id filter should match exactly user 1.' );
+		$this->assertSame( 80.0, $result['sum'], 'user_id filter should sum only user 1 grades.' );
 	}
 
 	/**
@@ -175,8 +175,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals( array( 'lesson_id' => $lesson_1 ) );
 
-		$this->assertSame( 1, $result['count'] );
-		$this->assertSame( 80.0, $result['sum'] );
+		$this->assertSame( 1, $result['count'], 'lesson_id filter should match exactly lesson 1.' );
+		$this->assertSame( 80.0, $result['sum'], 'lesson_id filter should sum only lesson 1 grades.' );
 	}
 
 	/**
@@ -200,8 +200,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals( array( 'post__in' => array( $lesson_1, $lesson_2 ) ) );
 
-		$this->assertSame( 2, $result['count'] );
-		$this->assertSame( 140.0, $result['sum'] );
+		$this->assertSame( 2, $result['count'], 'post__in filter should match the two specified lessons.' );
+		$this->assertSame( 140.0, $result['sum'], 'post__in filter should sum only the specified lessons.' );
 	}
 
 	/**
@@ -368,8 +368,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_grade_totals();
 
-		$this->assertSame( 3, $result['count'] );
-		$this->assertSame( 210.0, $result['sum'] ); // 80 + 90 + 40.
+		$this->assertSame( 3, $result['count'], 'Only graded/passed/failed statuses should be counted.' );
+		$this->assertSame( 210.0, $result['sum'], 'Sum should only include graded/passed/failed grades (80 + 90 + 40).' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -451,8 +451,9 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[1], 'passed' );
 
 		// Assign a grade to each lesson for each student.
-		$this->assignGrade( $comment_ids[0], '10' );
-		$this->assignGrade( $comment_ids[1], '50' );
+		// Lesson 0 has no quiz, so no quiz_answers.
+		$this->assignGrade( $comment_ids[0], '10', false );
+		$this->assignGrade( $comment_ids[1], '50', false );
 		$this->assignGrade( $comment_ids[2], '100' );
 		$this->assignGrade( $comment_ids[3], '35' );
 		$this->assignGrade( $comment_ids[4], '70' );
@@ -754,7 +755,10 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 * @param int    $comment_id Comment ID.
 	 * @param string $grade      Grade.
 	 */
-	private function assignGrade( $comment_id, $grade ) {
+	private function assignGrade( $comment_id, $grade, $has_quiz_answers = true ) {
 		add_comment_meta( $comment_id, 'grade', $grade );
+		if ( '' !== $grade && $has_quiz_answers ) {
+			add_comment_meta( $comment_id, 'quiz_answers', 'a:1:{i:0;s:1:"1";}' );
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Creates `Grading_Stats_Service_Interface` with 3 consolidated methods (`get_grade_totals`, `get_courses_average_grade`, `get_users_average_grade`) covering 8 previous use cases
- Adds tables-based implementation querying `sensei_lms_quiz_submissions.final_grade` and comments-based implementation with existing SQL
- Wires consumers: delegates 7 methods in `Sensei_Grading` and grade methods in both Reports Overview Services

## Bug Fix
- Fixes a bug where spurious `grade=0` comment meta (written by `Sensei_Utils::sensei_start_lesson()` on lesson start, not from actual grading) was included in grade averages, dragging them down. The new service filters by grading statuses (`graded`, `passed`, `failed`) to exclude these rows.

## Setup
After checking out the branch, run `composer dump-autoload` to register the new service classes in the autoload classmap.

## Test plan
- [x] Go to **Sensei LMS > Settings > Experimental Features** and ensure **Store the progress of your students in separate tables** is enabled, and **Synchronize student progress** is on
- [x] Set **Progress storage repository** to **WordPress comments based storage**
- [x] Go to **Sensei LMS > Reports > Courses** and note the **Average Grade (X%)** value in the column header and the per-row **Average Grade** values
- [x] Go to **Sensei LMS > Reports > Students** and note the **Average Grade (X%)** value in the column header and the per-row **Average Grade** values
- [x] On each Reports page, apply a date filter that narrows to a clearly different set of items (e.g. a range covering only 1–2 courses, or one with no graded items) and note the header value behaves consistently
- [x] Switch **Progress storage repository** to **Sensei LMS tables storage** and reload both Reports pages
- [x] The **Average Grade (X%)** header values should match between the two repository settings on both pages
- [x] The per-row **Average Grade** values should match between the two repository settings on both pages
- [x] Filtered header values should match between the two repository settings

Note that the Average Grade values should either be **the same or higher** when comparing against trunk, due to the bug fix mentioned above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
