### PR TITLE
Cover composite actions in Dependabot github-actions config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" covers .github/workflows + root action.yml only; the glob adds the
+    # nested composite actions (.github/actions/*/action.yml).
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    # "/" covers .github/workflows + root action.yml only; the glob adds the
-    # nested composite actions (.github/actions/*/action.yml).
+    # Scan composite actions too — their SHA-pinned `uses:` refs need update
+    # PRs just like the workflow files do ('**' covers nested action dirs).
     directories:
       - "/"
-      - "/.github/actions/*"
+      - "/.github/actions/**"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Follow-up to #7987 (DEVPROD-1072 SHA-pinning).

Dependabot's `github-actions` ecosystem with `directory: "/"` scans `.github/workflows/` plus a root `action.yml` only — **not** nested composite actions. The SHA-pinned refs in `.github/actions/install-php/action.yml` would therefore never receive Dependabot update PRs.

This switches the entry to the `directories` key with a glob, covering `/` **and** `/.github/actions/*` (and any composite actions added later).

Verify the scanning semantics: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference ("For GitHub Actions, use the value `/`. Dependabot will search the `/.github/workflows` directory, as well as the `action.yml/action.yaml` file from the root directory" — and "The `directories` key supports globbing").

Config-only change; no workflow behaviour change.