### PR TITLE
Fix memory exhaustion when filtering temporary users from activity lists

### DIFF
--- a/changelog/fix-temporary-user-activity-memory
+++ b/changelog/fix-temporary-user-activity-memory
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a memory-exhaustion error when filtering temporary users from activity lists on courses with many students.

--- a/includes/class-sensei-temporary-user.php
+++ b/includes/class-sensei-temporary-user.php
@@ -220,10 +220,26 @@ class Sensei_Temporary_User {
 			return $comments;
 		}
 
+		// Collect the user IDs that could be filtered out. Ungraded activity is always kept
+		// (the user shows up in the grading list), so those users don't need to be checked.
+		$user_ids = [];
+		foreach ( $comments as $comment ) {
+			if ( ! in_array( $comment->comment_approved, [ 'ungraded' ], true ) ) {
+				$user_ids[] = (int) $comment->user_id;
+			}
+		}
+
+		$temporary_user_ids = self::get_temporary_user_ids( array_unique( $user_ids ) );
+
+		// Nothing to filter out.
+		if ( empty( $temporary_user_ids ) ) {
+			return $comments;
+		}
+
 		return array_filter(
 			$comments,
-			function ( $comment ) {
-				return in_array( $comment->comment_approved, [ 'ungraded' ], true ) || ! self::is_temporary_user( $comment->user_id );
+			function ( $comment ) use ( $temporary_user_ids ) {
+				return in_array( $comment->comment_approved, [ 'ungraded' ], true ) || ! in_array( (int) $comment->user_id, $temporary_user_ids, true );
 			}
 		);
 	}
@@ -274,15 +290,38 @@ class Sensei_Temporary_User {
 	}
 
 	/**
-	 * Check if a user is a temporary user.
+	 * Get the subset of the given user IDs that belong to temporary (guest or preview) users.
 	 *
-	 * @param int $user_id User ID.
+	 * Temporary users are identified by their login prefix in a single query. This avoids
+	 * loading a full user object (and all of its meta) for every activity comment, which can
+	 * exhaust memory on courses with many students.
 	 *
-	 * @return bool
+	 * @param int[] $user_ids User IDs to check.
+	 *
+	 * @return int[] The temporary user IDs among the given user IDs.
 	 */
-	private static function is_temporary_user( $user_id ) {
-		// Has guest role.
-		$roles = get_userdata( $user_id )->roles ?? [];
-		return in_array( Sensei_Guest_User::ROLE, $roles, true ) || in_array( Sensei_Preview_User::ROLE, $roles, true );
+	private static function get_temporary_user_ids( array $user_ids ) {
+		global $wpdb;
+
+		if ( empty( $user_ids ) ) {
+			return [];
+		}
+
+		$user_ids     = array_map( 'intval', $user_ids );
+		$placeholders = implode( ',', array_fill( 0, count( $user_ids ), '%d' ) );
+
+		$guest_prefix   = $wpdb->esc_like( Sensei_Guest_User::LOGIN_PREFIX ) . '%';
+		$preview_prefix = $wpdb->esc_like( Sensei_Preview_User::LOGIN_PREFIX ) . '%';
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Lightweight lookup; $placeholders is a list of %d placeholders created dynamically.
+		$temporary_user_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->users} WHERE ID IN ( {$placeholders} ) AND ( user_login LIKE %s OR user_login LIKE %s )",
+				array_merge( $user_ids, [ $guest_prefix, $preview_prefix ] )
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return array_map( 'intval', $temporary_user_ids );
 	}
 }

