### PR TITLE
Skip Playground preview on non-product PRs

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -3,6 +3,12 @@ name: Playground PR Preview
 on:
     pull_request:
         types: [opened, synchronize, reopened]
+        paths-ignore:
+            - 'changelog/**'
+            - 'tests/**'
+            - 'scripts/**'
+            - '.github/**'
+            - '**/*.md'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -8,6 +8,8 @@ on:
             - 'tests/**'
             - 'scripts/**'
             - '.github/**'
+            - '.claude/**'
+            - '.husky/**'
             - '**/*.md'
 
 concurrency:


### PR DESCRIPTION
## Proposed Changes

The Playground PR Preview workflow runs a full plugin build and posts a preview comment on **every** PR, including ones that don't change the built plugin (e.g. #8015, which only touched a build script). That wastes CI on a preview no reviewer needs.

This PR adds a `paths-ignore` filter so the workflow is skipped when a PR touches *only* non-product paths (`changelog/`, `tests/`, `scripts/`, `.github/`, `.claude/`, `.husky/`, `*.md`). GitHub skips the run only when **all** changed files match, so any PR that also touches product code still gets its preview.

## Testing Instructions

1. This PR touches only `.github/`, so the Playground PR Preview workflow should **not** run and **no** preview comment should be posted here.
2. Confirm an unrelated PR that touches product code (`includes/`, `assets/`, …) still triggers the workflow and posts the preview comment as before.

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] Code is tested on the minimum supported PHP and WordPress versions
