### PR TITLE
Include private lessons in Grading and Lesson Reports

### DIFF
--- a/changelog/change-grading-include-private-lessons
+++ b/changelog/change-grading-include-private-lessons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Include private lessons in Grading page rows and tab counts, alongside published lessons.

--- a/changelog/change-grading-include-private-lessons
+++ b/changelog/change-grading-include-private-lessons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Include private lessons in Grading page rows and tab counts, alongside published lessons.

--- a/changelog/fix-grading-only-count-published-lessons
+++ b/changelog/fix-grading-only-count-published-lessons
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Grading and Reports: only count progress on published lessons; exclude trashed, draft, scheduled, and private lessons from listings and counts.
+Grading and Reports: Only count progress on published and private lessons in listings and counts.

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -746,7 +746,7 @@ class Sensei_Grading {
 				'order'            => 'ASC',
 				'meta_key'         => '_lesson_course',
 				'meta_value'       => $course_id,
-				'post_status'      => 'publish',
+				'post_status'      => array( 'publish', 'private' ),
 				'suppress_filters' => 0,
 				'fields'           => 'ids',
 			);

--- a/includes/internal/services/class-comments-based-grading-listing-service.php
+++ b/includes/internal/services/class-comments-based-grading-listing-service.php
@@ -31,11 +31,7 @@ class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_
 	 * @return array{ items: Grading_Item[], total_count: int }
 	 */
 	public function get_lesson_progress_items( array $args ): array {
-		// Exclude progress for non-published lessons. Matches the hardcoded
-		// `post_status = 'publish'` filter used by count_statuses, get_lesson_totals,
-		// and the tables-based grading listing — keep these in sync to avoid header/
-		// row count drift.
-		$args['post_status'] = 'publish';
+		$args['post_status'] = array( 'publish', 'private' );
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so run
 		// a separate count query first with no limit/offset.

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -73,7 +73,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		$comment_type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
-		$query = $wpdb->prepare( "SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status = 'publish' WHERE comment_type = %s", $comment_type );
+		$query = $wpdb->prepare( "SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
 
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
@@ -131,7 +131,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 			, SUM(IF(lesson_students.comment_approved IN ($has_completion), 1, 0)) days_to_complete_count
 			, SUM(IF(lesson_students.comment_approved IN ($has_completion), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM {$wpdb->comments} lesson_students
-			INNER JOIN {$wpdb->posts} post ON post.ID = lesson_students.comment_post_ID AND post.post_status = 'publish'
+			INNER JOIN {$wpdb->posts} post ON post.ID = lesson_students.comment_post_ID AND post.post_status IN ( 'publish', 'private' )
 			LEFT JOIN {$wpdb->commentmeta} lesson_start ON lesson_start.comment_id = lesson_students.comment_id
 			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $placeholders )",
 			array_merge( [ '%Y-%m-%d %H:%i:%s' ], $lesson_ids )

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -149,7 +149,7 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 		$query  = 'SELECT p.post_id, p.user_id, p.updated_at, COALESCE( q.status, p.status ) AS effective_status, qs.final_grade';
 		$query .= " FROM {$table} p";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status = 'publish'";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
@@ -184,7 +184,7 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 		$query  = 'SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT(*) AS total';
 		$query .= " FROM {$table} p";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status = 'publish'";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -134,7 +134,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, 1, 0)) AS days_to_complete_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1, 0)) AS days_to_complete_sum
 			FROM {$table} p
-			INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status = 'publish'
+			INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )
 			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
 			LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
 				AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )
@@ -183,7 +183,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query = "SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status = 'publish'";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
@@ -222,7 +222,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
 		$query  = "SELECT p.status, COUNT(*) AS total FROM {$table} p";
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status = 'publish'";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
 
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', $args['type'] );
 		$query .= $this->build_post_filter_clause( $args );

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -194,12 +194,10 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id      = $this->sensei_factory->user->create();
-		$excluded_id  = $this->sensei_factory->lesson->create();
-		$published_id = $this->sensei_factory->lesson->create();
+		$user_id     = $this->sensei_factory->user->create();
+		$excluded_id = $this->sensei_factory->lesson->create();
 
 		\Sensei_Utils::update_lesson_status( $user_id, $excluded_id, 'in-progress' );
-		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -211,15 +209,7 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$result = $service->get_lesson_progress_items( $this->get_default_args() );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['total_count'], "Lesson with post_status '{$excluded_status}' should be excluded from total count." );
-		$returned_lesson_ids = array_map(
-			function ( $item ) {
-				return $item->lesson_id;
-			},
-			$result['items']
-		);
-		$this->assertNotContains( $excluded_id, $returned_lesson_ids, "Lesson with post_status '{$excluded_status}' should not appear in items." );
-		$this->assertContains( $published_id, $returned_lesson_ids, 'Published lesson should appear in items.' );
+		$this->assertSame( 0, $result['total_count'], "Lesson with post_status '{$excluded_status}' should be excluded from total count." );
 	}
 
 	public function includedLessonStatusesProvider(): array {

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -184,6 +184,29 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertContains( $published_id, $returned_lesson_ids, 'Published lesson should appear in items.' );
 	}
 
