### PR TITLE
Remove HPPS parent_post_id reliance in grading stats

### DIFF
--- a/changelog/fix-hpps-grading-stats-parent-post-id
+++ b/changelog/fix-hpps-grading-stats-parent-post-id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fix HPPS grading stats when progress rows do not have parent post IDs.

--- a/changelog/fix-hpps-grading-stats-parent-post-id
+++ b/changelog/fix-hpps-grading-stats-parent-post-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fix HPPS grading stats when progress rows do not have parent post IDs.

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -105,11 +105,13 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 			"SELECT COUNT(*) AS count, COALESCE( SUM( qs.final_grade ), 0 ) AS sum
 			FROM %i q
 			INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
+			INNER JOIN %i lesson_quiz ON lesson_quiz.meta_key = '_lesson_quiz' AND lesson_quiz.meta_value = q.post_id
 			WHERE q.type = 'quiz'
 				AND q.status IN " . $this->get_graded_statuses_sql() . '
 				AND qs.final_grade IS NOT NULL',
 			$table,
-			$submissions_table
+			$submissions_table,
+			$wpdb->postmeta
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
@@ -154,33 +156,35 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		} else {
 			$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-			$course_filter = $wpdb->prepare( " AND p.parent_post_id IN ( $placeholders )", $course_ids );
+			$course_filter = $wpdb->prepare( " AND lesson_course.meta_value IN ( $placeholders )", $course_ids );
 		}
 
-		/**
-		 * Uses parent_post_id on lesson progress rows as the course ID.
-		 * The subquery computes AVG grade per course; the outer query averages those.
-		 */
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
 		$query = $wpdb->prepare(
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
 				SELECT AVG(qs.final_grade) AS course_average
 				FROM %i p
-				INNER JOIN %i q ON q.parent_post_id = p.post_id AND q.user_id = p.user_id AND q.type = 'quiz'
+				INNER JOIN %i lesson_course ON lesson_course.post_id = p.post_id
+					AND lesson_course.meta_key = '_lesson_course'
+					AND lesson_course.meta_value <> ''
+				INNER JOIN %i lesson_quiz ON lesson_quiz.post_id = p.post_id
+					AND lesson_quiz.meta_key = '_lesson_quiz'
+					AND lesson_quiz.meta_value > 0
+				INNER JOIN %i q ON q.post_id = lesson_quiz.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
 				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
 				WHERE p.type = 'lesson'
 					AND q.status IN " . $this->get_graded_statuses_sql() . '
-					AND qs.final_grade IS NOT NULL
-					AND p.parent_post_id IS NOT NULL
-					AND p.parent_post_id != 0',
+					AND qs.final_grade IS NOT NULL',
 			$table,
+			$wpdb->postmeta,
+			$wpdb->postmeta,
 			$table,
 			$submissions_table
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		$query .= $course_filter;
-		$query .= ' GROUP BY p.parent_post_id ) averages_by_course';
+		$query .= ' GROUP BY lesson_course.meta_value ) averages_by_course';
 
 		/** Query result. @var object|null $result */
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
@@ -268,11 +272,11 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		}
 
 		if ( ! empty( $args['lesson_id'] ) ) {
-			return $wpdb->prepare( ' AND q.parent_post_id = %d', $args['lesson_id'] );
+			return $wpdb->prepare( ' AND lesson_quiz.post_id = %d', $args['lesson_id'] );
 		}
 
 		$placeholders = implode( ', ', array_fill( 0, count( $args['post__in'] ), '%d' ) );
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholders created dynamically.
-		return $wpdb->prepare( " AND q.parent_post_id IN ( $placeholders )", $args['post__in'] );
+		return $wpdb->prepare( " AND lesson_quiz.post_id IN ( $placeholders )", $args['post__in'] );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-listing-service.php
@@ -26,9 +26,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 	 * @param int      $user_id        The user ID.
 	 * @param string   $type           The progress type.
 	 * @param string   $status         The progress status.
-	 * @param int|null $parent_post_id The parent post ID.
 	 */
-	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null ): void {
+	private function insert_progress( int $post_id, int $user_id, string $type, string $status ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
@@ -42,10 +41,6 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 			'updated_at' => $now,
 		];
 		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
-		if ( null !== $parent_post_id ) {
-			$data['parent_post_id'] = $parent_post_id;
-			$format[]               = '%d';
-		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
 		$wpdb->insert( $table, $data, $format );
 	}
@@ -104,7 +99,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -138,8 +133,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed' );
 		$this->insert_quiz_submission( $quiz_id, $user_id, 90 );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
@@ -168,9 +163,9 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson3   = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson2, $user_id, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $lesson3, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson2, $user_id, 'lesson', 'complete' );
+		$this->insert_progress( $lesson3, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -200,7 +195,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -237,14 +232,14 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
 		// User2 completed and submitted the quiz so is not excluded.
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user2, 'quiz', 'complete', $lesson_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user2, 'quiz', 'complete' );
 		$this->insert_quiz_submission( $quiz_id, $user2 );
 
