### PR TITLE
Speed up admin pages by replacing Grading menu badge query

### DIFF
--- a/changelog/fix-grading-badge-teacher-scope
+++ b/changelog/fix-grading-badge-teacher-scope
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Grading menu badge counting ungraded quizzes from other teachers' courses.

--- a/changelog/perf-grading-menu-badge-ungraded-count
+++ b/changelog/perf-grading-menu-badge-ungraded-count
@@ -1,4 +1,4 @@
 Significance: patch
-Type: tweak
+Type: changed
 
 Speed up admin pages by replacing the Grading menu badge query with a cheaper dedicated ungraded count.

--- a/changelog/perf-grading-menu-badge-ungraded-count
+++ b/changelog/perf-grading-menu-badge-ungraded-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Speed up admin pages by replacing the Grading menu badge query with a cheaper dedicated ungraded count.

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -111,10 +111,10 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		$indicator_html = '';
-		$grading_counts = Sensei()->grading->count_statuses( array( 'type' => 'lesson' ) );
+		$ungraded_count = $this->count_ungraded_quizzes();
 
-		if ( intval( $grading_counts['ungraded'] ) > 0 ) {
-			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
+		if ( $ungraded_count > 0 ) {
+			$indicator_html = ' <span class="awaiting-mod">' . esc_html( (string) $ungraded_count ) . '</span>';
 		}
 
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
@@ -627,6 +627,30 @@ class Sensei_Grading {
 		 * @return {array} Filtered counts.
 		 */
 		return apply_filters( 'sensei_count_statuses', $counts, $comment_type );
+	}
+
+	/**
+	 * Count ungraded quiz submissions for published lessons.
+	 *
+	 * Cheap query used by the Grading admin-menu badge, which only needs the
+	 * ungraded total rather than the full per-status breakdown.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int Number of ungraded quiz submissions for published lessons.
+	 */
+	public function count_ungraded_quizzes(): int {
+		$cache_key = 'sensei-ungraded-quizzes';
+		$cached    = wp_cache_get( $cache_key, 'counts' );
+
+		if ( false !== $cached ) {
+			return (int) $cached;
+		}
+
+		$count = self::get_aggregation_service()->count_ungraded_quizzes();
+		wp_cache_set( $cache_key, $count, 'counts' );
+
+		return $count;
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -111,7 +111,10 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		$indicator_html = '';
-		$ungraded_count = self::get_aggregation_service()->count_ungraded_quizzes();
+
+		/** This filter is documented in includes/class-sensei-grading.php */
+		$args           = apply_filters( 'sensei_count_statuses_args', array( 'type' => 'lesson' ) );
+		$ungraded_count = self::get_aggregation_service()->count_ungraded_quizzes( $args );
 
 		if ( $ungraded_count > 0 ) {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( (string) $ungraded_count ) . '</span>';

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -111,7 +111,7 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		$indicator_html = '';
-		$ungraded_count = $this->count_ungraded_quizzes();
+		$ungraded_count = self::get_aggregation_service()->count_ungraded_quizzes();
 
 		if ( $ungraded_count > 0 ) {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( (string) $ungraded_count ) . '</span>';
@@ -627,17 +627,6 @@ class Sensei_Grading {
 		 * @return {array} Filtered counts.
 		 */
 		return apply_filters( 'sensei_count_statuses', $counts, $comment_type );
-	}
-
-	/**
-	 * Count ungraded quiz submissions for published lessons.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return int Number of ungraded quiz submissions for published lessons.
-	 */
-	public function count_ungraded_quizzes(): int {
-		return self::get_aggregation_service()->count_ungraded_quizzes();
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -632,25 +632,12 @@ class Sensei_Grading {
 	/**
 	 * Count ungraded quiz submissions for published lessons.
 	 *
-	 * Cheap query used by the Grading admin-menu badge, which only needs the
-	 * ungraded total rather than the full per-status breakdown.
-	 *
 	 * @since $$next-version$$
 	 *
 	 * @return int Number of ungraded quiz submissions for published lessons.
 	 */
 	public function count_ungraded_quizzes(): int {
-		$cache_key = 'sensei-ungraded-quizzes';
-		$cached    = wp_cache_get( $cache_key, 'counts' );
-
-		if ( false !== $cached ) {
-			return (int) $cached;
-		}
-
-		$count = self::get_aggregation_service()->count_ungraded_quizzes();
-		wp_cache_set( $cache_key, $count, 'counts' );
-
-		return $count;
+		return self::get_aggregation_service()->count_ungraded_quizzes();
 	}
 
 	/**

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -945,31 +945,37 @@ AND comments.comment_type = 'sensei_course_status'";
 			return $args;
 		}
 
-		// get the teachers courses
-		// the query is already filtered to only the teacher
-		$courses = Sensei()->course->get_all_courses();
+		$courses = get_posts(
+			array(
+				'post_type'        => 'course',
+				'post_status'      => 'any',
+				'posts_per_page'   => -1,
+				'author'           => get_current_user_id(),
+				'fields'           => 'ids',
+				'suppress_filters' => false,
+			)
+		);
 
-		if ( empty( $courses ) || ! is_array( $courses ) ) {
+		// post__in => array( 0 ) forces an IN ( 0 ) clause that matches no
+		// rows. An empty array is skipped by the SQL builder and would count
+		// all ungraded quizzes site-wide.
+		if ( empty( $courses ) ) {
+			$args['post__in'] = array( 0 );
 			return $args;
 		}
 
-		// setup the lessons quizzes  to limit the grading totals to
 		$quiz_scope = array();
-		foreach ( $courses as $course ) {
-
-			$course_lessons = Sensei()->course->course_lessons( $course->ID );
+		foreach ( $courses as $course_id ) {
+			$course_lessons = Sensei()->course->course_lessons( $course_id );
 
 			if ( ! empty( $course_lessons ) && is_array( $course_lessons ) ) {
-
 				foreach ( $course_lessons as $lesson ) {
-
 					array_push( $quiz_scope, $lesson->ID );
-
 				}
 			}
 		}
 
-		$args['post__in'] = $quiz_scope;
+		$args['post__in'] = empty( $quiz_scope ) ? array( 0 ) : $quiz_scope;
 
 		return $args;
 	}

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -156,6 +156,28 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	}
 
 	/**
+	 * Count ungraded quiz submissions whose lesson is published.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int Number of ungraded quiz submissions for published lessons.
+	 */
+	public function count_ungraded_quizzes(): int {
+		$wpdb = $this->wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb. comment_type/comment_approved values are constants.
+		$query = "SELECT COUNT(*) FROM {$wpdb->comments}
+			INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status = 'publish'
+			WHERE {$wpdb->comments}.comment_type = 'sensei_lesson_status' AND {$wpdb->comments}.comment_approved = 'ungraded'";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only. Caching handled by callers.
+		$count = (int) $wpdb->get_var( $query );
+		Utils::log_query_error( $wpdb, 'Comments-based ungraded quizzes count' );
+
+		return $count;
+	}
+
+	/**
 	 * Build SQL clause for filtering by post ID(s).
 	 *
 	 * @since $$next-version$$

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -160,9 +160,10 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	 *
 	 * @since $$next-version$$
 	 *
+	 * @param array $args Optional restrictions; see interface.
 	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
-	public function count_ungraded_quizzes(): int {
+	public function count_ungraded_quizzes( array $args = array() ): int {
 		$wpdb = $this->wpdb;
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb. comment_type/comment_approved values are constants.
@@ -170,7 +171,15 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 			INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' )
 			WHERE {$wpdb->comments}.comment_type = 'sensei_lesson_status' AND {$wpdb->comments}.comment_approved = 'ungraded'";
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only. Caching handled by callers.
+		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$query .= $wpdb->prepare( " AND {$wpdb->comments}.comment_post_ID IN ( $placeholders )", $args['post__in'] );
+		}
+
+		$query .= $this->build_user_exclusion_clause( $args );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only.
 		$count = (int) $wpdb->get_var( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based ungraded quizzes count' );
 

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -156,18 +156,18 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	}
 
 	/**
-	 * Count ungraded quiz submissions whose lesson is published.
+	 * Count ungraded quiz submissions whose lesson is publicly available.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int Number of ungraded quiz submissions for published lessons.
+	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
 	public function count_ungraded_quizzes(): int {
 		$wpdb = $this->wpdb;
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb. comment_type/comment_approved values are constants.
 		$query = "SELECT COUNT(*) FROM {$wpdb->comments}
-			INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status = 'publish'
+			INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' )
 			WHERE {$wpdb->comments}.comment_type = 'sensei_lesson_status' AND {$wpdb->comments}.comment_approved = 'ungraded'";
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only. Caching handled by callers.

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -57,4 +57,17 @@ interface Progress_Aggregation_Service_Interface {
 	 * }
 	 */
 	public function get_lesson_totals( array $lesson_ids ): array;
+
+	/**
+	 * Count ungraded quiz submissions whose lesson is published.
+	 *
+	 * Dedicated lightweight query for the Grading admin-menu badge, which only
+	 * needs the ungraded count. Avoids the full per-status aggregation that
+	 * the badge previously triggered on every admin pageload.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int Number of ungraded quiz submissions for published lessons.
+	 */
+	public function count_ungraded_quizzes(): int;
 }

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -63,7 +63,13 @@ interface Progress_Aggregation_Service_Interface {
 	 *
 	 * @since $$next-version$$
 	 *
+	 * @param array $args {
+	 *     Optional restrictions.
+	 *
+	 *     @type int[]    $post__in                     Restrict to these lesson IDs.
+	 *     @type string[] $exclude_user_login_prefixes  Exclude users whose login starts with any of these prefixes.
+	 * }
 	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
-	public function count_ungraded_quizzes(): int;
+	public function count_ungraded_quizzes( array $args = array() ): int;
 }

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -59,11 +59,11 @@ interface Progress_Aggregation_Service_Interface {
 	public function get_lesson_totals( array $lesson_ids ): array;
 
 	/**
-	 * Count ungraded quiz submissions whose lesson is published.
+	 * Count ungraded quiz submissions whose lesson is publicly available.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int Number of ungraded quiz submissions for published lessons.
+	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
 	public function count_ungraded_quizzes(): int;
 }

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -61,10 +61,6 @@ interface Progress_Aggregation_Service_Interface {
 	/**
 	 * Count ungraded quiz submissions whose lesson is published.
 	 *
-	 * Dedicated lightweight query for the Grading admin-menu badge, which only
-	 * needs the ungraded count. Avoids the full per-status aggregation that
-	 * the badge previously triggered on every admin pageload.
-	 *
 	 * @since $$next-version$$
 	 *
 	 * @return int Number of ungraded quiz submissions for published lessons.

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -161,15 +161,11 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
-	 * Count ungraded quiz submissions whose lesson is published.
-	 *
-	 * In HPPS, the 'ungraded' status lives on quiz progress rows directly. The
-	 * lesson↔quiz map is taken from `_lesson_quiz` postmeta so the published
-	 * lesson check matches the semantics of `count_statuses( type=lesson )`.
+	 * Count ungraded quiz submissions whose lesson is publicly available.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return int Number of ungraded quiz submissions for published lessons.
+	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
 	public function count_ungraded_quizzes(): int {
 		$wpdb  = $this->wpdb;
@@ -178,7 +174,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix; status/type values are constants.
 		$query = "SELECT COUNT(*) FROM {$table} p
 			INNER JOIN {$wpdb->postmeta} pm ON pm.meta_key = '_lesson_quiz' AND pm.meta_value = p.post_id
-			INNER JOIN {$wpdb->posts} lesson_post ON lesson_post.ID = pm.post_id AND lesson_post.post_status = 'publish'
+			INNER JOIN {$wpdb->posts} lesson_post ON lesson_post.ID = pm.post_id AND lesson_post.post_status IN ( 'publish', 'private' )
 			WHERE p.type = 'quiz' AND p.status = 'ungraded'";
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only. Caching handled by callers.

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -161,6 +161,34 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
+	 * Count ungraded quiz submissions whose lesson is published.
+	 *
+	 * In HPPS, the 'ungraded' status lives on quiz progress rows directly. The
+	 * lesson↔quiz map is taken from `_lesson_quiz` postmeta so the published
+	 * lesson check matches the semantics of `count_statuses( type=lesson )`.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int Number of ungraded quiz submissions for published lessons.
+	 */
+	public function count_ungraded_quizzes(): int {
+		$wpdb  = $this->wpdb;
+		$table = $this->get_progress_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix; status/type values are constants.
+		$query = "SELECT COUNT(*) FROM {$table} p
+			INNER JOIN {$wpdb->postmeta} pm ON pm.meta_key = '_lesson_quiz' AND pm.meta_value = p.post_id
+			INNER JOIN {$wpdb->posts} lesson_post ON lesson_post.ID = pm.post_id AND lesson_post.post_status = 'publish'
+			WHERE p.type = 'quiz' AND p.status = 'ungraded'";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only. Caching handled by callers.
+		$count = (int) $wpdb->get_var( $query );
+		Utils::log_query_error( $wpdb, 'Tables-based ungraded quizzes count' );
+
+		return $count;
+	}
+
+	/**
 	 * Count lesson statuses using quiz status when a quiz exists.
 	 *
 	 * In HPPS, lesson progress rows only store 'in-progress' and 'complete',

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -185,7 +185,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			$query .= $wpdb->prepare( " AND lesson_post.ID IN ( $placeholders )", $args['post__in'] );
 		}
 
-		$query .= Utils::build_user_exclusion_clause( $wpdb, $args, 'p.status' );
+		$query .= $this->build_user_exclusion_clause( $args );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only.
 		$count = (int) $wpdb->get_var( $query );

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -175,6 +175,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$query = "SELECT COUNT(*) FROM {$table} p
 			INNER JOIN {$wpdb->postmeta} pm ON pm.meta_key = '_lesson_quiz' AND pm.meta_value = p.post_id
 			INNER JOIN {$wpdb->posts} lesson_post ON lesson_post.ID = pm.post_id AND lesson_post.post_status IN ( 'publish', 'private' )
+			INNER JOIN {$table} lp ON lp.post_id = pm.post_id AND lp.user_id = p.user_id AND lp.type = 'lesson'
 			WHERE p.type = 'quiz' AND p.status = 'ungraded'";
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only. Caching handled by callers.

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -165,9 +165,10 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	 *
 	 * @since $$next-version$$
 	 *
+	 * @param array $args Optional restrictions; see interface.
 	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
-	public function count_ungraded_quizzes(): int {
+	public function count_ungraded_quizzes( array $args = array() ): int {
 		$wpdb  = $this->wpdb;
 		$table = $this->get_progress_table_name();
 
@@ -178,7 +179,15 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			INNER JOIN {$table} lp ON lp.post_id = pm.post_id AND lp.user_id = p.user_id AND lp.type = 'lesson'
 			WHERE p.type = 'quiz' AND p.status = 'ungraded'";
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only. Caching handled by callers.
+		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
+			$query .= $wpdb->prepare( " AND lesson_post.ID IN ( $placeholders )", $args['post__in'] );
+		}
+
+		$query .= Utils::build_user_exclusion_clause( $wpdb, $args, 'p.status' );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL built from literals only.
 		$count = (int) $wpdb->get_var( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based ungraded quizzes count' );
 

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -534,4 +534,48 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Assert. */
 		$this->assertSame( 0, $result, 'Ungraded lesson on draft post should not be counted.' );
 	}
+
+	public function testCountUngradedQuizzes_WithPostInFilter_RestrictsToLessons(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id    = $this->sensei_factory->user->create();
+		$lesson_in  = $this->sensei_factory->lesson->create();
+		$lesson_out = $this->sensei_factory->lesson->create();
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_in, 'ungraded' );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_out, 'ungraded' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_in ) ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result, 'Only ungraded lessons in post__in should be counted.' );
+	}
+
+	public function testCountUngradedQuizzes_WithExcludeUserLoginPrefixes_ExcludesMatchingUsers(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$regular_user = $this->sensei_factory->user->create();
+		$guest_user   = $this->sensei_factory->user->create(
+			array( 'user_login' => 'sensei_guest_42' )
+		);
+		$lesson_id    = $this->sensei_factory->lesson->create();
+
+		\Sensei_Utils::update_lesson_status( $regular_user, $lesson_id, 'ungraded' );
+		\Sensei_Utils::update_lesson_status( $guest_user, $lesson_id, 'ungraded' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes(
+			array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) )
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result, 'Guest user ungraded lesson should be excluded.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -481,7 +481,43 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 0, $result, 'Graded lesson should not be counted as ungraded.' );
 	}
 
-	public function testCountUngradedQuizzes_UnpublishedLesson_NotCounted(): void {
+	public function testCountUngradedQuizzes_TrashedLesson_NotCounted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'trash' ) );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result, 'Ungraded lesson on trashed post should not be counted.' );
+	}
+
+	public function testCountUngradedQuizzes_PrivateLesson_Counted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'private' ) );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 1, $result, 'Ungraded lesson on private post should be counted.' );
+	}
+
+	public function testCountUngradedQuizzes_DraftLesson_NotCounted(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -496,6 +532,6 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$result = $service->count_ungraded_quizzes();
 
 		/* Assert. */
-		$this->assertSame( 0, $result, 'Ungraded lesson on unpublished post should not be counted.' );
+		$this->assertSame( 0, $result, 'Ungraded lesson on draft post should not be counted.' );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -539,20 +539,21 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id    = $this->sensei_factory->user->create();
-		$lesson_in  = $this->sensei_factory->lesson->create();
-		$lesson_out = $this->sensei_factory->lesson->create();
+		$user1    = $this->sensei_factory->user->create();
+		$user2    = $this->sensei_factory->user->create();
+		$lesson_a = $this->sensei_factory->lesson->create();
+		$lesson_b = $this->sensei_factory->lesson->create();
 
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_in, 'ungraded' );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_out, 'ungraded' );
+		// Lesson A: 1 ungraded. Lesson B: 2 ungraded.
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_a, 'ungraded' );
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_b, 'ungraded' );
+		\Sensei_Utils::update_lesson_status( $user2, $lesson_b, 'ungraded' );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
-		/* Act. */
-		$result = $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_in ) ) );
-
-		/* Assert. */
-		$this->assertSame( 1, $result, 'Only ungraded lessons in post__in should be counted.' );
+		/* Act & Assert. */
+		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_a ) ) ), 'post__in=[A] should count only lesson A ungraded.' );
+		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_b ) ) ), 'post__in=[B] should count only lesson B ungraded.' );
 	}
 
 	public function testCountUngradedQuizzes_WithExcludeUserLoginPrefixes_ExcludesMatchingUsers(): void {
@@ -570,12 +571,8 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
-		/* Act. */
-		$result = $service->count_ungraded_quizzes(
-			array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) )
-		);
-
-		/* Assert. */
-		$this->assertSame( 1, $result, 'Guest user ungraded lesson should be excluded.' );
+		/* Act & Assert. */
+		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
+		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -431,4 +431,71 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Assert. */
 		$this->assertSame( 1, $result['complete'], 'Completed lesson with quiz but no answers should be included by default.' );
 	}