+	public function testGetLessonProgressItems_WithPrivateLesson_IncludesInResults(): void {
+		/* Arrange. */
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'private' ) );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items( $this->get_default_args() );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'], 'Private lesson should be included in total count.' );
+		$returned_lesson_ids = array_map(
+			function ( $item ) {
+				return $item->lesson_id;
+			},
+			$result['items']
+		);
+		$this->assertContains( $lesson_id, $returned_lesson_ids, 'Private lesson should appear in items.' );
+	}
+
 	public function testGetLessonProgressItems_WithOffsetBeyondTotal_CorrectsPagination(): void {
 		/* Arrange. */
 		$user_id   = $this->sensei_factory->user->create();

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-listing-service.php
@@ -151,21 +151,23 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertNull( $service->get_status_counts(), 'Comments-based service should always return null.' );
 	}
 
-	public function testGetLessonProgressItems_WithTrashedLesson_ExcludesFromResults(): void {
+	/**
+	 * Verifies lessons with an "included" post_status appear in the listing.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testGetLessonProgressItems_WithIncludedLessonStatus_IncludesInResults( string $included_status ): void {
 		/* Arrange. */
-		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$published_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
-		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress' );
 
-		wp_trash_post( $lesson_id );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Comments_Based_Grading_Listing_Service();
 
@@ -173,38 +175,68 @@ class Comments_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$result = $service->get_lesson_progress_items( $this->get_default_args() );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['total_count'], 'Trashed lesson progress should be excluded from total count.' );
+		$this->assertSame( 1, $result['total_count'], "Lesson with post_status '{$included_status}' should be included in total count." );
 		$returned_lesson_ids = array_map(
 			function ( $item ) {
 				return $item->lesson_id;
 			},
 			$result['items']
 		);
-		$this->assertNotContains( $lesson_id, $returned_lesson_ids, 'Trashed lesson should not appear in items.' );
+		$this->assertContains( $lesson_id, $returned_lesson_ids, "Lesson with post_status '{$included_status}' should appear in items." );
+	}
+
+	/**
+	 * Verifies lessons with an "excluded" post_status are omitted from the listing.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testGetLessonProgressItems_WithExcludedLessonStatus_ExcludesFromResults( string $excluded_status ): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id      = $this->sensei_factory->user->create();
+		$excluded_id  = $this->sensei_factory->lesson->create();
+		$published_id = $this->sensei_factory->lesson->create();
+
+		\Sensei_Utils::update_lesson_status( $user_id, $excluded_id, 'in-progress' );
+		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
+		clean_post_cache( $excluded_id );
+
+		$service = new Comments_Based_Grading_Listing_Service();
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items( $this->get_default_args() );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'], "Lesson with post_status '{$excluded_status}' should be excluded from total count." );
+		$returned_lesson_ids = array_map(
+			function ( $item ) {
+				return $item->lesson_id;
+			},
+			$result['items']
+		);
+		$this->assertNotContains( $excluded_id, $returned_lesson_ids, "Lesson with post_status '{$excluded_status}' should not appear in items." );
 		$this->assertContains( $published_id, $returned_lesson_ids, 'Published lesson should appear in items.' );
 	}
 
-	public function testGetLessonProgressItems_WithPrivateLesson_IncludesInResults(): void {
-		/* Arrange. */
-		$user_id   = $this->sensei_factory->user->create();
-		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'private' ) );
-
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
-
-		$service = new Comments_Based_Grading_Listing_Service();
-
-		/* Act. */
-		$result = $service->get_lesson_progress_items( $this->get_default_args() );
-
-		/* Assert. */
-		$this->assertSame( 1, $result['total_count'], 'Private lesson should be included in total count.' );
-		$returned_lesson_ids = array_map(
-			function ( $item ) {
-				return $item->lesson_id;
-			},
-			$result['items']
+	public function includedLessonStatusesProvider(): array {
+		return array(
+			'publish' => array( 'publish' ),
+			'private' => array( 'private' ),
 		);
-		$this->assertContains( $lesson_id, $returned_lesson_ids, 'Private lesson should appear in items.' );
+	}
+
+	public function excludedLessonStatusesProvider(): array {
+		return array(
+			'draft'      => array( 'draft' ),
+			'pending'    => array( 'pending' ),
+			'future'     => array( 'future' ),
+			'auto-draft' => array( 'auto-draft' ),
+			'trash'      => array( 'trash' ),
+		);
 	}
 
 	public function testGetLessonProgressItems_WithOffsetBeyondTotal_CorrectsPagination(): void {

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -195,7 +195,12 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Excluded user status should not appear.' );
 	}
 
-	public function testGetLessonTotals_WithCompletedLessons_ReturnsCorrectAggregates(): void {
+	/**
+	 * Verifies totals across all aggregate fields for lessons with an "included" post_status.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithCompletedLessons_ReturnsCorrectAggregates( string $included_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -209,6 +214,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
 		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', [ 'start' => $start_date ] );
 		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', [ 'start' => $start_date ] );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -399,22 +408,27 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 	}
 
 	/**
-	 * Verifies lessons with an "included" post_status are surfaced.
+	 * Verifies lessons with an "excluded" post_status are skipped from totals.
 	 *
-	 * @dataProvider includedLessonStatusesProvider
+	 * @dataProvider excludedLessonStatusesProvider
 	 */
-	public function testGetLessonTotals_WithIncludedLessonStatus_IncludesInTotals( string $included_status ): void {
+	public function testGetLessonTotals_WithExcludedLessonStatus_ReturnsZeros( string $excluded_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id   = $this->sensei_factory->user->create();
-		$lesson_id = $this->sensei_factory->lesson->create();
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
 
-		$start_date = current_time( 'mysql' );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
+		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $lesson_id ) );
 		clean_post_cache( $lesson_id );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
@@ -423,37 +437,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$included_status}' should count towards unique students." );
-		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$included_status}' should count towards lesson starts." );
-	}
-
-	/**
-	 * Verifies lessons with an "excluded" post_status are skipped.
-	 *
-	 * @dataProvider excludedLessonStatusesProvider
-	 */
-	public function testGetLessonTotals_WithExcludedLessonStatus_ExcludesFromTotals( string $excluded_status ): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id     = $this->sensei_factory->user->create();
-		$excluded_id = $this->sensei_factory->lesson->create();
-
-		$start_date = current_time( 'mysql' );
-		\Sensei_Utils::update_lesson_status( $user_id, $excluded_id, 'in-progress', array( 'start' => $start_date ) );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
-		clean_post_cache( $excluded_id );
-
-		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->get_lesson_totals( array( $excluded_id ) );
-
-		/* Assert. */
 		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
 		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+		$this->assertSame( 0, $result['lesson_completed_count'], "Lesson with post_status '{$excluded_status}' should not count towards completions." );
