### PR TITLE
Replace broken `npm run lint-php` and standardize on Makefile commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,12 @@
+See `make help` for the full list of available dev commands.
+
 ## Linting
-- **PHPCS**: Run `npm run lint-php`.
-- **Psalm**: Run `vendor/bin/psalm --no-cache --diff`. CI runs Psalm against every PHP version in `.github/workflows/psalm.yml`'s matrix; type narrowing differs between versions, so run Psalm under each of those versions before pushing (e.g. `PATH="/opt/homebrew/opt/php@<version>/bin:$PATH" vendor/bin/psalm --no-cache --diff`).
-- **Before pushing**: The pre-commit hook only lints new files. CI lints all changed lines. Always run PHPCS and the full Psalm matrix on modified files before pushing to avoid CI failures.
+- **PHPCS**: Run `make lint` (the same diff-based check CI uses; requires a clean working tree). Whole-codebase scans: `./vendor/bin/phpcs`.
+- **Psalm**: Run `make psalm`. CI runs Psalm against every PHP version in `.github/workflows/psalm.yml`'s matrix; type narrowing differs between versions, so run Psalm under each of those versions before pushing — `make psalm` uses the active PHP, so for the matrix run the underlying command directly: `PATH="/opt/homebrew/opt/php@<version>/bin:$PATH" vendor/bin/psalm --no-cache --diff`.
+- **Before pushing**: The pre-commit hook only lints PHP files added after 2020-01-01. CI lints all changed lines. Always run PHPCS and the full Psalm matrix on modified files before pushing to avoid CI failures.
 
 ## Conventions
-- **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `npm run changelog` (entries stored in `changelog/`).
+- **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `make changelog` (entries stored in `changelog/`). For purely internal changes (refactors, test-only changes), apply the `No Changelog` label to the PR instead.
 - **Version placeholders in docblocks**: Never hardcode a release number in `@since` tags for new code. Use `@since $$next-version$$` — release tooling replaces the placeholder on version bump.
 - **Array syntax**: Use the long form `array( ... )` in new PHP code, per the [WordPress PHP coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#declaring-arrays). Sensei's `phpcs.xml.dist` excludes the short-array disallow sniff, so `[ ... ]` won't fail lint, but new code should follow the upstream standard anyway. Do not mass-convert existing code.
 - **Test assertions**: When a single test has multiple assertions, pass a message as the third argument to each assertion (e.g., `self::assertSame( $expected, $actual, 'Foo should be updated.' );`) so a failure points to the specific check that failed.

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-php: ## Run PHPUnit tests via wp-env (requires: make up)
 	$(WP_ENV) run tests-cli --env-cwd='wp-content/plugins/sensei' vendor/bin/phpunit -c phpunit.xml
 
 ## Code quality
-lint: ## Run PHPCS via the same diff-based check CI uses (requires committed working tree)
+lint: ## Run PHPCS via the same diff-based check CI uses
 	./scripts/linter-ci
 
 ## Build

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ test-php: ## Run PHPUnit tests via wp-env (requires: make up)
 	$(WP_ENV) run tests-cli --env-cwd='wp-content/plugins/sensei' vendor/bin/phpunit -c phpunit.xml
 
 ## Code quality
-lint: ## Run PHP CodeSniffer
-	npm run lint-php
+lint: ## Run PHPCS via the same diff-based check CI uses (requires committed working tree)
+	./scripts/linter-ci
 
 ## Build
 build: ## Build plugin zip via wp-env (requires: make up)

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "lint-e2e": "eslint -c ./tests/e2e-playwright/.eslintrc.js ./tests/e2e-playwright/ && tsc --noEmit --project tests/e2e-playwright/tsconfig.json",
     "lint-js": "wp-scripts lint-js --ext js,jsx,ts,tsx assets",
     "lint-js:fix": "npm run lint-js -- --fix",
-    "lint-php": "wp-scripts lint-php",
     "lint-pkg-json": "wp-scripts lint-pkg-json",
     "lint-types": "tsc --project tsconfig.json",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",


### PR DESCRIPTION
## Summary

- `npm run lint-php` (and therefore the Makefile `lint` target that wrapped it) errored with `"Script name is missing"`. It runs `wp-scripts lint-php` → `composer run lint`, but `composer.json` has no `lint` script defined. CI never used it; the lint gate in `.github/workflows/php.yml` runs `./scripts/linter-ci` and direct `./vendor/bin/phpcs` invocations.
- Repoint `make lint` at `./scripts/linter-ci` so it mirrors the CI "Check for new issues" gate, drop the broken `lint-php` script from `package.json`, and update AGENTS.md to document the working commands.
- While in AGENTS.md, standardize on `make` commands for the common cases, add the `No Changelog` label as the escape hatch for non-user-facing PRs, and add a `make help` discovery pointer at the top.

## Test plan

- [x] `make lint` runs `./scripts/linter-ci` and exits 0 on a clean trunk checkout.
- [x] `npm run lint-php` is no longer present in `package.json` scripts (`grep -n lint-php package.json` returns nothing).
- [x] `make help` shows the new descriptions for `lint` (mentions diff-based) and lists `psalm`, `changelog`, `test-php-filter`.
- [x] Skim AGENTS.md and confirm there are no remaining references to `npm run lint-php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)