### PR TITLE
Fix: wrap add_query_arg() with esc_url() in three analysis nav methods

### DIFF
--- a/changelog/fix-analysis-nav-esc-url
+++ b/changelog/fix-analysis-nav-esc-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Fix missing esc_url() on add_query_arg() calls in analysis nav breadcrumb links.

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -719,7 +719,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->get_name() ) );
+		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'admin.php' ) ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
@@ -761,7 +761,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->get_name() ) );
+		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'admin.php' ) ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
@@ -803,7 +803,7 @@ class Sensei_Analysis {
 		$analysis_args = array(
 			'page' => self::PAGE_SLUG,
 		);
-		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'admin.php' ) ), esc_html( $this->get_name() ) );
+		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'admin.php' ) ) ), esc_html( $this->get_name() ) );
 		if ( isset( $_GET['lesson_id'] ) ) {
 			$lesson_id = intval( $_GET['lesson_id'] );
 			$course_id = intval( get_post_meta( $lesson_id, '_lesson_course', true ) );


### PR DESCRIPTION
Resolves #7988

## Proposed Changes

Three nav methods in `class-sensei-analysis.php` — `analysis_course_nav()`, `analysis_course_users_nav()`, and `analysis_lesson_users_nav()` — build an admin link via `add_query_arg()` and pass it directly as the `%s` href argument to `sprintf()` without wrapping in `esc_url()`. The two sibling methods in the same file (`analysis_user_profile_nav()` and `analysis_user_course_nav()`) correctly apply `esc_url()`. This makes the three older methods consistent with the rest of the file.

## Testing Instructions

1. In a WordPress install with Sensei LMS active, navigate to **Sensei > Reports**.
2. Open the Course, Course Users, and Lesson Users report pages.
3. Confirm the breadcrumb nav links render correctly and point to valid admin URLs.
4. No change in visible behaviour — this is a security consistency fix.

## New/Updated Hooks

*None.*

## Deprecated Code

*None.*

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards (PHP)
- [x] All strings are translatable (without concatenation, handles plurals) — no string changes

---
*Developed with AI assistance (Claude). Manually reviewed and tested.*
