### PR TITLE
Sync HPPS parent_post_id when a lesson is reassigned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 
 ## Conventions
 - **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `npm run changelog` (entries stored in `changelog/`).
+- **Test assertions**: When a single test has multiple assertions, pass a message as the third argument to each assertion (e.g., `self::assertSame( $expected, $actual, 'Foo should be updated.' );`) so a failure points to the specific check that failed.

--- a/changelog/fix-hpps-lesson-course-sync
+++ b/changelog/fix-hpps-lesson-course-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync the HPPS progress table's course association when a lesson is moved between courses.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -30,6 +30,7 @@ use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progres
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Interface;
 use Sensei\Internal\Student_Progress\Services\Course_Deleted_Handler;
+use Sensei\Internal\Student_Progress\Services\Lesson_Course_Sync_Handler;
 use Sensei\Internal\Student_Progress\Services\Lesson_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\Quiz_Deleted_Handler;
 use Sensei\Internal\Student_Progress\Services\User_Deleted_Handler;
@@ -819,6 +820,11 @@ class Sensei_Main {
 		( new Quiz_Deleted_Handler( $this->quiz_progress_repository ) )->init();
 		( new User_Deleted_Handler( $this->course_progress_repository, $this->lesson_progress_repository, $this->quiz_progress_repository ) )->init();
 
+		// Keep parent_post_id on lesson progress rows in sync with the lesson's _lesson_course postmeta.
+		if ( $tables_feature_enabled ) {
+			( new Lesson_Course_Sync_Handler( $GLOBALS['wpdb'] ) )->init();
+		}
+
 		// Cron for periodically cleaning guest user related data.
 		Sensei_Temporary_User_Cleaner::instance()->init();
 
@@ -846,7 +852,7 @@ class Sensei_Main {
 		 * @return {bool} Whether to enable feature.
 		 */
 		if ( apply_filters( 'sensei_email_mailpoet_feature', true ) ) {
-			add_action( 'mailpoet_initialized', [ $this, 'initialize_mailpoet' ] );
+			add_action( 'mailpoet_initialized', array( $this, 'initialize_mailpoet' ) );
 		}
 	}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -852,7 +852,7 @@ class Sensei_Main {
 		 * @return {bool} Whether to enable feature.
 		 */
 		if ( apply_filters( 'sensei_email_mailpoet_feature', true ) ) {
-			add_action( 'mailpoet_initialized', array( $this, 'initialize_mailpoet' ) );
+			add_action( 'mailpoet_initialized', [ $this, 'initialize_mailpoet' ] );
 		}
 	}
 

--- a/includes/internal/student-progress/services/class-lesson-course-sync-handler.php
+++ b/includes/internal/student-progress/services/class-lesson-course-sync-handler.php
@@ -7,6 +7,7 @@
 
 namespace Sensei\Internal\Student_Progress\Services;
 
+use Sensei\Internal\Services\Utils;
 use wpdb;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -52,9 +53,9 @@ class Lesson_Course_Sync_Handler {
 	 * Adds hooks.
 	 */
 	public function init(): void {
-		add_action( 'added_post_meta', array( $this, 'handle_meta_change' ), 10, 4 );
-		add_action( 'updated_post_meta', array( $this, 'handle_meta_change' ), 10, 4 );
-		add_action( 'deleted_post_meta', array( $this, 'handle_meta_delete' ), 10, 3 );
+		add_action( 'added_post_meta', [ $this, 'handle_meta_change' ], 10, 4 );
+		add_action( 'updated_post_meta', [ $this, 'handle_meta_change' ], 10, 4 );
+		add_action( 'deleted_post_meta', [ $this, 'handle_meta_delete' ], 10, 3 );
 	}
 
 	/**
@@ -70,7 +71,7 @@ class Lesson_Course_Sync_Handler {
 			return;
 		}
 
-		$course_id = (int) $meta_value;
+		$course_id = is_scalar( $meta_value ) ? (int) $meta_value : 0;
 		$this->update_parent_post_id( $object_id, $course_id > 0 ? $course_id : null );
 	}
 
@@ -111,19 +112,22 @@ class Lesson_Course_Sync_Handler {
 	 * @param int|null $parent_post_id New course ID, or null to clear.
 	 */
 	private function update_parent_post_id( int $lesson_id, ?int $parent_post_id ): void {
-		if ( $lesson_id <= 0 ) {
-			return;
-		}
-
-		$this->wpdb->update(
+		$result = $this->wpdb->update(
 			$this->wpdb->prefix . 'sensei_lms_progress',
 			array( 'parent_post_id' => $parent_post_id ),
 			array(
 				'post_id' => $lesson_id,
 				'type'    => 'lesson',
 			),
-			null === $parent_post_id ? null : array( '%d' ),
+			array( '%d' ),
 			array( '%d', '%s' )
 		);
+
+		if ( false === $result ) {
+			Utils::log_query_error(
+				$this->wpdb,
+				sprintf( 'Lesson_Course_Sync_Handler::update_parent_post_id lesson_id=%d parent_post_id=%s', $lesson_id, null === $parent_post_id ? 'NULL' : (string) $parent_post_id )
+			);
+		}
 	}
 }

--- a/includes/internal/student-progress/services/class-lesson-course-sync-handler.php
+++ b/includes/internal/student-progress/services/class-lesson-course-sync-handler.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * File containing the Lesson_Course_Sync_Handler class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Student_Progress\Services;
+
+use wpdb;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Lesson_Course_Sync_Handler.
+ *
+ * Keeps the parent_post_id column on lesson progress rows in the
+ * wp_sensei_lms_progress table in sync with the lesson's _lesson_course
+ * postmeta. Without this, reassigning a lesson to a different course leaves
+ * the table-based storage pointing at the old course, causing HPPS code
+ * paths that group or filter by parent_post_id to return stale results.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+class Lesson_Course_Sync_Handler {
+	/**
+	 * The lesson course meta key.
+	 */
+	private const LESSON_COURSE_META_KEY = '_lesson_course';
+
+	/**
+	 * WordPress database object.
+	 *
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param wpdb $wpdb WordPress database object.
+	 */
+	public function __construct( wpdb $wpdb ) {
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Adds hooks.
+	 */
+	public function init(): void {
+		add_action( 'added_post_meta', array( $this, 'handle_meta_change' ), 10, 4 );
+		add_action( 'updated_post_meta', array( $this, 'handle_meta_change' ), 10, 4 );
+		add_action( 'deleted_post_meta', array( $this, 'handle_meta_delete' ), 10, 3 );
+	}
+
+	/**
+	 * Handle a postmeta add/update event.
+	 *
+	 * @param int    $meta_id    Meta ID (unused).
+	 * @param int    $object_id  Post ID the meta belongs to.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value New meta value.
+	 */
+	public function handle_meta_change( $meta_id, int $object_id, $meta_key, $meta_value ): void {
+		if ( ! $this->is_relevant_meta( $meta_key, $object_id ) ) {
+			return;
+		}
+
+		$course_id = (int) $meta_value;
+		$this->update_parent_post_id( $object_id, $course_id > 0 ? $course_id : null );
+	}
+
+	/**
+	 * Handle a postmeta delete event.
+	 *
+	 * @param array  $meta_ids  Meta IDs (unused).
+	 * @param int    $object_id Post ID the meta belongs to.
+	 * @param string $meta_key  Meta key.
+	 */
+	public function handle_meta_delete( $meta_ids, int $object_id, $meta_key ): void {
+		if ( ! $this->is_relevant_meta( $meta_key, $object_id ) ) {
+			return;
+		}
+
+		$this->update_parent_post_id( $object_id, null );
+	}
+
+	/**
+	 * Whether the meta event applies to a lesson's _lesson_course postmeta.
+	 *
+	 * @param string $meta_key  Meta key.
+	 * @param int    $object_id Post ID.
+	 * @return bool
+	 */
+	private function is_relevant_meta( $meta_key, int $object_id ): bool {
+		if ( self::LESSON_COURSE_META_KEY !== $meta_key ) {
+			return false;
+		}
+
+		return 'lesson' === get_post_type( $object_id );
+	}
+
+	/**
+	 * Update parent_post_id on all lesson progress rows for the given lesson.
+	 *
+	 * @param int      $lesson_id     Lesson ID.
+	 * @param int|null $parent_post_id New course ID, or null to clear.
+	 */
+	private function update_parent_post_id( int $lesson_id, ?int $parent_post_id ): void {
+		if ( $lesson_id <= 0 ) {
+			return;
+		}
+
+		$this->wpdb->update(
+			$this->wpdb->prefix . 'sensei_lms_progress',
+			array( 'parent_post_id' => $parent_post_id ),
+			array(
+				'post_id' => $lesson_id,
+				'type'    => 'lesson',
+			),
+			null === $parent_post_id ? null : array( '%d' ),
+			array( '%d', '%s' )
+		);
+	}
+}

--- a/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
@@ -268,6 +268,32 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the full add → update → delete lifecycle end-to-end via the WP meta API,
+	 * locking in that all three registered hooks are wired correctly.
+	 */
+	public function testHandleMeta_FullLifecycle_AddUpdateDelete(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id = $this->factory->lesson->create();
+		$row       = $this->insert_progress_row( $lesson_id, 11, 0 );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+		$handler->init();
+
+		/* Act + Assert: add. */
+		add_post_meta( $lesson_id, '_lesson_course', 100, true );
+		self::assertSame( 100, $this->get_parent_post_id( $row ), 'add_post_meta should set parent_post_id to the new course.' );
+
+		/* Act + Assert: update. */
+		update_post_meta( $lesson_id, '_lesson_course', 200 );
+		self::assertSame( 200, $this->get_parent_post_id( $row ), 'update_post_meta should set parent_post_id to the new course.' );
+
+		/* Act + Assert: delete. */
+		delete_post_meta( $lesson_id, '_lesson_course' );
+		$this->assertParentPostIdIsSqlNull( $row );
+	}
+
+	/**
 	 * Data provider for invalid meta values.
 	 *
 	 * @return array<string, array{mixed}>

--- a/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
@@ -160,7 +160,7 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 		$handler->handle_meta_change( 1, $lesson_id, '_lesson_course', $meta_value );
 
 		/* Assert. */
-		self::assertNull( $this->get_parent_post_id( $row ) );
+		$this->assertParentPostIdIsSqlNull( $row );
 	}
 
 	/**
@@ -217,7 +217,7 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 		$handler->handle_meta_delete( array( 1 ), $lesson_id, '_lesson_course' );
 
 		/* Assert. */
-		self::assertNull( $this->get_parent_post_id( $row ) );
+		$this->assertParentPostIdIsSqlNull( $row );
 	}
 
 	/**
@@ -260,7 +260,7 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 		delete_post_meta( $lesson_id, '_lesson_course' );
 
 		/* Assert. */
-		self::assertNull( $this->get_parent_post_id( $row ) );
+		$this->assertParentPostIdIsSqlNull( $row );
 
 		remove_action( 'added_post_meta', array( $handler, 'handle_meta_change' ), 10 );
 		remove_action( 'updated_post_meta', array( $handler, 'handle_meta_change' ), 10 );
@@ -323,5 +323,22 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 			)
 		);
 		return null === $value ? null : (int) $value;