-		$this->insert_progress( $lesson_id, $user3, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user3, 'quiz', 'graded', $lesson_id );
+		$this->insert_progress( $lesson_id, $user3, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user3, 'quiz', 'graded' );
 		$this->insert_quiz_submission( $quiz_id, $user3 );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
@@ -279,8 +274,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -308,7 +303,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		);
 		for ( $i = 0; $i < 3; $i++ ) {
 			$user_id = $this->sensei_factory->user->create();
-			$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+			$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 		}
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
@@ -337,8 +332,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -370,11 +365,11 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
 		// User1: in-progress lesson (no quiz interaction).
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
 
 		// User2: completed lesson with passed quiz.
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user2, 'quiz', 'passed', $lesson_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user2, 'quiz', 'passed' );
 		$this->insert_quiz_submission( $quiz_id, $user2, 85 );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
@@ -409,8 +404,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -447,11 +442,11 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
 		// Real student: in-progress.
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
 
 		// Preview user: completed with ungraded quiz — should be kept because of override.
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user2, 'quiz', 'ungraded', $lesson_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user2, 'quiz', 'ungraded' );
 		$this->insert_quiz_submission( $quiz_id, $user2 );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
@@ -488,8 +483,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 
@@ -522,7 +517,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
@@ -553,7 +548,7 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
-		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -596,8 +591,8 @@ class Tables_Based_Grading_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Grading_Listing_Service( $wpdb );
 

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -38,9 +38,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	 * @param int      $user_id        The user ID.
 	 * @param string   $type           The progress type.
 	 * @param string   $status         The progress status.
-	 * @param int|null $parent_post_id The parent post ID.
 	 */
-	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null ): void {
+	private function insert_progress( int $post_id, int $user_id, string $type, string $status ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
@@ -54,10 +53,6 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 			'updated_at' => $now,
 		);
 		$format = array( '%d', '%d', '%s', '%s', '%s', '%s', '%s' );
-		if ( null !== $parent_post_id ) {
-			$data['parent_post_id'] = $parent_post_id;
-			$format[]               = '%d';
-		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
 		$wpdb->insert( $table, $data, $format );
 	}
@@ -99,8 +94,11 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 	 * @param int    $grade      The grade value.
 	 */
 	private function create_graded_lesson( int $lesson_id, int $quiz_id, int $user_id, int $course_id, string $status, int $grade ): void {
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', $status, $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', $status, $lesson_id );
+		update_post_meta( $lesson_id, '_lesson_course', $course_id );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', $status );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', $status );
 		$this->insert_quiz_submission( $quiz_id, $user_id, $grade );
 	}
 
@@ -215,8 +213,10 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		$quiz_id   = $this->sensei_factory->quiz->create();
 
 		// Lesson progress exists but quiz submission has no grade.
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'graded', $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded', $lesson_id );
+		update_post_meta( $lesson_id, '_lesson_course', $course_id );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'graded' );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded' );
 		$this->insert_quiz_submission( $quiz_id, $user_id, null );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
@@ -361,8 +361,10 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 		// This should be excluded: 'in-progress' status with a grade.
 		$lesson_4 = $this->sensei_factory->lesson->create();
 		$quiz_4   = $this->sensei_factory->quiz->create();
-		$this->insert_progress( $lesson_4, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $quiz_4, $user_id, 'quiz', 'in-progress', $lesson_4 );
+		update_post_meta( $lesson_4, '_lesson_course', $course_id );
+		update_post_meta( $lesson_4, '_lesson_quiz', $quiz_4 );
+		$this->insert_progress( $lesson_4, $user_id, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_4, $user_id, 'quiz', 'in-progress' );
 		$this->insert_quiz_submission( $quiz_4, $user_id, 100 );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
@@ -387,7 +389,8 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 		// Lesson without quiz: only lesson progress, no quiz progress or submission.
 		$lesson_2 = $this->sensei_factory->lesson->create();
