### PR TITLE
Speed up PR CI with concurrency cancellation and trimmed matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
     - pull_request
     - workflow_call
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     build:
         name: Plugin Build

--- a/.github/workflows/dependencies-report.yml
+++ b/.github/workflows/dependencies-report.yml
@@ -3,6 +3,10 @@ name: WordPress Dependencies Report
 on:
     pull_request:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref }}
+    cancel-in-progress: true
+
 jobs:
     build-trunk:
         runs-on: ubuntu-latest
@@ -58,7 +62,6 @@ jobs:
             -   uses: actions/setup-node@v4
                 with:
                     node-version-file: '.nvmrc'
-            -   uses: actions/checkout@v4
             -   name: Get npm cache directory
                 id: npm-cache
                 run: |

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
     workflow_call:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     lint:
         name: JS Linting

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -63,20 +63,7 @@ jobs:
             matrix:
                 # On pull_request: a focused subset (lowest supported PHP, current target, HPPS variant).
                 # On workflow_call (trunk push): the full matrix including older WP versions, multisite, and nightly.
-                include: ${{ github.event_name == 'pull_request' && fromJSON('[
-                    {"php":"7.4","wp":"latest"},
-                    {"php":"8.2","wp":"latest"},
-                    {"php":"8.2","wp":"latest","hpps":1}
-                ]') || fromJSON('[
-                    {"php":"7.4","wp":"latest"},
-                    {"php":"8.1","wp":"latest"},
-                    {"php":"8.2","wp":"6.7"},
-                    {"php":"8.2","wp":"6.8"},
-                    {"php":"8.2","wp":"latest"},
-                    {"php":"8.2","wp":"nightly"},
-                    {"php":"8.2","wp":"latest","wpmu":1},
-                    {"php":"8.2","wp":"latest","hpps":1}
-                ]') }}
+                include: ${{ github.event_name == 'pull_request' && fromJSON('[{"php":"7.4","wp":"latest"},{"php":"8.2","wp":"latest"},{"php":"8.2","wp":"latest","hpps":1}]') || fromJSON('[{"php":"7.4","wp":"latest"},{"php":"8.1","wp":"latest"},{"php":"8.2","wp":"6.7"},{"php":"8.2","wp":"6.8"},{"php":"8.2","wp":"latest"},{"php":"8.2","wp":"nightly"},{"php":"8.2","wp":"latest","wpmu":1},{"php":"8.2","wp":"latest","hpps":1}]') }}
         env:
             WP_VERSION: ${{ matrix.wp }}
             WP_MULTISITE: ${{ matrix.wpmu }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
     workflow_call:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     lint:
         name: PHP Linting
@@ -57,25 +61,22 @@ jobs:
             fail-fast: true
             max-parallel: 10
             matrix:
-                include:
-                    - php: '7.4'
-                      wp: latest
-                    - php: '8.1'
-                      wp: latest
-                    - php: '8.2'
-                      wp: '6.7'
-                    - php: '8.2'
-                      wp: '6.8'
-                    - php: '8.2'
-                      wp: latest
-                    - php: '8.2'
-                      wp: nightly
-                    - php: '8.2'
-                      wp: latest
-                      wpmu: 1
-                    - php: '8.2'
-                      wp: latest
-                      hpps: 1
+                # On pull_request: a focused subset (lowest supported PHP, current target, HPPS variant).
+                # On workflow_call (trunk push): the full matrix including older WP versions, multisite, and nightly.
+                include: ${{ github.event_name == 'pull_request' && fromJSON('[
+                    {"php":"7.4","wp":"latest"},
+                    {"php":"8.2","wp":"latest"},
+                    {"php":"8.2","wp":"latest","hpps":1}
+                ]') || fromJSON('[
+                    {"php":"7.4","wp":"latest"},
+                    {"php":"8.1","wp":"latest"},
+                    {"php":"8.2","wp":"6.7"},
+                    {"php":"8.2","wp":"6.8"},
+                    {"php":"8.2","wp":"latest"},
+                    {"php":"8.2","wp":"nightly"},
+                    {"php":"8.2","wp":"latest","wpmu":1},
+                    {"php":"8.2","wp":"latest","hpps":1}
+                ]') }}
         env:
             WP_VERSION: ${{ matrix.wp }}
             WP_MULTISITE: ${{ matrix.wpmu }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -2,7 +2,11 @@ name: Playground PR Preview
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened, edited]
+        types: [opened, synchronize, reopened]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref }}
+    cancel-in-progress: true
 
 jobs:
     build:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, milestoned, demilestoned]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   check-milestone:
     name: Check Milestone

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -5,8 +5,8 @@ on:
     workflow_call:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     tests:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,7 +16,8 @@ jobs:
             fail-fast: true
             max-parallel: 10
             matrix:
-                php: ['7.4', '8.2']
+                # On pull_request: only the current target version. On workflow_call (trunk push): both versions.
+                php: ${{ github.event_name == 'pull_request' && fromJSON('["8.2"]') || fromJSON('["7.4", "8.2"]') }}
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -10,6 +10,9 @@ jobs:
   unit-php:
     uses: ./.github/workflows/php.yml
     secrets: inherit
+  psalm:
+    uses: ./.github/workflows/psalm.yml
+    secrets: inherit
   e2e:
     uses: ./.github/workflows/e2e.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Add `concurrency: cancel-in-progress` to `build.yml`, `php.yml`, `js.yml`, `playground-preview.yml`, `dependencies-report.yml`, and `pr-validation.yml`. Previously a new push spawned fully independent runs in parallel with older ones; now superseded PR runs are cancelled. Workflows reused from `trunk.yml` (`build`, `php`, `js`) use a sha-based group on non-PR events so trunk pushes never cancel each other.
- Trim the per-PR PHPUnit matrix in `php.yml` from 8 cells to 3 (7.4/latest, 8.2/latest, 8.2/HPPS). The full matrix (older WP versions, multisite, nightly) still runs on trunk push via `workflow_call`.
- Trim the per-PR Psalm matrix in `psalm.yml` to PHP 8.2 only; both 7.4 and 8.2 still run on trunk via `workflow_call`. Added `psalm` to `trunk.yml` so the 7.4 coverage runs post-merge.
- Drop `edited` from the `playground-preview.yml` trigger so the build doesn't re-run on PR title/description edits.
- Remove a duplicate `actions/checkout@v4` step in `dependencies-report.yml`.

## Coverage tradeoff
Older WP versions, multisite, nightly, and PHP 7.4 Psalm move from per-PR to post-merge (trunk) runs. Regressions in those combos would be caught at merge instead of on the PR.

## Follow-ups not in this PR
- Share the `npm run build` artifact across `build.yml`, `playground-preview.yml`, and `e2e.yml` instead of rebuilding three times per PR.
- Cache Playwright browsers and wp-env Docker images in `e2e.yml`.
- Consolidate the three near-identical jobs in `js.yml`.

## Test plan
- [ ] Push a follow-up commit to this PR and confirm the older in-flight runs for `build`, `php`, `js`, etc. are cancelled rather than running to completion.
- [ ] Confirm the PR's PHPUnit matrix shows 3 cells (7.4/latest, 8.2/latest, 8.2/HPPS).
- [ ] Confirm the PR's Psalm run is a single PHP 8.2 cell.
- [ ] After merge, confirm `Trunk Workflow` runs the full 8-cell PHPUnit matrix and both Psalm cells.
- [ ] Edit this PR's title/description and confirm `Playground PR Preview` does not re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)