+
+	public function testCountUngradedQuizzes_NoUngradedComments_ReturnsZero(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result );
+	}
+
+	public function testCountUngradedQuizzes_OneUngradedComment_ReturnsOne(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 1, $result );
+	}
+
+	public function testCountUngradedQuizzes_NonUngradedStatuses_NotCounted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'graded' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result, 'Graded lesson should not be counted as ungraded.' );
+	}
+
+	public function testCountUngradedQuizzes_UnpublishedLesson_NotCounted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'draft' ) );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result, 'Ungraded lesson on unpublished post should not be counted.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -945,4 +945,66 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 0, $result, 'Ungraded quiz on draft lesson should not be counted.' );
 	}
+
+	public function testCountUngradedQuizzes_WithPostInFilter_RestrictsToLessons(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id     = $this->sensei_factory->user->create();
+		$course_id   = $this->sensei_factory->course->create();
+		$lesson_in   = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$lesson_out  = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_in_id  = $this->sensei_factory->quiz->create();
+		$quiz_out_id = $this->sensei_factory->quiz->create();
+		update_post_meta( $lesson_in, '_lesson_quiz', $quiz_in_id );
+		update_post_meta( $lesson_out, '_lesson_quiz', $quiz_out_id );
+
+		$this->insert_progress( $lesson_in, $user_id, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_in_id, $user_id, 'quiz', 'ungraded' );
+		$this->insert_progress( $lesson_out, $user_id, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_out_id, $user_id, 'quiz', 'ungraded' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_in ) ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result, 'Only ungraded quizzes for lessons in post__in should be counted.' );
+	}
+
+	public function testCountUngradedQuizzes_WithExcludeUserLoginPrefixes_ExcludesMatchingUsers(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$regular_user = $this->sensei_factory->user->create();
+		$guest_user   = $this->sensei_factory->user->create(
+			array( 'user_login' => 'sensei_guest_42' )
+		);
+		$course_id    = $this->sensei_factory->course->create();
+		$lesson_id    = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_id      = $this->sensei_factory->quiz->create();
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_id, $regular_user, 'quiz', 'ungraded' );
+		$this->insert_progress( $lesson_id, $guest_user, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_id, $guest_user, 'quiz', 'ungraded' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes(
+			array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) )
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result, 'Guest user ungraded quiz should be excluded.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -780,4 +780,104 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['complete'], 'Non-trashed course should be counted.' );
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Trashed course status should not appear.' );
 	}
