### PR TITLE
Fix: tables-based lesson progress ignores pass_required for failed quiz status

### DIFF
--- a/changelog/fix-tables-based-lesson-progress-pass-required
+++ b/changelog/fix-tables-based-lesson-progress-pass-required
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Tables_Based_Lesson_Progress to return 'complete' when Pass Required is disabled and a quiz is failed.

--- a/includes/internal/student-progress/lesson-progress/models/class-tables-based-lesson-progress.php
+++ b/includes/internal/student-progress/lesson-progress/models/class-tables-based-lesson-progress.php
@@ -19,4 +19,43 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.18.0
  */
 class Tables_Based_Lesson_Progress extends Lesson_Progress_Abstract {
+	/**
+	 * Returns the lesson progress status.
+	 *
+	 * When a lesson's quiz has pass_required disabled, a 'failed' quiz status
+	 * still means the lesson is complete — the learner is only required to
+	 * attempt the quiz, not to pass it. Mirrors the equivalent logic in
+	 * Comments_Based_Lesson_Progress::get_status().
+	 *
+	 * @internal
+	 *
+	 * @since $next-version$
+	 *
+	 * @return string|null
+	 */
+	public function get_status(): ?string {
+		switch ( $this->status ) {
+			case 'complete':
+			case 'graded':
+			case 'passed':
+				return self::STATUS_COMPLETE;
+
+			case 'failed':
+				// This may be 'completed' depending on...
+				// Get Quiz ID, this won't be needed once all Quiz meta fields are stored on the Lesson.
+				$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $this->lesson_id );
+				if ( $lesson_quiz_id ) {
+					// ...the quiz pass setting.
+					$pass_required = get_post_meta( $lesson_quiz_id, '_pass_required', true );
+					if ( empty( $pass_required ) ) {
+						// We just require the user to have done the quiz, not to have passed.
+						return self::STATUS_COMPLETE;
+					}
+				}
+				return self::STATUS_IN_PROGRESS;
+
+			default:
+				return self::STATUS_IN_PROGRESS;
+		}
+	}
 }

--- a/includes/internal/student-progress/lesson-progress/models/class-tables-based-lesson-progress.php
+++ b/includes/internal/student-progress/lesson-progress/models/class-tables-based-lesson-progress.php
@@ -41,7 +41,7 @@ class Tables_Based_Lesson_Progress extends Lesson_Progress_Abstract {
 				return self::STATUS_COMPLETE;
 
 			case 'failed':
-				// This may be 'completed' depending on...
+				// This may be 'complete' depending on...
 				// Get Quiz ID, this won't be needed once all Quiz meta fields are stored on the Lesson.
 				$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $this->lesson_id );
 				if ( $lesson_quiz_id ) {

--- a/tests/unit-tests/internal/student-progress/lesson-progress/models/test-class-tables-based-lesson-progress.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/models/test-class-tables-based-lesson-progress.php
@@ -219,6 +219,66 @@ class Tables_Based_Lesson_Progress_Test extends \WP_UnitTestCase {
 		self::assertSame( $completed_at, $progress->get_completed_at() );
 	}
 
+	public function testGetStatus_ConstructedWithFailedStatusAndPassNotRequired_ReturnsComplete(): void {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create();
+		$this->factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+				'meta_input'  => array(
+					'_pass_required' => 0,
+				),
+			)
+		);
+
+		$progress = new Tables_Based_Lesson_Progress(
+			1,
+			$lesson_id,
+			3,
+			'failed',
+			new \DateTime( '2020-01-01 00:00:00' ),
+			new \DateTime( '2020-01-01 00:00:01' ),
+			new \DateTime( '2020-01-01 00:00:02' ),
+			new \DateTime( '2020-01-01 00:00:03' )
+		);
+
+		/* Act. */
+		$actual = $progress->get_status();
+
+		/* Assert. */
+		self::assertSame( 'complete', $actual );
+	}
+
+	public function testGetStatus_ConstructedWithFailedStatusAndPassRequired_ReturnsInProgress(): void {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create();
+		$this->factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+				'meta_input'  => array(
+					'_pass_required' => 1,
+				),
+			)
+		);
+
+		$progress = new Tables_Based_Lesson_Progress(
+			1,
+			$lesson_id,
+			3,
+			'failed',
+			new \DateTime( '2020-01-01 00:00:00' ),
+			new \DateTime( '2020-01-01 00:00:01' ),
+			new \DateTime( '2020-01-01 00:00:02' ),
+			new \DateTime( '2020-01-01 00:00:03' )
+		);
+
+		/* Act. */
+		$actual = $progress->get_status();
+
+		/* Assert. */
+		self::assertSame( 'in-progress', $actual );
+	}
+
 	private function create_progress( string $status = null ): Tables_Based_Lesson_Progress {
 		return new Tables_Based_Lesson_Progress(
 			1,


### PR DESCRIPTION
## What this fixes

When a lesson's quiz has **Pass Required** disabled, a learner who submits a failed quiz should still have the lesson marked complete — they only need to have _attempted_ the quiz, not passed it.

The `Comments_Based_Lesson_Progress::get_status()` already handles this correctly. The HPPS equivalent, `Tables_Based_Lesson_Progress`, inherits a bare `get_status()` from `Lesson_Progress_Abstract` that simply returns `$this->status` verbatim — so a `'failed'` internal status is returned as `'failed'` (maps to `STATUS_IN_PROGRESS`) regardless of the `_pass_required` setting on the quiz.

This is the root cause of #7943.

## What changed

**`includes/internal/student-progress/lesson-progress/models/class-tables-based-lesson-progress.php`**
- Added `get_status()` override that mirrors `Comments_Based_Lesson_Progress::get_status()`, including the `_pass_required` check for the `'failed'` case
- `passed` / `graded` statuses correctly return `STATUS_COMPLETE`
- `failed` + `pass_required` disabled → `STATUS_COMPLETE`
- `failed` + `pass_required` enabled → `STATUS_IN_PROGRESS`
- All other statuses delegate to `STATUS_IN_PROGRESS`

**`tests/unit-tests/internal/student-progress/lesson-progress/models/test-class-tables-based-lesson-progress.php`**
- `testGetStatus_ConstructedWithFailedStatusAndPassNotRequired_ReturnsComplete`
- `testGetStatus_ConstructedWithFailedStatusAndPassRequired_ReturnsInProgress`

## Testing

```bash
phpunit --filter Tables_Based_Lesson_Progress
```

Both new tests should pass. Existing tests in this file are unaffected.

## Related

Resolves #7943

---

_This PR was developed with AI assistance (research, implementation, and test generation). All code was reviewed and validated before submission._