+		$this->assertSame( 0, $result['days_to_complete_count'], "Lesson with post_status '{$excluded_status}' should not have a completion date." );
+		$this->assertSame( 0, $result['days_to_complete_sum'], "Lesson with post_status '{$excluded_status}' should not contribute to days to complete." );
 	}
 
 	public function includedLessonStatusesProvider(): array {

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -321,6 +321,43 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 0, $result['days_to_complete_sum'] );
 	}
 
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped from totals.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithExcludedLessonStatus_ReturnsZeros( string $excluded_status ): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
+		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+		$this->assertSame( 0, $result['lesson_completed_count'], "Lesson with post_status '{$excluded_status}' should not count towards completions." );
+		$this->assertSame( 0, $result['days_to_complete_count'], "Lesson with post_status '{$excluded_status}' should not have a completion date." );
+		$this->assertSame( 0, $result['days_to_complete_sum'], "Lesson with post_status '{$excluded_status}' should not contribute to days to complete." );
+	}
+
 	public function testCountStatuses_WithIncludeStatusesOverride_KeepsExcludedUsersForOverrideStatuses(): void {
 		/* Arrange. */
 		global $wpdb;
@@ -405,43 +442,6 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Assert. */
 		$this->assertSame( 0, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
-	}
-
-	/**
-	 * Verifies lessons with an "excluded" post_status are skipped from totals.
-	 *
-	 * @dataProvider excludedLessonStatusesProvider
-	 */
-	public function testGetLessonTotals_WithExcludedLessonStatus_ReturnsZeros( string $excluded_status ): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user1     = $this->sensei_factory->user->create();
-		$user2     = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-
-		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
-		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', array( 'start' => $start_date ) );
-		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $lesson_id ) );
-		clean_post_cache( $lesson_id );
-
-		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
-
-		/* Assert. */
-		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
-		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
-		$this->assertSame( 0, $result['lesson_completed_count'], "Lesson with post_status '{$excluded_status}' should not count towards completions." );
-		$this->assertSame( 0, $result['days_to_complete_count'], "Lesson with post_status '{$excluded_status}' should not have a completion date." );
-		$this->assertSame( 0, $result['days_to_complete_sum'], "Lesson with post_status '{$excluded_status}' should not contribute to days to complete." );
 	}
 
 	public function includedLessonStatusesProvider(): array {

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -344,41 +344,23 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 1, $result['ungraded'], 'Excluded user with override status should still be counted.' );
 	}
 
