### PR TITLE
Re-enable Playground preview artifact cleanup

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -48,10 +48,6 @@ jobs:
                   pr-number: ${{ github.event.pull_request.number }}
                   commit-sha: ${{ github.sha }}
                   release-tag: 'ci-playground-artifacts'
-                  # Upstream cleanup sorts assets by `.created_at` but the
-                  # GitHub API returns `createdAt`, so it deletes by filename
-                  # order — which can wipe the asset just uploaded.
-                  cleanup-enabled: 'false'
 
     create-blueprint:
         name: Create Playground Blueprint


### PR DESCRIPTION
## Description

PR #7959 disabled the `expose-artifact-on-public-url` cleanup step because of an upstream bug: the cleanup sorted assets by `.created_at`, but the GitHub API returns `createdAt`, so every asset evaluated to `null` and the sort fell back to filename order — which could delete the asset just uploaded. As a result, assets accumulated on the [`ci-playground-artifacts` release](https://github.com/Automattic/sensei/releases/tag/ci-playground-artifacts) (119 at last count).

The fix ([WordPress/action-wp-playground-pr-preview#73](https://github.com/WordPress/action-wp-playground-pr-preview/pull/73)) has been cherry-picked upstream into the `v2.0.1` commit we already pin (`06d6a7e`), so this PR removes the `cleanup-enabled: 'false'` override and its explanatory comment. Cleanup defaults back on and keeps the 2 newest assets per PR.

Stale assets from merged/closed PRs have already been purged manually; the release now only holds assets for open PRs.

## Test plan

- Push a few commits to a PR and verify the `ci-playground-artifacts` release retains only the 2 newest `pr-<number>-*.zip` assets for that PR, including the one just uploaded.
- Verify the Playground preview comment link still works after each push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)