### PR TITLE
Skip Markdown files in replace-next-version-tag.sh

### DIFF
--- a/scripts/replace-next-version-tag.sh
+++ b/scripts/replace-next-version-tag.sh
@@ -73,7 +73,10 @@ VE=$(sed 's/[&\\/]/\\&/g' <<<"$VERSION")
 cd "$BASE"
 EXIT=0
 for FILE in $(git ls-files); do
-	[ "$FILE" == "scripts/replace-next-version-tag.sh" ] && continue;
+	# Skip md files, which only document the token, and this script itself.
+	case "$FILE" in
+		*.md | scripts/replace-next-version-tag.sh ) continue ;;
+	esac
 	grep -F -q '$$next-version$$' "$FILE" 2>/dev/null || continue
 	debug "Processing $FILE"
 


### PR DESCRIPTION
## Proposed Changes

`scripts/replace-next-version-tag.sh` runs at release time to replace the `$$next-version$$` placeholder in docblock tags. It scanned every tracked file (including `AGENTS.md`, which only *documents* the convention), so the release script rewrote its own documentation.

With this PR, skip all `.md` files (apart from the already skipped script).

## Testing Instructions

1. Run `bash scripts/replace-next-version-tag.sh -v 9.9.9` → `AGENTS.md` is no longer processed and `git diff` shows it unchanged (on `trunk` it rewrites `AGENTS.md:42`).
2. Confirm real tokens still work: add a temp file with a `@since $$next-version$$` docblock under `includes/`, `git add` it, run the script → it becomes `@since 9.9.9`.

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