-	public function testCountStatuses_WithTrashedLesson_ExcludesFromCounts(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$published_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
-		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress' );
-
-		wp_trash_post( $lesson_id );
-
-		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses( [ 'type' => 'lesson' ] );
-
-		/* Assert. */
-		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Trashed lesson progress should be excluded from counts.' );
-	}
-
-	public function testCountStatuses_WithPrivateLesson_IncludesInCounts(): void {
+	/**
+	 * Verifies lessons with an "included" post_status are surfaced.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testCountStatuses_WithIncludedLessonStatus_IncludesInCounts( string $included_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
 		$user_id   = $this->sensei_factory->user->create();
-		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'private' ) );
+		$lesson_id = $this->sensei_factory->lesson->create();
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -386,18 +368,56 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Private lesson progress should be included in counts.' );
+		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$included_status}' should be included in counts." );
 	}
 
-	public function testGetLessonTotals_WithPrivateLesson_IncludesInTotals(): void {
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testCountStatuses_WithExcludedLessonStatus_ExcludesFromCounts( string $excluded_status ): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id      = $this->sensei_factory->user->create();
+		$excluded_id  = $this->sensei_factory->lesson->create();
+		$published_id = $this->sensei_factory->lesson->create();
+
+		\Sensei_Utils::update_lesson_status( $user_id, $excluded_id, 'in-progress' );
+		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
+		clean_post_cache( $excluded_id );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
+	}
+
+	/**
+	 * Verifies lessons with an "included" post_status are surfaced.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithIncludedLessonStatus_IncludesInTotals( string $included_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
 		$user_id   = $this->sensei_factory->user->create();
-		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'private' ) );
+		$lesson_id = $this->sensei_factory->lesson->create();
 
 		$start_date = current_time( 'mysql' );
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -405,37 +425,56 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], 'Private lesson progress should count towards unique students.' );
-		$this->assertSame( 1, $result['lesson_start_count'], 'Private lesson progress should count towards lesson starts.' );
+		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$included_status}' should count towards unique students." );
+		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$included_status}' should count towards lesson starts." );
 	}
 
-	public function testGetLessonTotals_WithTrashedLesson_ExcludesFromTotals(): void {
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithExcludedLessonStatus_ExcludesFromTotals( string $excluded_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
 		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$published_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
+		$excluded_id  = $this->sensei_factory->lesson->create();
+		$published_id = $this->sensei_factory->lesson->create();
 
 		$start_date = current_time( 'mysql' );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress', [ 'start' => $start_date ] );
-		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress', [ 'start' => $start_date ] );
+		\Sensei_Utils::update_lesson_status( $user_id, $excluded_id, 'in-progress', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress', array( 'start' => $start_date ) );
 
-		wp_trash_post( $lesson_id );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
+		clean_post_cache( $excluded_id );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id, $published_id ] );
+		$result = $service->get_lesson_totals( array( $excluded_id, $published_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], 'Trashed lesson progress should not count towards unique students.' );
-		$this->assertSame( 1, $result['lesson_start_count'], 'Trashed lesson progress should not count towards lesson starts.' );
+		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
+		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+	}
+
+	public function includedLessonStatusesProvider(): array {
+		return array(
+			'publish' => array( 'publish' ),
+			'private' => array( 'private' ),
+		);
+	}
+
+	public function excludedLessonStatusesProvider(): array {
+		return array(
+			'draft'      => array( 'draft' ),
+			'pending'    => array( 'pending' ),
+			'future'     => array( 'future' ),
+			'auto-draft' => array( 'auto-draft' ),
+			'trash'      => array( 'trash' ),
+		);
 	}
 
 	public function testCountStatuses_LessonWithQuizButNoAnswers_IncludedByDefault(): void {

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -371,6 +371,44 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Trashed lesson progress should be excluded from counts.' );
 	}
 
+	public function testCountStatuses_WithPrivateLesson_IncludesInCounts(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'private' ) );
+
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Private lesson progress should be included in counts.' );
+	}
+
+	public function testGetLessonTotals_WithPrivateLesson_IncludesInTotals(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$lesson_id = $this->sensei_factory->lesson->create( array( 'post_status' => 'private' ) );
+
+		$start_date = current_time( 'mysql' );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['unique_student_count'], 'Private lesson progress should count towards unique students.' );
+		$this->assertSame( 1, $result['lesson_start_count'], 'Private lesson progress should count towards lesson starts.' );
+	}
+
 	public function testGetLessonTotals_WithTrashedLesson_ExcludesFromTotals(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -380,12 +380,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id      = $this->sensei_factory->user->create();
-		$excluded_id  = $this->sensei_factory->lesson->create();
-		$published_id = $this->sensei_factory->lesson->create();
+		$user_id     = $this->sensei_factory->user->create();
+		$excluded_id = $this->sensei_factory->lesson->create();
 
 		\Sensei_Utils::update_lesson_status( $user_id, $excluded_id, 'in-progress' );
-		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -397,7 +395,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
+		$this->assertSame( 0, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
 	}
 
 	/**
@@ -438,13 +436,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id      = $this->sensei_factory->user->create();
-		$excluded_id  = $this->sensei_factory->lesson->create();
-		$published_id = $this->sensei_factory->lesson->create();
+		$user_id     = $this->sensei_factory->user->create();
+		$excluded_id = $this->sensei_factory->lesson->create();
 
 		$start_date = current_time( 'mysql' );
 		\Sensei_Utils::update_lesson_status( $user_id, $excluded_id, 'in-progress', array( 'start' => $start_date ) );
-		\Sensei_Utils::update_lesson_status( $user_id, $published_id, 'in-progress', array( 'start' => $start_date ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -453,11 +449,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $excluded_id, $published_id ) );
+		$result = $service->get_lesson_totals( array( $excluded_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
-		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
+		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
 	}
 
 	public function includedLessonStatusesProvider(): array {

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -547,17 +547,13 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 	public function testGetLessonProgressItems_WithExcludedLessonStatus_ExcludesFromResults( string $excluded_status ): void {
 		/* Arrange. */
 		global $wpdb;
-		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$excluded_id  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$published_id = $this->sensei_factory->lesson->create(
+		$user_id     = $this->sensei_factory->user->create();
+		$course_id   = $this->sensei_factory->course->create();
+		$excluded_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -570,16 +566,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$counts = $service->get_status_counts();
 
 		/* Assert. */
-		$this->assertSame( 1, $result['total_count'], "Lesson with post_status '{$excluded_status}' should be excluded from total count." );
-		$returned_lesson_ids = array_map(
-			function ( $item ) {
-				return $item->lesson_id;
-			},
-			$result['items']
-		);
-		$this->assertNotContains( $excluded_id, $returned_lesson_ids, "Lesson with post_status '{$excluded_status}' should not appear in items." );
-		$this->assertContains( $published_id, $returned_lesson_ids, 'Published lesson should appear in items.' );
-		$this->assertSame( 1, $counts['in-progress'] ?? 0, "Status counts should exclude lesson with post_status '{$excluded_status}'." );
+		$this->assertSame( 0, $result['total_count'], "Lesson with post_status '{$excluded_status}' should be excluded from total count." );
+		$this->assertSame( 0, $counts['in-progress'] ?? 0, "Status counts should exclude lesson with post_status '{$excluded_status}'." );
 	}
 
 	public function includedLessonStatusesProvider(): array {

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -508,22 +508,25 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Expected cached counts to also exclude the preview user.' );
 	}
 
-	public function testGetLessonProgressItems_WithTrashedLesson_ExcludesFromResults(): void {
+	/**
+	 * Verifies lessons with an "included" post_status are surfaced.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testGetLessonProgressItems_WithIncludedLessonStatus_IncludesInResults( string $included_status ): void {
 		/* Arrange. */
 		global $wpdb;
-		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$published_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
 
-		wp_trash_post( $lesson_id );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -532,41 +535,68 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$counts = $service->get_status_counts();
 
 		/* Assert. */
-		$this->assertSame( 1, $result['total_count'], 'Trashed lesson progress should be excluded from total count.' );
+		$this->assertSame( 1, $result['total_count'], "Lesson with post_status '{$included_status}' should be included in total count." );
+		$this->assertSame( 1, $counts['in-progress'] ?? 0, "Status counts should include lesson with post_status '{$included_status}'." );
+	}
+
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testGetLessonProgressItems_WithExcludedLessonStatus_ExcludesFromResults( string $excluded_status ): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id      = $this->sensei_factory->user->create();
+		$course_id    = $this->sensei_factory->course->create();
+		$excluded_id  = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$published_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
+		clean_post_cache( $excluded_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items( $this->get_default_args() );
+		$counts = $service->get_status_counts();
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'], "Lesson with post_status '{$excluded_status}' should be excluded from total count." );
 		$returned_lesson_ids = array_map(
 			function ( $item ) {
 				return $item->lesson_id;
 			},
 			$result['items']
 		);
-		$this->assertNotContains( $lesson_id, $returned_lesson_ids, 'Trashed lesson should not appear in items.' );
+		$this->assertNotContains( $excluded_id, $returned_lesson_ids, "Lesson with post_status '{$excluded_status}' should not appear in items." );
 		$this->assertContains( $published_id, $returned_lesson_ids, 'Published lesson should appear in items.' );
-		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Status counts should also exclude trashed lesson.' );
+		$this->assertSame( 1, $counts['in-progress'] ?? 0, "Status counts should exclude lesson with post_status '{$excluded_status}'." );
 	}
 
-	public function testGetLessonProgressItems_WithPrivateLesson_IncludesInResults(): void {
-		/* Arrange. */
-		global $wpdb;
-		$user_id   = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array(
-				'post_status' => 'private',
-				'meta_input'  => array( '_lesson_course' => $course_id ),
-			)
+	public function includedLessonStatusesProvider(): array {
+		return array(
+			'publish' => array( 'publish' ),
+			'private' => array( 'private' ),
 		);
+	}
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
-
-		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->get_lesson_progress_items( $this->get_default_args() );
-		$counts = $service->get_status_counts();
-
-		/* Assert. */
-		$this->assertSame( 1, $result['total_count'], 'Private lesson should be included in total count.' );
-		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Status counts should include private lesson.' );
+	public function excludedLessonStatusesProvider(): array {
+		return array(
+			'draft'      => array( 'draft' ),
+			'pending'    => array( 'pending' ),
+			'future'     => array( 'future' ),
+			'auto-draft' => array( 'auto-draft' ),
+			'trash'      => array( 'trash' ),
+		);
 	}
 
 	public function testGetStatusCounts_WithStatusFilter_ReturnsAllStatuses(): void {

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -544,6 +544,31 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Status counts should also exclude trashed lesson.' );
 	}
 
+	public function testGetLessonProgressItems_WithPrivateLesson_IncludesInResults(): void {
+		/* Arrange. */
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'post_status' => 'private',
+				'meta_input'  => array( '_lesson_course' => $course_id ),
+			)
+		);
+
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_progress_items( $this->get_default_args() );
+		$counts = $service->get_status_counts();
+
+		/* Assert. */
+		$this->assertSame( 1, $result['total_count'], 'Private lesson should be included in total count.' );
+		$this->assertSame( 1, $counts['in-progress'] ?? 0, 'Status counts should include private lesson.' );
+	}
+
 	public function testGetStatusCounts_WithStatusFilter_ReturnsAllStatuses(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -369,6 +369,66 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Verifies lessons with an "included" post_status are surfaced.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testCountStatuses_WithIncludedLessonStatus_IncludesInCounts( string $included_status ): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$included_status}' should be included in counts." );