+	}
+
+	/**
+	 * Assert that a row's parent_post_id is SQL NULL (not 0 or empty string).
+	 *
+	 * @param int $row_id Row ID.
+	 */
+	private function assertParentPostIdIsSqlNull( int $row_id ): void {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$matches = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}sensei_lms_progress WHERE id = %d AND parent_post_id IS NULL",
+				$row_id
+			)
+		);
+		self::assertSame( 1, $matches );
 	}
 }

--- a/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * File containing the Lesson_Course_Sync_Handler_Test class.
+ *
+ * @package sensei
+ */
+
+namespace SenseiTest\Internal\Student_Progress\Services;
+
+use Sensei\Internal\Student_Progress\Services\Lesson_Course_Sync_Handler;
+
+/**
+ * Tests for Lesson_Course_Sync_Handler.
+ *
+ * @covers \Sensei\Internal\Student_Progress\Services\Lesson_Course_Sync_Handler
+ */
+class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
+	/**
+	 * Sensei factory.
+	 *
+	 * @var \Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	/**
+	 * Tests that init registers the postmeta hooks.
+	 */
+	public function testInit_WhenCalled_AddsHooks(): void {
+		/* Arrange. */
+		global $wpdb;
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->init();
+
+		/* Assert. */
+		self::assertSame( 10, has_action( 'added_post_meta', array( $handler, 'handle_meta_change' ) ), 'added_post_meta hook should be registered.' );
+		self::assertSame( 10, has_action( 'updated_post_meta', array( $handler, 'handle_meta_change' ) ), 'updated_post_meta hook should be registered.' );
+		self::assertSame( 10, has_action( 'deleted_post_meta', array( $handler, 'handle_meta_delete' ) ), 'deleted_post_meta hook should be registered.' );
+
+		remove_action( 'added_post_meta', array( $handler, 'handle_meta_change' ), 10 );
+		remove_action( 'updated_post_meta', array( $handler, 'handle_meta_change' ), 10 );
+		remove_action( 'deleted_post_meta', array( $handler, 'handle_meta_delete' ), 10 );
+	}
+
+	/**
+	 * Tests that updating _lesson_course updates parent_post_id on every matching row.
+	 */
+	public function testHandleMetaChange_LessonCourseUpdated_UpdatesParentPostIdOnAllRows(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id  = $this->factory->lesson->create();
+		$old_course = 100;
+		$new_course = 200;
+
+		$row_one = $this->insert_progress_row( $lesson_id, 11, $old_course );
+		$row_two = $this->insert_progress_row( $lesson_id, 22, $old_course );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_change( 1, $lesson_id, '_lesson_course', $new_course );
+
+		/* Assert. */
+		self::assertSame( $new_course, $this->get_parent_post_id( $row_one ), 'First user row should be updated to the new course.' );
+		self::assertSame( $new_course, $this->get_parent_post_id( $row_two ), 'Second user row should be updated to the new course.' );
+	}
+
+	/**
+	 * Tests that updating _lesson_course on a non-lesson post does not touch progress rows.
+	 */
+	public function testHandleMetaChange_NonLessonPost_DoesNotUpdateRows(): void {
+		/* Arrange. */
+		global $wpdb;
+		$course_id  = $this->factory->course->create();
+		$lesson_id  = $this->factory->lesson->create();
+		$old_course = 100;
+		$row        = $this->insert_progress_row( $lesson_id, 11, $old_course );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_change( 1, $course_id, '_lesson_course', 999 );
+
+		/* Assert. */
+		self::assertSame( $old_course, $this->get_parent_post_id( $row ) );
+	}
+
+	/**
+	 * Tests that updates to unrelated meta keys do not touch progress rows.
+	 */
+	public function testHandleMetaChange_UnrelatedMetaKey_DoesNotUpdateRows(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id  = $this->factory->lesson->create();
+		$old_course = 100;
+		$row        = $this->insert_progress_row( $lesson_id, 11, $old_course );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_change( 1, $lesson_id, '_some_other_meta', 999 );
+
+		/* Assert. */
+		self::assertSame( $old_course, $this->get_parent_post_id( $row ) );
+	}
+
+	/**
+	 * Tests that quiz progress rows (which use parent_post_id for the lesson) are left alone.
+	 */
+	public function testHandleMetaChange_DoesNotTouchQuizRows(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id = $this->factory->lesson->create();
+		// Quiz row uses parent_post_id for the lesson — not the course — but we
+		// match on type='lesson', so it must be left alone.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_progress',
+			array(
+				'post_id'        => 999,
+				'user_id'        => 11,
+				'parent_post_id' => $lesson_id,
+				'type'           => 'quiz',
+				'status'         => 'in-progress',
+				'created_at'     => current_time( 'mysql' ),
+				'updated_at'     => current_time( 'mysql' ),
+			)
+		);
+		$quiz_row = (int) $wpdb->insert_id;
+
+		// And a lesson row that should be updated.
+		$lesson_row = $this->insert_progress_row( $lesson_id, 11, 100 );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_change( 1, $lesson_id, '_lesson_course', 200 );
+
+		/* Assert. */
+		self::assertSame( 200, $this->get_parent_post_id( $lesson_row ), 'Lesson row should be updated to the new course.' );
+		self::assertSame( $lesson_id, $this->get_parent_post_id( $quiz_row ), 'Quiz row should be left untouched.' );
+	}
+
+	/**
+	 * Tests that a zero/invalid course value clears parent_post_id to NULL.
+	 */
+	public function testHandleMetaChange_ZeroOrInvalidValue_SetsParentPostIdToNull(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id = $this->factory->lesson->create();
+		$row       = $this->insert_progress_row( $lesson_id, 11, 100 );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_change( 1, $lesson_id, '_lesson_course', 0 );
+
+		/* Assert. */
+		self::assertNull( $this->get_parent_post_id( $row ) );
+	}
+
+	/**
+	 * Tests that deleting _lesson_course clears parent_post_id to NULL.
+	 */
+	public function testHandleMetaDelete_LessonCourseDeleted_SetsParentPostIdToNull(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id = $this->factory->lesson->create();
+		$row       = $this->insert_progress_row( $lesson_id, 11, 100 );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_delete( array( 1 ), $lesson_id, '_lesson_course' );
+
+		/* Assert. */
+		self::assertNull( $this->get_parent_post_id( $row ) );
+	}
+
+	/**
+	 * Tests that calling update_post_meta() triggers the registered hook end-to-end.
+	 */
+	public function testHandleMetaChange_TriggersFromUpdatePostMeta_UpdatesRow(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id = $this->factory->lesson->create();
+		$row       = $this->insert_progress_row( $lesson_id, 11, 100 );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+		$handler->init();
+
+		/* Act. */
+		update_post_meta( $lesson_id, '_lesson_course', 200 );
+
+		/* Assert. */
+		self::assertSame( 200, $this->get_parent_post_id( $row ) );
+
+		remove_action( 'added_post_meta', array( $handler, 'handle_meta_change' ), 10 );
+		remove_action( 'updated_post_meta', array( $handler, 'handle_meta_change' ), 10 );
+		remove_action( 'deleted_post_meta', array( $handler, 'handle_meta_delete' ), 10 );
+	}
+
+	/**
+	 * Insert a lesson progress row and return its ID.
+	 *
+	 * @param int $lesson_id Lesson ID (post_id column).
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Parent course ID.
+	 * @return int Inserted row ID.
+	 */
+	private function insert_progress_row( int $lesson_id, int $user_id, int $course_id ): int {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->prefix . 'sensei_lms_progress',
+			array(
+				'post_id'        => $lesson_id,
+				'user_id'        => $user_id,
+				'parent_post_id' => $course_id,
+				'type'           => 'lesson',
+				'status'         => 'in-progress',
+				'created_at'     => current_time( 'mysql' ),
+				'updated_at'     => current_time( 'mysql' ),
+			)
+		);
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Read the parent_post_id of a progress row by ID.
+	 *
+	 * @param int $row_id Row ID.
+	 * @return int|null
+	 */
+	private function get_parent_post_id( int $row_id ): ?int {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$value = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT parent_post_id FROM {$wpdb->prefix}sensei_lms_progress WHERE id = %d",
+				$row_id
+			)
+		);
+		return null === $value ? null : (int) $value;
+	}
+}

