### PR TITLE
Fix PHP warning when calculating average grade with no graded quizzes

### DIFF
--- a/changelog/fix-null-courses-average-grade
+++ b/changelog/fix-null-courses-average-grade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP warning when calculating the average grade for courses with no graded quizzes.

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1430,7 +1430,7 @@ class Sensei_Grading {
 			) averages_by_course"
 		);
 
-		return floatval( $result->courses_average ?? 0 );
+		return floatval( isset( $result->courses_average ) ? $result->courses_average : 0 );
 	}
 }
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1430,7 +1430,7 @@ class Sensei_Grading {
 			) averages_by_course"
 		);
 
-		return floatval( $result->courses_average );
+		return floatval( $result->courses_average ?? 0 );
 	}
 }
 

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -125,7 +125,7 @@ class Sensei_Reports_Overview_Service_Courses {
 		) averages_by_course'
 		);
 
-		return floatval( $result->courses_average ?? 0 );
+		return floatval( isset( $result->courses_average ) ? $result->courses_average : 0 );
 	}
 
 	/**

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -125,7 +125,7 @@ class Sensei_Reports_Overview_Service_Courses {
 		) averages_by_course'
 		);
 
-		return floatval( $result->courses_average );
+		return floatval( $result->courses_average ?? 0 );
 	}
 
 	/**

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
@@ -400,6 +400,23 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		self::assertSame( 2, $actual );
 	}
 
+	/**
+	 * Tests that average grade returns zero when courses have no graded quizzes.
+	 *
+	 * @covers Sensei_Reports_Overview_Service_Courses::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGrade_WhenNoGradedQuizzes_ReturnsZero() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+		$instance  = new Sensei_Reports_Overview_Service_Courses();
+
+		/* Act. */
+		$actual = $instance->get_courses_average_grade( [ $course_id ] );
+
+		/* Assert. */
+		self::assertSame( 0.0, $actual, 'Average grade should be zero when there are no graded quizzes.' );
+	}
+
 	public function testGetAverageDaysToCompletionTotalWithoutCompletionsReturnsZero() {
 		$instance = new Sensei_Reports_Overview_Service_Courses();
 		$actual   = $instance->get_average_days_to_completion( [] );

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -290,6 +290,15 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that courses average grade returns zero when there are no courses with graded quizzes.
+	 *
+	 * @covers Sensei_Grading::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGrade_WhenNoCourses_ReturnsZero() {
+		$this->assertSame( 0.0, Sensei()->grading->get_courses_average_grade(), 'Average grade should be zero when there are no courses with graded quizzes.' );
+	}
+
+	/**
 	 *
 	 * This tests generated graded lessons and makes sure that the function
 	 * get graded lessons average is returning expected value for average lesson.


### PR DESCRIPTION
## Summary

- Fix `E_WARNING: Attempt to read property "courses_average" on null` triggered on course pages when there are no graded quizzes
- Apply `isset()` checks in both `Sensei_Grading::get_courses_average_grade()` and `Sensei_Reports_Overview_Service_Courses::get_courses_average_grade()`
- Add tests for both methods to verify they return `0.0` when no graded quiz data exists

**Source:** `GET https://learn.wordpress.org/course/creating-a-4-page-business-website/`

## Test plan

- [ ] Verify the warning no longer appears on course pages with no graded quizzes
- [ ] Verify average grade still calculates correctly when graded quizzes exist
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)