+	}
+
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testCountStatuses_WithExcludedLessonStatus_ExcludesFromCounts( string $excluded_status ): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id     = $this->sensei_factory->user->create();
+		$course_id   = $this->sensei_factory->course->create();
+		$excluded_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
+		clean_post_cache( $excluded_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
+	}
+
+	/**
 	 * Verifies totals across all aggregate fields for lessons with an "included" post_status.
 	 *
 	 * @dataProvider includedLessonStatusesProvider
@@ -474,104 +534,6 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result['days_to_complete_sum'], 'Ungraded quiz should not contribute to days to complete.' );
 	}
 
-	/**
-	 * Verifies lessons with an "included" post_status are surfaced.
-	 *
-	 * @dataProvider includedLessonStatusesProvider
-	 */
-	public function testCountStatuses_WithIncludedLessonStatus_IncludesInCounts( string $included_status ): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id   = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
-		clean_post_cache( $lesson_id );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
-
-		/* Assert. */
-		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$included_status}' should be included in counts." );
-	}
-
-	/**
-	 * Verifies lessons with an "excluded" post_status are skipped.
-	 *
-	 * @dataProvider excludedLessonStatusesProvider
-	 */
-	public function testCountStatuses_WithExcludedLessonStatus_ExcludesFromCounts( string $excluded_status ): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id     = $this->sensei_factory->user->create();
-		$course_id   = $this->sensei_factory->course->create();
-		$excluded_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-
-		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
-		clean_post_cache( $excluded_id );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
-
-		/* Assert. */
-		$this->assertSame( 0, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
-	}
-
-	/**
-	 * Verifies lessons with an "excluded" post_status are skipped from totals.
-	 *
-	 * @dataProvider excludedLessonStatusesProvider
-	 */
-	public function testGetLessonTotals_WithExcludedLessonStatus_ReturnsZeros( string $excluded_status ): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user1     = $this->sensei_factory->user->create();
-		$user2     = $this->sensei_factory->user->create();
-		$course_id = $this->sensei_factory->course->create();
-		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-
-		$started_at   = '2024-01-01 10:00:00';
-		$completed_at = '2024-01-03 10:00:00';
-		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $lesson_id ) );
-		clean_post_cache( $lesson_id );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
-
-		/* Assert. */
-		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
-		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
-		$this->assertSame( 0, $result['lesson_completed_count'], "Lesson with post_status '{$excluded_status}' should not count towards completions." );
-		$this->assertSame( 0, $result['days_to_complete_count'], "Lesson with post_status '{$excluded_status}' should not have a completion date." );
-		$this->assertSame( 0, $result['days_to_complete_sum'], "Lesson with post_status '{$excluded_status}' should not contribute to days to complete." );
-	}
-
 	public function includedLessonStatusesProvider(): array {
 		return array(
 			'publish' => array( 'publish' ),
@@ -671,6 +633,44 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result['lesson_completed_count'] );
 		$this->assertSame( 0, $result['days_to_complete_count'] );
 		$this->assertSame( 0, $result['days_to_complete_sum'] );
+	}
+
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped from totals.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithExcludedLessonStatus_ReturnsZeros( string $excluded_status ): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$started_at   = '2024-01-01 10:00:00';
+		$completed_at = '2024-01-03 10:00:00';
+		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
+
+		/* Assert. */
+		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
+		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+		$this->assertSame( 0, $result['lesson_completed_count'], "Lesson with post_status '{$excluded_status}' should not count towards completions." );
+		$this->assertSame( 0, $result['days_to_complete_count'], "Lesson with post_status '{$excluded_status}' should not have a completion date." );
+		$this->assertSame( 0, $result['days_to_complete_sum'], "Lesson with post_status '{$excluded_status}' should not contribute to days to complete." );
 	}
 
 	public function testGetLessonTotals_WithUtcDatesNearMidnight_ConvertsToLocalTimeBeforeDatediff(): void {

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -368,7 +368,12 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Raw lesson status should not appear when quiz status exists.' );
 	}
 
