### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/install-php/action.yml
+++ b/.github/actions/install-php/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
     using: 'composite'
     steps:
-        - uses: shivammathur/setup-php@v2
+        - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
           with:
               php-version: ${{ inputs.php-version }}
               tools: composer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
                   npm ci
                   npm run build:docs
             - name: Deploy to GH Pages
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: './hookdocs'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
                   name: sensei-lms-${{ github.event.pull_request.head.sha }}
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: ${{ matrix.php }}
                   tools: phplint

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
                   retention-days: 30
                   if-no-files-found: ignore
             - name: Slack Notification on Failure
-              uses: rtCamp/action-slack-notify@v2
+              uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
               if: ${{ failure() && github.event_name == 'push' }}
               env:
                 SLACK_CHANNEL: ${{ secrets.SLACK_SENSEI_CHANNEL }}

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -22,7 +22,7 @@ jobs:
          node-version-file: '.nvmrc'
 
      - name: Wait for prior instances of the workflow to finish
-       uses: softprops/turnstyle@v1
+       uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # v0.1.5
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -94,7 +94,7 @@ jobs:
                   NODE_OPTIONS: "--max_old_space_size=4096"
               run: npm run test-js
             - name: Slack Notification on Failure
-              uses: rtCamp/action-slack-notify@v2
+              uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
               if: ${{ failure() && github.event_name == 'push' }}
               env:
                 SLACK_CHANNEL: ${{ secrets.SLACK_SENSEI_CHANNEL }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,7 +29,7 @@ jobs:
                   key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '7.4'
                   tools: composer
@@ -96,7 +96,7 @@ jobs:
                   key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: ${{ matrix.php }}
                   extensions: mysql
@@ -118,7 +118,7 @@ jobs:
               run: ./vendor/bin/phpunit
 
             - name: Slack Notification on Failure
-              uses: rtCamp/action-slack-notify@v2
+              uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
               if: ${{ failure() && github.event_name == 'push' }}
               env:
                 SLACK_CHANNEL: ${{ secrets.SLACK_SENSEI_CHANNEL }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -41,7 +41,7 @@ jobs:
         steps:
             - name: Expose built artifact
               id: expose
-              uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+              uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@06d6a7e5e287101f5a496ef3361aa07967448813 # v2.0.1
               with:
                   artifact-name: playground-plugin-${{ github.event.pull_request.number }}-${{ github.sha }}
                   artifact-filename: sensei-lms.zip
@@ -95,7 +95,7 @@ jobs:
             issues: write
         steps:
             - name: Post Playground Preview Button
-              uses: WordPress/action-wp-playground-pr-preview@v2
+              uses: WordPress/action-wp-playground-pr-preview@06d6a7e5e287101f5a496ef3361aa07967448813 # v2.0.1
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   mode: comment

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -35,7 +35,7 @@ jobs:
                   key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

Tracking: DEVPROD-1072

Changes:
- Pins 6 distinct third-party action refs to full commit SHAs with readable version comments.
- Updates: .github/actions/install-php/action.yml, .github/dependabot.yml, .github/workflows/build-docs.yml, .github/workflows/build.yml, .github/workflows/e2e.yml, .github/workflows/gardening.yml, .github/workflows/js.yml, .github/workflows/php.yml, .github/workflows/playground-preview.yml, .github/workflows/psalm.yml
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)

Notes:
- `softprops/turnstyle` input ref changed from `v1` to `v0.1.5` because both refs resolve to the same commit and `v0.1.5` is the more specific tag.

Verification commands:

```bash
# peaceiris/actions-gh-pages # v3.9.3 -> 373f7f263a76c20808c831209c920827a82a2847
gh api repos/peaceiris/actions-gh-pages/commits/v3.9.3 --jq '.sha'
# expected: 373f7f263a76c20808c831209c920827a82a2847

# rtCamp/action-slack-notify # v2.3.3 -> e31e87e03dd19038e411e38ae27cbad084a90661
gh api repos/rtCamp/action-slack-notify/commits/v2.3.3 --jq '.sha'
# expected: e31e87e03dd19038e411e38ae27cbad084a90661

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# softprops/turnstyle # v0.1.5 -> 8db075d65b19bf94e6e8687b504db69938dc3c65
gh api repos/softprops/turnstyle/commits/v0.1.5 --jq '.sha'
# expected: 8db075d65b19bf94e6e8687b504db69938dc3c65

# WordPress/action-wp-playground-pr-preview # v2.0.1 -> 06d6a7e5e287101f5a496ef3361aa07967448813
gh api repos/WordPress/action-wp-playground-pr-preview/commits/v2.0.1 --jq '.sha'
# expected: 06d6a7e5e287101f5a496ef3361aa07967448813

# WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url # v2.0.1 -> 06d6a7e5e287101f5a496ef3361aa07967448813
gh api repos/WordPress/action-wp-playground-pr-preview/commits/v2.0.1 --jq '.sha'
# expected: 06d6a7e5e287101f5a496ef3361aa07967448813
```
