### PR TITLE
Expand AGENTS.md with dev workflow and add e2e-testing skill

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -26,7 +26,7 @@ The most common surfaces ranked by what a Sensei change typically touches:
 | Tools | `/wp-admin/admin.php?page=sensei-tools` | Diagnostic / repair actions |
 | Reports | `/wp-admin/admin.php?page=sensei_reports` | Analytics output, filters |
 | Students (Learners) | `/wp-admin/admin.php?page=sensei_learners` | Enrollment management, learner search |
-| Grading | `/wp-admin/edit.php?post_type=lesson&page=sensei_grading` | Manual grading list, filters, status counts |
+| Grading | `/wp-admin/admin.php?page=sensei_grading` | Manual grading list, filters, status counts |
 | Courses CPT | `/wp-admin/edit.php?post_type=course` | Course list table, columns, filters |
 | Lessons CPT | `/wp-admin/edit.php?post_type=lesson` | Lesson list table, columns |
 | Modules taxonomy | `/wp-admin/edit-tags.php?taxonomy=module&post_type=course` | Module CRUD |

--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -63,15 +63,22 @@ If empty, run `make up` and wait ~30–60s on a warm Docker daemon (longer on a 
 
 ### 3. Seed enough test data
 
-wp-env starts empty. For most flows you'll need at least one published course with one lesson. Quick seed:
+wp-env starts empty. For most flows you'll need at least one published course with one lesson and one quiz. Quick seed:
 
 ```bash
 make wp CMD="post create --post_type=course --post_title='Sensei E2E' --post_status=publish --porcelain"
 # capture COURSE_ID
 make wp CMD="post create --post_type=lesson --post_title='Lesson 1' --post_status=publish --post_parent=COURSE_ID --porcelain"
+# capture LESSON_ID
+make wp CMD="post create --post_type=quiz --post_title='Quiz 1' --post_status=publish --post_parent=LESSON_ID --porcelain"
+# capture QUIZ_ID, then link the quiz to the lesson
+make wp CMD="post meta add LESSON_ID _lesson_quiz QUIZ_ID"
+make wp CMD="post create --post_type=question --post_title='Q1' --post_status=publish --porcelain"
+# capture QUESTION_ID
+make wp CMD="post meta add QUESTION_ID _quiz_id QUIZ_ID"
 ```
 
-For quiz/grading flows you'll also need a quiz attached to the lesson with at least one question. Bare `wp post create` doesn't set up the quiz structure (questions, settings, lesson↔quiz linkage), so for those flows mirror the factories in `tests/e2e-playwright/factories/`.
+The bare question above has no `question-type` taxonomy term or `_question_right_answer` meta, so it renders but isn't gradable. For take-quiz / grading flows that exercise correctness, mirror the factories in `tests/e2e-playwright/factories/` (or `tests/framework/factories/` for PHPUnit fixtures).
 
 ### 4. Drive the surfaces
 

--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -63,7 +63,7 @@ If empty, run `make up` and wait ~30–60s on a warm Docker daemon (longer on a 
 
 ### 3. Seed enough test data
 
-wp-env starts empty. For most flows you'll need at least one published course with one lesson and one quiz. Quick seed:
+wp-env starts empty. For most flows you'll need at least one published course with one lesson. Quick seed:
 
 ```bash
 make wp CMD="post create --post_type=course --post_title='Sensei E2E' --post_status=publish --porcelain"
@@ -71,7 +71,7 @@ make wp CMD="post create --post_type=course --post_title='Sensei E2E' --post_sta
 make wp CMD="post create --post_type=lesson --post_title='Lesson 1' --post_status=publish --post_parent=COURSE_ID --porcelain"
 ```
 
-For richer fixtures, mirror the factories in `tests/e2e-playwright/factories/`.
+For quiz/grading flows you'll also need a quiz attached to the lesson with at least one question. Bare `wp post create` doesn't set up the quiz structure (questions, settings, lesson↔quiz linkage), so for those flows mirror the factories in `tests/e2e-playwright/factories/`.
 
 ### 4. Drive the surfaces
 

--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -9,10 +9,10 @@ This skill verifies that a change actually behaves correctly from a user's persp
 
 ## Prerequisites
 
-- wp-env is running (`npx wp-env start --update`). The dev site listens on `http://localhost:8888` (admin: `admin` / `password` — wp-env defaults).
+- `make up` is running. The wp-env dev site listens on `http://localhost:8888` (admin: `admin` / `password` — wp-env defaults).
 - The active theme is `course` (`Automattic/themes/course`, pinned in `.wp-env.json`). All frontend verification should run against it.
 - Chrome DevTools MCP tools (`mcp__chrome-devtools__*`) are available.
-- For PHP changes that touch built assets, run `npm run build:assets` first. For changes that affect the scoped vendor tree, follow the build sequence in `AGENTS.md` (Building section).
+- For PHP changes that touch built assets, run `npm run build:assets` first. For changes that affect the scoped vendor tree, run `make build`.
 
 ## Sensei surface map
 
@@ -59,16 +59,16 @@ Heuristics:
 curl -sI http://localhost:8888 | head -1
 ```
 
-If empty, run `npx wp-env start --update` and wait ~30–60s on a warm Docker daemon (longer on a cold start).
+If empty, run `make up` and wait ~30–60s on a warm Docker daemon (longer on a cold start).
 
 ### 3. Seed enough test data
 
 wp-env starts empty. For most flows you'll need at least one published course with one lesson and one quiz. Quick seed:
 
 ```bash
-npx wp-env run cli wp post create --post_type=course --post_title='Sensei E2E' --post_status=publish --porcelain
+make wp CMD="post create --post_type=course --post_title='Sensei E2E' --post_status=publish --porcelain"
 # capture COURSE_ID
-npx wp-env run cli wp post create --post_type=lesson --post_title='Lesson 1' --post_status=publish --post_parent=COURSE_ID --porcelain
+make wp CMD="post create --post_type=lesson --post_title='Lesson 1' --post_status=publish --post_parent=COURSE_ID --porcelain"
 ```
 
 For richer fixtures, mirror the factories in `tests/e2e-playwright/factories/`.
@@ -107,16 +107,16 @@ Reference saved screenshots in the PR description if useful.
 
 - **Action Scheduler-driven side effects don't fire on click.** Sensei queues many flows (course completion emails, lesson progress recalc, enrollment recalculation, retroactive enrolment recalc) via Action Scheduler. The action runs on the next WP-Cron tick, not on the request that scheduled it. To force a sweep:
   ```bash
-  npx wp-env run cli wp action-scheduler run
+  make wp CMD="action-scheduler run"
   ```
 - **Course theme not active.** If the frontend looks unstyled, confirm:
   ```bash
-  npx wp-env run cli wp theme list --status=active
+  make wp CMD="theme list --status=active"
   ```
-  The active theme should be `course`. Re-activate with `npx wp-env run cli wp theme activate course`.
+  The active theme should be `course`. Re-activate with `make wp CMD="theme activate course"`.
 - **Stale built assets.** wp-env mounts the plugin live, but JS/CSS in `assets/dist/` need a rebuild after source changes: `npm run build:assets`. The browser may also need a hard reload.
 - **Comment-meta vs. tables drift on grading.** When verifying grading flows, check both the listing page (counts/filters) and the per-quiz "Review Grade" detail page; the two query paths can diverge during HPPS migrations.
-- **Empty Reports.** Reports require at least one enrolled student with progress. Create a second wp-env user (`npx wp-env run cli wp user create student student@example.com --role=subscriber`) and enroll them programmatically before verifying reports.
+- **Empty Reports.** Reports require at least one enrolled student with progress. Create a second wp-env user (`make wp CMD="user create student student@example.com --role=subscriber"`) and enroll them programmatically before verifying reports.
 
 ## When to skip this skill
 

--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: e2e-testing
+description: Use when verifying a Sensei UI or behavior change end-to-end against the running wp-env site. Boots / checks the env, scopes verification from `git diff`, drives the Sensei admin and frontend surfaces via Chrome DevTools MCP, and captures screenshots. Complements `npm run test:e2e` (full Playwright regression).
+---
+
+# Sensei E2E Verification
+
+This skill verifies that a change actually behaves correctly from a user's perspective. Use it after the unit-test loop passes and before relying on Playwright for full regression.
+
+## Prerequisites
+
+- wp-env is running (`npx wp-env start --update`). The dev site listens on `http://localhost:8888` (admin: `admin` / `password` — wp-env defaults).
+- The active theme is `course` (`Automattic/themes/course`, pinned in `.wp-env.json`). All frontend verification should run against it.
+- Chrome DevTools MCP tools (`mcp__chrome-devtools__*`) are available.
+- For PHP changes that touch built assets, run `npm run build:assets` first. For changes that affect the scoped vendor tree, follow the build sequence in `AGENTS.md` (Building section).
+
+## Sensei surface map
+
+The most common surfaces ranked by what a Sensei change typically touches:
+
+| Area | Path | Verify when changing |
+|------|------|----------------------|
+| Sensei Home | `/wp-admin/admin.php?page=sensei` | Top-level dashboard, quick links, onboarding |
+| Setup Wizard | `/wp-admin/admin.php?page=sensei_setup_wizard` | First-run flow |
+| Settings | `/wp-admin/admin.php?page=sensei-settings` | Settings save/load, tab routing |
+| Tools | `/wp-admin/admin.php?page=sensei-tools` | Diagnostic / repair actions |
+| Reports | `/wp-admin/admin.php?page=sensei_reports` | Analytics output, filters |
+| Students (Learners) | `/wp-admin/admin.php?page=sensei_learners` | Enrollment management, learner search |
+| Grading | `/wp-admin/edit.php?post_type=lesson&page=sensei_grading` | Manual grading list, filters, status counts |
+| Courses CPT | `/wp-admin/edit.php?post_type=course` | Course list table, columns, filters |
+| Lessons CPT | `/wp-admin/edit.php?post_type=lesson` | Lesson list table, columns |
+| Modules taxonomy | `/wp-admin/edit-tags.php?taxonomy=module&post_type=course` | Module CRUD |
+| Course editor | `/wp-admin/post.php?post={id}&action=edit` | Course blocks, structure, settings panel |
+| Lesson editor | same with a lesson ID | Lesson blocks, embedded quiz structure |
+| Course archive | `/courses/` | Frontend listing, theme integration |
+| Single course | `/course/{slug}/` | Take-course button, progress, prerequisites |
+| Single lesson | `/lesson/{slug}/` | Complete-lesson button, quiz embed |
+
+## Workflow
+
+### 1. Scope from the diff
+
+```bash
+git diff trunk...HEAD --name-only
+```
+
+Map changed files to surfaces using the table above. Skip surfaces the diff doesn't touch.
+
+Heuristics:
+- `includes/admin/` or files under `assets/admin/` → admin surfaces.
+- `includes/blocks/` or `assets/blocks/` → both editor and frontend.
+- `includes/internal/quiz-submission/`, `includes/quiz/`, `includes/lesson/` → quiz/lesson flows; verify both editor and frontend.
+- `includes/internal/services/class-comments-based-*` or anything HPPS-related → run with HPPS too (see step 5).
+- `includes/rest-api/` → check the surface that consumes the endpoint, not just the endpoint.
+
+### 2. Confirm the env is live
+
+```bash
+curl -sI http://localhost:8888 | head -1
+```
+
+If empty, run `npx wp-env start --update` and wait ~30–60s on a warm Docker daemon (longer on a cold start).
+
+### 3. Seed enough test data
+
+wp-env starts empty. For most flows you'll need at least one published course with one lesson and one quiz. Quick seed:
+
+```bash
+npx wp-env run cli wp post create --post_type=course --post_title='Sensei E2E' --post_status=publish --porcelain
+# capture COURSE_ID
+npx wp-env run cli wp post create --post_type=lesson --post_title='Lesson 1' --post_status=publish --post_parent=COURSE_ID --porcelain
+```
+
+For richer fixtures, mirror the factories in `tests/e2e-playwright/factories/`.
+
+### 4. Drive the surfaces
+
+Per in-scope surface:
+
+1. Authenticate once: `mcp__chrome-devtools__new_page` to `http://localhost:8888/wp-login.php`, fill `admin` / `password`, click Log In.
+2. Navigate to the surface URL.
+3. `mcp__chrome-devtools__take_snapshot` for DOM (lets you target by ID/role) and `mcp__chrome-devtools__take_screenshot` for visual.
+4. Drive any specific interaction the change requires (click, fill, navigate). After each interaction, take another screenshot.
+5. Watch `mcp__chrome-devtools__list_console_messages` for new JS errors introduced by the change.
+
+### 5. HPPS variant where relevant
+
+If the change touches grading, lesson/course progress, comment-meta paths, or analytics, also verify with HPPS enabled (the project's High-Performance Progress Storage). At minimum, run the HPPS PHPUnit variant:
+
+```bash
+npm run test-php:wp-env:hpps
+```
+
+For browser verification with HPPS, follow the toggle pattern used by `tests/e2e-playwright/specs/` (the existing suite already wires this up).
+
+### 6. Persist artifacts
+
+Save screenshots to `.claude/tmp/screenshots/YYYY-MM-DD-<surface>.png`. The `.claude/tmp/` tree is gitignored but does not exist in a fresh checkout — create it first:
+
+```bash
+mkdir -p .claude/tmp/screenshots
+```
+
+Reference saved screenshots in the PR description if useful.
+
+## Common Sensei-specific failure modes
+
+- **Action Scheduler-driven side effects don't fire on click.** Sensei queues many flows (course completion emails, lesson progress recalc, enrollment recalculation, retroactive enrolment recalc) via Action Scheduler. The action runs on the next WP-Cron tick, not on the request that scheduled it. To force a sweep:
+  ```bash
+  npx wp-env run cli wp action-scheduler run
+  ```
+- **Course theme not active.** If the frontend looks unstyled, confirm:
+  ```bash
+  npx wp-env run cli wp theme list --status=active
+  ```
+  The active theme should be `course`. Re-activate with `npx wp-env run cli wp theme activate course`.
+- **Stale built assets.** wp-env mounts the plugin live, but JS/CSS in `assets/dist/` need a rebuild after source changes: `npm run build:assets`. The browser may also need a hard reload.
+- **Comment-meta vs. tables drift on grading.** When verifying grading flows, check both the listing page (counts/filters) and the per-quiz "Review Grade" detail page; the two query paths can diverge during HPPS migrations.
+- **Empty Reports.** Reports require at least one enrolled student with progress. Create a second wp-env user (`npx wp-env run cli wp user create student student@example.com --role=subscriber`) and enroll them programmatically before verifying reports.
+
+## When to skip this skill
+
+- Pure refactor with full unit-test coverage and no behavior change.
+- Documentation, changelog, or build-only changes.
+- Changes already covered by a targeted Playwright spec — run that spec instead:
+  ```bash
+  npm run test:e2e -- tests/e2e-playwright/specs/<spec>.spec.ts
+  ```

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tests/e2e-playwright/contexts/*
 playwright-report/
 .vscode
 .worktrees/
+.claude/tmp/
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ See `make help` for the full list of available dev commands.
 ## Building
 - `make build` produces the plugin zip via wp-env, which sidesteps host PHP version issues.
 - Avoid running `npm run build` directly on the host: the pinned `humbug/php-scoper` ships an old `symfony/console` whose `HelperSet::getIterator()` is incompatible with PHP 8.1+ return-type checks. Either use `make build` or prefix `PATH` with a PHP 7.4 binary.
-- `make build` runs `composer install --no-dev` inside the container, which strips dev dependencies (including `vendor/bin/phpunit`). After a build, restore dev tooling before running PHPUnit with `make install-php`.
+- `make build` runs `composer install --no-dev` inside the container, which strips all dev dependencies (`vendor/bin/phpunit`, `vendor/bin/psalm`, etc.). After a build, restore dev tooling before running tests or static analysis with `make install-php`.
 
 ## Testing
 - **Test-driven development**: Follow a TDD approach for new behavior and bug fixes — write a failing test that captures the desired behavior first, then implement until it passes. This applies to PHPUnit, JS unit, and (where practical) Playwright suites.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - WordPress / PHP version overrides: write a `.wp-env.override.json` such as `{ "core": "WordPress/WordPress#6.8-branch", "phpVersion": "8.3" }` before `npx wp-env start --update`.
 
 ## Building
-- Avoid `npm run build` directly on the host: `humbug/php-scoper@0.15.0` ships an old `symfony/console` whose `HelperSet::getIterator()` is incompatible with PHP 8.1+ return-type checks. Build via wp-env instead:
+- Avoid `npm run build` directly on the host: the pinned `humbug/php-scoper` ships an old `symfony/console` whose `HelperSet::getIterator()` is incompatible with PHP 8.1+ return-type checks. Build via wp-env instead:
   ```
   npm run build:assets
   rm -f assets/dist/css/jquery-ui.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ See `make help` for the full list of available dev commands.
 ## Building
 - `make build` produces the plugin zip via wp-env, which sidesteps host PHP version issues.
 - Avoid running `npm run build` directly on the host: the pinned `humbug/php-scoper` ships an old `symfony/console` whose `HelperSet::getIterator()` is incompatible with PHP 8.1+ return-type checks. Either use `make build` or prefix `PATH` with a PHP 7.4 binary.
+- On a fresh checkout, run `make install-php` before `make build`. The build runs `composer install --no-dev --no-scripts`, which skips the `post-autoload-dump` hook that generates the scoped vendor tree at `vendor/sensei-lms/third-party-libs/` (consumed at runtime, e.g. `Sensei\ThirdParty\Pelago\Emogrifier\CssInliner`). `make install-php` runs the full composer install with scripts and populates that tree.
 - `make build` runs `composer install --no-dev` inside the container, which strips all dev dependencies (`vendor/bin/phpunit`, `vendor/bin/psalm`, etc.). After a build, restore dev tooling before running tests or static analysis with `make install-php`.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 ## Development environment
 - Run all dev commands inside the wp-env Docker sandbox rather than against any host WordPress install — this keeps mistakes off shared/local state.
 - Use the Node version pinned in `.nvmrc`.
-- Ensure Docker Desktop (or Colima) is running before starting wp-env; verify with `docker info`.
+- Ensure Docker Desktop (or Colima) is running before starting wp-env; verify with `docker info`. If it isn't running, start it first (`open -a Docker` on macOS, `colima start` on Colima, `sudo systemctl start docker` on Linux) and wait until `docker info` succeeds.
 - Start the env: `npx wp-env start --update`.
 - Stop the env: `npx wp-env stop`. Wipe and recreate from scratch: `npx wp-env destroy`.
 - Open a shell in the WordPress container: `npx wp-env run cli bash`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,43 @@
+See `make help` for the full list of available dev commands.
+
 ## Repository layout
 - `includes/` — main plugin PHP source.
 - `assets/` — JS/CSS source, blocks, and built artifacts under `assets/dist/`.
 - `tests/unit-tests/` — PHPUnit suite.
 - `tests/e2e-playwright/` — Playwright end-to-end suite (see "End-to-end" below).
-- `changelog/` — per-PR changelog entries (added via `npm run changelog`).
+- `changelog/` — per-PR changelog entries (added via `make changelog`).
 - `config/scoper.inc.php` — php-scoper config used during the build.
-- `scripts/linter-ci` — the diff-based PHPCS runner used by the lint command and CI.
+- `scripts/linter-ci` — the diff-based PHPCS runner used by `make lint` and CI.
 - `.github/workflows/` — CI definitions; PR previews are built by `playground-preview.yml`.
 
 ## Development environment
-- Run all dev commands inside the wp-env Docker sandbox rather than against any host WordPress install — this keeps mistakes off shared/local state.
+- Run all dev commands inside the `make up` (wp-env) sandbox rather than against any host WordPress install — this keeps mistakes off shared/local state.
 - Use the Node version pinned in `.nvmrc`.
-- Ensure Docker Desktop (or Colima) is running before starting wp-env; verify with `docker info`. If it isn't running, start it first (`open -a Docker` on macOS, `colima start` on Colima, `sudo systemctl start docker` on Linux) and wait until `docker info` succeeds.
-- Start the env: `npx wp-env start --update`.
-- Stop the env: `npx wp-env stop`. Wipe and recreate from scratch: `npx wp-env destroy`.
-- Open a shell in the WordPress container: `npx wp-env run cli bash`.
-- Run WP-CLI: `npx wp-env run cli wp <command>` (e.g. `npx wp-env run cli wp plugin list`).
-- WordPress / PHP version overrides: write a `.wp-env.override.json` such as `{ "core": "WordPress/WordPress#6.8-branch", "phpVersion": "8.3" }` before `npx wp-env start --update`.
+- Ensure Docker Desktop (or Colima) is running before `make up`; verify with `docker info`. If it isn't running, start it first (`open -a Docker` on macOS, `colima start` on Colima, `sudo systemctl start docker` on Linux) and wait until `docker info` succeeds.
+- `make up` boots the wp-env Docker stack; `make down` stops it; `make destroy` wipes containers and data for a clean slate.
+- `make shell` opens a shell inside the WordPress container; `make wp CMD="..."` runs wp-cli commands against it.
+- Override the WordPress or PHP version with `make up WP=6.8 PHP=8.3` (writes a transient `.wp-env.override.json`).
 
 ## Building
-- Avoid `npm run build` directly on the host: the pinned `humbug/php-scoper` ships an old `symfony/console` whose `HelperSet::getIterator()` is incompatible with PHP 8.1+ return-type checks. Build via wp-env instead:
-  ```
-  npm run build:assets
-  rm -f assets/dist/css/jquery-ui.js
-  npx wp-env run cli --env-cwd=wp-content/plugins/sensei composer install --no-dev --prefer-dist --optimize-autoloader --no-scripts
-  npm run archive
-  ```
-- The `--no-dev` step strips dev dependencies (including `vendor/bin/phpunit`). After a build, restore dev tooling before running PHPUnit:
-  ```
-  npx wp-env run cli --env-cwd=wp-content/plugins/sensei composer install
-  ```
+- `make build` produces the plugin zip via wp-env, which sidesteps host PHP version issues.
+- Avoid running `npm run build` directly on the host: the pinned `humbug/php-scoper` ships an old `symfony/console` whose `HelperSet::getIterator()` is incompatible with PHP 8.1+ return-type checks. Either use `make build` or prefix `PATH` with a PHP 7.4 binary.
+- `make build` runs `composer install --no-dev` inside the container, which strips dev dependencies (including `vendor/bin/phpunit`). After a build, restore dev tooling before running PHPUnit with `make install-php`.
 
 ## Testing
 - **Test-driven development**: Follow a TDD approach for new behavior and bug fixes — write a failing test that captures the desired behavior first, then implement until it passes. This applies to PHPUnit, JS unit, and (where practical) Playwright suites.
-- **PHPUnit**: `npm run test-php:wp-env` (runs inside wp-env). Targeted runs: `npm run test-php:wp-env -- --filter "TestClass"` or `--filter "TestClass::method"`.
+- **PHPUnit**: `make test-php` (runs inside wp-env). Targeted runs: `make test-php-filter FILTER="TestClass"` or `FILTER="TestClass::method"`.
 - **PHPUnit with HPPS enabled**: `npm run test-php:wp-env:hpps`.
 - **JS unit tests**: `npm run test-js`.
-- **End-to-end (Playwright)**: `npm run test:e2e` runs headless against the wp-env stack; `npm run test:e2e:debug` runs headed. Requires wp-env to be running first. The `pretest:e2e` hook runs ESLint + `tsc` before Playwright launches — failures there appear before any test output. See `tests/e2e-playwright/README.md` for details.
-- **Ad-hoc UI verification**: Once wp-env is up, the dev site is at `http://localhost:8888` with admin credentials `admin` / `password` (wp-env defaults). For agent-driven verification, use the `/e2e-testing` skill (`.claude/skills/e2e-testing/SKILL.md`) — it scopes from `git diff`, lists Sensei's admin/frontend surfaces, and walks the Chrome DevTools MCP through the relevant flow.
+- **End-to-end (Playwright)**: `npm run test:e2e` runs headless against the wp-env stack; `npm run test:e2e:debug` runs headed. Requires `make up` to be running first. The `pretest:e2e` hook runs ESLint + `tsc` before Playwright launches — failures there appear before any test output. See `tests/e2e-playwright/README.md` for details.
+- **Ad-hoc UI verification**: After `make up`, the dev site is at `http://localhost:8888` with admin credentials `admin` / `password` (wp-env defaults). For agent-driven verification, use the `/e2e-testing` skill (`.claude/skills/e2e-testing/SKILL.md`) — it scopes from `git diff`, lists Sensei's admin/frontend surfaces, and walks the Chrome DevTools MCP through the relevant flow.
 
 ## Linting
-- **PHPCS**: Run `./scripts/linter-ci` (the same diff-based check CI uses; requires a clean working tree). Whole-codebase scans: `./vendor/bin/phpcs`.
-- **Psalm**: Run `vendor/bin/psalm --no-cache --diff`. CI runs the full PHP-version matrix from `.github/workflows/psalm.yml`; type narrowing differs between versions, so for changes touching type-sensitive code, run Psalm against each matrix PHP version locally (each requires the matching `php@<version>` brew formula on `PATH`).
-- **Before pushing**: The pre-commit hook only lints PHP files added after 2020-01-01. CI lints all changed lines. Always run PHPCS and Psalm on modified files before pushing to avoid CI failures.
+- **PHPCS**: Run `make lint` (the same diff-based check CI uses; requires a clean working tree). Whole-codebase scans: `./vendor/bin/phpcs`.
+- **Psalm**: Run `make psalm`. This runs Psalm against every PHP version in `.github/workflows/psalm.yml`'s matrix (parsed at runtime) since type narrowing differs between versions. Requires the matching `php@<version>` brew formulae installed.
+- **Before pushing**: The pre-commit hook only lints PHP files added after 2020-01-01. CI lints all changed lines. Always run PHPCS and the full Psalm matrix on modified files before pushing to avoid CI failures.
 
 ## Conventions
-- **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `npm run changelog` (entries stored in `changelog/`). For purely internal changes (refactors, test-only changes), apply the `No Changelog` label to the PR instead.
+- **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `make changelog` (entries stored in `changelog/`). For purely internal changes (refactors, test-only changes), apply the `No Changelog` label to the PR instead.
 - **Version placeholders in docblocks**: Never hardcode a release number in `@since` tags for new code. Use `@since $$next-version$$` — release tooling replaces the placeholder on version bump.
 - **Array syntax**: Use the long form `array( ... )` in new PHP code, per the [WordPress PHP coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#declaring-arrays). Sensei's `phpcs.xml.dist` excludes the short-array disallow sniff, so `[ ... ]` won't fail lint, but new code should follow the upstream standard anyway. Do not mass-convert existing code.
 - **Test assertions**: When a single test has multiple assertions, pass a message as the third argument to each assertion (e.g., `self::assertSame( $expected, $actual, 'Foo should be updated.' );`) so a failure points to the specific check that failed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,51 @@
-See `make help` for the full list of available dev commands.
+## Repository layout
+- `includes/` — main plugin PHP source.
+- `assets/` — JS/CSS source, blocks, and built artifacts under `assets/dist/`.
+- `tests/unit-tests/` — PHPUnit suite.
+- `tests/e2e-playwright/` — Playwright end-to-end suite (see "End-to-end" below).
+- `changelog/` — per-PR changelog entries (added via `npm run changelog`).
+- `config/scoper.inc.php` — php-scoper config used during the build.
+- `scripts/linter-ci` — the diff-based PHPCS runner used by the lint command and CI.
+- `.github/workflows/` — CI definitions; PR previews are built by `playground-preview.yml`.
+
+## Development environment
+- Run all dev commands inside the wp-env Docker sandbox rather than against any host WordPress install — this keeps mistakes off shared/local state.
+- Use the Node version pinned in `.nvmrc`.
+- Ensure Docker Desktop (or Colima) is running before starting wp-env; verify with `docker info`.
+- Start the env: `npx wp-env start --update`.
+- Stop the env: `npx wp-env stop`. Wipe and recreate from scratch: `npx wp-env destroy`.
+- Open a shell in the WordPress container: `npx wp-env run cli bash`.
+- Run WP-CLI: `npx wp-env run cli wp <command>` (e.g. `npx wp-env run cli wp plugin list`).
+- WordPress / PHP version overrides: write a `.wp-env.override.json` such as `{ "core": "WordPress/WordPress#6.8-branch", "phpVersion": "8.3" }` before `npx wp-env start --update`.
+
+## Building
+- Avoid `npm run build` directly on the host: `humbug/php-scoper@0.15.0` ships an old `symfony/console` whose `HelperSet::getIterator()` is incompatible with PHP 8.1+ return-type checks. Build via wp-env instead:
+  ```
+  npm run build:assets
+  rm -f assets/dist/css/jquery-ui.js
+  npx wp-env run cli --env-cwd=wp-content/plugins/sensei composer install --no-dev --prefer-dist --optimize-autoloader --no-scripts
+  npm run archive
+  ```
+- The `--no-dev` step strips dev dependencies (including `vendor/bin/phpunit`). After a build, restore dev tooling before running PHPUnit:
+  ```
+  npx wp-env run cli --env-cwd=wp-content/plugins/sensei composer install
+  ```
+
+## Testing
+- **Test-driven development**: Follow a TDD approach for new behavior and bug fixes — write a failing test that captures the desired behavior first, then implement until it passes. This applies to PHPUnit, JS unit, and (where practical) Playwright suites.
+- **PHPUnit**: `npm run test-php:wp-env` (runs inside wp-env). Targeted runs: `npm run test-php:wp-env -- --filter "TestClass"` or `--filter "TestClass::method"`.
+- **PHPUnit with HPPS enabled**: `npm run test-php:wp-env:hpps`.
+- **JS unit tests**: `npm run test-js`.
+- **End-to-end (Playwright)**: `npm run test:e2e` runs headless against the wp-env stack; `npm run test:e2e:debug` runs headed. Requires wp-env to be running first. The `pretest:e2e` hook runs ESLint + `tsc` before Playwright launches — failures there appear before any test output. See `tests/e2e-playwright/README.md` for details.
+- **Ad-hoc UI verification**: Once wp-env is up, the dev site is at `http://localhost:8888` with admin credentials `admin` / `password` (wp-env defaults). For agent-driven verification, use the `/e2e-testing` skill (`.claude/skills/e2e-testing/SKILL.md`) — it scopes from `git diff`, lists Sensei's admin/frontend surfaces, and walks the Chrome DevTools MCP through the relevant flow.
 
 ## Linting
-- **PHPCS**: Run `make lint` (the same diff-based check CI uses; requires a clean working tree). Whole-codebase scans: `./vendor/bin/phpcs`.
-- **Psalm**: Run `make psalm`. This runs Psalm against every PHP version in `.github/workflows/psalm.yml`'s matrix (parsed at runtime) since type narrowing differs between versions. Requires the matching `php@<version>` brew formulae installed.
-- **Before pushing**: The pre-commit hook only lints PHP files added after 2020-01-01. CI lints all changed lines. Always run PHPCS and the full Psalm matrix on modified files before pushing to avoid CI failures.
+- **PHPCS**: Run `./scripts/linter-ci` (the same diff-based check CI uses; requires a clean working tree). Whole-codebase scans: `./vendor/bin/phpcs`.
+- **Psalm**: Run `vendor/bin/psalm --no-cache --diff`. CI runs the full PHP-version matrix from `.github/workflows/psalm.yml`; type narrowing differs between versions, so for changes touching type-sensitive code, run Psalm against each matrix PHP version locally (each requires the matching `php@<version>` brew formula on `PATH`).
+- **Before pushing**: The pre-commit hook only lints PHP files added after 2020-01-01. CI lints all changed lines. Always run PHPCS and Psalm on modified files before pushing to avoid CI failures.
 
 ## Conventions
-- **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `make changelog` (entries stored in `changelog/`). For purely internal changes (refactors, test-only changes), apply the `No Changelog` label to the PR instead.
+- **Changelogs**: Every user-facing change MUST have a changelog entry before opening a PR. Run `npm run changelog` (entries stored in `changelog/`). For purely internal changes (refactors, test-only changes), apply the `No Changelog` label to the PR instead.
 - **Version placeholders in docblocks**: Never hardcode a release number in `@since` tags for new code. Use `@since $$next-version$$` — release tooling replaces the placeholder on version bump.
 - **Array syntax**: Use the long form `array( ... )` in new PHP code, per the [WordPress PHP coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#declaring-arrays). Sensei's `phpcs.xml.dist` excludes the short-array disallow sniff, so `[ ... ]` won't fail lint, but new code should follow the upstream standard anyway. Do not mass-convert existing code.
 - **Test assertions**: When a single test has multiple assertions, pass a message as the third argument to each assertion (e.g., `self::assertSame( $expected, $actual, 'Foo should be updated.' );`) so a failure points to the specific check that failed.

--- a/package.json
+++ b/package.json
@@ -131,19 +131,19 @@
     "run-phpcs": "./vendor/bin/phpcs --encoding=utf-8",
     "start": "cross-env NODE_ENV=development wp-scripts start",
     "test": "npm run test-php && npm run test-js",
-    "test:e2e": "playwright test --grep-invert @setup",
+    "test:e2e": "COMPOSE_PROJECT_NAME=sensei-lms playwright test --grep-invert @setup",
     "test:e2e:gutenberg": "ENABLE_GUTENBERG=true npm run test:e2e",
-    "test:e2e:setup-only": "playwright test --grep @setup",
+    "test:e2e:setup-only": "COMPOSE_PROJECT_NAME=sensei-lms playwright test --grep @setup",
     "test:e2e:debug": "npm run test:e2e -- --headed",
     "test-js": "wp-scripts test-unit-js",
     "test-js:coverage": "wp-scripts test-unit-js --coverage",
     "test-js:watch": "wp-scripts test-unit-js --watch",
     "test-php": "./vendor/bin/phpunit",
-    "test-php:wp-env": "wp-env run --env-cwd='wp-content/plugins/sensei' tests-cli vendor/bin/phpunit -c phpunit.xml",
-    "test-php:wp-env:hpps": "wp-env run --env-cwd='wp-content/plugins/sensei' tests-cli env ENABLE_HPPS=1 vendor/bin/phpunit -c phpunit.xml",
+    "test-php:wp-env": "COMPOSE_PROJECT_NAME=sensei-lms wp-env run --env-cwd='wp-content/plugins/sensei' tests-cli vendor/bin/phpunit -c phpunit.xml",
+    "test-php:wp-env:hpps": "COMPOSE_PROJECT_NAME=sensei-lms wp-env run --env-cwd='wp-content/plugins/sensei' tests-cli env ENABLE_HPPS=1 vendor/bin/phpunit -c phpunit.xml",
     "test-php:coverage-clover": "php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml",
     "test-php:coverage-html": "php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-html=coverage",
-    "wp-env": "wp-env"
+    "wp-env": "COMPOSE_PROJECT_NAME=sensei-lms wp-env"
   },
   "lint-staged": {
     "package.json": [


### PR DESCRIPTION
## Summary

- Expands `AGENTS.md` with repository layout, development environment, build sequence, testing, linting, and conventions sections so an agent dropped into the repo can build, test, and verify a change end-to-end without external context.
- Adds a Sensei-specific `e2e-testing` skill at `.claude/skills/e2e-testing/SKILL.md` covering admin/frontend surface map, scope-from-diff heuristics, Chrome DevTools MCP-driven verification flow, fixture seeding (course/lesson/quiz/question with the right meta linkages), and Sensei-specific failure modes (Action Scheduler timing, comment-meta vs tables drift, course theme).
- Pins `COMPOSE_PROJECT_NAME=sensei-lms` across the wp-env/test npm scripts in `package.json` so they target the same Docker project that `make up` uses; fixes a silent mismatch where `npm run test:e2e` couldn't find the running stack.
- Gitignores `.claude/tmp/` (screenshot output) and `.claude/settings.local.json`.

Documents the fresh-checkout build order (`make install-php` → `make build`) so the scoped vendor tree exists, the host PHP 8.1+ `php-scoper`/`symfony/console` trap, and the dev-tool restore step needed after a build before re-running tests or static analysis.

## Test plan
- [x] Walk through one ad-hoc UI verification with the skill: spin wp-env, log in at `http://localhost:8888`, navigate to a Sensei admin screen of choice, confirm the surface map matches reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
