### PR TITLE
Switch Claude Code action to agent mode

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -60,6 +60,10 @@ jobs:
           branch_prefix: fix/
           additional_permissions: |
             actions: read
+          prompt: |
+            You were triggered on a ${{ github.event_name }} event in ${{ github.repository }}.
+            Issue/PR number: ${{ github.event.issue.number || github.event.pull_request.number }}.
+            Read it with `gh issue view` or `gh pr view` and follow the system prompt instructions.
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 50

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -62,9 +62,9 @@ jobs:
             actions: read
           prompt: |
             You were triggered on a ${{ github.event_name }} event in ${{ github.repository }}.
-            Issue/PR number: ${{ github.event.issue.number || github.event.pull_request.number }}.
+            Issue/PR number: ${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}.
             Read it with `gh issue view` or `gh pr view` and follow the system prompt instructions.
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 50
-            --disallowedTools "Bash(gh pr merge:*)"
+            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(gh release:*)" "Bash(npm publish:*)" "Bash(gh repo delete:*)"


### PR DESCRIPTION
## Summary
- Adds a `prompt:` input to the `anthropics/claude-code-action` step, which switches the action from tag mode to agent mode.
- Tag mode (the default for issue/PR triggers) applies a hardcoded read-only tool allowlist: only `Glob`, `Grep`, `LS`, `Read`, the comment-update MCP tool, and a few `git` bash commands. It blocks `Edit`, `Write`, general `Bash`, `gh`, and `make` — so Claude can't run lint, tests, `make changelog`, or modify files.
- Agent mode honors the allowlist parsed from our `claude_args` instead, unlocking the full 10-step autonomous flow.

## Background
On the first end-to-end test (issue #7942), the run hit the 50-turn cap because Claude couldn't use the tools the system prompt instructs it to use. Logs showed:

```
ALLOWED_TOOLS: Glob,Grep,LS,Read,mcp__github_comment__update_claude_comment,
Bash(git add:*),Bash(git commit:*),Bash(.../git-push.sh:*),Bash(git rm:*)
```

The action's mode detector (\`src/modes/detector.ts\`) switches to agent mode when \`prompt\` is non-empty. Agent mode skips the @claude-mention check and tracking comment but uses our \`claude_args\` allowlist as-is. The \`if:\` block in the workflow already gates triggers, so the loss of mention-checking is a non-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)