### PR TITLE
Hotfix: stop reusable workflows from cancelling each other on trunk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ concurrency:
     # Hardcoded prefix because github.workflow resolves to the caller's name
     # when invoked via workflow_call, which would put every reusable workflow
     # called from trunk.yml in the same group and cancel each other.
-    group: plugin-build-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    group: plugin-build-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,10 @@ on:
     - workflow_call
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # Hardcoded prefix because github.workflow resolves to the caller's name
+    # when invoked via workflow_call, which would put every reusable workflow
+    # called from trunk.yml in the same group and cancel each other.
+    group: plugin-build-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
     - workflow_call
 
 concurrency:
-    # Hardcoded prefix because github.workflow resolves to the caller's name
-    # when invoked via workflow_call, which would put every reusable workflow
-    # called from trunk.yml in the same group and cancel each other.
     group: plugin-build-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ env:
 # which would put every reusable workflow called from trunk.yml in the same
 # group and cancel each other.
 concurrency:
-    group: e2e-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,10 +5,6 @@ on:
 env:
     CI: true
 
-# Cancels superseded PR runs but never trunk runs. Hardcoded prefix because
-# github.workflow resolves to the caller's name when invoked via workflow_call,
-# which would put every reusable workflow called from trunk.yml in the same
-# group and cancel each other.
 concurrency:
     group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,12 +5,13 @@ on:
 env:
     CI: true
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Cancels superseded PR runs but never trunk runs. Hardcoded prefix because
+# github.workflow resolves to the caller's name when invoked via workflow_call,
+# which would put every reusable workflow called from trunk.yml in the same
+# group and cancel each other.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-    cancel-in-progress: true
+    group: e2e-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     test:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -5,9 +5,6 @@ on:
     workflow_call:
 
 concurrency:
-    # Hardcoded prefix because github.workflow resolves to the caller's name
-    # when invoked via workflow_call, which would put every reusable workflow
-    # called from trunk.yml in the same group and cancel each other.
     group: js-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -5,7 +5,10 @@ on:
     workflow_call:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # Hardcoded prefix because github.workflow resolves to the caller's name
+    # when invoked via workflow_call, which would put every reusable workflow
+    # called from trunk.yml in the same group and cancel each other.
+    group: js-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -8,7 +8,7 @@ concurrency:
     # Hardcoded prefix because github.workflow resolves to the caller's name
     # when invoked via workflow_call, which would put every reusable workflow
     # called from trunk.yml in the same group and cancel each other.
-    group: js-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    group: js-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,9 +5,6 @@ on:
     workflow_call:
 
 concurrency:
-    # Hardcoded prefix because github.workflow resolves to the caller's name
-    # when invoked via workflow_call, which would put every reusable workflow
-    # called from trunk.yml in the same group and cancel each other.
     group: php-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,7 +5,10 @@ on:
     workflow_call:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # Hardcoded prefix because github.workflow resolves to the caller's name
+    # when invoked via workflow_call, which would put every reusable workflow
+    # called from trunk.yml in the same group and cancel each other.
+    group: php-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ concurrency:
     # Hardcoded prefix because github.workflow resolves to the caller's name
     # when invoked via workflow_call, which would put every reusable workflow
     # called from trunk.yml in the same group and cancel each other.
-    group: php-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    group: php-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -5,9 +5,6 @@ on:
     workflow_call:
 
 concurrency:
-    # Hardcoded prefix because github.workflow resolves to the caller's name
-    # when invoked via workflow_call, which would put every reusable workflow
-    # called from trunk.yml in the same group and cancel each other.
     group: psalm-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -5,7 +5,10 @@ on:
     workflow_call:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # Hardcoded prefix because github.workflow resolves to the caller's name
+    # when invoked via workflow_call, which would put every reusable workflow
+    # called from trunk.yml in the same group and cancel each other.
+    group: psalm-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -8,7 +8,7 @@ concurrency:
     # Hardcoded prefix because github.workflow resolves to the caller's name
     # when invoked via workflow_call, which would put every reusable workflow
     # called from trunk.yml in the same group and cancel each other.
-    group: psalm-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    group: psalm-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced by #7970. After merge to trunk, only `e2e` ran. The other reusable workflows were either cancelled by a concurrency-group collision (`js`, `php`, `psalm`) or skipped because their `needs` had been cancelled (`build`, `docs`).

## Root cause
The concurrency group from #7970 was `${{ github.workflow }}-${{ ... github.sha }}`. When `trunk.yml` invokes a workflow via `workflow_call`, `github.workflow` inside the called file resolves to the **caller's** name (`Trunk Workflow`), not the called workflow's own name. All four workflows that started in parallel from the trunk push (`js`, `php`, `psalm`, `e2e`) therefore evaluated to the same group `Trunk Workflow-<sha>`. GitHub kept one running (`e2e`) and cancelled the rest with `Canceling since a higher priority waiting request for Trunk Workflow-<sha> exists`. `build` and `docs` then got skipped because their `needs: [unit-js, unit-php, e2e]` couldn't be satisfied.

## Fix
Hardcode a per-workflow prefix in each file's `concurrency.group` (`plugin-build-`, `php-`, `js-`, `psalm-`, `e2e-`) so each workflow owns its own group regardless of caller context.

Two follow-up tweaks based on Copilot's review:
- Tightened `e2e.yml`'s pre-existing `cancel-in-progress: true` to only fire on `pull_request` (the same bug would have hit it once the group was distinct).
- Switched the PR-side key from `github.head_ref` to `github.event.pull_request.number` so PRs from forks using identical branch names don't share groups.

## Affected files
`build.yml`, `php.yml`, `js.yml`, `psalm.yml`, `e2e.yml`. The other PR-only workflows (`playground-preview`, `dependencies-report`, `pr-validation`) only trigger on `pull_request`, so `github.workflow` resolves correctly there and they don't need changes.

## Test plan
- [ ] After merge, push to trunk and confirm all reusable workflows run instead of being cancelled.
- [ ] On a PR, push a follow-up commit and verify older runs are cancelled (cancel-in-progress still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
