### PR TITLE
Use injected clock in format_last_activity_date

### DIFF
--- a/changelog/fix-format-last-activity-clock
+++ b/changelog/fix-format-last-activity-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix off-by-one in last activity date formatting by using the injected clock for the time diff.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -3000,7 +3000,7 @@ class Sensei_Utils {
 			return sprintf(
 			/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */
 				__( '%s ago', 'sensei-lms' ),
-				human_time_diff( $date->getTimestamp() )
+				human_time_diff( $date->getTimestamp(), $now->getTimestamp() )
 			);
 		}
 


### PR DESCRIPTION
## Summary
- `Sensei_Utils::format_last_activity_date()` injects a clock for "now" via `Sensei()->clock->now()`, but then calls `human_time_diff( $date->getTimestamp() )` with a single argument — so WordPress falls back to real `time()` for the comparison, defeating the injected clock.
- Pass `$now->getTimestamp()` as the second argument so the time diff uses the same clock as the rest of the method.
- Caused intermittent CI failures in `Sensei_Utils_Test::testFormatLastActivityDate_WhenCalled_ReturnsCorrectlyFormattedDates` (`"seconds"` data set) when wall-clock time advanced between freezing the clock and the `human_time_diff` call, producing `'21 seconds ago'` instead of `'20 seconds ago'`.

## Test plan
- [x] CI is green (the previously flaky test should now be deterministic).
- [x] Manually verify the "Last Activity" column on student/learner reports still renders sensible relative times (e.g. "5 minutes ago", "2 days ago") and falls back to a date for activity older than 7 days.