-	public function testGetLessonTotals_WithCompletedLessons_ReturnsCorrectAggregates(): void {
+	/**
+	 * Verifies totals across all aggregate fields for lessons with an "included" post_status.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithCompletedLessons_ReturnsCorrectAggregates( string $included_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -383,6 +388,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$completed_at = '2024-01-03 10:00:00';
 		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
 		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -526,24 +535,28 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Verifies lessons with an "included" post_status are surfaced.
+	 * Verifies lessons with an "excluded" post_status are skipped from totals.
 	 *
-	 * @dataProvider includedLessonStatusesProvider
+	 * @dataProvider excludedLessonStatusesProvider
 	 */
-	public function testGetLessonTotals_WithIncludedLessonStatus_IncludesInTotals( string $included_status ): void {
+	public function testGetLessonTotals_WithExcludedLessonStatus_ReturnsZeros( string $excluded_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id   = $this->sensei_factory->user->create();
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$started_at   = '2024-01-01 10:00:00';
+		$completed_at = '2024-01-03 10:00:00';
+		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $lesson_id ) );
 		clean_post_cache( $lesson_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -552,39 +565,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$included_status}' should count towards unique students." );
-		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$included_status}' should count towards lesson starts." );
-	}
-
-	/**
-	 * Verifies lessons with an "excluded" post_status are skipped.
-	 *
-	 * @dataProvider excludedLessonStatusesProvider
-	 */
-	public function testGetLessonTotals_WithExcludedLessonStatus_ExcludesFromTotals( string $excluded_status ): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id     = $this->sensei_factory->user->create();
-		$course_id   = $this->sensei_factory->course->create();
-		$excluded_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-
-		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
-		clean_post_cache( $excluded_id );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->get_lesson_totals( array( $excluded_id ) );
-
-		/* Assert. */
 		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
 		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+		$this->assertSame( 0, $result['lesson_completed_count'], "Lesson with post_status '{$excluded_status}' should not count towards completions." );
