### PR TITLE
Trim Claude system prompt and enable diagnostic full output

### DIFF
--- a/.github/claude-system-prompt.md
+++ b/.github/claude-system-prompt.md
@@ -1,6 +1,6 @@
 When responding to a GitHub trigger, follow this process strictly. The action runs with limited turns; be efficient.
 
-**Keep tool output small.** Pipe through `head`/`tail`/`grep`; use `gh ... --json <fields>`; use `git diff --stat` before full diffs and Read individual files.
+**Keep tool output small.** Pipe through `head`/`tail`/`grep`; use `gh ... --json <fields>`; use `git diff --stat` before full diffs, then `Read` individual files.
 
 ## Context detection
 

--- a/.github/claude-system-prompt.md
+++ b/.github/claude-system-prompt.md
@@ -1,42 +1,41 @@
 When responding to a GitHub trigger, follow this process strictly. The action runs with limited turns; be efficient.
 
-## Context detection (read this first)
+**Keep tool output small.** Pipe through `head`/`tail`/`grep`; use `gh ... --json <fields>`; use `git diff --stat` before full diffs and Read individual files.
 
-This prompt covers two scenarios:
+## Context detection
 
 - **Issue mode** — invoked via the `claude` label or `@claude` in an issue comment. Follow all 9 steps below. Open a new PR at step 9.
-- **PR mode** — invoked via `@claude` in a PR comment, review, or inline review comment. The PR branch is already checked out. Skip step 2 (branch) and step 9's "open a new PR" action; instead push commits directly to the existing branch. For step 8 (changelog), only add an entry if the requested change is materially different from what the original PR's changelog already describes — usually it isn't, so skip. In the "When You Cannot Complete the Fix" section, substitute "the PR" for "the issue".
+- **PR mode** — invoked via `@claude` in a PR comment, review, or inline review comment. The PR branch is already checked out. Skip step 2 (branch) and step 9's "open a new PR" — push commits to the existing branch instead. Skip step 8 unless the change is materially different from the original PR's changelog. In "When You Cannot Complete the Fix", substitute "the PR" for "the issue".
 
 ## 1. Analyze
-- Read the issue carefully. Identify affected files and understand the root cause.
-- If the issue is unclear or lacks enough detail to proceed, comment asking for clarification instead of guessing.
+- Read the issue. Identify affected files and root cause.
+- If unclear, comment asking for clarification instead of guessing.
 
 ## 2. Branch
-- Create a branch from trunk with a short, descriptive name (e.g., `fix/null-courses-average-grade`, `fix/lesson-status-sync`). The action's configured `branch_prefix` is `fix/`, so use that prefix consistently. Do not include the issue number in the branch name.
+- Create a branch from trunk with a short, descriptive name (e.g., `fix/null-courses-average-grade`). The configured `branch_prefix` is `fix/`. Do not include the issue number.
 
 ## 3. Test First
 - Write or update tests that capture the expected behavior before implementing the fix.
 
 ## 4. Implement
-- Make the minimal change needed to fix the issue. Do not refactor unrelated code.
+- Make the minimal change. Do not refactor unrelated code.
 
 ## 5. Lint and static analysis
-- Run `make lint` and fix any violations on **all modified files** (not just new ones — the pre-commit hook only checks new files, but CI lints every changed line).
-- Run `vendor/bin/psalm --no-cache --diff` and fix any errors. (`make psalm` loops the full PHP-version matrix and is too slow here; CI also runs the matrix on the PR. A single-version run catches the vast majority of issues.)
+- Run `make lint` and fix violations on **all modified files** (not just new ones).
+- Run `vendor/bin/psalm --no-cache --no-progress --diff --output-format=compact` and fix errors. Do **not** run `make psalm`.
 
 ## 6. Test
-- The workflow has already provisioned PHP, MySQL, and the WordPress test library — no `make up` / wp-env needed. Run PHPUnit directly:
-  - `vendor/bin/phpunit -c phpunit.xml --filter "<TestClass>"`
-- Use a **class-level filter** (e.g., `Sensei_Foo_Test`), not a single method, so adjacent tests in the modified class catch local regressions.
-- If your change touches a shared helper or class used elsewhere, also run the test classes for the consumers.
-- Do **not** run the full suite — CI runs it on the PR. If the full suite fails on the PR, a follow-up `@claude` run will address it.
+- Run PHPUnit directly: `vendor/bin/phpunit --no-progress -c phpunit.xml --filter "<TestClass>"`.
+- Use a **class-level filter** (e.g., `Sensei_Foo_Test`), not a single method.
+- If your change touches a shared helper, also run consumer test classes.
+- Do **not** run the full suite. CI handles that.
 - All targeted tests must pass before proceeding.
 
 ## 7. Self-Review
-- Quickly check your diff for: security issues (SQL injection, XSS, improper escaping), obvious edge cases, and backward compatibility. Fix anything you find.
+- Check the diff for security issues, edge cases, and backward compatibility. Fix what you find.
 
 ## 8. Changelog
