### PR TITLE
Switch Claude action to allowlist-based permissions

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -68,5 +68,6 @@ jobs:
             --model claude-sonnet-4-6
             --max-turns 50
             --max-budget-usd 5.00
-            --permission-mode bypassPermissions
-            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(gh release:*)" "Bash(npm publish:*)" "Bash(gh repo delete:*)" "Bash(curl:*)" "Bash(wget:*)" "Bash(ssh:*)" "Bash(scp:*)" "Bash(sudo:*)" "Bash(env)" "Bash(printenv:*)"
+            --permission-mode acceptEdits
+            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(make *),Bash(npm ci),Bash(npm run *),Bash(composer install*),Bash(git diff*),Bash(git log*),Bash(git show*),Bash(git status*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git checkout *),Bash(git switch *),Bash(git branch *),Bash(git fetch*),Bash(git rev-parse*),Bash(gh api *),Bash(gh pr *),Bash(gh issue *),Bash(gh run *),Bash(gh label *)"
+            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -75,4 +75,4 @@ jobs:
             --max-budget-usd 5.00
             --permission-mode acceptEdits
             --allowedTools "Read,Glob,Grep,Edit,Write,Bash(make *),Bash(npm ci),Bash(npm run *),Bash(composer install*),Bash(git diff*),Bash(git log*),Bash(git show*),Bash(git status*),Bash(git add *),Bash(git commit *),Bash(git push origin*),Bash(git push -u origin*),Bash(git checkout *),Bash(git switch *),Bash(git branch *),Bash(git fetch*),Bash(git rev-parse*),Bash(gh api *),Bash(gh pr *),Bash(gh issue *),Bash(gh run *),Bash(gh label *)"
-            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(git push --mirror*)" "Bash(git push --delete*)" "Bash(gh api -X*)" "Bash(gh api * -X*)" "Bash(gh api --method*)" "Bash(gh api * --method*)"
+            --disallowedTools "Bash(gh pr merge:*)" "Bash(gh pr close:*)" "Bash(gh issue close:*)" "Bash(gh label delete:*)" "Bash(gh run delete:*)" "Bash(gh run cancel:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(git push --mirror*)" "Bash(git push --delete*)" "Bash(gh api -X*)" "Bash(gh api * -X*)" "Bash(gh api --method*)" "Bash(gh api * --method*)"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -67,5 +67,6 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 50
+            --max-budget-usd 5.00
             --permission-mode bypassPermissions
-            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(gh release:*)" "Bash(npm publish:*)" "Bash(gh repo delete:*)"
+            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(gh release:*)" "Bash(npm publish:*)" "Bash(gh repo delete:*)" "Bash(curl:*)" "Bash(wget:*)" "Bash(ssh:*)" "Bash(scp:*)" "Bash(sudo:*)" "Bash(env)" "Bash(printenv:*)"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
+      - name: Configure git for Claude commits
+        run: |
+          git config --global user.name "claude[bot]"
+          git config --global user.email "claude[bot]@users.noreply.github.com"
+
       - name: Load Claude system prompt
         id: prompt
         run: echo "APPEND_SYSTEM_PROMPT<<PROMPT_EOF" >> "$GITHUB_ENV" && cat .github/claude-system-prompt.md >> "$GITHUB_ENV" && echo "PROMPT_EOF" >> "$GITHUB_ENV"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Configure git for Claude commits
         run: |
-          git config --global user.name "claude[bot]"
-          git config --global user.email "claude[bot]@users.noreply.github.com"
+          git config user.name "claude[bot]"
+          git config user.email "claude[bot]@users.noreply.github.com"
 
       - name: Load Claude system prompt
         id: prompt
@@ -74,5 +74,5 @@ jobs:
             --max-turns 50
             --max-budget-usd 5.00
             --permission-mode acceptEdits
-            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(make *),Bash(npm ci),Bash(npm run *),Bash(composer install*),Bash(git diff*),Bash(git log*),Bash(git show*),Bash(git status*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git checkout *),Bash(git switch *),Bash(git branch *),Bash(git fetch*),Bash(git rev-parse*),Bash(gh api *),Bash(gh pr *),Bash(gh issue *),Bash(gh run *),Bash(gh label *)"
-            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)"
+            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(make *),Bash(npm ci),Bash(npm run *),Bash(composer install*),Bash(git diff*),Bash(git log*),Bash(git show*),Bash(git status*),Bash(git add *),Bash(git commit *),Bash(git push origin*),Bash(git push -u origin*),Bash(git checkout *),Bash(git switch *),Bash(git branch *),Bash(git fetch*),Bash(git rev-parse*),Bash(gh api *),Bash(gh pr *),Bash(gh issue *),Bash(gh run *),Bash(gh label *)"
+            --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(git push --mirror*)" "Bash(git push --delete*)" "Bash(gh api -X*)" "Bash(gh api * -X*)" "Bash(gh api --method*)" "Bash(gh api * --method*)"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -67,4 +67,5 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 50
+            --permission-mode bypassPermissions
             --disallowedTools "Bash(gh pr merge:*)" "Bash(git push --force*)" "Bash(git push -f*)" "Bash(gh release:*)" "Bash(npm publish:*)" "Bash(gh repo delete:*)"


### PR DESCRIPTION
## Summary

Configures `claude_args` so the Claude Code GitHub Action can complete its 10-step workflow without burning turns on permission denials (the failure mode in run [25075231740](https://github.com/Automattic/sensei/actions/runs/25075231740/job/73465941056), where 16 turns produced 17 permission denials and no PR).

Changes to `.github/workflows/claude-code.yml`:
- `--permission-mode acceptEdits` — auto-accept file edits in non-interactive CI.
- `--allowedTools "..."` — explicit allowlist of the tools the system prompt actually needs (`make`, `npm`, `composer`, scoped `git` and `gh` subcommands, plus `Read`/`Glob`/`Grep`/`Edit`/`Write`).
- `--disallowedTools` — narrow denylist for dangerous matches inside the allowlist (`gh pr merge`, `git push --force`/`-f`).
- `--max-budget-usd 5.00` — spend cap.
- New step: configure git `user.name`/`user.email` so Claude's commits don't fail with \"Author identity unknown\".

## Why allowlist instead of `bypassPermissions`

Default-deny is more robust than denylist against escape hatches that are hard to enumerate (`php -r`, `node -e`, `WebFetch`, edits to `.github/workflows/*` or `.git/hooks/*`). The allowlist is short and stable because Sensei's command surface is narrow (`make`, `npm`, `composer`, `git`, `gh`).

## Test plan

Pre-merge:
- [x] CI green on this PR (Linting, Psalm, PHP Unit Tests, E2E, Changelogger).

Post-merge (smoke test on a real issue):
- [ ] Add the \`claude\` label to a small, well-scoped issue.
- [ ] Confirm the workflow run reaches step 10 (opens a PR) without exhausting \`--max-turns\` and without permission-denial messages in the log.
- [ ] Verify the PR has a changelog entry, milestone assigned, and lint/test checks running.