+
+	public function testCountUngradedQuizzes_NoUngradedQuizzes_ReturnsZero(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result );
+	}
+
+	public function testCountUngradedQuizzes_OneUngradedQuiz_ReturnsOne(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 1, $result );
+	}
+
+	public function testCountUngradedQuizzes_NonUngradedStatuses_NotCounted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded', $lesson_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result, 'Graded quiz should not be counted as ungraded.' );
+	}
+
+	public function testCountUngradedQuizzes_UnpublishedLesson_NotCounted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'post_status' => 'draft',
+				'meta_input'  => array( '_lesson_course' => $course_id ),
+			)
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result, 'Ungraded quiz on unpublished lesson should not be counted.' );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -806,6 +806,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -815,6 +816,29 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertSame( 1, $result );
+	}
+
+	public function testCountUngradedQuizzes_QuizWithoutLessonProgressRow_NotCounted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create();
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result, 'Ungraded quiz without a matching lesson progress row should not be counted.' );
 	}
 
 	public function testCountUngradedQuizzes_NonUngradedStatuses_NotCounted(): void {
@@ -829,6 +853,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -855,6 +880,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -881,6 +907,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -907,6 +934,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -451,7 +451,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		// Lesson is in-progress, quiz is ungraded (submitted but not yet graded).
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 		$this->insert_quiz_submission( $quiz_id, $user_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -806,7 +806,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -829,7 +829,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded', $lesson_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -855,7 +855,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -840,7 +840,59 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result, 'Graded quiz should not be counted as ungraded.' );
 	}
 
-	public function testCountUngradedQuizzes_UnpublishedLesson_NotCounted(): void {
+	public function testCountUngradedQuizzes_TrashedLesson_NotCounted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'post_status' => 'trash',
+				'meta_input'  => array( '_lesson_course' => $course_id ),
+			)
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create();
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 0, $result, 'Ungraded quiz on trashed lesson should not be counted.' );
+	}
+
+	public function testCountUngradedQuizzes_PrivateLesson_Counted(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'post_status' => 'private',
+				'meta_input'  => array( '_lesson_course' => $course_id ),
+			)
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create();
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_ungraded_quizzes();
+
+		/* Assert. */
+		$this->assertSame( 1, $result, 'Ungraded quiz on private lesson should be counted.' );
+	}
+
+	public function testCountUngradedQuizzes_DraftLesson_NotCounted(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -863,6 +915,6 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$result = $service->count_ungraded_quizzes();
 
 		/* Assert. */
-		$this->assertSame( 0, $result, 'Ungraded quiz on unpublished lesson should not be counted.' );
+		$this->assertSame( 0, $result, 'Ungraded quiz on draft lesson should not be counted.' );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -950,31 +950,33 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id     = $this->sensei_factory->user->create();
+		$user1       = $this->sensei_factory->user->create();
+		$user2       = $this->sensei_factory->user->create();
 		$course_id   = $this->sensei_factory->course->create();
-		$lesson_in   = $this->sensei_factory->lesson->create(
+		$lesson_a    = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$lesson_out  = $this->sensei_factory->lesson->create(
+		$lesson_b    = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$quiz_in_id  = $this->sensei_factory->quiz->create();
-		$quiz_out_id = $this->sensei_factory->quiz->create();
-		update_post_meta( $lesson_in, '_lesson_quiz', $quiz_in_id );
-		update_post_meta( $lesson_out, '_lesson_quiz', $quiz_out_id );
+		$quiz_a_id   = $this->sensei_factory->quiz->create();
+		$quiz_b_id   = $this->sensei_factory->quiz->create();
+		update_post_meta( $lesson_a, '_lesson_quiz', $quiz_a_id );
+		update_post_meta( $lesson_b, '_lesson_quiz', $quiz_b_id );
 
-		$this->insert_progress( $lesson_in, $user_id, 'lesson', 'in-progress' );
-		$this->insert_progress( $quiz_in_id, $user_id, 'quiz', 'ungraded' );
-		$this->insert_progress( $lesson_out, $user_id, 'lesson', 'in-progress' );
-		$this->insert_progress( $quiz_out_id, $user_id, 'quiz', 'ungraded' );
+		// Lesson A: 1 ungraded quiz. Lesson B: 2 ungraded quizzes.
+		$this->insert_progress( $lesson_a, $user1, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_a_id, $user1, 'quiz', 'ungraded' );
+		$this->insert_progress( $lesson_b, $user1, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_b_id, $user1, 'quiz', 'ungraded' );
+		$this->insert_progress( $lesson_b, $user2, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_b_id, $user2, 'quiz', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
-		/* Act. */
-		$result = $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_in ) ) );
-
-		/* Assert. */
-		$this->assertSame( 1, $result, 'Only ungraded quizzes for lessons in post__in should be counted.' );
+		/* Act & Assert. */
+		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_a ) ) ), 'post__in=[A] should count only lesson A ungraded quizzes.' );
+		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'post__in' => array( $lesson_b ) ) ), 'post__in=[B] should count only lesson B ungraded quizzes.' );
 	}
 
 	public function testCountUngradedQuizzes_WithExcludeUserLoginPrefixes_ExcludesMatchingUsers(): void {
@@ -999,12 +1001,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
-		/* Act. */
-		$result = $service->count_ungraded_quizzes(
-			array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) )
-		);
-
-		/* Assert. */
-		$this->assertSame( 1, $result, 'Guest user ungraded quiz should be excluded.' );
+		/* Act & Assert. */
+		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
+		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -950,17 +950,17 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		global $wpdb;
 