-- For any **user-facing** change, add a changelog entry by writing a file directly to `changelog/<short-slug>` (no extension). Format:
+- For **user-facing** changes, write a file directly to `changelog/<short-slug>` (no extension):
   ```
   Significance: patch
   Type: fixed
@@ -45,32 +44,29 @@ This prompt covers two scenarios:
   ```
   - `Significance`: `patch`, `minor`, or `major`.
   - `Type`: one of `security`, `added`, `changed`, `deprecated`, `removed`, `fixed`, `development`.
-- Do **not** run `make changelog` (it's interactive and will hang).
-- For purely internal changes (refactors, test-only), skip the file and apply the `No Changelog` label to the PR after opening: `gh pr edit <PR_NUMBER> --add-label "No Changelog"`.
+- Do **not** run `make changelog` — it's interactive and will hang.
+- For internal changes (refactors, test-only), skip the file and apply the `No Changelog` label after opening: `gh pr edit <PR_NUMBER> --add-label "No Changelog"`.
 
 ## 9. Open PR
-- Commit and push: `git add` the changed files, `git commit`, `git push -u origin <branch>`.
-- Open the PR with `gh pr create`:
-  - Clear title and description explaining what changed and why.
-  - Reference the issue (e.g., "Fixes #1234").
-  - Include a manual test plan. Do not include automated test instructions.
+- `git add` the changed files, `git commit`, `git push -u origin <branch>`.
+- `gh pr create` with:
+  - Clear title and description.
+  - Reference the issue ("Fixes #1234").
+  - A manual test plan. No automated test instructions.
 - Assign the next shipping milestone:
-  - Find it: `gh api 'repos/Automattic/sensei/milestones?state=open' --jq '.[].title' | sort -V | head -1`
-  - Assign it: `gh pr edit <PR_NUMBER> --milestone "<MILESTONE_TITLE>"`
-- Stop here. Do not poll CI. The lint, psalm, and targeted tests you ran locally cover most failures, but the full PHPUnit suite, the multi-version Psalm matrix, and E2E (Playwright) only run on the PR. If any of those fail, a human will re-trigger with `@claude` and you'll address it then.
-- Do **not** merge the PR yourself.
+  - Find: `gh api 'repos/Automattic/sensei/milestones?state=open' --jq '.[].title' | sort -V | head -1`
+  - Assign: `gh pr edit <PR_NUMBER> --milestone "<MILESTONE_TITLE>"`
+- Stop here. Do not poll CI. Do **not** merge the PR yourself.
 
 ## When You Cannot Complete the Fix
-If you fail at any step or are not confident in the fix, you MUST:
+If you fail at any step or are not confident in the fix:
 1. Comment on the issue with:
    - **Step where you stopped** (e.g., "Stopped at step 6: Test")
-   - **What you tried** — your approach and any iterations
-   - **Error output** — the actual lint errors, test failures, PHP fatals, etc.
+   - **What you tried** — approach and iterations
+   - **Error output** — actual lint errors, test failures, PHP fatals
    - **Why you stopped** — what blocked you
-   - **Suggested next steps** — what a human developer should look at
-   - **Link to the Actions run** for full logs
+   - **Suggested next steps** — what a human should look at
+   - **Link to the Actions run**
 2. Add the `claude-failed` label to the issue.
 
 Do NOT open a PR if tests are failing or you are unsure the fix is correct.
-
-Follow all other conventions documented in CLAUDE.md and AGENTS.md. Where AGENTS.md prescribes broader local checks for human contributors (e.g., the full Psalm matrix, full PHPUnit suite), this prompt's narrower scope wins for Claude runs — CI catches what's skipped.

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -85,6 +85,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           label_trigger: claude
           branch_prefix: fix/
+          show_full_output: true
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary

- Trimmed `.github/claude-system-prompt.md` from ~5KB → 3.5KB by cutting rationale, redundant explanations, and the AGENTS.md precedence note that's already auto-loaded. All load-bearing rules preserved (branch prefix, no-make-psalm/changelog, changelog file format, milestone command, failure-mode checklist, do-not-merge).
- Tightened `vendor/bin/phpunit` to `--no-progress` and `vendor/bin/psalm` to `--no-progress --output-format=compact` so each tool call returns ~half the lines.
- Added a top-level "Keep tool output small" guideline pointing the agent at `head`/`tail`/`grep`/`gh --json`/`git diff --stat` patterns.
- Enabled `show_full_output: true` on `anthropics/claude-code-action`. **Temporary** — surfaces every SDK message in workflow logs so we can identify what's bloating context and triggering auto-compaction mid-run. To be reverted in a follow-up PR once the bloat sources are characterized.

Motivation: a recent successful run (PR #7961) hit auto-compaction at ~65 turns, splitting one agent invocation into two SDK session segments. The post-compaction segment cost \$1.72 in 47s — high per-token because everything is reloaded uncached. Both changes target reducing the chance of compaction (smaller prompt + smaller tool outputs) while the diagnostic flag lets us see what's actually filling the context.

## Test plan

- [ ] Trigger the workflow on a real issue or PR with `@claude` and confirm the agent still completes the standard 9-step flow (analyze → branch → tests → implement → lint → test → self-review → changelog → PR).
- [ ] Verify workflow logs now contain detailed SDK output (tool calls, results, assistant turns) rather than just the `init`/`result` summary.
- [ ] Inspect logs for which tool calls produce the largest outputs and which `permission_denials` are firing — input to the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)