### PR TITLE
Single-pipe and chunked-Read guidance; revert show_full_output

### DIFF
--- a/.github/claude-system-prompt.md
+++ b/.github/claude-system-prompt.md
@@ -1,6 +1,8 @@
 When responding to a GitHub trigger, follow this process strictly. The action runs with limited turns; be efficient.
 
-**Keep tool output small.** Pipe through `head`/`tail`/`grep`; use `gh ... --json <fields>`; use `git diff --stat` before full diffs, then `Read` individual files.
+**Keep tool output small.** Use a single pipe (`| head -N` or `| tail -N`), not chained pipes. Use `gh ... --json <fields>`. Use `git diff --stat` before full diffs.
+
+**Read large files in chunks.** For files >300 lines, use `Read` with `offset`/`limit` to target the section you need. Re-reading whole files after edits is rarely necessary — trust the edit succeeded.
 
 ## Context detection
 

--- a/.github/claude-system-prompt.md
+++ b/.github/claude-system-prompt.md
@@ -1,6 +1,6 @@
 When responding to a GitHub trigger, follow this process strictly. The action runs with limited turns; be efficient.
 
-**Keep tool output small.** Use a single pipe (`| head -N` or `| tail -N`), not chained pipes. Use `gh ... --json <fields>`. Use `git diff --stat` before full diffs.
+**Keep tool output small.** Use a single pipe (e.g. `| head -30` or `| tail -30`), not chained pipes. Use `gh ... --json <fields>`. Use `git diff --stat` before full diffs.
 
 **Read large files in chunks.** For files >300 lines, use `Read` with `offset`/`limit` to target the section you need. Re-reading whole files after edits is rarely necessary — trust the edit succeeded.
 

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -85,7 +85,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           label_trigger: claude
           branch_prefix: fix/
-          show_full_output: true
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
Follow-up to #7962 (now merged), acting on the diagnostic data that PR's `show_full_output` flag captured during the run on PR #7964.

## Summary

- **Disable `show_full_output`.** Diagnostic captured what we needed; verbose logs are no longer worth the noise or the public exposure of file contents in run logs.
- **Add single-pipe guidance** to the system prompt. Diagnostic showed the bash matcher denied `psalm | grep | grep | head` while single-pipe variants succeeded. Steering toward `| head -N` / `| tail -N` avoids burning turns on retries.
- **Add chunked-Read guidance** for files >300 lines. The diagnostic run loaded ~100 KB of file content via full-file `Read` calls (a 23 KB test file plus eight more 7–14 KB files), including re-reads after edits. Pointing the agent at `Read` with `offset`/`limit` and "trust the edit" cuts the dominant context-bloat source.

## Test plan

- [ ] Trigger the workflow with `@claude` on a representative issue and confirm the run still completes the standard 9-step flow.
- [ ] Compare total turn count and `total_cost_usd` against the diagnostic baseline (PR #7964: 71 turns, \$2.14, hit auto-compaction once). Expect lower or equal.
- [ ] Confirm workflow logs no longer dump full SDK output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)