-		$this->insert_progress( $lesson_2, $user_id, 'lesson', 'complete', $course_id );
+		update_post_meta( $lesson_2, '_lesson_course', $course_id );
+		$this->insert_progress( $lesson_2, $user_id, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
 		$result  = $service->get_courses_average_grade();

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -30,9 +30,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 	 * @param int         $user_id        The user ID.
 	 * @param string      $type           The progress type ('course' or 'lesson').
 	 * @param string      $status         The progress status.
-	 * @param int|null    $parent_post_id The parent post ID.
 	 */
-	private function insert_progress_with_dates( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id, string $started_at, string $completed_at ): void {
+	private function insert_progress_with_dates( int $post_id, int $user_id, string $type, string $status, string $started_at, string $completed_at ): void {
 		$wpdb  = $GLOBALS['wpdb'];
 		$table = $wpdb->prefix . 'sensei_lms_progress';
 		$now   = current_time( 'mysql' );
@@ -49,16 +48,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' ];
 
-		if ( null !== $parent_post_id ) {
-			$data['parent_post_id'] = $parent_post_id;
-			$format[]               = '%d';
-		}
-
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper inserting directly into custom table.
 		$wpdb->insert( $table, $data, $format );
 	}
 
-	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null, ?string $completed_at = null ): void {
+	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?string $completed_at = null ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
@@ -72,11 +66,6 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			'updated_at' => $now,
 		];
 		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
-
-		if ( null !== $parent_post_id ) {
-			$data['parent_post_id'] = $parent_post_id;
-			$format[]               = '%d';
-		}
 
 		if ( null !== $completed_at ) {
 			$data['completed_at'] = $completed_at;
@@ -120,7 +109,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -148,8 +137,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson2, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson2, $user_id, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -179,8 +168,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson1, $user_id, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $lesson2, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson1, $user_id, 'lesson', 'complete' );
+		$this->insert_progress( $lesson2, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -208,8 +197,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -240,8 +229,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $guest_user, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson_id, $guest_user, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -276,8 +265,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded', $lesson_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'graded' );
 		$this->insert_quiz_submission( $quiz_id, $user_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -304,7 +293,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -341,14 +330,14 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
 
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user1, 'quiz', 'graded', $lesson_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user1, 'quiz', 'graded' );
 		$this->insert_quiz_submission( $quiz_id, $user1 );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user2, 'quiz', 'passed', $lesson_id );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user2, 'quiz', 'passed' );
 		$this->insert_quiz_submission( $quiz_id, $user2 );
-		$this->insert_progress( $lesson_id, $user3, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $quiz_id, $user3, 'quiz', 'ungraded', $lesson_id );
+		$this->insert_progress( $lesson_id, $user3, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_id, $user3, 'quiz', 'ungraded' );
 		$this->insert_quiz_submission( $quiz_id, $user3 );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -383,7 +372,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
@@ -413,7 +402,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
-		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $excluded_id, $user_id, 'lesson', 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $excluded_id ) );
@@ -446,8 +435,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$started_at   = '2024-01-01 10:00:00';
 		$completed_at = '2024-01-03 10:00:00';
-		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $started_at, $completed_at );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
@@ -486,8 +475,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		// Lesson is complete but quiz is still in-progress — COALESCE should
 		// produce 'in-progress' which is NOT in the completed statuses list.
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id, current_time( 'mysql' ) );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'in-progress', $lesson_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', current_time( 'mysql' ) );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'in-progress' );
 		$this->insert_quiz_submission( $quiz_id, $user_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -519,7 +508,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
 		// Lesson is in-progress, quiz is ungraded (submitted but not yet graded).
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
 		$this->insert_quiz_submission( $quiz_id, $user_id );
 
@@ -569,8 +558,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
 		// Lesson is in-progress, quiz is failed (pass required, student didn't pass).
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'failed', $lesson_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'failed' );
 		$this->insert_quiz_submission( $quiz_id, $user_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -603,8 +592,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$started_at   = '2024-01-01 10:00:00';
 		$completed_at = '2024-01-04 10:00:00';
-		$this->insert_progress_with_dates( $lesson_id, $user_id, 'lesson', 'complete', $course_id, $started_at, $completed_at );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_progress_with_dates( $lesson_id, $user_id, 'lesson', 'complete', $started_at, $completed_at );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed' );
 		$this->insert_quiz_submission( $quiz_id, $user_id );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
@@ -653,8 +642,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$started_at   = '2024-01-01 10:00:00';
 		$completed_at = '2024-01-03 10:00:00';
-		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $course_id, $started_at, $completed_at );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress_with_dates( $lesson_id, $user1, 'lesson', 'complete', $started_at, $completed_at );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $excluded_status ), array( 'ID' => $lesson_id ) );
@@ -693,7 +682,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		// but in UTC-5 they're same day (Jan 1 00:00 → Jan 1 23:00).
 		$started_at   = '2024-01-01 05:00:00';
 		$completed_at = '2024-01-02 04:00:00';
