### PR TITLE
Interpolate trusted table names instead of %i placeholder

### DIFF
--- a/changelog/fix-wpdb-identifier-placeholder
+++ b/changelog/fix-wpdb-identifier-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix empty Reports and Grading statistics on hosts whose `wpdb` does not support the `%i` identifier placeholder.

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -79,30 +79,25 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		// The quiz_answers EXISTS check restricts results to attempts where the
 		// student actually submitted answers. This excludes auto-passed students
 		// whose lesson was marked passed without ever taking the quiz.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
-		$query = $wpdb->prepare(
+		// Table names are trusted $wpdb properties; statuses are from constants, not user input.
+		$query =
 			"SELECT COUNT(*) AS count, COALESCE( SUM( cm.meta_value ), 0 ) AS sum
-			FROM %i c
-			INNER JOIN %i cm ON c.comment_ID = cm.comment_id
+			FROM `{$wpdb->comments}` c
+			INNER JOIN `{$wpdb->commentmeta}` cm ON c.comment_ID = cm.comment_id
 			WHERE c.comment_type = 'sensei_lesson_status'
 				AND c.comment_approved IN " . $this->get_graded_statuses_sql() . "
 				AND cm.meta_key = 'grade'
 				AND EXISTS (
-					SELECT 1 FROM %i cm2
+					SELECT 1 FROM `{$wpdb->commentmeta}` cm2
 					WHERE cm2.comment_id = c.comment_ID
 						AND cm2.meta_key = 'quiz_answers'
-				)",
-			$wpdb->comments,
-			$wpdb->commentmeta,
-			$wpdb->commentmeta
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+				)";
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
 
 		/** Query result row. @var object|null $row */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names trusted; value filters use $wpdb->prepare(). Caching handled by callers.
 		$row = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based grade totals' );
 
@@ -149,37 +144,30 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		 *   - Be associated with a course.
 		 *   - Have quiz answers (excludes auto-passed students who never took the quiz).
 		 */
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
-		$query = $wpdb->prepare(
+		// Table names are trusted $wpdb properties; statuses are from constants, not user input.
+		$query  =
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
 				SELECT AVG(cm.meta_value) AS course_average
-				FROM %i c
-				INNER JOIN %i cm ON c.comment_ID = cm.comment_id
-				INNER JOIN %i course ON c.comment_post_ID = course.post_id
-				INNER JOIN %i p ON p.ID = course.meta_value
+				FROM `{$wpdb->comments}` c
+				INNER JOIN `{$wpdb->commentmeta}` cm ON c.comment_ID = cm.comment_id
+				INNER JOIN `{$wpdb->postmeta}` course ON c.comment_post_ID = course.post_id
+				INNER JOIN `{$wpdb->posts}` p ON p.ID = course.meta_value
 				WHERE c.comment_type = 'sensei_lesson_status'
 					AND c.comment_approved IN " . $this->get_graded_statuses_sql() . "
 					AND cm.meta_key = 'grade'
 					AND course.meta_key = '_lesson_course'
 					AND course.meta_value <> ''
 					AND EXISTS (
-						SELECT 1 FROM %i cm2
+						SELECT 1 FROM `{$wpdb->commentmeta}` cm2
 						WHERE cm2.comment_id = c.comment_ID
 							AND cm2.meta_key = 'quiz_answers'
-					)",
-			$wpdb->comments,
-			$wpdb->commentmeta,
-			$wpdb->postmeta,
-			$wpdb->posts,
-			$wpdb->commentmeta
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+					)";
 		$query .= $course_filter;
 		$query .= ' GROUP BY course.meta_value ) averages_by_course';
 
 		/** Query result. @var object|null $result */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names trusted; value filters use $wpdb->prepare(). Caching handled by callers.
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Comments-based courses average grade' );
 
