### PR TITLE
Migrate admin React entry points to createRoot() for React 19

### DIFF
--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -11,6 +11,18 @@ import { ExitSurveyForm } from './form';
 
 ( function senseiExitSurvey() {
 	/**
+	 * Id of the container the survey is mounted into.
+	 */
+	const CONTAINER_ID = 'sensei-exit-survey-modal';
+
+	/**
+	 * The single React root for the survey, reused across opens.
+	 *
+	 * @type {?Object}
+	 */
+	let surveyRoot = null;
+
+	/**
 	 * Add exit survey modal when clicking the Deactivate link for Sensei LMS plugin.
 	 */
 	const addExitSurveyOnDeactivate = () => {
@@ -61,16 +73,21 @@ import { ExitSurveyForm } from './form';
 		 *
 		 */
 		open = () => {
-			let container = document.querySelector( '#sensei-exit-survey' );
+			let container = document.getElementById( CONTAINER_ID );
 			if ( ! container ) {
 				container = document.createElement( 'div' );
-				container.setAttribute( 'id', 'sensei-exit-survey-modal' );
+				container.setAttribute( 'id', CONTAINER_ID );
 				document.body.appendChild( container );
 			}
 
 			this.container = container;
 
-			this.root = createRoot( container );
+			// Reuse a single root so repeated opens don't mount twice
+			// into the same container.
+			if ( ! surveyRoot ) {
+				surveyRoot = createRoot( container );
+			}
+			this.root = surveyRoot;
 			this.root.render(
 				<ExitSurveyForm
 					submit={ this.submitExitSurvey }
@@ -116,6 +133,7 @@ import { ExitSurveyForm } from './form';
 		 */
 		closeAndDeactivate = () => {
 			this.root?.unmount();
+			surveyRoot = null;
 			this.container.remove();
 			window.location = this.href;
 		};

--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,6 +45,7 @@ import { ExitSurveyForm } from './form';
 	class ExitSurveyModal {
 		href;
 		container;
+		root;
 
 		/**
 		 * Exit survey constructor.
@@ -69,12 +70,12 @@ import { ExitSurveyForm } from './form';
 
 			this.container = container;
 
-			render(
+			this.root = createRoot( container );
+			this.root.render(
 				<ExitSurveyForm
 					submit={ this.submitExitSurvey }
 					skip={ this.closeAndDeactivate }
-				/>,
-				container
+				/>
 			);
 		};
 
@@ -114,6 +115,7 @@ import { ExitSurveyForm } from './form';
 		 * Close survey modal and continue plugin deactivation.
 		 */
 		closeAndDeactivate = () => {
+			this.root?.unmount();
 			this.container.remove();
 			window.location = this.href;
 		};

--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { DropdownMenu } from '@wordpress/components';
-import { render, useState } from '@wordpress/element';
+import { createRoot, useState } from '@wordpress/element';
 import { moreVertical } from '@wordpress/icons';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -124,13 +124,12 @@ export const StudentActionMenu = ( {
 
 Array.from( document.getElementsByClassName( 'student-action-menu' ) ).forEach(
 	( actionMenu ) => {
-		render(
+		createRoot( actionMenu ).render(
 			<StudentActionMenu
 				studentId={ actionMenu?.dataset?.userId }
 				studentName={ actionMenu?.dataset?.userName }
 				studentDisplayName={ actionMenu?.dataset?.userDisplayName }
-			/>,
-			actionMenu
+			/>
 		);
 	}
 );

--- a/assets/admin/students/student-bulk-action-button/index.js
+++ b/assets/admin/students/student-bulk-action-button/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { render, useEffect, useState } from '@wordpress/element';
+import { createRoot, useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
@@ -145,5 +145,5 @@ export const StudentBulkActionButton = ( { isDisabled = true } ) => {
 Array.from(
 	document.querySelectorAll( 'div.sensei-student-bulk-actions__button' )
 ).forEach( ( button ) => {
-	render( <StudentBulkActionButton />, button );
+	createRoot( button ).render( <StudentBulkActionButton /> );
 } );

--- a/assets/course-theme/learning-mode-templates/index.js
+++ b/assets/course-theme/learning-mode-templates/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,4 +10,6 @@ import { TemplateSelector } from './template-selector';
 
 const element = document.getElementById( 'sensei-lm-block-template__options' );
 
-render( <TemplateSelector />, element );
+if ( element ) {
+	createRoot( element ).render( <TemplateSelector /> );
+}

--- a/assets/data-port/export.js
+++ b/assets/data-port/export.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import SenseiExportPage from './export/index';
 
-render( <SenseiExportPage />, document.getElementById( 'sensei-export-page' ) );
+const root = createRoot( document.getElementById( 'sensei-export-page' ) );
+root.render( <SenseiExportPage /> );

--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { render, useLayoutEffect } from '@wordpress/element';
+import { createRoot, useLayoutEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -59,4 +59,5 @@ const SenseiImportPage = () => {
 	);
 };
 
-render( <SenseiImportPage />, document.getElementById( 'sensei-import-page' ) );
+const root = createRoot( document.getElementById( 'sensei-import-page' ) );
+root.render( <SenseiImportPage /> );

--- a/assets/home/index.js
+++ b/assets/home/index.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Main from './main';
 
-render( <Main />, document.getElementById( 'sensei-home-page' ) );
+const root = createRoot( document.getElementById( 'sensei-home-page' ) );
+root.render( <Main /> );

--- a/assets/setup-wizard/index.js
+++ b/assets/setup-wizard/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { render, useLayoutEffect } from '@wordpress/element';
+import { createRoot, useLayoutEffect } from '@wordpress/element';
 import { Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -110,7 +110,7 @@ const SenseiSetupWizardPage = () => {
 	);
 };
 
-render(
-	<SenseiSetupWizardPage />,
+const root = createRoot(
 	document.getElementById( 'sensei-setup-wizard-page' )
 );
+root.render( <SenseiSetupWizardPage /> );

--- a/changelog/migrate-to-createroot-react-19
+++ b/changelog/migrate-to-createroot-react-19
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Internal: Migrate admin React entry points to createRoot() for React 19 compatibility.


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/SEN-41/migrate-sensei-lms-to-createroot-for-react-19-wordpress-71.

## What

React 19 (shipping in WordPress 7.1 via Gutenberg 23.3) removes the legacy `render()` mount path from `@wordpress/element` in favor of `createRoot()`. This migrates the Sensei LMS admin entry points that still call the legacy `render`.

Context / audit: pgle0O-1ET-p2

## Changes

Converted `render( <App />, container )` → `createRoot( container ).render( <App /> )` in every Sensei LMS source mount point:

- `assets/home/index.js`
- `assets/setup-wizard/index.js`
- `assets/admin/exit-survey/index.js`
- `assets/data-port/export.js`
- `assets/data-port/import.js`
- `assets/admin/students/student-action-menu/index.js`
- `assets/admin/students/student-bulk-action-button/index.js`
- `assets/course-theme/learning-mode-templates/index.js`

The exit survey modal now uses a consistent container id and reuses a single React root across opens, calling `root.unmount()` on close so the tree isn't orphaned and a repeated open doesn't mount twice into the same node. (This also tidies a latent dead-selector mismatch — the lookup queried `#sensei-exit-survey` while the created element used id `sensei-exit-survey-modal` — so the container is now actually reused. It was effectively unreachable in practice, since the modal always navigates away on close; the change is defensive, to keep `createRoot` from being called twice on the same node.)

## Why now

At runtime the browser uses whichever React the site's WordPress version provides — 18.3.1 on WP ≤7.0, React 19 on WP 7.1+. `createRoot()` works on React 18 today, so this is safe to land now and is picked up automatically when WP 7.1 swaps in React 19. On React 19 the legacy `render` is removed, so these mounts would otherwise throw and fail to render.

No `react` / `@wordpress/element` version bump is included — that waits for WordPress/Gutenberg to ship the React 19 build. `forwardRef` usage is intentionally out of scope: it is deprecated but not removed in React 19, and the React 19 replacement (ref-as-prop) does **not** work on React 18, so it can't be migrated until WP drops React 18 support.

## Test plan

For each surface below, confirm it renders and behaves exactly as before, with no console warnings/errors:

1. **Sensei → Home** — page loads and renders.
2. **Setup Wizard** — loads and steps through.
3. **Tools → Import** and **Tools → Export** — both pages render and run.
4. **Students** (Sensei LMS → Students):
   - Per-row action menu (⋮) opens; "Add to Course" / "Remove" / "Reset Progress" open the modal.
   - Select students → bulk **Select Action** button enables and opens the modal.
5. **Learning Mode templates** — Sensei LMS → Settings → Appearance (with Learning Mode enabled): the "Learning Mode Templates" options (radio cards) render.
6. **Exit Survey** — Plugins screen → click **Deactivate** on Sensei LMS: modal opens; skip and submit both close it cleanly. Double-click Deactivate does not produce a duplicate modal or a "cannot update an unmounted root" / duplicate-root warning.

> Tip: enable `SCRIPT_DEBUG` to load the development React build — pre-change, these surfaces log `ReactDOM.render is no longer supported in React 18`; after this PR the warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)