### PR TITLE
Skip learner term cache priming on front-end course queries

### DIFF
--- a/changelog/fix-course-term-cache-frontend-oom
+++ b/changelog/fix-course-term-cache-frontend-oom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a fatal memory error on front-end course listings (such as the Query Loop block) for sites with many enrolled students by skipping learner term cache priming on course queries.

--- a/changelog/fix-course-term-cache-frontend-oom
+++ b/changelog/fix-course-term-cache-frontend-oom
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a fatal memory error on front-end course listings (such as the Query Loop block) for sites with many enrolled students by skipping learner term cache priming on course queries.
+Fix a fatal memory error on front-end course listings for sites with many enrolled students.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -74,9 +74,6 @@ class Sensei_Course {
 			add_filter( 'manage_course_posts_columns', [ $this, 'add_column_headings' ], 20, 1 );
 			add_action( 'manage_course_posts_custom_column', [ $this, 'add_column_data' ], 10, 2 );
 
-			// Disable term cache priming on the Courses list table.
-			add_action( 'pre_get_posts', [ __CLASS__, 'disable_term_cache_on_course_list' ] );
-
 			// Enqueue scripts.
 			add_action( 'admin_enqueue_scripts', [ $this, 'register_admin_scripts' ] );
 		} else {
@@ -126,6 +123,9 @@ class Sensei_Course {
 
 		// filter the course query in Sensei specific instances
 		add_filter( 'pre_get_posts', [ __CLASS__, 'course_query_filter' ] );
+
+		// Disable learner term cache priming on course queries.
+		add_action( 'pre_get_posts', [ __CLASS__, 'disable_term_cache_on_course_queries' ] );
 
 		// attache the sorting to the course archive
 		add_action( 'sensei_archive_before_course_loop', [ 'Sensei_Course', 'course_archive_sorting' ] );
@@ -3031,12 +3031,13 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Disable term cache priming on the admin Courses list table.
+	 * Disable term cache priming on course queries.
 	 *
 	 * The `sensei_learner` taxonomy stores one term per enrolled user attached to each course. On large
-	 * sites the default object term cache priming loads every learner term for the listed courses at once,
-	 * which can exhaust the PHP memory limit. The list table does not need those terms, so priming is
-	 * skipped here; the remaining course taxonomies are queried lazily per row.
+	 * sites the default object term cache priming loads every learner term for the queried courses at once,
+	 * which can exhaust the PHP memory limit. This affects both the admin Courses list table and front-end
+	 * course listings such as the Query Loop / Course List block. Those listings do not need the learner
+	 * terms, so priming is skipped here; the remaining course taxonomies are queried lazily where rendered.
 	 *
 	 * @since 4.26.0
 	 *
@@ -3044,11 +3045,7 @@ class Sensei_Course {
 	 *
 	 * @param WP_Query $query The query object.
 	 */
-	public static function disable_term_cache_on_course_list( $query ) {
-		if ( ! is_admin() || ! $query->is_main_query() ) {
-			return;
-		}
-
+	public static function disable_term_cache_on_course_queries( $query ) {
 		if ( 'course' !== $query->get( 'post_type' ) ) {
 			return;
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -124,8 +124,9 @@ class Sensei_Course {
 		// filter the course query in Sensei specific instances
 		add_filter( 'pre_get_posts', [ __CLASS__, 'course_query_filter' ] );
 
-		// Disable learner term cache priming on course queries.
-		add_action( 'pre_get_posts', [ __CLASS__, 'disable_term_cache_on_course_queries' ] );
+		// Disable learner term cache priming on course queries. Runs at a late priority so it sees the
+		// final `post_type` after other `pre_get_posts` callbacks (e.g. teacher author archives) have set it.
+		add_action( 'pre_get_posts', [ __CLASS__, 'disable_term_cache_on_course_queries' ], 999 );
 
 		// attache the sorting to the course archive
 		add_action( 'sensei_archive_before_course_loop', [ 'Sensei_Course', 'course_archive_sorting' ] );
@@ -3046,7 +3047,10 @@ class Sensei_Course {
 	 * @param WP_Query $query The query object.
 	 */
 	public static function disable_term_cache_on_course_queries( $query ) {
-		if ( 'course' !== $query->get( 'post_type' ) ) {
+		// `post_type` may be a single slug or an array (e.g. teacher author archives merge
+		// `course` into the existing post types), so treat any query that can return courses as one.
+		$post_types = (array) $query->get( 'post_type' );
+		if ( ! in_array( 'course', $post_types, true ) ) {
 			return;
 		}
 

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -936,18 +936,24 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A secondary course query (e.g. the Course List block / Query Loop, which is not the main query)
-	 * must skip object term cache priming so the large `sensei_learner` taxonomy is not loaded into memory.
+	 * A secondary query that returns courses — whether `post_type` is `course` (e.g. the Course List
+	 * block / Query Loop) or an array that includes `course` (e.g. teacher author archives, which merge
+	 * `course` into the existing post types) — must skip object term cache priming so the large
+	 * `sensei_learner` taxonomy is not loaded into memory.
+	 *
+	 * @dataProvider data_postTypesIncludingCourse
+	 *
+	 * @param string|array $post_type The post type query var to run the secondary query with.
 	 */
-	public function testDisableTermCacheOnCourseQueries_SecondaryCourseQuery_SkipsLearnerTermPriming() {
+	public function testDisableTermCacheOnCourseQueries_PostTypeIncludesCourse_SkipsLearnerTermPriming( $post_type ) {
 		// Arrange: a course with a learner term attached, with its relationship cache cleared.
 		$relationships_group = Sensei_PostTypes::LEARNER_TAXONOMY_NAME . '_relationships';
 		$course_id           = $this->factory->course->create();
 		wp_set_object_terms( $course_id, 'user-1', Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
 		wp_cache_delete( $course_id, $relationships_group );
 
-		// Act: run a secondary (non-main) course query, mirroring the Course List block.
-		$query = new WP_Query( array( 'post_type' => 'course' ) );
+		// Act: run a secondary (non-main) query that returns courses.
+		$query = new WP_Query( array( 'post_type' => $post_type ) );
 
 		// Assert.
 		self::assertFalse( $query->is_main_query(), 'The query should be a secondary query, not the main query.' );
@@ -956,22 +962,15 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A query whose `post_type` is an array that includes `course` (e.g. teacher author archives, which
-	 * merge `course` into the existing post types) must also skip learner term cache priming.
+	 * Data source for ::testDisableTermCacheOnCourseQueries_PostTypeIncludesCourse_SkipsLearnerTermPriming
+	 *
+	 * @return array
 	 */
-	public function testDisableTermCacheOnCourseQueries_ArrayPostTypeIncludingCourse_SkipsLearnerTermPriming() {
-		// Arrange: a course with a learner term attached, with its relationship cache cleared.
-		$relationships_group = Sensei_PostTypes::LEARNER_TAXONOMY_NAME . '_relationships';
-		$course_id           = $this->factory->course->create();
-		wp_set_object_terms( $course_id, 'user-1', Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
-		wp_cache_delete( $course_id, $relationships_group );
-
-		// Act: run a secondary query mixing post types, mirroring the teacher author archive.
-		$query = new WP_Query( array( 'post_type' => array( 'post', 'course' ) ) );
-
-		// Assert.
-		self::assertFalse( $query->get( 'update_post_term_cache' ), 'Queries whose post_type array includes course should disable term cache priming.' );
-		self::assertFalse( wp_cache_get( $course_id, $relationships_group ), 'Learner term relationships should not be primed into the object cache.' );
+	public function data_postTypesIncludingCourse() {
+		return array(
+			'course post type'                => array( 'course' ),
+			'array of post types with course' => array( array( 'post', 'course' ) ),
+		);
 	}
 
 	/**

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -956,6 +956,25 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A query whose `post_type` is an array that includes `course` (e.g. teacher author archives, which
+	 * merge `course` into the existing post types) must also skip learner term cache priming.
+	 */
+	public function testDisableTermCacheOnCourseQueries_ArrayPostTypeIncludingCourse_SkipsLearnerTermPriming() {
+		// Arrange: a course with a learner term attached, with its relationship cache cleared.
+		$relationships_group = Sensei_PostTypes::LEARNER_TAXONOMY_NAME . '_relationships';
+		$course_id           = $this->factory->course->create();
+		wp_set_object_terms( $course_id, 'user-1', Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
+		wp_cache_delete( $course_id, $relationships_group );
+
+		// Act: run a secondary query mixing post types, mirroring the teacher author archive.
+		$query = new WP_Query( array( 'post_type' => array( 'post', 'course' ) ) );
+
+		// Assert.
+		self::assertFalse( $query->get( 'update_post_term_cache' ), 'Queries whose post_type array includes course should disable term cache priming.' );
+		self::assertFalse( wp_cache_get( $course_id, $relationships_group ), 'Learner term relationships should not be primed into the object cache.' );
+	}
+
+	/**
 	 * Non-course queries must be left untouched so their term cache is still primed as usual.
 	 */
 	public function testDisableTermCacheOnCourseQueries_NonCourseQuery_LeavesTermPrimingEnabled() {

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -934,4 +934,41 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		// Cleanup.
 		remove_all_filters( 'is_tax' );
 	}
+
+	/**
+	 * A secondary course query (e.g. the Course List block / Query Loop, which is not the main query)
+	 * must skip object term cache priming so the large `sensei_learner` taxonomy is not loaded into memory.
+	 */
+	public function testDisableTermCacheOnCourseQueries_SecondaryCourseQuery_SkipsLearnerTermPriming() {
+		// Arrange: a course with a learner term attached, with its relationship cache cleared.
+		$relationships_group = Sensei_PostTypes::LEARNER_TAXONOMY_NAME . '_relationships';
+		$course_id           = $this->factory->course->create();
+		wp_set_object_terms( $course_id, 'user-1', Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
+		wp_cache_delete( $course_id, $relationships_group );
+
+		// Act: run a secondary (non-main) course query, mirroring the Course List block.
+		$query = new WP_Query( array( 'post_type' => 'course' ) );
+
+		// Assert.
+		self::assertFalse( $query->is_main_query(), 'The query should be a secondary query, not the main query.' );
+		self::assertFalse( $query->get( 'update_post_term_cache' ), 'Course queries should disable term cache priming.' );
+		self::assertFalse( wp_cache_get( $course_id, $relationships_group ), 'Learner term relationships should not be primed into the object cache.' );
+	}
+
+	/**
+	 * Non-course queries must be left untouched so their term cache is still primed as usual.
+	 */
+	public function testDisableTermCacheOnCourseQueries_NonCourseQuery_LeavesTermPrimingEnabled() {
+		// Arrange: a post with a category, with its relationship cache cleared.
+		$post_id = $this->factory->post->create();
+		wp_set_object_terms( $post_id, 'Test Category', 'category' );
+		wp_cache_delete( $post_id, 'category_relationships' );
+
+		// Act.
+		$query = new WP_Query( array( 'post_type' => 'post' ) );
+
+		// Assert.
+		self::assertNotFalse( $query->get( 'update_post_term_cache' ), 'Non-course queries should keep term cache priming enabled.' );
+		self::assertNotFalse( wp_cache_get( $post_id, 'category_relationships' ), 'Non-course queries should still prime the term cache.' );
+	}
 }


### PR DESCRIPTION
## Problem

[PR #7986](https://github.com/Automattic/sensei/pull/7986) (shipped in 4.26.0) stopped the `sensei_learner` object term cache from being primed on the **admin** Courses list, which was exhausting PHP memory on large-enrolment sites. That fix gated on `is_admin()` **and** `is_main_query()`.

Front-end course listings rendered by the **Course List block** — a `core/query` variation (`sensei-lms/course-list`) — run a **secondary** `WP_Query`, so they pass neither gate and still fatal with the same out-of-memory error. The `sensei_learner` taxonomy stores one term per enrolled user attached to each course, so priming the term cache for a page of courses loads (courses × enrolled users) term rows at once.

Reported on `learn.wordpress.org/courses/` (paginated Course List / Query Loop over the `course` post type). Render path: `gutenberg_render_block_core_post_template` → `WP_Query` → `_prime_post_caches` → `update_object_term_cache`.

## Change

- Broaden `Sensei_Course::disable_term_cache_on_course_list()` → `disable_term_cache_on_course_queries()`: drop the `is_admin()` / `is_main_query()` gates and match any query whose `post_type` is `course` or an array that includes `course` (e.g. teacher author archives merge `course` into the existing post types via `Sensei_Teacher::add_courses_to_author_archive()`).
- Register the `pre_get_posts` hook unconditionally (was admin-only) so it runs on the front end too, at a late priority (`999`) so it sees the final `post_type` after other `pre_get_posts` callbacks have set it.

Learner terms are never rendered in a course listing, so the only effect is trading one memory-heavy batch term prime for a few lazy per-row term queries where category/module are actually displayed.

## Test plan

Enable Query Monitor. On a site with courses that have enrolled students, open each surface with QM:

1. **Course List block** — a page with a Course List block (or a course archive).
2. **Teacher author archive** — a teacher's front-end author archive (`/author/<teacher>/`).

For each, in QM → Queries look for the term cache prime query — the one selecting `DISTINCT t.term_id, tr.object_id` for all the listed course IDs across `('sensei_learner', 'course-category', 'module')`:

- Before this change: that prime query is present.
- After this change: it is gone.

(Other `sensei_learner` queries scoped to a single `user-N` term remain — those are the viewer's own enrolment lookups, not the prime.)

Refs SEN-35.