### PR TITLE
Fix flaky E2E: serialize global user creation

### DIFF
--- a/tests/e2e-playwright/config/global-setup.ts
+++ b/tests/e2e-playwright/config/global-setup.ts
@@ -67,7 +67,13 @@ const setupDefaultUsers = async (): Promise< void > => {
 };
 
 const createGlobalUsers = async ( users: User[] ): Promise< User[] > => {
-	return Promise.all( users.map( ( user ) => setupUser( user ) ) );
+	// Serialize: parallel `wp-env run tests-cli` invocations race on wp-env's
+	// internal state check and intermittently fail with "Environment not initialized".
+	const created: User[] = [];
+	for ( const user of users ) {
+		created.push( await setupUser( user ) );
+	}
+	return created;
 };
 
 async function setupUser( user: User ) {


### PR DESCRIPTION
## Summary
- The trunk E2E job intermittently fails at the `Setting the users...` step with `✖ Environment not initialized. Run \`wp-env start\` first.` (e.g. runs [25116428795](https://github.com/Automattic/sensei/actions/runs/25116428795/job/73604677280) and [25073389880](https://github.com/Automattic/sensei/actions/runs/25073389880)).
- Root cause: `createGlobalUsers` in `tests/e2e-playwright/config/global-setup.ts` ran `wp user create` for every entry in `GLOBAL_USERS` in parallel via `Promise.all`. Each call shells out to `npm run wp-env run tests-cli`, and concurrent invocations race on wp-env's internal state check — sometimes one loses and aborts with the "not initialized" error. The failing user differs run-to-run (`lms-administrator` vs `student`), consistent with a race rather than a deterministic bug.
- Fix: run the per-user `setupUser` calls sequentially. Costs a few extra seconds in setup, removes the flake.

## Test plan
- [x] Re-run the E2E job a few times on this PR and confirm no `Environment not initialized` failures.
- [x] Confirm all 5 setup tests still pass and that the main E2E suite proceeds past `Setting the users...` to actual specs.