### PR TITLE
Add (type, post_id) index to HPPS progress table

### DIFF
--- a/changelog/perf-hpps-progress-type-post-id-index
+++ b/changelog/perf-hpps-progress-type-post-id-index
@@ -1,4 +1,4 @@
 Significance: patch
-Type: tweak
+Type: changed
 
 Add a composite (type, post_id) index to the HPPS progress table to speed up admin lesson queries.

--- a/changelog/perf-hpps-progress-type-post-id-index
+++ b/changelog/perf-hpps-progress-type-post-id-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add a composite (type, post_id) index to the HPPS progress table to speed up admin lesson queries.

--- a/includes/internal/installer/class-schema.php
+++ b/includes/internal/installer/class-schema.php
@@ -107,7 +107,8 @@ CREATE TABLE {$wpdb->prefix}sensei_lms_progress (
 	updated_at datetime NOT NULL,
 	PRIMARY KEY  (id),
 	UNIQUE KEY user_progress (post_id, user_id, type),
-	KEY status (status)
+	KEY status (status),
+	KEY type_post_id (type, post_id)
 ) $collate;
 ",
 			"{$wpdb->prefix}sensei_lms_quiz_submissions" => "
@@ -197,4 +198,3 @@ CREATE TABLE {$wpdb->prefix}sensei_lms_quiz_grades (
 		return $tables;
 	}
 }
-


### PR DESCRIPTION
## Summary

- Add a composite `KEY type_post_id (type, post_id)` to `wp_sensei_lms_progress`
- `dbDelta` applies the new index on plugin upgrade

## Why

Lesson-status aggregation queries filter `WHERE p.type = 'lesson'`. The existing `UNIQUE KEY user_progress (post_id, user_id, type)` keeps `type` as the last column, so it can't satisfy the filter. `Tables_Based_Grading_Listing_Service::build_count_query` (and any future type-filtered scan) currently does a full table scan.

The new composite key lets MySQL range-scan by type and cover the `INNER JOIN wp_posts ON post.ID = p.post_id` lookup. On a ~211k-row dataset the lesson subset is ~88k rows, so the scanned row count drops by ~2.4x. Expected effect on the Grading listing count query: ~3.1s → ~1.3s.

## Test plan

- [ ] Update the plugin on a site that already has data; confirm the `type_post_id` key appears in `SHOW INDEX FROM wp_sensei_lms_progress`
- [ ] Run `EXPLAIN` on `Tables_Based_Grading_Listing_Service::build_count_query` output and verify `p.key = type_post_id` with `rows ≈ 88k` (down from full scan)
- [ ] Reload `/wp-admin/admin.php?page=sensei_grading` with HPPS enabled and confirm the listing count query time drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)