+		$this->assertSame( 0, $result['days_to_complete_count'], "Lesson with post_status '{$excluded_status}' should not have a completion date." );
+		$this->assertSame( 0, $result['days_to_complete_sum'], "Lesson with post_status '{$excluded_status}' should not contribute to days to complete." );
 	}
 
 	public function includedLessonStatusesProvider(): array {

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -492,6 +492,55 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Trashed lesson progress should be excluded from counts.' );
 	}
 
+	public function testCountStatuses_WithPrivateLesson_IncludesInCounts(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'post_status' => 'private',
+				'meta_input'  => array( '_lesson_course' => $course_id ),
+			)
+		);
+
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Private lesson progress should be included in counts.' );
+	}
+
+	public function testGetLessonTotals_WithPrivateLesson_IncludesInTotals(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'post_status' => 'private',
+				'meta_input'  => array( '_lesson_course' => $course_id ),
+			)
+		);
+
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['unique_student_count'], 'Private lesson progress should count towards unique students.' );
+		$this->assertSame( 1, $result['lesson_start_count'], 'Private lesson progress should count towards lesson starts.' );
+	}
+
 	public function testGetLessonTotals_WithTrashedLesson_ExcludesFromTotals(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -504,17 +504,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$excluded_id  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$published_id = $this->sensei_factory->lesson->create(
+		$user_id     = $this->sensei_factory->user->create();
+		$course_id   = $this->sensei_factory->course->create();
+		$excluded_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -526,7 +522,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
+		$this->assertSame( 0, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
 	}
 
 	/**
@@ -569,17 +565,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		global $wpdb;
 
-		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$excluded_id  = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
-		);
-		$published_id = $this->sensei_factory->lesson->create(
+		$user_id     = $this->sensei_factory->user->create();
+		$course_id   = $this->sensei_factory->course->create();
+		$excluded_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -588,11 +580,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $excluded_id, $published_id ) );
+		$result = $service->get_lesson_totals( array( $excluded_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
-		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+		$this->assertSame( 0, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
+		$this->assertSame( 0, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
 	}
 
 	public function includedLessonStatusesProvider(): array {

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -465,47 +465,26 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 0, $result['days_to_complete_sum'], 'Ungraded quiz should not contribute to days to complete.' );
 	}
 
-	public function testCountStatuses_WithTrashedLesson_ExcludesFromCounts(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_id      = $this->sensei_factory->user->create();
-		$course_id    = $this->sensei_factory->course->create();
-		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-		$published_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
-		);
-
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
-
-		wp_trash_post( $lesson_id );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses( [ 'type' => 'lesson' ] );
-
-		/* Assert. */
-		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Trashed lesson progress should be excluded from counts.' );
-	}
-
-	public function testCountStatuses_WithPrivateLesson_IncludesInCounts(): void {
+	/**
+	 * Verifies lessons with an "included" post_status are surfaced.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testCountStatuses_WithIncludedLessonStatus_IncludesInCounts( string $included_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array(
-				'post_status' => 'private',
-				'meta_input'  => array( '_lesson_course' => $course_id ),
-			)
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -513,23 +492,63 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['in-progress'] ?? 0, 'Private lesson progress should be included in counts.' );
+		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$included_status}' should be included in counts." );
 	}
 
-	public function testGetLessonTotals_WithPrivateLesson_IncludesInTotals(): void {
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testCountStatuses_WithExcludedLessonStatus_ExcludesFromCounts( string $excluded_status ): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id      = $this->sensei_factory->user->create();
+		$course_id    = $this->sensei_factory->course->create();
+		$excluded_id  = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$published_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
+		clean_post_cache( $excluded_id );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result['in-progress'] ?? 0, "Lesson with post_status '{$excluded_status}' should be excluded from counts." );
+	}
+
+	/**
+	 * Verifies lessons with an "included" post_status are surfaced.
+	 *
+	 * @dataProvider includedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithIncludedLessonStatus_IncludesInTotals( string $included_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array(
-				'post_status' => 'private',
-				'meta_input'  => array( '_lesson_course' => $course_id ),
-			)
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
+		clean_post_cache( $lesson_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -537,36 +556,60 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], 'Private lesson progress should count towards unique students.' );
-		$this->assertSame( 1, $result['lesson_start_count'], 'Private lesson progress should count towards lesson starts.' );
+		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$included_status}' should count towards unique students." );
+		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$included_status}' should count towards lesson starts." );
 	}
 
-	public function testGetLessonTotals_WithTrashedLesson_ExcludesFromTotals(): void {
+	/**
+	 * Verifies lessons with an "excluded" post_status are skipped.
+	 *
+	 * @dataProvider excludedLessonStatusesProvider
+	 */
+	public function testGetLessonTotals_WithExcludedLessonStatus_ExcludesFromTotals( string $excluded_status ): void {
 		/* Arrange. */
 		global $wpdb;
 
 		$user_id      = $this->sensei_factory->user->create();
 		$course_id    = $this->sensei_factory->course->create();
-		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		$excluded_id  = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$published_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
 		$this->insert_progress( $published_id, $user_id, 'lesson', 'in-progress', $course_id );
 
-		wp_trash_post( $lesson_id );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
+		clean_post_cache( $excluded_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id, $published_id ] );
+		$result = $service->get_lesson_totals( array( $excluded_id, $published_id ) );
 
 		/* Assert. */
-		$this->assertSame( 1, $result['unique_student_count'], 'Trashed lesson progress should not count towards unique students.' );
-		$this->assertSame( 1, $result['lesson_start_count'], 'Trashed lesson progress should not count towards lesson starts.' );
+		$this->assertSame( 1, $result['unique_student_count'], "Lesson with post_status '{$excluded_status}' should not count towards unique students." );
+		$this->assertSame( 1, $result['lesson_start_count'], "Lesson with post_status '{$excluded_status}' should not count towards lesson starts." );
+	}
+
+	public function includedLessonStatusesProvider(): array {
+		return array(
+			'publish' => array( 'publish' ),
+			'private' => array( 'private' ),
+		);
+	}
+
+	public function excludedLessonStatusesProvider(): array {
+		return array(
+			'draft'      => array( 'draft' ),
+			'pending'    => array( 'pending' ),
+			'future'     => array( 'future' ),
+			'auto-draft' => array( 'auto-draft' ),
+			'trash'      => array( 'trash' ),
+		);
 	}
 
 	public function testGetLessonTotals_WithFailedQuizStatus_CountsAsCompletedButNotDaysToComplete(): void {


### PR DESCRIPTION
## Summary

- Broaden the `post_status='publish'` filter introduced by #7964 to `post_status IN ('publish', 'private')` in all eight query paths
- Apply to both comments-based and tables-based services
- Add private-lesson regression tests alongside the existing trashed-lesson tests

## Why

#7964 added a hardcoded `publish`-only filter to the Grading aggregation/listing queries and `get_lesson_totals`. Private lessons are still visible to enrolled students, so progress recorded against them is just as actionable as on public lessons.

This also fixes a user-visible inconsistency in Reports → Lessons. The row list (`reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php:72`) already queries `post_status IN ('publish', 'private')`, but #7964 narrowed `get_lesson_totals` to `publish` only. Result: private lesson rows display zero unique students, lesson starts, and completion days even when students did the lesson. After this PR, rows and aggregate stats line up.

Trash, draft, future, pending, and auto-draft remain excluded.

## Affected paths

Comments-based:
- `Comments_Based_Grading_Listing_Service::get_lesson_progress_items` (post_status arg)
- `Comments_Based_Progress_Aggregation_Service::count_statuses`
- `Comments_Based_Progress_Aggregation_Service::get_lesson_totals`

Tables-based:
- `Tables_Based_Grading_Listing_Service::build_base_query`
- `Tables_Based_Grading_Listing_Service::build_count_query`
- `Tables_Based_Progress_Aggregation_Service::count_lesson_statuses_with_quiz`
- `Tables_Based_Progress_Aggregation_Service::count_course_statuses`
- `Tables_Based_Progress_Aggregation_Service::get_lesson_totals`

## Test plan

### Setup

1. Create a course with a published lesson and a **private** lesson. Attach a quiz to the private lesson with **auto-grade disabled** (or include at least one manually-graded question type, e.g. file upload / multi-line text), so submissions land on `ungraded` until manually graded.
2. Enrol Student A, then have them **start** the private lesson (no quiz submission yet).
3. Enrol Student B, then have them **submit** the private lesson's quiz (status → `ungraded`).
4. Enrol Student C, then have them **submit** the private lesson's quiz; manually grade it as passing from the Grading page.

### Grading page

Run this twice — once with HPPS off (comments-based path), once with HPPS on (tables-based path). Toggle via Sensei LMS → Settings → Experimental Features.

At `wp-admin/admin.php?page=sensei_grading`, each student's progress on the private lesson should appear under the listed tab:

| Student | Tab |
| --- | --- |
| A (started, no quiz submission) | **In Progress** |
| B (submitted quiz, awaiting grade) | **Ungraded** |
| C (submitted quiz, manually graded as passing) | **Graded** |

Tab counts should reflect the same — each of the three tabs has at least one private-lesson row.

- [x] **HPPS off:** rows and tab counts match the table above.
- [x] **HPPS on:** same result.

### Reports → Lessons

Same toggle. Navigate to `wp-admin/admin.php?page=sensei_reports&view=lessons` and locate the private lesson's row. Expected values for that row:

| Column | Expected value | Why |
| --- | --- | --- |
| **Students** | `3` | Students A, B, and C all have lesson progress. |
| **Completions** | `2` | Both `ungraded` (B) and `passed` (C) count as completions. A is still `in-progress` and does not. |
| **Days to Completion** | non-blank number | Only `passed` (C) contributes a completion date, so the average is over 1 student. |
| **Completion Rate** | `67%` | Computed as `lesson_completed_count / lesson_start_count = 2 / 3`. A blank / "N/A" value here would mean `lesson_start_count = 0` (i.e. the private lesson was excluded from the SQL). |

- [x] **HPPS off:** the private lesson's row matches the table above.
- [x] **HPPS on:** same result.

### Excluded statuses (regression)

For each excluded status below, set the private lesson's `post_status` to that value and reload both Grading and Reports → Lessons in **both** HPPS modes. Expected in every case:

- The lesson's row disappears entirely from **Reports → Lessons** (the row list itself filters on `post_status IN ('publish','private')`, so the row drops out — not just its stats).
- The lesson's progress rows disappear from every **Grading** tab.
- Grading tab counts drop by the previously-listed amounts (A from In Progress, B from Ungraded, C from Graded).

- [x] Set the private lesson's `post_status` to **Draft** → row + Grading entries disappear as described above.
- [x] Restore to **Private** → row + Grading entries return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