@@ -214,18 +202,18 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( cm.meta_value ) AS grade_sum, COUNT( * ) AS grade_count
-				FROM %i c
-				INNER JOIN %i cm ON c.comment_ID = cm.comment_id
+				FROM `{$wpdb->comments}` c
+				INNER JOIN `{$wpdb->commentmeta}` cm ON c.comment_ID = cm.comment_id
 				WHERE c.comment_type = 'sensei_lesson_status'
 					AND c.comment_approved IN " . $this->get_graded_statuses_sql() . "
 					AND cm.meta_key = 'grade'
 					AND EXISTS (
-						SELECT 1 FROM %i cm2
+						SELECT 1 FROM `{$wpdb->commentmeta}` cm2
 						WHERE cm2.comment_id = c.comment_ID
 							AND cm2.meta_key = 'quiz_answers'
 					)
 					AND c.user_id IN ( $placeholders )",
-				array_merge( array( $wpdb->comments, $wpdb->commentmeta, $wpdb->commentmeta ), $user_ids )
+				$user_ids
 			)
 		);
 		// phpcs:enable

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -100,26 +100,21 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$table             = $this->get_progress_table_name();
 		$submissions_table = $this->get_submissions_table_name();
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
-		$query = $wpdb->prepare(
+		// Table names are trusted (built from $wpdb->prefix); statuses are from constants, not user input.
+		$query =
 			"SELECT COUNT(*) AS count, COALESCE( SUM( qs.final_grade ), 0 ) AS sum
-			FROM %i q
-			INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
-			INNER JOIN %i lesson_quiz ON lesson_quiz.meta_key = '_lesson_quiz' AND lesson_quiz.meta_value = q.post_id
+			FROM `$table` q
+			INNER JOIN `$submissions_table` qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
+			INNER JOIN `{$wpdb->postmeta}` lesson_quiz ON lesson_quiz.meta_key = '_lesson_quiz' AND lesson_quiz.meta_value = q.post_id
 			WHERE q.type = 'quiz'
 				AND q.status IN " . $this->get_graded_statuses_sql() . '
-				AND qs.final_grade IS NOT NULL',
-			$table,
-			$submissions_table,
-			$wpdb->postmeta
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+				AND qs.final_grade IS NOT NULL';
 
 		$query .= $this->build_user_filter( $args );
 		$query .= $this->build_post_filter( $args );
 
 		/** Query result row. @var object|null $row */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names trusted; value filters use $wpdb->prepare(). Caching handled by callers.
 		$row = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based grade totals' );
 
@@ -159,35 +154,28 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 			$course_filter = $wpdb->prepare( " AND lesson_course.meta_value IN ( $placeholders )", $course_ids );
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Statuses are from constants, not user input.
-		$query = $wpdb->prepare(
+		// Table names are trusted (built from $wpdb->prefix); statuses are from constants, not user input.
+		$query  =
 			"SELECT AVG(course_average) AS courses_average
 			FROM (
 				SELECT AVG(qs.final_grade) AS course_average
-				FROM %i p
-				INNER JOIN %i lesson_course ON lesson_course.post_id = p.post_id
+				FROM `$table` p
+				INNER JOIN `{$wpdb->postmeta}` lesson_course ON lesson_course.post_id = p.post_id
 					AND lesson_course.meta_key = '_lesson_course'
 					AND lesson_course.meta_value <> ''
-				INNER JOIN %i lesson_quiz ON lesson_quiz.post_id = p.post_id
+				INNER JOIN `{$wpdb->postmeta}` lesson_quiz ON lesson_quiz.post_id = p.post_id
 					AND lesson_quiz.meta_key = '_lesson_quiz'
 					AND lesson_quiz.meta_value > 0
-				INNER JOIN %i q ON q.post_id = lesson_quiz.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
-				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
+				INNER JOIN `$table` q ON q.post_id = lesson_quiz.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
+				INNER JOIN `$submissions_table` qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
 				WHERE p.type = 'lesson'
 					AND q.status IN " . $this->get_graded_statuses_sql() . '
-					AND qs.final_grade IS NOT NULL',
-			$table,
-			$wpdb->postmeta,
-			$wpdb->postmeta,
-			$table,
-			$submissions_table
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+					AND qs.final_grade IS NOT NULL';
 		$query .= $course_filter;
 		$query .= ' GROUP BY lesson_course.meta_value ) averages_by_course';
 
 		/** Query result. @var object|null $result */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared above. Caching handled by callers.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names trusted; value filters use $wpdb->prepare(). Caching handled by callers.
 		$result = $wpdb->get_row( $query );
 		Utils::log_query_error( $wpdb, 'Tables-based courses average grade' );
 
@@ -221,13 +209,13 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT SUM( qs.final_grade ) AS grade_sum, COUNT( * ) AS grade_count
-				FROM %i q
-				INNER JOIN %i qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
+				FROM `$table` q
+				INNER JOIN `$submissions_table` qs ON qs.quiz_id = q.post_id AND qs.user_id = q.user_id
 				WHERE q.type = 'quiz'
 					AND q.status IN " . $this->get_graded_statuses_sql() . "
 					AND qs.final_grade IS NOT NULL
 					AND q.user_id IN ( $placeholders )",
-				array_merge( array( $table, $submissions_table ), $user_ids )
+				$user_ids
 			)
 		);
 		// phpcs:enable

--- a/includes/internal/services/class-tables-based-reports-listing-service.php
+++ b/includes/internal/services/class-tables-based-reports-listing-service.php
@@ -76,27 +76,23 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 		$pagination = $this->build_pagination( $where, $args );
 
 		/** Query result rows. @var object[] $rows */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Clauses are built from $wpdb->prepare() or sanitized values.
+		// Table names are trusted $wpdb properties; value clauses use $wpdb->prepare().
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = (array) $wpdb->get_results(
-			$wpdb->prepare(
-				// Fetch each student's lesson progress with their effective quiz/lesson status and grade.
-				// Join quiz progress (q) to get the quiz-aware status via COALESCE: if a quiz
-				// exists for this lesson, its status takes precedence over the lesson status.
-				// Join quiz submissions (qs) to get the final_grade when available.
-				'SELECT p.user_id, COALESCE( q.status, p.status ) AS effective_status, p.started_at, p.completed_at, qs.final_grade AS grade'
-				. ' FROM %i p'
-				. ' LEFT JOIN %i pm ON pm.post_id = p.post_id AND pm.meta_key = \'_lesson_quiz\' AND pm.meta_value > 0'
-				. ' LEFT JOIN %i q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = \'quiz\''
-				. ' LEFT JOIN %i qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id',
-				$table,
-				$wpdb->postmeta,
-				$table,
-				$submissions_table
-			)
+			// Fetch each student's lesson progress with their effective quiz/lesson status and grade.
+			// Join quiz progress (q) to get the quiz-aware status via COALESCE: if a quiz
+			// exists for this lesson, its status takes precedence over the lesson status.
+			// Join quiz submissions (qs) to get the final_grade when available.
+			'SELECT p.user_id, COALESCE( q.status, p.status ) AS effective_status, p.started_at, p.completed_at, qs.final_grade AS grade'
+			. " FROM `$table` p"
+			. " LEFT JOIN `{$wpdb->postmeta}` pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0"
+			. " LEFT JOIN `$table` q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'"
+			. " LEFT JOIN `$submissions_table` qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id"
 			. $where
 			. $pagination['order_clause']
 			. $pagination['limit_clause']
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		Utils::log_query_error( $wpdb, 'Reports lesson students items' );
 
 		$items = array();
@@ -136,7 +132,8 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 		$total_lessons = count( Sensei()->course->course_lessons( $course_id, 'publish', 'ids' ) );
 
 		/** Query result rows. @var object[] $rows */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Clauses are built from $wpdb->prepare() or sanitized values.
+		// Table names are trusted $wpdb properties; value clauses use $wpdb->prepare().
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = (array) $wpdb->get_results(
 			$wpdb->prepare(
 				// Fetch each student's course progress with a computed percent column.
@@ -144,27 +141,24 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 				// The total_lessons denominator is pre-computed in PHP since all rows share the same course.
 				'SELECT p.user_id, p.status, p.started_at, p.completed_at,'
 				. ' COALESCE( completed.cnt * 100.0 / NULLIF( %d, 0 ), 0 ) AS percent'
-				. ' FROM %i p'
+				. " FROM `$table` p"
 				// Derived table: count completed published lessons per student in this course.
 				. ' LEFT JOIN ('
 				. '   SELECT lp.user_id, COUNT(*) AS cnt'
-				. '   FROM %i lp'
-				. '   INNER JOIN %i pm ON pm.post_id = lp.post_id AND pm.meta_key = \'_lesson_course\' AND pm.meta_value = %d'
-				. '   INNER JOIN %i lpost ON lpost.ID = lp.post_id AND lpost.post_status = \'publish\''
-				. '   WHERE lp.type = \'lesson\' AND lp.status = \'complete\''
+				. "   FROM `$table` lp"
+				. "   INNER JOIN `{$wpdb->postmeta}` pm ON pm.post_id = lp.post_id AND pm.meta_key = '_lesson_course' AND pm.meta_value = %d"
+				. "   INNER JOIN `{$wpdb->posts}` lpost ON lpost.ID = lp.post_id AND lpost.post_status = 'publish'"
+				. "   WHERE lp.type = 'lesson' AND lp.status = 'complete'"
 				. '   GROUP BY lp.user_id'
 				. ' ) completed ON completed.user_id = p.user_id',
 				$total_lessons,
-				$table,
-				$table,
-				$wpdb->postmeta,
-				$course_id,
-				$wpdb->posts
+				$course_id
 			)
 			. $where
 			. $pagination['order_clause']
 			. $pagination['limit_clause']
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		Utils::log_query_error( $wpdb, 'Reports course students items' );
 
 		$items = array();
@@ -202,26 +196,24 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 		$post_id = (int) ( $args['post_id'] ?? 0 );
 		$user_id = (int) ( $args['user_id'] ?? 0 );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Caching handled by callers.
+		// Table names are trusted $wpdb properties; value clauses use $wpdb->prepare(). Caching handled by callers.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				// Fetch one lesson's progress for one user, with quiz-aware effective status.
 				// Same JOIN pattern as get_lesson_students but for a single row.
 				'SELECT COALESCE( q.status, p.status ) AS effective_status,'
 				. ' p.started_at, p.completed_at, qs.final_grade AS grade'
-				. ' FROM %i p'
-				. ' LEFT JOIN %i pm ON pm.post_id = p.post_id AND pm.meta_key = \'_lesson_quiz\' AND pm.meta_value > 0'
-				. ' LEFT JOIN %i q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = \'quiz\''
-				. ' LEFT JOIN %i qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id'
-				. ' WHERE p.post_id = %d AND p.user_id = %d AND p.type = \'lesson\'',
-				$table,
-				$wpdb->postmeta,
-				$table,
-				$submissions_table,
+				. " FROM `$table` p"
+				. " LEFT JOIN `{$wpdb->postmeta}` pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0"
+				. " LEFT JOIN `$table` q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'"
+				. " LEFT JOIN `$submissions_table` qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id"
+				. " WHERE p.post_id = %d AND p.user_id = %d AND p.type = 'lesson'",
 				$post_id,
 				$user_id
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		Utils::log_query_error( $wpdb, 'Reports user lesson progress' );
 
 		if ( ! $row ) {
@@ -255,56 +247,54 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 		$where   = " WHERE p.type = 'course'" . $this->build_filters( $args );
 
 		if ( ! empty( $args['post_author'] ) ) {
+			// Table name is a trusted $wpdb property; value clause uses $wpdb->prepare().
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$where .= $wpdb->prepare(
-				' AND p.post_id IN ( SELECT ID FROM %i WHERE post_author = %d )',
-				$wpdb->posts,
+				" AND p.post_id IN ( SELECT ID FROM `{$wpdb->posts}` WHERE post_author = %d )",
 				(int) $args['post_author']
 			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 
 		$pagination = $this->build_pagination( $where, $args );
 
 		/** Query result rows. @var object[] $rows */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Clauses are built from $wpdb->prepare() or sanitized values.
+		// Table names are trusted $wpdb properties; value clauses use $wpdb->prepare().
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = (array) $wpdb->get_results(
 			$wpdb->prepare(
 				// Fetch each course's progress for this user with a computed percent column.
 				// percent = (completed lessons / total lessons) * 100.
 				'SELECT p.post_id, p.status, p.started_at, p.completed_at,'
 				. ' COALESCE( completed.cnt * 100.0 / NULLIF( total.cnt, 0 ), 0 ) AS percent'
-				. ' FROM %i p'
+				. " FROM `$table` p"
 				// Derived table: count completed published lessons per course for this user.
 				// Lessons are mapped to courses via the _lesson_course postmeta.
 				. ' LEFT JOIN ('
 				. '   SELECT pm.meta_value AS course_id, COUNT(*) AS cnt'
-				. '   FROM %i lp'
-				. '   INNER JOIN %i pm ON pm.post_id = lp.post_id AND pm.meta_key = \'_lesson_course\''
-				. '   INNER JOIN %i lpost ON lpost.ID = lp.post_id AND lpost.post_status = \'publish\''
-				. '   WHERE lp.type = \'lesson\' AND lp.user_id = %d'
-				. '   AND lp.status = \'complete\''
+				. "   FROM `$table` lp"
+				. "   INNER JOIN `{$wpdb->postmeta}` pm ON pm.post_id = lp.post_id AND pm.meta_key = '_lesson_course'"
+				. "   INNER JOIN `{$wpdb->posts}` lpost ON lpost.ID = lp.post_id AND lpost.post_status = 'publish'"
+				. "   WHERE lp.type = 'lesson' AND lp.user_id = %d"
+				. "   AND lp.status = 'complete'"
 				. '   GROUP BY pm.meta_value'
 				. ' ) completed ON completed.course_id = p.post_id'
 				// Derived table: count total published lessons per course
 				// via the _lesson_course postmeta that maps each lesson to its course.
 				. ' LEFT JOIN ('
 				. '   SELECT pm.meta_value AS course_id, COUNT(*) AS cnt'
-				. '   FROM %i pm'
-				. '   INNER JOIN %i lpost ON lpost.ID = pm.post_id AND lpost.post_status = \'publish\''
-				. '   WHERE pm.meta_key = \'_lesson_course\''
+				. "   FROM `{$wpdb->postmeta}` pm"
+				. "   INNER JOIN `{$wpdb->posts}` lpost ON lpost.ID = pm.post_id AND lpost.post_status = 'publish'"
+				. "   WHERE pm.meta_key = '_lesson_course'"
 				. '   GROUP BY pm.meta_value'
 				. ' ) total ON total.course_id = p.post_id',
-				$table,
-				$table,
-				$wpdb->postmeta,
-				$wpdb->posts,
-				$user_id,
-				$wpdb->postmeta,
-				$wpdb->posts
+				$user_id
 			)
 			. $where
 			. $pagination['order_clause']
 			. $pagination['limit_clause']
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		Utils::log_query_error( $wpdb, 'Reports user courses items' );
 
 		$items = array();
@@ -348,8 +338,8 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 			$where .= " AND p.status IN ( {$status_sql} )";
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- $where is built from $wpdb->prepare() calls.
-		$count = $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT( DISTINCT p.user_id ) FROM %i p', $table ) . $where );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table name is a trusted $wpdb property; $where is built from $wpdb->prepare() calls.
+		$count = $wpdb->get_var( "SELECT COUNT( DISTINCT p.user_id ) FROM `$table` p" . $where );
 		Utils::log_query_error( $wpdb, 'Reports lesson student count' );
 
 		return (int) $count;
@@ -370,23 +360,21 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 		$status_sql = $this->statuses_sql( $args );
 
 		// Count students whose effective status (quiz status when available,
-		// lesson status otherwise) is in the caller-provided set.
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- $status_sql is built from escaped args.
+		// lesson status otherwise) is in the caller-provided set. Table names are trusted
+		// $wpdb properties and $status_sql is built from escaped args; the post_id uses a placeholder.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$count = $wpdb->get_var(
 			$wpdb->prepare(
 				'SELECT COUNT( DISTINCT p.user_id )'
-				. ' FROM %i p'
-				. ' LEFT JOIN %i pm ON pm.post_id = p.post_id AND pm.meta_key = \'_lesson_quiz\' AND pm.meta_value > 0'
-				. ' LEFT JOIN %i q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = \'quiz\''
-				. ' WHERE p.post_id = %d AND p.type = \'lesson\''
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $status_sql is built from escaped args.
+				. " FROM `$table` p"
+				. " LEFT JOIN `{$wpdb->postmeta}` pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0"
+				. " LEFT JOIN `$table` q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'"
+				. " WHERE p.post_id = %d AND p.type = 'lesson'"
 				. " AND ( q.status IN ( {$status_sql} ) OR ( q.post_id IS NULL AND p.status IN ( {$status_sql} ) ) )",
-				$table,
-				$wpdb->postmeta,
-				$table,
 				$post_id
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		Utils::log_query_error( $wpdb, 'Reports lesson completion count' );
 
 		return (int) $count;
@@ -412,25 +400,22 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 		$status_sql        = $this->statuses_sql( $args );
 
 		// Filter by the caller-provided statuses on the effective quiz status,
-		// then average the grade from quiz_submissions.
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- $status_sql is built from escaped args.
+		// then average the grade from quiz_submissions. Table names are trusted $wpdb
+		// properties and $status_sql is built from escaped args; the post_id uses a placeholder.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$avg = $wpdb->get_var(
 			$wpdb->prepare(
 				'SELECT AVG( qs.final_grade )'
-				. ' FROM %i p'
-				. ' LEFT JOIN %i pm ON pm.post_id = p.post_id AND pm.meta_key = \'_lesson_quiz\' AND pm.meta_value > 0'
-				. ' LEFT JOIN %i q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = \'quiz\''
-				. ' LEFT JOIN %i qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id'
-				. ' WHERE p.post_id = %d AND p.type = \'lesson\' AND qs.final_grade IS NOT NULL'
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $status_sql is built from escaped args.
+				. " FROM `$table` p"
+				. " LEFT JOIN `{$wpdb->postmeta}` pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0"
+				. " LEFT JOIN `$table` q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'"
+				. " LEFT JOIN `$submissions_table` qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id"
+				. " WHERE p.post_id = %d AND p.type = 'lesson' AND qs.final_grade IS NOT NULL"
 				. " AND ( q.status IN ( {$status_sql} ) OR ( q.post_id IS NULL AND p.status IN ( {$status_sql} ) ) )",
-				$table,
-				$wpdb->postmeta,
-				$table,
-				$submissions_table,
 				$post_id
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		Utils::log_query_error( $wpdb, 'Reports lesson average grade' );
 
 		return null !== $avg ? round( (float) $avg, 2 ) : null;
@@ -448,8 +433,8 @@ class Tables_Based_Reports_Listing_Service implements Reports_Listing_Service_In
 		$wpdb  = $this->wpdb;
 		$table = $this->get_progress_table_name();
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- $where is built from $wpdb->prepare() calls.
-		$total_count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i p', $table ) . $where );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table name is a trusted $wpdb property; $where is built from $wpdb->prepare() calls.
+		$total_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM `$table` p" . $where );
 		Utils::log_query_error( $wpdb, 'Reports pagination count' );
 
 		$number = (int) ( $args['number'] ?? 0 );


### PR DESCRIPTION
## Problem

The `%i` identifier placeholder added in WordPress 6.2's `$wpdb->prepare()` is **not supported on all hosts** (notably WordPress.com, whose `wpdb::prepare()` predates `%i` and escapes any unknown `%x` to a literal). On those hosts the table-name placeholder is emitted as a literal string, the query errors, and **Reports and Grading statistics come back empty**.

The HPPS reporting/grading services (shipped in 4.26.0) used `%i` for every table identifier.

## Fix

Replace `%i` with backtick-quoted interpolation of the table names. Every identifier is a trusted `$wpdb` property (`$wpdb->postmeta`, `$wpdb->comments`, …) or a `$wpdb->prefix . 'sensei_lms_…'` constant — never user input — so direct interpolation is safe and matches what `%i` does semantically. Value placeholders (`%d`/`%s`) are unchanged.

Two mechanical consequences handled:
- Dropping a `%i` also drops its positional argument, so remaining `%d`/`%s` don't shift.
- Queries left with only `%i` (no value placeholders) no longer call `prepare()` at all, avoiding the zero-placeholder `doing_it_wrong`.

### Files
- `class-tables-based-reports-listing-service.php`
- `class-comments-based-grading-stats-service.php`
- `class-tables-based-grading-stats-service.php`

## Testing
1. On a site whose `wpdb` lacks `%i` support (e.g. WordPress.com), open **Sensei → Reports** for lessons and courses, and the **Grading** overview.
2. Confirm student rows, completion counts, percentages, and average grades populate (were empty before).
3. Verify both storage backends: comments-based (legacy) and tables-based (HPPS enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)