--- a/includes/class-sensei-temporary-user.php
+++ b/includes/class-sensei-temporary-user.php
@@ -239,6 +239,8 @@ class Sensei_Temporary_User {
 		// Flip to a lookup set so membership checks are O(1) per comment.
 		$temporary_user_id_set = array_flip( $temporary_user_ids );
 
+		// Keep a comment when it is ungraded (the user needs to appear in the grading
+		// list) or when it does not belong to a temporary user.
 		return array_filter(
 			$comments,
 			function ( $comment ) use ( $temporary_user_id_set ) {

--- a/includes/class-sensei-temporary-user.php
+++ b/includes/class-sensei-temporary-user.php
@@ -236,10 +236,13 @@ class Sensei_Temporary_User {
 			return $comments;
 		}
 
+		// Flip to a lookup set so membership checks are O(1) per comment.
+		$temporary_user_id_set = array_flip( $temporary_user_ids );
+
 		return array_filter(
 			$comments,
-			function ( $comment ) use ( $temporary_user_ids ) {
-				return in_array( $comment->comment_approved, [ 'ungraded' ], true ) || ! in_array( (int) $comment->user_id, $temporary_user_ids, true );
+			function ( $comment ) use ( $temporary_user_id_set ) {
+				return in_array( $comment->comment_approved, [ 'ungraded' ], true ) || ! isset( $temporary_user_id_set[ (int) $comment->user_id ] );
 			}
 		);
 	}

--- a/tests/unit-tests/test-class-sensei-temporary-user.php
+++ b/tests/unit-tests/test-class-sensei-temporary-user.php
@@ -162,4 +162,83 @@ class Sensei_Temporary_User_Test extends WP_UnitTestCase {
 
 		self::assertSame( array( 'admin@example.org', 'user1@example.com', 'user2@example.com' ), $learners );
 	}
+
+	/**
+	 * Test that activity queries for multiple users exclude temporary (guest and preview) users.
+	 *
+	 * @covers Sensei_Temporary_User::filter_sensei_activity
+	 */
+	public function test_FilterSenseiActivity_WhenListingUsers_ExcludesTemporaryUsers() {
+		/* Arrange. */
+		$user1_id   = $this->factory->user->create( [ 'user_email' => 'real1@example.com' ] );
+		$user2_id   = $this->factory->user->create( [ 'user_email' => 'real2@example.com' ] );
+		$guest_id   = $this->factory->user->create(
+			[
+				'user_login' => 'sensei_guest_filter',
+				'role'       => Sensei_Guest_User::ROLE,
+			]
+		);
+		$preview_id = $this->factory->user->create(
+			[
+				'user_login' => 'sensei_preview_filter',
+				'role'       => Sensei_Preview_User::ROLE,
+			]
+		);
+		$course_id  = $this->factory->course->create();
+
+		Sensei_Utils::update_course_status( $user1_id, $course_id );
+		Sensei_Utils::update_course_status( $user2_id, $course_id );
+		Sensei_Utils::update_course_status( $guest_id, $course_id );
+		Sensei_Utils::update_course_status( $preview_id, $course_id );
+
+		/* Act. */
+		$comments = Sensei_Utils::sensei_check_for_activity(
+			[
+				'type'    => 'sensei_course_status',
+				'post_id' => $course_id,
+			],
+			true
+		);
+		$user_ids = array_map( 'intval', wp_list_pluck( (array) $comments, 'user_id' ) );
+
+		/* Assert. */
+		$this->assertContains( $user1_id, $user_ids );
+		$this->assertContains( $user2_id, $user_ids );
+		$this->assertNotContains( $guest_id, $user_ids, 'Guest users should be excluded from activity lists.' );
+		$this->assertNotContains( $preview_id, $user_ids, 'Preview users should be excluded from activity lists.' );
+	}
+
+	/**
+	 * Test that a temporary user with ungraded activity is kept, so they appear in the grading list.
+	 *
+	 * @covers Sensei_Temporary_User::filter_sensei_activity
+	 */
+	public function test_FilterSenseiActivity_WhenTemporaryUserUngraded_KeepsUser() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create( [ 'user_email' => 'real3@example.com' ] );
+		$guest_id  = $this->factory->user->create(
+			[
+				'user_login' => 'sensei_guest_ungraded',
+				'role'       => Sensei_Guest_User::ROLE,
+			]
+		);
+		$lesson_id = $this->factory->lesson->create();
+
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
+		Sensei_Utils::update_lesson_status( $guest_id, $lesson_id, 'ungraded' );
+
+		/* Act. */
+		$comments = Sensei_Utils::sensei_check_for_activity(
+			[
+				'type'    => 'sensei_lesson_status',
+				'post_id' => $lesson_id,
+			],
+			true
+		);
+		$user_ids = array_map( 'intval', wp_list_pluck( (array) $comments, 'user_id' ) );
+
+		/* Assert. */
+		$this->assertContains( $user_id, $user_ids );
+		$this->assertContains( $guest_id, $user_ids, 'Temporary users with ungraded activity should be kept for grading.' );
+	}
 }


### PR DESCRIPTION
### Problem

Loading the Students screen for a course with many students could fatal with:

```
Fatal error: Allowed memory size of 536870912 bytes exhausted ... in object-cache.php
```

`Sensei_Temporary_User::filter_sensei_activity()` is hooked on the `sensei_check_for_activity` filter and runs whenever activity is queried for multiple users (no `user_id` in the args). For each comment in the result it called `is_temporary_user()`, which did `get_userdata( $user_id )` to read the user's roles.

On a broad query that returns one row per student, this instantiates a full `WP_User` object — and loads **all** of that user's meta — once per student. On a large course that is hundreds of MB and exhausts the PHP memory limit. The backtrace bottoms out in `get_userdata()` → `get_user_meta()` → `wp_cache_get()`, but the memory was consumed by the cumulative per-user loads.

### Measurements (real site, course with 1,412 students)

| | Memory | Time |
|---|---|---|
| Old: `get_userdata()` × 200 students | 66.9 MB | 0.5 s |
| Old: extrapolated to 1,412 students | **~472 MB** | — |
| New: single batched query for 1,412 IDs | **~0 MB** | 6 ms |

### Fix

Resolve the temporary users in a **single batched query** by login prefix (`Sensei_Guest_User::LOGIN_PREFIX` / `Sensei_Preview_User::LOGIN_PREFIX`) — the same invariant `filter_out_temporary_users()` and `filter_learners_query()` already rely on — instead of one `get_userdata()` per comment. No full user objects or meta are loaded.

- `filter_sensei_activity()` now gathers the candidate user IDs once, calls `get_temporary_user_ids()`, and filters by membership. Ungraded activity is still always kept (those students appear in the grading list).
- `is_temporary_user()` is replaced by `get_temporary_user_ids( array $user_ids )`. It was only ever called from `filter_sensei_activity()`.

Behavior is unchanged: the same students are filtered out; only the mechanism (and its memory cost) differs.

### Files

- `includes/class-sensei-temporary-user.php`

### Testing

- [x] Load `https://learna8c.wordpress.com/wp-admin/admin.php?page=sensei_learners&course_id=5278&view=learners` while sandboxed.
- [x] Ensure the page renders.

**Behavior — temporary users excluded (correctness)**

- [x] Create a preview user: open the course as admin → **Preview as Student** (creates a `sensei_preview_*` user).
- [x] Create a guest user: enable Guest Access on the course → open a lesson while logged out (creates a `sensei_guest_*` user).
- [x] Sensei LMS → Students for the course → the preview and guest users are **absent**; real students are **present**.
- [x] Have one temporary user leave an **ungraded** quiz → Sensei LMS → Grading still lists them (ungraded activity is always kept).

**Query reduction (the fix), measured cold so the object cache can't mask it**

Run on a course with many students (seed with `wp user generate` + enroll), on each branch:

```bash
wp eval '
$args = array( "post_id" => COURSE_ID, "type" => "sensei_course_status", "status" => "any" );
$before = get_num_queries();
$c = Sensei_Utils::sensei_check_for_activity( $args, true );
printf( "comments=%d queries=%d\n", is_array($c)?count($c):0, get_num_queries() - $before );
'
```

- trunk: ~2 queries per student (≈1242 for 620 students).
- fix branch: flat (3 queries), same comments returned.