### PR TITLE
Disable onboarding tour

### DIFF
--- a/changelog/fix-disable-onboarding-tour
+++ b/changelog/fix-disable-onboarding-tour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disable the onboarding tour.

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -38,7 +38,7 @@ class Sensei_Feature_Flags {
 			'course_outline_ai'          => true,
 			'tutor_ai'                   => true,
 			'experimental_features_ui'   => true,
-			'onboarding_tour'            => true,
+			'onboarding_tour'            => false,
 		],
 		'development' => [
 			'enrolment_provider_tooltip' => false,
@@ -46,7 +46,7 @@ class Sensei_Feature_Flags {
 			'email_customization'        => true,
 			'course_outline_ai'          => true,
 			'experimental_features_ui'   => true,
-			'onboarding_tour'            => true,
+			'onboarding_tour'            => false,
 		],
 	];
 


### PR DESCRIPTION
Resolves [SEN-57](https://linear.app/a8c/issue/SEN-57/disable-onboarding-tour)

## Proposed Changes
* Disable the onboarding tour by defaulting the `onboarding_tour` feature flag to `false` in both production and development environments. The tour is buggy and inconsistent across themes, so we're turning it off until it can be polished.

## Testing Instructions
1. The tour only auto-starts once per user, so clear any saved completion for your admin user first: `wp user meta delete admin sensei_tours`
2. Go to `Courses → Add New` (the course block editor).
3. Confirm the guided tour popover no longer appears.

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