-		$user1       = $this->sensei_factory->user->create();
-		$user2       = $this->sensei_factory->user->create();
-		$course_id   = $this->sensei_factory->course->create();
-		$lesson_a    = $this->sensei_factory->lesson->create(
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_a  = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$lesson_b    = $this->sensei_factory->lesson->create(
+		$lesson_b  = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$quiz_a_id   = $this->sensei_factory->quiz->create();
-		$quiz_b_id   = $this->sensei_factory->quiz->create();
+		$quiz_a_id = $this->sensei_factory->quiz->create();
+		$quiz_b_id = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_a, '_lesson_quiz', $quiz_a_id );
 		update_post_meta( $lesson_b, '_lesson_quiz', $quiz_b_id );
 

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -803,12 +803,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
-				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
-		);
+		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );
@@ -831,12 +826,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
-				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
-		);
+		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded', $lesson_id );
@@ -862,12 +852,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 				'meta_input'  => array( '_lesson_course' => $course_id ),
 			)
 		);
-		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
-				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
-		);
+		$quiz_id   = $this->sensei_factory->quiz->create();
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded', $lesson_id );


### PR DESCRIPTION
## Summary

- Add `count_ungraded_quizzes( array $args = array() )` to `Progress_Aggregation_Service_Interface` plus tables-based and comments-based implementations
- Route the Grading admin-menu badge through the new method directly (`Sensei_Grading::grading_admin_menu` calls the aggregation service inline) instead of the full `count_statuses( [ 'type' => 'lesson' ] )` aggregation
- Tables-based query joins through `_lesson_quiz` postmeta to filter by lesson `post_status IN ( 'publish', 'private' )` and requires a matching lesson progress row, so the badge counts the same population the Grading listing displays
- The badge call passes through `apply_filters( 'sensei_count_statuses_args', ... )`, so `Sensei_Teacher::limit_grading_totals` and `Sensei_Temporary_User::filter_count_statuses` keep affecting the badge as they do the listing

