### PR TITLE
Add sensei/update-enrollment ability

### DIFF
--- a/includes/abilities/class-sensei-abilities.php
+++ b/includes/abilities/class-sensei-abilities.php
@@ -67,6 +67,7 @@ class Sensei_Abilities {
 
 		self::register_get_courses_ability();
 		self::register_get_students_ability();
+		self::register_update_enrollment_ability();
 	}
 
 	/**
@@ -423,5 +424,109 @@ class Sensei_Abilities {
 			return Course_Progress_Interface::STATUS_IN_PROGRESS;
 		}
 		return null;
+	}
+
+	/**
+	 * Register the sensei/update-enrollment ability.
+	 */
+	private static function register_update_enrollment_ability(): void {
+		wp_register_ability(
+			'sensei/update-enrollment',
+			array(
+				'label'               => __( 'Update enrollment', 'sensei-lms' ),
+				'description'         => __( 'Enroll or remove students on Sensei courses.', 'sensei-lms' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'course_ids', 'user_ids', 'action' ),
+					'properties'           => array(
+						'course_ids' => array(
+							'type'        => 'array',
+							'description' => __( 'One or more course IDs to modify enrollment on.', 'sensei-lms' ),
+							'items'       => array( 'type' => 'integer' ),
+							'minItems'    => 1,
+						),
+						'user_ids'   => array(
+							'type'        => 'array',
+							'description' => __( 'One or more user IDs to enroll or remove.', 'sensei-lms' ),
+							'items'       => array( 'type' => 'integer' ),
+							'minItems'    => 1,
+						),
+						'action'     => array(
+							'type'        => 'string',
+							'description' => __( 'Whether to enroll or remove the listed users.', 'sensei-lms' ),
+							'enum'        => array( 'enroll', 'remove' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'execute_update_enrollment' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_courses_from_input' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Execute sensei/update-enrollment.
+	 *
+	 * @access private
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public static function execute_update_enrollment( $input ): array {
+		$course_ids = array_map( 'intval', $input['course_ids'] );
+		$user_ids   = array_map( 'intval', $input['user_ids'] );
+		$action     = $input['action'];
+
+		$controller = new Sensei_REST_API_Course_Students_Controller( 'sensei-internal/v1' );
+		$request    = new WP_REST_Request( 'enroll' === $action ? 'POST' : 'DELETE', '' );
+		$request->set_param( 'course_ids', $course_ids );
+		$request->set_param( 'student_ids', $user_ids );
+
+		$response = 'enroll' === $action
+			? $controller->batch_create_items( $request )
+			: $controller->batch_remove_items( $request );
+
+		return array(
+			'course_ids' => $course_ids,
+			'action'     => $action,
+			'results'    => $response->get_data(),
+		);
+	}
+
+	/**
+	 * Permission check: user can edit every course in the input.
+	 *
+	 * @access private
+	 *
+	 * @param array $input Ability input.
+	 */
+	public static function can_edit_courses_from_input( $input = array() ): bool {
+		if ( empty( $input['course_ids'] ) || ! is_array( $input['course_ids'] ) ) {
+			return false;
+		}
+		$post_type = get_post_type_object( 'course' );
+		if ( ! $post_type ) {
+			return false;
+		}
+		foreach ( $input['course_ids'] as $course_id ) {
+			$course = get_post( (int) $course_id );
+			if ( ! $course || 'course' !== $course->post_type ) {
+				return false;
+			}
+			if ( ! current_user_can( $post_type->cap->edit_post, (int) $course_id ) ) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/tests/unit-tests/abilities/test-class-sensei-abilities.php
+++ b/tests/unit-tests/abilities/test-class-sensei-abilities.php
@@ -117,6 +117,70 @@ class Sensei_Abilities_Test extends WP_UnitTestCase {
 		$this->assertContains( $user_id, $ids );
 	}
 
+	public function testUpdateEnrollment_WithEnrollAction_EnrollsUsers() {
+		$factory   = new Sensei_Factory();
+		$course_id = $factory->course->create();
+		$user_id   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$this->login_as_admin();
+		$ability = wp_get_ability( 'sensei/update-enrollment' );
+
+		$ability->execute(
+			array(
+				'course_ids' => array( $course_id ),
+				'user_ids'   => array( $user_id ),
+				'action'     => 'enroll',
+			)
+		);
+
+		$this->assertTrue( Sensei_Course_Enrolment::get_course_instance( $course_id )->is_enrolled( $user_id ) );
+
+		$factory->tearDown();
+	}
+
+	public function testUpdateEnrollment_WithRemoveAction_RemovesUsers() {
+		$factory   = new Sensei_Factory();
+		$course_id = $factory->course->create();
+		$user_id   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		Sensei_Course_Manual_Enrolment_Provider::instance()->enrol_learner( $user_id, $course_id );
+
+		$this->login_as_admin();
+		$ability = wp_get_ability( 'sensei/update-enrollment' );
+
+		$ability->execute(
+			array(
+				'course_ids' => array( $course_id ),
+				'user_ids'   => array( $user_id ),
+				'action'     => 'remove',
+			)
+		);
+
+		$this->assertFalse( Sensei_Course_Enrolment::get_course_instance( $course_id )->is_enrolled( $user_id ) );
+
+		$factory->tearDown();
+	}
+
+	public function testUpdateEnrollment_WhenUserCannotEditCourse_FailsPermission() {
+		$factory   = new Sensei_Factory();
+		$course_id = $factory->course->create();
+
+		wp_set_current_user( 0 );
+		$ability = wp_get_ability( 'sensei/update-enrollment' );
+
+		$this->assertFalse(
+			$ability->check_permissions(
+				array(
+					'course_ids' => array( $course_id ),
+					'user_ids'   => array( 1 ),
+					'action'     => 'enroll',
+				)
+			)
+		);
+
+		$factory->tearDown();
+	}
+
 	public function testGetStudents_Always_IncludesUserContactDetails() {
 		$user_id = $this->factory->user->create(
 			array(


### PR DESCRIPTION
## Proposed Changes

Adds the `sensei/update-enrollment` ability — a write ability for enrolling or removing students on one or more Sensei courses in a single call. Stacked on top of #7952 (read-only abilities); merge that first.

**Ability:** `sensei/update-enrollment`

- **Inputs:** `course_ids: int[]`, `user_ids: int[]`, `action: 'enroll' | 'remove'`.
- **Behavior:** delegates to `Sensei_REST_API_Course_Students_Controller::batch_create_items` (enroll) or `batch_remove_items` (remove), the same endpoints the admin Students screen uses.
- **Permission:** caller must have `edit_post` on every course ID in the input.
- **Annotations:** `destructive: true`, `idempotent: true`.

**Intended use cases:** natural-language workflows like *"Enroll bob@example.com in the beer making course"* (chains `get-students` + `get-courses` from #7952 → `update-enrollment`) and bulk enrollment from customer requests (ticket #6107, 12 Zendesk tickets demonstrating real demand).

## Testing Instructions

Requires WordPress 6.9+.

### 1. `wp shell` smoke test

```bash
wp shell
```
```php
> wp_set_current_user( 1 );
> wp_get_ability( 'sensei/update-enrollment' )->execute( array(
>     'course_ids' => array( <course_id> ),
>     'user_ids'   => array( <user_id> ),
>     'action'     => 'enroll',
> ) );
> Sensei_Course_Enrolment::get_course_instance( <course_id> )->is_enrolled( <user_id> ); // true
> wp_get_ability( 'sensei/update-enrollment' )->execute( array(
>     'course_ids' => array( <course_id> ),
>     'user_ids'   => array( <user_id> ),
>     'action'     => 'remove',
> ) );
> Sensei_Course_Enrolment::get_course_instance( <course_id> )->is_enrolled( <user_id> ); // false
```

### 2. Permission check

```php
> wp_set_current_user( 0 );
> wp_get_ability( 'sensei/update-enrollment' )->check_permissions( array(
>     'course_ids' => array( <course_id> ),
>     'user_ids'   => array( 1 ),
>     'action'     => 'enroll',
> ) ); // false
```

### 3. (Optional) End-to-end via Claude Code + MCP

1. Install an MCP bridge such as the [WordPress MCP plugin](https://github.com/Automattic/wordpress-mcp).
2. Prompt Claude: *"Add bob@example.com to the &lt;course name&gt; course."* Claude should chain `get-students` (to resolve the email) → `get-courses` (to resolve the name) → `update-enrollment`. Approve the destructive call when prompted.

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards
- [x] All strings are translatable
- [x] Follows naming conventions
- [x] Hooks and functions are documented
- [ ] New UIs are responsive and use a mobile-first approach (no UI changes)
- [x] Code is tested on the minimum supported PHP and WordPress versions (guarded for WP < 6.9)