-		$this->insert_progress_with_dates( $lesson_id, $user_id, 'lesson', 'complete', $course_id, $started_at, $completed_at );
+		$this->insert_progress_with_dates( $lesson_id, $user_id, 'lesson', 'complete', $started_at, $completed_at );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -721,8 +710,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
-		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress', $course_id );
-		$this->insert_progress( $lesson_id, $guest_user, 'lesson', 'ungraded', $course_id );
+		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress' );
+		$this->insert_progress( $lesson_id, $guest_user, 'lesson', 'ungraded' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
@@ -759,8 +748,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
 
 		// Quiz progress exists but no quiz submission (e.g. migration phantom or lost data).
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed' );
 
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 

--- a/tests/unit-tests/internal/services/test-class-tables-based-reports-listing-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-reports-listing-service.php
@@ -39,9 +39,8 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 	 * @param int      $user_id        The user ID.
 	 * @param string   $type           The progress type.
 	 * @param string   $status         The progress status.
-	 * @param int|null $parent_post_id The parent post ID.
 	 */
-	private function insert_progress( int $post_id, int $user_id, string $type, string $status, ?int $parent_post_id = null ): void {
+	private function insert_progress( int $post_id, int $user_id, string $type, string $status ): void {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql', true );
@@ -56,10 +55,6 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 			'updated_at'   => $now,
 		);
 		$format = array( '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' );
-		if ( null !== $parent_post_id ) {
-			$data['parent_post_id'] = $parent_post_id;
-			$format[]               = '%d';
-		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
 		$wpdb->insert( $table, $data, $format );
 	}
@@ -103,7 +98,7 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
 
@@ -146,8 +141,8 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed', $lesson_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'passed' );
 		$this->insert_quiz_submission( $quiz_id, $user_id, 90 );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
@@ -182,7 +177,7 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$this->insert_progress( $course_id, $user_id, 'course', 'in-progress' );
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
 
@@ -217,7 +212,7 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'complete' );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
 
@@ -312,8 +307,8 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
 
@@ -344,8 +339,8 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete' );
+		$this->insert_progress( $lesson_id, $user2, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
 
@@ -383,8 +378,8 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete', $course_id );
-		$this->insert_progress( $quiz_id, $user1, 'quiz', 'passed', $lesson_id );
+		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete' );
+		$this->insert_progress( $quiz_id, $user1, 'quiz', 'passed' );
 		$this->insert_quiz_submission( $quiz_id, $user1, 80 );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
@@ -416,7 +411,7 @@ class Tables_Based_Reports_Listing_Service_Test extends \WP_UnitTestCase {
 		$lesson_id = $this->sensei_factory->lesson->create(
 			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
-		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress', $course_id );
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
 
 		$service = new Tables_Based_Reports_Listing_Service( $wpdb );
 


### PR DESCRIPTION
## Proposed Changes

- Remove the runtime dependency on `parent_post_id` from the table-based grading stats service.
- Use the existing lesson-to-quiz and lesson-to-course relationships when filtering grade totals or calculating course average grades.
- Update table-based grading stats tests so HPPS progress rows no longer seed parent IDs.

## Why

HPPS progress rows currently store `parent_post_id` as `null`, so grading stats that rely on that field return empty results in table mode. This keeps the progress table schema as-is while removing the incorrect runtime assumption.

## Testing

Automated checks:

- `make test-php-filter FILTER=Tables_Based_Grading_Stats_Service_Test`
- Focused PHPCS on:
  - `includes/internal/services/class-tables-based-grading-stats-service.php`
  - `tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php`

Manual admin testing, direct impact only:

1. Enable HPPS and select the `High-Performance progress storage (experimental)` tables repository.
2. Create graded quiz progress for at least two courses, using HPPS progress rows where `sensei_lms_progress.parent_post_id` remains `NULL`. Example:
   - Course A: one lesson quiz graded `80%`.
   - Course B: one lesson quiz graded `40%`.
3. Go to `Sensei > Reports > Courses`.
   - Check each course row's `Average Grade` column.
   - Course A should show `80%`.
   - Course B should show `40%`.
   - Check the `Average Grade (...)` value in the Courses table header/summary. It should show `60%`.
4. Go to `Sensei > Reports > Students`.
   - For the student with both graded quizzes, check the `Average Grade` column.
   - It should show `60%`.

No broader Grading table, completion-rate, date-started, date-completed, or quiz grading flow checks are needed for this PR; those are adjacent HPPS surfaces, not production paths changed here.