### PR TITLE
Fix alignment in setup wizard purpose step

### DIFF
--- a/assets/setup-wizard/purpose/style.scss
+++ b/assets/setup-wizard/purpose/style.scss
@@ -44,12 +44,12 @@ $checked-color: #000000;
 
 	&__purpose-children {
 		display: block;
-		padding: 5px 0 0 36px;
+		padding: 5px 0 0 32px;
 		font-size: 14px;
 		opacity: 0.6;
 
 		@media (min-width: $small-screen-break) {
-			padding-left: 32px;
+			padding-left: 24px;
 		}
 	}
 

--- a/changelog/fix-setup-wizard-purpose-alignment
+++ b/changelog/fix-setup-wizard-purpose-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix alignment of option descriptions in the setup wizard's purpose step.


### PR DESCRIPTION
Resolves [SEN-58](https://linear.app/a8c/issue/SEN-58/fix-alignment-issues-in-setup-wizard)

## Proposed Changes
Fix the left-alignment of the option descriptions (e.g. "WooCommerce will be installed for free.") and the "Other" description field in the setup wizard's purpose step so they line up with the checkbox label text above them.

## Testing Instructions
1. Start the setup wizard and go to the "Choose the purpose of your site" step (`/wp-admin/admin.php?page=sensei_setup_wizard&step=purpose`).
2. Check the "Sell courses and generate income" and "Provide certification" options, and the "Other" option.
3. Confirm each option's description text and the "Other" input box are left-aligned with the option label above them, at both desktop (≥600px) and mobile (<600px) widths.

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [x] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