## Why

The Grading menu rebuilds on every admin pageload. The badge only needs the ungraded total but was triggering the full per-status COALESCE aggregation. On a real dataset (~211k progress rows / ~88k lessons) the HPPS variant took ~3.1s and dominated query time across Reports → Courses, Lessons, Users, Grading, and Learner Management.

The dedicated `count_ungraded_quizzes` query is targeted at the single status the badge cares about. Measured on the same dataset: comments mode <1ms, tables mode ~3ms with the lesson-progress join in place.

The tables-mode query requires the matching lesson progress row so that an orphan quiz progress row (data drift — lesson row missing) is not counted in the badge while being absent from the Grading listing. Both badge and listing now walk the same population.

Private lessons are included alongside `publish` because they remain visible to enrolled students and progress on them is just as actionable. Trash, draft, future, pending, and auto-draft remain excluded.

The badge stays subject to `sensei_count_statuses_args`, which is how teachers see only their own ungraded quizzes and how `Sensei_Temporary_User` excludes guest users from the counter.

## Metrics

Measured on a real dataset (~211k progress rows, ~88k lessons, HPPS enabled). Format: page time / query time / query count.

| Page | Before | After | Page speedup | Query speedup |
|---|---|---|---|---|
| Reports → Courses | 3.93s / 3.60s / 119Q | 0.76s / 0.41s / 118Q | 5.2× | 8.8× |
| Reports → Lessons | 3.62s / 3.19s / 48Q | 0.78s / 0.33s / 47Q | 4.6× | 9.7× |
| Reports → Students | 3.80s / 3.47s / 119Q | 0.76s / 0.40s / 118Q | 5.0× | 8.7× |
| Grading | 6.69s / 6.46s / 149Q | 3.62s / 3.42s / 149Q | 1.85× | 1.9× |
| Students (Learner Mgmt) | 3.71s / 3.31s / 161Q | 0.83s / 0.26s / 159Q | 4.5× | 12.7× |

