### PR TITLE
Fix WPcom linter: split chained assignment

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -477,7 +477,10 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	 */
 	private function get_user_lesson_view_row_data( $item ) {
 		$status          = __( 'Not started', 'sensei-lms' );
-		$user_start_date = $user_end_date = $status_class = $grade = '';
+		$user_start_date = '';
+		$user_end_date   = '';
+		$status_class    = '';
+		$grade           = '';
 
 		$lesson_args = array(
 			'post_id' => $item->ID,


### PR DESCRIPTION
## Summary

Split a chained assignment into separate statements to satisfy `Squiz.PHP.DisallowMultipleAssignments`, which WPcom CI (`phpcs-changed`) flagged when the file synced into the monorepo.

`includes/class-sensei-analysis-course-list-table.php:480` assigned four variables on one line:

```php
$user_start_date = $user_end_date = $status_class = $grade = '';
```

Now one assignment per line.

## Test plan

- `./vendor/bin/phpcs` on the changed file reports no `DisallowMultipleAssignments` violations.
- No behavior change — purely a formatting fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)