### PR TITLE
Enable block editor Notes for courses and lessons

### DIFF
--- a/changelog/add-editor-notes-support
+++ b/changelog/add-editor-notes-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable the block editor Notes feature for courses and lessons.

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -224,7 +224,7 @@ class Sensei_PostTypes {
 	public function exclude_sitemaps_post_types( $post_types ) {
 		return array_filter(
 			$post_types,
-			function( $post_type ) {
+			function ( $post_type ) {
 				return ! in_array( $post_type->name, self::SITEMAPS_EXCLUDED_PUBLIC_POST_TYPES, true );
 			}
 		);
@@ -290,7 +290,15 @@ class Sensei_PostTypes {
 			'has_archive'           => $this->get_course_post_type_archive_slug(),
 			'hierarchical'          => false,
 			'menu_position'         => 51,
-			'supports'              => array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions', 'custom-fields' ),
+			// 'editor' uses the keyed form to enable the block editor Notes feature (WordPress 6.9+). Ignored on earlier versions.
+			'supports'              => array(
+				'title',
+				'excerpt',
+				'thumbnail',
+				'revisions',
+				'custom-fields',
+				'editor' => array( 'notes' => true ),
+			),
 			'show_in_rest'          => true,
 			'rest_base'             => 'courses',
 			'rest_controller_class' => 'WP_REST_Posts_Controller',
@@ -395,7 +403,14 @@ class Sensei_PostTypes {
 	 */
 	public function setup_lesson_post_type() {
 
-		$supports_array = array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions' );
+		// 'editor' uses the keyed form to enable the block editor Notes feature (WordPress 6.9+). Ignored on earlier versions.
+		$supports_array = array(
+			'title',
+			'excerpt',
+			'thumbnail',
+			'revisions',
+			'editor' => array( 'notes' => true ),
+		);
 		$allow_comments = false;
 		if ( isset( Sensei()->settings->settings['lesson_comments'] ) ) {
 			$allow_comments = Sensei()->settings->settings['lesson_comments'];


### PR DESCRIPTION
## Description

Enables the WordPress 6.9 [Notes feature](https://make.wordpress.org/core/2025/11/15/notes-feature-in-wordpress-6-9/) in the course and lesson editors.

The change adds the `notes` argument to the `editor` post type support, using the keyed form:

```php
'editor' => array( 'notes' => true )
```

This is applied to both the `course` and `lesson` post types in `Sensei_PostTypes`.

No WordPress version gate is needed: the keyed `editor` support arg is ignored by versions earlier than 6.9, so the editor behaves exactly as before on older WordPress.

## How to test

Requires WordPress 6.9 or later.

1. Edit a course (**Courses → Edit**).
2. Confirm the Notes UI is available in the block editor (select a block, add a note via the block toolbar / options).
3. Repeat for a lesson (**Lessons → Edit**).
4. On WordPress < 6.9, confirm the editors load normally with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)