### PR TITLE
Add cannot-reproduce guidance to Claude system prompt

### DIFF
--- a/.github/claude-system-prompt.md
+++ b/.github/claude-system-prompt.md
@@ -12,6 +12,7 @@ When responding to a GitHub trigger, follow this process strictly. The action ru
 ## 1. Analyze
 - Read the issue. Identify affected files and root cause.
 - If unclear, comment asking for clarification instead of guessing.
+- If you cannot reproduce the reported behavior (e.g., a failing test that captures it, or tracing the code path to confirm the bug), do not attempt a speculative fix. Comment with what you tried, ask the reporter for reproduction steps (WordPress/PHP versions, active plugins, relevant settings), add the `claude-needs-info` label, and stop.
 
 ## 2. Branch
 - Create a branch from trunk with a short, descriptive name (e.g., `fix/null-courses-average-grade`). The configured `branch_prefix` is `fix/`. Do not include the issue number.

--- a/.github/claude-system-prompt.md
+++ b/.github/claude-system-prompt.md
@@ -12,7 +12,7 @@ When responding to a GitHub trigger, follow this process strictly. The action ru
 ## 1. Analyze
 - Read the issue. Identify affected files and root cause.
 - If unclear, comment asking for clarification instead of guessing.
-- If you cannot reproduce the reported behavior (e.g., a failing test that captures it, or tracing the code path to confirm the bug), do not attempt a speculative fix. Comment with what you tried, ask the reporter for reproduction steps (WordPress/PHP versions, active plugins, relevant settings), add the `claude-needs-info` label, and stop.
+- If you cannot reproduce or confirm the reported behavior after attempting to (e.g., by writing a failing test that captures it, or tracing the code path), do not attempt a speculative fix. Comment with what you tried, ask the reporter for reproduction steps (WordPress/PHP versions, active plugins, relevant settings), add the `claude-needs-info` label, and stop.
 
 ## 2. Branch
 - Create a branch from trunk with a short, descriptive name (e.g., `fix/null-courses-average-grade`). The configured `branch_prefix` is `fix/`. Do not include the issue number.


### PR DESCRIPTION
When the Claude Code workflow cannot reproduce a reported issue, it previously had no dedicated path — failures of any kind fell through to the `claude-failed` label, which conflates "the bug is real but my fix attempt failed" with "I can't confirm the bug exists."

This adds a step to the Analyze phase of `.github/claude-system-prompt.md`: if Claude cannot reproduce the reported behavior, it must not attempt a speculative fix. Instead it comments with what it tried, asks the reporter for reproduction details (WordPress/PHP versions, active plugins, relevant settings), adds the `claude-needs-info` label, and stops.

The `claude-needs-info` label has already been created in the repo.

## Test plan

1. Open a test issue describing behavior that doesn't actually occur on trunk (or is environment-specific).
2. Add the `claude` label to trigger the workflow.
3. Verify Claude comments asking for reproduction details, applies the `claude-needs-info` label, and does not open a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)