--- a/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
+++ b/tests/unit-tests/internal/student-progress/services/test-class-lesson-course-sync-handler.php
@@ -83,42 +83,25 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that updating _lesson_course on a non-lesson post does not touch progress rows.
+	 * Tests that updating one lesson's course leaves other lessons' progress rows alone,
+	 * even when they currently share the same parent_post_id.
 	 */
-	public function testHandleMetaChange_NonLessonPost_DoesNotUpdateRows(): void {
+	public function testHandleMetaChange_OtherLessonRows_AreNotTouched(): void {
 		/* Arrange. */
 		global $wpdb;
-		$course_id  = $this->factory->course->create();
-		$lesson_id  = $this->factory->lesson->create();
-		$old_course = 100;
-		$row        = $this->insert_progress_row( $lesson_id, 11, $old_course );
+		$lesson_a = $this->factory->lesson->create();
+		$lesson_b = $this->factory->lesson->create();
+		$row_a    = $this->insert_progress_row( $lesson_a, 11, 100 );
+		$row_b    = $this->insert_progress_row( $lesson_b, 11, 100 );
 
 		$handler = new Lesson_Course_Sync_Handler( $wpdb );
 
 		/* Act. */
-		$handler->handle_meta_change( 1, $course_id, '_lesson_course', 999 );
+		$handler->handle_meta_change( 1, $lesson_a, '_lesson_course', 200 );
 
 		/* Assert. */
-		self::assertSame( $old_course, $this->get_parent_post_id( $row ) );
-	}
-
-	/**
-	 * Tests that updates to unrelated meta keys do not touch progress rows.
-	 */
-	public function testHandleMetaChange_UnrelatedMetaKey_DoesNotUpdateRows(): void {
-		/* Arrange. */
-		global $wpdb;
-		$lesson_id  = $this->factory->lesson->create();
-		$old_course = 100;
-		$row        = $this->insert_progress_row( $lesson_id, 11, $old_course );
-
-		$handler = new Lesson_Course_Sync_Handler( $wpdb );
-
-		/* Act. */
-		$handler->handle_meta_change( 1, $lesson_id, '_some_other_meta', 999 );
-
-		/* Assert. */
-		self::assertSame( $old_course, $this->get_parent_post_id( $row ) );
+		self::assertSame( 200, $this->get_parent_post_id( $row_a ), 'Lesson A row should be updated.' );
+		self::assertSame( 100, $this->get_parent_post_id( $row_b ), 'Lesson B row sharing the old course should be untouched.' );
 	}
 
 	/**
@@ -159,9 +142,13 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a zero/invalid course value clears parent_post_id to NULL.
+	 * Tests that a zero, non-numeric, or non-scalar course value clears parent_post_id to NULL.
+	 *
+	 * @dataProvider provideInvalidMetaValues
+	 *
+	 * @param mixed $meta_value Bogus meta value coming from the hook.
 	 */
-	public function testHandleMetaChange_ZeroOrInvalidValue_SetsParentPostIdToNull(): void {
+	public function testHandleMetaChange_InvalidValue_SetsParentPostIdToNull( $meta_value ): void {
 		/* Arrange. */
 		global $wpdb;
 		$lesson_id = $this->factory->lesson->create();
@@ -170,10 +157,49 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 		$handler = new Lesson_Course_Sync_Handler( $wpdb );
 
 		/* Act. */
-		$handler->handle_meta_change( 1, $lesson_id, '_lesson_course', 0 );
+		$handler->handle_meta_change( 1, $lesson_id, '_lesson_course', $meta_value );
 
 		/* Assert. */
 		self::assertNull( $this->get_parent_post_id( $row ) );
+	}
+
+	/**
+	 * Tests that updates to unrelated meta keys do not touch progress rows.
+	 */
+	public function testHandleMetaChange_UnrelatedMetaKey_DoesNotUpdateRows(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id  = $this->factory->lesson->create();
+		$old_course = 100;
+		$row        = $this->insert_progress_row( $lesson_id, 11, $old_course );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_change( 1, $lesson_id, '_some_other_meta', 999 );
+
+		/* Assert. */
+		self::assertSame( $old_course, $this->get_parent_post_id( $row ) );
+	}
+
+	/**
+	 * Tests that updating _lesson_course on a non-lesson post does not touch progress rows.
+	 */
+	public function testHandleMetaChange_NonLessonPost_DoesNotUpdateRows(): void {
+		/* Arrange. */
+		global $wpdb;
+		$course_id  = $this->factory->course->create();
+		$lesson_id  = $this->factory->lesson->create();
+		$old_course = 100;
+		$row        = $this->insert_progress_row( $lesson_id, 11, $old_course );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+
+		/* Act. */
+		$handler->handle_meta_change( 1, $course_id, '_lesson_course', 200 );
+
+		/* Assert. */
+		self::assertSame( $old_course, $this->get_parent_post_id( $row ) );
 	}
 
 	/**
@@ -218,6 +244,44 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that calling delete_post_meta() triggers the registered hook end-to-end.
+	 */
+	public function testHandleMetaDelete_TriggersFromDeletePostMeta_ClearsRow(): void {
+		/* Arrange. */
+		global $wpdb;
+		$lesson_id = $this->factory->lesson->create();
+		update_post_meta( $lesson_id, '_lesson_course', 100 );
+		$row = $this->insert_progress_row( $lesson_id, 11, 100 );
+
+		$handler = new Lesson_Course_Sync_Handler( $wpdb );
+		$handler->init();
+
+		/* Act. */
+		delete_post_meta( $lesson_id, '_lesson_course' );
+
+		/* Assert. */
+		self::assertNull( $this->get_parent_post_id( $row ) );
+
+		remove_action( 'added_post_meta', array( $handler, 'handle_meta_change' ), 10 );
+		remove_action( 'updated_post_meta', array( $handler, 'handle_meta_change' ), 10 );
+		remove_action( 'deleted_post_meta', array( $handler, 'handle_meta_delete' ), 10 );
+	}
+
+	/**
+	 * Data provider for invalid meta values.
+	 *
+	 * @return array<string, array{mixed}>
+	 */
+	public function provideInvalidMetaValues(): array {
+		return array(
+			'zero int'        => array( 0 ),
+			'negative int'    => array( -1 ),
+			'non-numeric str' => array( 'not-a-number' ),
+			'array'           => array( array( 100 ) ),
+		);
+	}
+
+	/**
 	 * Insert a lesson progress row and return its ID.
 	 *
 	 * @param int $lesson_id Lesson ID (post_id column).
@@ -251,7 +315,7 @@ class Lesson_Course_Sync_Handler_Test extends \WP_UnitTestCase {
 	 */
 	private function get_parent_post_id( int $row_id ): ?int {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$value = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT parent_post_id FROM {$wpdb->prefix}sensei_lms_progress WHERE id = %d",


### PR DESCRIPTION
## Summary

When a lesson is reassigned to a different course (admin UI, WPML, data import, or any other path that calls `update_post_meta( $lesson_id, '_lesson_course', $course_id )`), the `_lesson_course` postmeta was being updated but the `parent_post_id` column on existing rows in `wp_sensei_lms_progress` was not. This caused the tables-based and comments-based code paths to disagree on which course a lesson's progress belongs to, returning stale course associations from any HPPS code that groups or filters by `parent_post_id`.

This PR adds a `Lesson_Course_Sync_Handler` that listens for `added_post_meta`, `updated_post_meta`, and `deleted_post_meta` events on the `_lesson_course` key for lesson posts, and updates `parent_post_id` on all matching `type='lesson'` rows in `wp_sensei_lms_progress`. NULL is written on delete or when the meta value is zero/invalid. Quiz progress rows (which use `parent_post_id` for the parent lesson, not the course) are not touched.

The handler is gated on `$tables_feature_enabled` and wired up alongside the other student-progress handlers in `Sensei::init()`, matching the `Progress_Tables_Eraser` precedent. It stays active regardless of the sync/read-direction settings, so the scenario where a user flips from tables to comments (with sync off), reassigns lessons, and flips back to tables will still land on correct data.

Also documents in `AGENTS.md` the convention of passing a message as the third argument to assertions in tests that have multiple assertions.

## Test plan

### Test 1: Adding a course to a lesson (`added_post_meta`)
                                                                                                                                            
  **Settings:**                                                                                                                             
  - [x] "Store the progress of your students in separate tables." → **checked**                                                             
  - [x] "Synchronize the student progress between storages." → **checked**
  - [x] "Progress storage repository" → **High-Performance progress storage (experimental)**                                                
  
  **Steps:**                                                                                                                                
  - [x] Create a lesson **Lesson M** with **no course assigned**.
  - [x] As a student, start Lesson M (any action that creates a progress row). Confirm via Database Manager that the new row in             
  `wp_sensei_lms_progress` has `parent_post_id IS NULL`.                                                                                    
  - [x] As an admin, edit Lesson M and assign it to a course. Save.                                                                         
  - [x] **Expected:** the row's `parent_post_id` is now the course's ID.                                                                    
                                                    
  ### Test 2: Updating a lesson's course (`updated_post_meta`)                                                                              
                                                                                                                                            
  **Steps:**
  - [x] Create two courses, **Course A** and **Course B**, and a lesson **Lesson L** assigned to Course A.                                  
  - [x] As a student, start Lesson L. Confirm via Database Manager that the new row in `wp_sensei_lms_progress` has `parent_post_id = Course
   A`.                                                                                                                                      
  - [x] As an admin, edit Lesson L and reassign it to Course B. Save.                                                                       
  - [x] **Expected:** the row's `parent_post_id` is now Course B's ID.                                                                      
  - [x] Reassign back to Course A and confirm the row updates again.                                                                        
                                                    
  ### Test 3: Removing a lesson's course (`deleted_post_meta`)                                                                              
                               
  **Settings:**                                                                                                                             
                                                                                                                                            
  **Steps:**
  - [x] Use Lesson L from Test 2 (or create a new lesson with a course assigned and a student progress row).                                
  - [x] Set the Course for Lesson L to None                                                                                                                        
  - [x] **Expected:** the row's `parent_post_id` is now `NULL`.                                                                             
                                                                                                                                            
  ### Test 4: Handler stays active across the cross-storage scenario                                                                        
                                                    
  This verifies the handler works even when reads aren't coming from tables and sync is off, which is the scenario where this fix matters   
  most for users mid-migration.
                                                    
  **Settings:**                                                                                                                             
  - [x] "Store the progress of your students in separate tables." → **checked**
  - [x] "Synchronize the student progress between storages." → **unchecked**                                                                
  - [x] "Progress storage repository" → **WordPress comments based storage**
                                                                                                                                            
  **Steps:**
  - [x] Starting from Test 2's setup (Lesson L exists with a tables row pointing at Course A), switch the settings to the values above.     
  - [x] As an admin, reassign Lesson L from Course A to Course B. Save.                                                                     
  - [x] **Expected:** the existing `wp_sensei_lms_progress` row's `parent_post_id` is now Course B's ID, even though sync is off and reads
  are coming from comments.                                                                                                                 
                               
  ### Test 5: Handler is inactive when HPPS is disabled                                                                                     
                               
  **Settings:**                                                                                                                             
  - [x] "Store the progress of your students in separate tables." → **unchecked** (the other two settings are then moot)
                                                    
  **Steps:**
  - [x] Reassign a lesson's course in the editor. Save.
  - [x] **Expected:** no errors. The `wp_sensei_lms_progress` table (if it has any leftover rows) is not modified. The handler should not be
   registered at all.                                

🤖 Generated with [Claude Code](https://claude.com/claude-code)