Four of five pages drop to sub-1s. The Grading page is still ~3.6s because its listing service runs a second postmeta-joined count query (`Tables_Based_Grading_Listing_Service::build_count_query`). That is out of scope for this PR — addressed in follow-up work (index + cache).

## Test plan

- [x] With HPPS enabled, load each of these pages and confirm `count_lesson_statuses_with_quiz` no longer appears in Query Monitor:
  - Sensei LMS → **Reports** (Courses tab — default) — `/wp-admin/admin.php?page=sensei_reports`
  - Sensei LMS → **Reports** → **Lessons** tab at top of page — `/wp-admin/admin.php?page=sensei_reports&view=lessons`
  - Sensei LMS → **Reports** → **Students** tab at top of page — `/wp-admin/admin.php?page=sensei_reports&view=users`
  - Sensei LMS → **Students** (top-level menu item, Learner Management) — `/wp-admin/admin.php?page=sensei_learners`
- [x] Toggle HPPS off and reload the same pages — confirm `Comments_Based_Progress_Aggregation_Service::count_statuses` is also gone from the menu hook
- [x] Create an ungraded quiz on a published lesson — confirm the **Grading** menu badge (Sensei LMS → Grading) appears with the right count
- [x] Move the lesson to private — confirm the badge still counts it
- [x] Move the lesson to trash / draft — confirm the badge no longer counts it
- [x] Grade the quiz — confirm the badge disappears
- [x] Log in as a teacher who owns only one of two lessons with ungraded quizzes — confirm the badge shows 1, not 2
- [x] With Sensei Pro installed, assign a teacher as a **co-teacher** on a course they don't own that has an ungraded quiz. Log in as the co-teacher — confirm the badge includes that ungraded quiz in the count
- [x] Log in as a teacher who owns no courses (or whose courses have no lessons) — confirm the badge shows no number (count is 0), not the global ungraded total
- [x] Create a temporary/guest user with an ungraded quiz (enable open access on a course, log out, attempt a manual-grade quiz) — confirm the badge counts them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
