### PR TITLE
Fix student progress date timezone mismatch with HPPS enabled

### DIFF
--- a/changelog/fix-progress-start-date-timezone
+++ b/changelog/fix-progress-start-date-timezone
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix student progress dates being stored in inconsistent timezones, making Date Started and Date Completed mismatch on the Students screen and in reports.
+Fix student progress dates being stored in inconsistent timezones when HPPS is enabled.

--- a/changelog/fix-progress-start-date-timezone
+++ b/changelog/fix-progress-start-date-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix student progress dates being stored in inconsistent timezones, making Date Started and Date Completed mismatch on the Students screen and in reports.

--- a/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-comments-based-course-progress-repository.php
@@ -209,9 +209,11 @@ class Comments_Based_Course_Progress_Repository implements Course_Progress_Repos
 	 */
 	public function save( Course_Progress_Interface $course_progress ): void {
 		$this->assert_comments_based_course_progress( $course_progress );
-		$metadata = [];
-		if ( $course_progress->get_started_at() ) {
-			$metadata['start'] = $course_progress->get_started_at()->format( 'Y-m-d H:i:s' );
+		$metadata   = [];
+		$started_at = $course_progress->get_started_at();
+		if ( $started_at ) {
+			// Comment dates are stored in the site timezone.
+			$metadata['start'] = wp_date( 'Y-m-d H:i:s', $started_at->getTimestamp() );
 		}
 		Sensei_Utils::update_course_status( $course_progress->get_user_id(), $course_progress->get_course_id(), $course_progress->get_status(), $metadata );
 	}

--- a/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-tables-based-course-progress-repository.php
@@ -249,8 +249,9 @@ class Tables_Based_Course_Progress_Repository implements Course_Progress_Reposit
 			$this->wpdb->prefix . 'sensei_lms_progress',
 			[
 				'status'       => $course_progress->get_status(),
-				'started_at'   => $course_progress->get_started_at() ? $course_progress->get_started_at()->format( $date_format ) : null,
-				'completed_at' => $course_progress->get_completed_at() ? $course_progress->get_completed_at()->format( $date_format ) : null,
+				// Table columns are stored in UTC.
+				'started_at'   => $course_progress->get_started_at() ? gmdate( $date_format, $course_progress->get_started_at()->getTimestamp() ) : null,
+				'completed_at' => $course_progress->get_completed_at() ? gmdate( $date_format, $course_progress->get_completed_at()->getTimestamp() ) : null,
 				'updated_at'   => $course_progress->get_updated_at()->format( $date_format ),
 			],
 			[

--- a/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-comments-based-lesson-progress-repository.php
@@ -153,9 +153,11 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 	public function save( Lesson_Progress_Interface $lesson_progress ): void {
 		$this->assert_comments_based_lesson_progress( $lesson_progress );
 
-		$metadata = [];
-		if ( $lesson_progress->get_started_at() ) {
-			$metadata['start'] = $lesson_progress->get_started_at()->format( 'Y-m-d H:i:s' );
+		$metadata   = [];
+		$started_at = $lesson_progress->get_started_at();
+		if ( $started_at ) {
+			// Comment dates are stored in the site timezone.
+			$metadata['start'] = wp_date( 'Y-m-d H:i:s', $started_at->getTimestamp() );
 		}
 
 		// We need to use internal value for status, not the one returned by the getter.
@@ -172,10 +174,12 @@ class Comments_Based_Lesson_Progress_Repository implements Lesson_Progress_Repos
 			$metadata
 		);
 
-		if ( $lesson_progress->is_complete() && $comment_id ) {
+		$completed_at = $lesson_progress->get_completed_at();
+		if ( $lesson_progress->is_complete() && $comment_id && $completed_at ) {
 			$comment = [
 				'comment_ID'   => $comment_id,
-				'comment_date' => $lesson_progress->get_completed_at()->format( 'Y-m-d H:i:s' ),
+				// Comment dates are stored in the site timezone.
+				'comment_date' => wp_date( 'Y-m-d H:i:s', $completed_at->getTimestamp() ),
 			];
 			wp_update_comment( $comment );
 			Sensei()->flush_comment_counts_cache( $lesson_progress->get_lesson_id() );

--- a/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-tables-based-lesson-progress-repository.php
@@ -251,8 +251,9 @@ class Tables_Based_Lesson_Progress_Repository implements Lesson_Progress_Reposit
 			$this->wpdb->prefix . 'sensei_lms_progress',
 			[
 				'status'       => $lesson_progress->get_status(),
-				'started_at'   => $lesson_progress->get_started_at() ? $lesson_progress->get_started_at()->format( $date_format ) : null,
-				'completed_at' => $lesson_progress->get_completed_at() ? $lesson_progress->get_completed_at()->format( $date_format ) : null,
+				// Table columns are stored in UTC.
+				'started_at'   => $lesson_progress->get_started_at() ? gmdate( $date_format, $lesson_progress->get_started_at()->getTimestamp() ) : null,
+				'completed_at' => $lesson_progress->get_completed_at() ? gmdate( $date_format, $lesson_progress->get_completed_at()->getTimestamp() ) : null,
 				'updated_at'   => $lesson_progress->get_updated_at()->format( $date_format ),
 			],
 			[

--- a/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-comments-based-quiz-progress-repository.php
@@ -155,10 +155,12 @@ class Comments_Based_Quiz_Progress_Repository implements Quiz_Progress_Repositor
 	public function save( Quiz_Progress_Interface $quiz_progress ): void {
 		$this->assert_comments_based_quiz_progress( $quiz_progress );
 
-		$lesson_id = (int) Sensei()->quiz->get_lesson_id( $quiz_progress->get_quiz_id() );
-		$metadata  = [];
-		if ( $quiz_progress->get_started_at() ) {
-			$metadata['start'] = $quiz_progress->get_started_at()->format( 'Y-m-d H:i:s' );
+		$lesson_id  = (int) Sensei()->quiz->get_lesson_id( $quiz_progress->get_quiz_id() );
+		$metadata   = [];
+		$started_at = $quiz_progress->get_started_at();
+		if ( $started_at ) {
+			// Comment dates are stored in the site timezone.
+			$metadata['start'] = wp_date( 'Y-m-d H:i:s', $started_at->getTimestamp() );
 		}
 
 		// We need to use internal value for status, not the one returned by the getter.

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -256,8 +256,9 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			$this->wpdb->prefix . 'sensei_lms_progress',
 			[
 				'status'       => $quiz_progress->get_status(),
-				'started_at'   => $quiz_progress->get_started_at() ? $quiz_progress->get_started_at()->format( $date_format ) : null,
-				'completed_at' => $quiz_progress->get_completed_at() ? $quiz_progress->get_completed_at()->format( $date_format ) : null,
+				// Table columns are stored in UTC.
+				'started_at'   => $quiz_progress->get_started_at() ? gmdate( $date_format, $quiz_progress->get_started_at()->getTimestamp() ) : null,
+				'completed_at' => $quiz_progress->get_completed_at() ? gmdate( $date_format, $quiz_progress->get_completed_at()->getTimestamp() ) : null,
 				'updated_at'   => $quiz_progress->get_updated_at()->format( $date_format ),
 			],
 			[

--- a/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-tables-based-quiz-progress-repository.php
@@ -266,7 +266,7 @@ class Tables_Based_Quiz_Progress_Repository implements Quiz_Progress_Repository_
 			],
 			[
 				'%s',
-				'%s',
+				$quiz_progress->get_started_at() ? '%s' : null,
 				$quiz_progress->get_completed_at() ? '%s' : null,
 				'%s',
 			],

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-comments-based-course-progress-repository.php
@@ -2,6 +2,7 @@
 
 namespace SenseiTest\Internal\Student_Progress\Course_Progress\Repositories;
 
+use Sensei\Internal\Student_Progress\Course_Progress\Models\Comments_Based_Course_Progress;
 use Sensei\Internal\Student_Progress\Course_Progress\Models\Course_Progress_Interface;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Comments_Based_Course_Progress_Repository;
 
@@ -206,6 +207,38 @@ class Comments_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 		$this->expectException( \InvalidArgumentException::class );
 		$this->expectExceptionMessage( 'Expected Comments_Based_Course_Progress, got ' . get_class( $progress ) . '.' );
 		$repository->save( $progress );
+	}
+
+	public function testSave_StartedAtInDifferentTimezone_StoresStartMetaInSiteTimezone(): void {
+		/* Arrange. */
+		update_option( 'timezone_string', 'America/New_York' );
+		$course_id  = $this->factory->course->create();
+		$user_id    = $this->factory->user->create();
+		$repository = new Comments_Based_Course_Progress_Repository();
+		$created    = $repository->create( $course_id, $user_id );
+
+		// A started_at instant expressed in UTC (as a cached table read would produce).
+		$started_at = new \DateTimeImmutable( '2026-06-09 19:49:33', new \DateTimeZone( 'UTC' ) );
+		$progress   = new Comments_Based_Course_Progress(
+			$created->get_id(),
+			$course_id,
+			$user_id,
+			$created->get_status(),
+			$started_at,
+			null,
+			$created->get_created_at(),
+			$created->get_updated_at()
+		);
+
+		/* Act. */
+		$repository->save( $progress );
+
+		/* Assert. */
+		self::assertSame(
+			'2026-06-09 15:49:33',
+			get_comment_meta( $created->get_id(), 'start', true ),
+			'Start meta should be stored in the site timezone, not UTC.'
+		);
 	}
 
 	public function testFind_ArgumentsGiven_ReturnsMatchingProgress(): void {

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-tables-based-course-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-tables-based-course-progress-repository.php
@@ -441,6 +441,43 @@ class Tables_Based_Course_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository->save( $progress );
 	}
 
+	public function testSave_SiteTimezoneDatetimes_StoresColumnsInUtc(): void {
+		/* Arrange. */
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', -4 );
+
+		$wpdb       = $this->createMock( wpdb::class );
+		$progress   = new Tables_Based_Course_Progress(
+			1,
+			2,
+			3,
+			'complete',
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:44', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() )
+		);
+		$repository = new Tables_Based_Course_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'update' )
+			->with(
+				'sensei_lms_progress',
+				$this->callback(
+					function ( $data ) {
+						return '2026-06-09 19:49:33' === $data['started_at']
+							&& '2026-06-09 19:49:44' === $data['completed_at'];
+					}
+				),
+				self::anything(),
+				self::anything(),
+				self::anything()
+			);
+		$repository->save( $progress );
+	}
+
 	public function testSave_CacheEnabled_InvalidatesCache(): void {
 		/* Arrange. */
 		global $wpdb;

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
@@ -24,7 +24,7 @@ class Comments_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		$this->factory->tearDown();
 	}
 
-	public function testSave_StartedAtInDifferentTimezone_StoresStartMetaInSiteTimezone(): void {
+	public function testSave_DatesInDifferentTimezone_StoresCommentDatesInSiteTimezone(): void {
 		/* Arrange. */
 		update_option( 'timezone_string', 'America/New_York' );
 		$lesson_id  = $this->factory->lesson->create();
@@ -32,15 +32,16 @@ class Comments_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		$repository = new Comments_Based_Lesson_Progress_Repository();
 		$created    = $repository->create( $lesson_id, $user_id );
 
-		// A started_at instant expressed in UTC (as a cached table read would produce).
-		$started_at = new \DateTimeImmutable( '2026-06-09 19:49:33', new \DateTimeZone( 'UTC' ) );
-		$progress   = new Comments_Based_Lesson_Progress(
+		// Instants expressed in UTC (as a cached table read would produce).
+		$started_at   = new \DateTimeImmutable( '2026-06-09 19:49:33', new \DateTimeZone( 'UTC' ) );
+		$completed_at = new \DateTimeImmutable( '2026-06-09 19:49:44', new \DateTimeZone( 'UTC' ) );
+		$progress     = new Comments_Based_Lesson_Progress(
 			$created->get_id(),
 			$lesson_id,
 			$user_id,
-			$created->get_status(),
+			'complete',
 			$started_at,
-			null,
+			$completed_at,
 			$created->get_created_at(),
 			$created->get_updated_at()
 		);
@@ -53,6 +54,11 @@ class Comments_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 			'2026-06-09 15:49:33',
 			get_comment_meta( $created->get_id(), 'start', true ),
 			'Start meta should be stored in the site timezone, not UTC.'
+		);
+		self::assertSame(
+			'2026-06-09 15:49:44',
+			get_comment( $created->get_id() )->comment_date,
+			'Comment date should be stored in the site timezone, not UTC.'
 		);
 	}
 

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-comments-based-lesson-progress-repository.php
@@ -2,6 +2,7 @@
 
 namespace SenseiTest\Internal\Student_Progress\Lesson_Progress\Repositories;
 
+use Sensei\Internal\Student_Progress\Lesson_Progress\Models\Comments_Based_Lesson_Progress;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Models\Lesson_Progress_Interface;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comments_Based_Lesson_Progress_Repository;
 
@@ -21,6 +22,38 @@ class Comments_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 		$this->factory->tearDown();
+	}
+
+	public function testSave_StartedAtInDifferentTimezone_StoresStartMetaInSiteTimezone(): void {
+		/* Arrange. */
+		update_option( 'timezone_string', 'America/New_York' );
+		$lesson_id  = $this->factory->lesson->create();
+		$user_id    = $this->factory->user->create();
+		$repository = new Comments_Based_Lesson_Progress_Repository();
+		$created    = $repository->create( $lesson_id, $user_id );
+
+		// A started_at instant expressed in UTC (as a cached table read would produce).
+		$started_at = new \DateTimeImmutable( '2026-06-09 19:49:33', new \DateTimeZone( 'UTC' ) );
+		$progress   = new Comments_Based_Lesson_Progress(
+			$created->get_id(),
+			$lesson_id,
+			$user_id,
+			$created->get_status(),
+			$started_at,
+			null,
+			$created->get_created_at(),
+			$created->get_updated_at()
+		);
+
+		/* Act. */
+		$repository->save( $progress );
+
+		/* Assert. */
+		self::assertSame(
+			'2026-06-09 15:49:33',
+			get_comment_meta( $created->get_id(), 'start', true ),
+			'Start meta should be stored in the site timezone, not UTC.'
+		);
 	}
 
 	public function testGet_WhenStatusFound_ReturnsLessonProgress(): void {

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-tables-based-lesson-progress-repository.php
@@ -366,6 +366,43 @@ class Tables_Based_Lesson_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertTrue( $has );
 	}
 
+	public function testSave_SiteTimezoneDatetimes_StoresColumnsInUtc(): void {
+		/* Arrange. */
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', -4 );
+
+		$wpdb       = $this->createMock( wpdb::class );
+		$progress   = new Tables_Based_Lesson_Progress(
+			1,
+			2,
+			3,
+			'complete',
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:44', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() )
+		);
+		$repository = new Tables_Based_Lesson_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'update' )
+			->with(
+				'sensei_lms_progress',
+				$this->callback(
+					function ( $data ) {
+						return '2026-06-09 19:49:33' === $data['started_at']
+							&& '2026-06-09 19:49:44' === $data['completed_at'];
+					}
+				),
+				self::anything(),
+				self::anything(),
+				self::anything()
+			);
+		$repository->save( $progress );
+	}
+
 	public function testSave_ProgressGiven_CallsWpdbUpdate(): void {
 		/* Arrange. */
 		$wpdb       = $this->createMock( wpdb::class );

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-comments-based-quiz-progress-repository.php
@@ -2,6 +2,7 @@
 
 namespace SenseiTest\Internal\Student_Progress\Repositories;
 
+use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Comments_Based_Quiz_Progress;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Models\Quiz_Progress_Interface;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Comments_Based_Quiz_Progress_Repository;
 
@@ -27,6 +28,40 @@ class Comments_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		parent::tearDown();
 		$this->factory->tearDown();
 	}
+	public function testSave_StartedAtInDifferentTimezone_StoresStartMetaInSiteTimezone(): void {
+		/* Arrange. */
+		update_option( 'timezone_string', 'America/New_York' );
+		$lesson_id  = $this->factory->lesson->create();
+		$user_id    = $this->factory->user->create();
+		$quiz_id    = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+		$repository = new Comments_Based_Quiz_Progress_Repository();
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+		$created = $repository->create( $quiz_id, $user_id );
+
+		// A started_at instant expressed in UTC (as a cached table read would produce).
+		$started_at = new \DateTimeImmutable( '2026-06-09 19:49:33', new \DateTimeZone( 'UTC' ) );
+		$progress   = new Comments_Based_Quiz_Progress(
+			$created->get_id(),
+			$quiz_id,
+			$user_id,
+			$created->get_status(),
+			$started_at,
+			null,
+			$created->get_created_at(),
+			$created->get_updated_at()
+		);
+
+		/* Act. */
+		$repository->save( $progress );
+
+		/* Assert. */
+		self::assertSame(
+			'2026-06-09 15:49:33',
+			get_comment_meta( $created->get_id(), 'start', true ),
+			'Start meta should be stored in the site timezone, not UTC.'
+		);
+	}
+
 	public function testCreate_WhenLessonStatusFound_ReturnsQuizProgress(): void {
 		/* Arrange. */
 		$lesson_id  = $this->factory->lesson->create();

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-tables-based-quiz-progress-repository.php
@@ -365,6 +365,43 @@ class Tables_Based_Quiz_Progress_Repository_Test extends \WP_UnitTestCase {
 		self::assertTrue( $has );
 	}
 
+	public function testSave_SiteTimezoneDatetimes_StoresColumnsInUtc(): void {
+		/* Arrange. */
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', -4 );
+
+		$wpdb       = $this->createMock( wpdb::class );
+		$progress   = new Tables_Based_Quiz_Progress(
+			1,
+			2,
+			3,
+			'complete',
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:44', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() ),
+			new DateTimeImmutable( '2026-06-09 15:49:33', wp_timezone() )
+		);
+		$repository = new Tables_Based_Quiz_Progress_Repository( $wpdb );
+
+		/* Expect & Act. */
+		$wpdb
+			->expects( self::once() )
+			->method( 'update' )
+			->with(
+				'sensei_lms_progress',
+				$this->callback(
+					function ( $data ) {
+						return '2026-06-09 19:49:33' === $data['started_at']
+							&& '2026-06-09 19:49:44' === $data['completed_at'];
+					}
+				),
+				self::anything(),
+				self::anything(),
+				self::anything()
+			);
+		$repository->save( $progress );
+	}
+
 	public function testSave_ProgressGiven_CallsWpdbUpdate(): void {
 		/* Arrange. */
 		$wpdb       = $this->createMock( wpdb::class );


### PR DESCRIPTION
## Proposed Changes

When high-performance progress storage (HPPS / custom tables) is enabled, student progress models hold datetimes in mixed timezones — UTC when read from the progress tables (`new DateTimeImmutable($row, 'UTC')`), site timezone when freshly set (`current_datetime()`). The repositories wrote these values verbatim with `->format()`, which renders in the datetime's own timezone. As a result a value could be persisted in the wrong timezone for its store:

- **Tables** (columns are UTC by convention): `completed_at` from `complete()` was written in the site timezone.
- **Comments** (dates are site-local by convention): the `start` meta, fed the table's UTC `started_at`, was written in UTC.

Surfaces that read these fields then show the two dates hours apart — e.g. the **Students** screen and **reports** (Date Started vs Date Completed). With the default comments storage the dates stay consistent; the mismatch only appears with custom tables enabled.

### Fix

Normalize each value to its store's convention on write, independent of the model's timezone:

- Tables `started_at` / `completed_at` → `gmdate( $format, $dt->getTimestamp() )` (always UTC).
- Comments `start` meta and lesson `comment_date` → `wp_date( $format, $dt->getTimestamp() )` (always site timezone).

`getTimestamp()` is timezone-independent, so the stored value is correct regardless of which timezone the in-memory model carried. Applied across course, lesson, and quiz for both stores.

Adds timezone regression tests for all three progress types in both repositories.

## Testing Instructions

1. **Settings → Sensei LMS → Experimental** → set Progress Storage to **Custom Tables**.
2. **Settings → General** → set a timezone with a non-zero offset (e.g. UTC-4).
3. As a student, start a course and then complete it (separate page loads).
4. Open the **Students** screen for that course.
5. Confirm **Date Started** and **Date Completed** show the same local time (seconds apart), not a multi-hour gap.
6. Check the same student in **Reports** — start/completion dates should line up too.
7. Switch Progress Storage back to **Comments** and repeat — dates should remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
