### PR TITLE
Auto-generate changelog entry from PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,3 +34,32 @@ Both the PR author and reviewer are responsible for ensuring the checklist is co
 - [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
 - [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
 - [ ] Code is tested on the minimum supported PHP and WordPress versions
+
+## Changelog entry
+<!-- Tick the box below to have CI create the changelog/ entry from the details here.
+Otherwise run `make changelog` locally, or apply the "No Changelog" label for internal-only changes. -->
+
+- [ ] Automatically create a changelog entry from the details below.
+
+<details>
+<summary>Changelog Entry Details</summary>
+
+#### Significance
+<!-- Choose only one -->
+- [ ] Patch - Backwards-compatible bug fixes
+- [ ] Minor - Added or deprecated functionality in a backwards-compatible manner
+- [ ] Major - Broke backwards compatibility in some way
+
+#### Type
+<!-- Choose only one -->
+- [ ] Added - Adds new functionality
+- [ ] Changed - Changes existing functionality
+- [ ] Fixed - Fixes a bug
+- [ ] Deprecated - Marks functionality as deprecated
+- [ ] Removed - Removes functionality
+- [ ] Security - Security-related change
+- [ ] Development - Development or internal task
+
+#### Message <!-- Add the changelog message here -->
+
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@ Both the PR author and reviewer are responsible for ensuring the checklist is co
 - [ ] Code is tested on the minimum supported PHP and WordPress versions
 
 ## Changelog entry
-<!-- Tick the box below to have CI create the changelog/ entry from the details here.
+<!-- Tick the box below to have CI create the changelog/ entry from the details here (only available for branches in this repository; forks should run `make changelog`).
 Otherwise run `make changelog` locally, or apply the "No Changelog" label for internal-only changes. -->
 
 - [ ] Automatically create a changelog entry from the details below.

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -25,17 +25,19 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+            const isFork = pr.head.repo?.full_name !== pr.base.repo.full_name;
+            const optedIn = /\[(?:x|X)\] Automatically create a changelog/m.test( pr.body || '' );
 
             // Exempt via the "No Changelog" label.
             if ( ( pr.labels || [] ).some( ( l ) => l.name === 'No Changelog' ) ) {
               return core.setOutput( 'generate', 'false' );
             }
 
-            // Opt-in: (re)generate from the description on every run, so edits to the
-            // section propagate even after an entry was already generated. The description
-            // is the source of truth; an unchanged description regenerates identical content
-            // and commits nothing.
-            if ( /\[(?:x|X)\] Automatically create a changelog/m.test( pr.body || '' ) ) {
+            // Opt-in (re)generates from the description on every run, so edits to the section
+            // propagate even after an entry was generated (the description is the source of
+            // truth; an unchanged one regenerates identical content and commits nothing). Only
+            // same-repo PRs can be pushed to, so forks fall through to the existing-entry check.
+            if ( optedIn && ! isFork ) {
               return core.setOutput( 'generate', 'true' );
             }
 
@@ -49,7 +51,12 @@ jobs:
               return core.setOutput( 'generate', 'false' );
             }
 
-            // Nothing satisfies the changelog requirement.
+            // Nothing satisfies the requirement — fail with the right guidance.
+            if ( optedIn && isFork ) {
+              return core.setFailed(
+                'Auto-generation can\'t push to a forked branch. Run `make changelog` and commit the entry, or have a maintainer add it.'
+              );
+            }
             return core.setFailed(
               'No changelog entry found. Run `make changelog`, tick "Automatically create a changelog entry" in the PR description, or apply the "No Changelog" label.'
             );

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -78,11 +78,17 @@ jobs:
           script: |
             const fs = require( 'node:fs' );
             const pr = context.payload.pull_request;
-            const body = pr.body || '';
+
+            // Scope parsing to the "Changelog Entry Details" section, so checked boxes elsewhere
+            // in the description (e.g. under Proposed Changes) can't be mistaken for selections.
+            const section = ( ( pr.body || '' ).match( /<summary>\s*Changelog Entry Details\s*<\/summary>([\s\S]*?)<\/details>/i ) || [] )[ 1 ];
+            if ( ! section ) {
+              throw new Error( 'Could not find the "Changelog Entry Details" section in the PR description.' );
+            }
 
             // Pick exactly one checked option from a list, or fail the job.
             const pickOne = ( regex, label ) => {
-              const matches = [ ...body.matchAll( regex ) ];
+              const matches = [ ...section.matchAll( regex ) ];
               if ( matches.length === 0 ) {
                 throw new Error( `No changelog ${ label } selected. Tick exactly one option in the PR description.` );
               }
@@ -95,7 +101,7 @@ jobs:
             const significance = pickOne( /\[(?:x|X)\] (Patch|Minor|Major)\b/gm, 'significance' );
             const type = pickOne( /\[(?:x|X)\] (Added|Changed|Fixed|Deprecated|Removed|Security|Development)\b/gm, 'type' );
 
-            const messageMatch = /#### Message ?(<!--.*?-->)?(.*?)<\/details>/gms.exec( body );
+            const messageMatch = /#### Message ?(<!--[\s\S]*?-->)?([\s\S]*)/.exec( section );
             if ( ! messageMatch ) {
               throw new Error( 'Could not find the "#### Message" block in the Changelog Entry Details.' );
             }

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -1,27 +1,111 @@
 name: Changelogger checks
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
     branches-ignore:
       - 'release/**'
       - 'feature/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
-    changelogger_used:
-        if: ${{ !contains( github.event.pull_request.labels.*.name, 'No Changelog') }}
-        name: Changelogger used
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v6.0.3
-            - uses: ./.github/actions/deepen-to-merge-base
-            - uses: ./.github/actions/install-php
-            - name: Check change files are touched for touched projects
-              env:
-                  BASE: ${{ github.event.pull_request.base.sha }}
-                  HEAD: ${{ github.event.pull_request.head.sha }}
-              run: ./scripts/check-changelogger-use.php --debug "$BASE" "$HEAD"
+  changelogger_used:
+    name: Changelogger used
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Check for a changelog entry
+        id: gate
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // No entry needed if exempted by label or one is already present (e.g. `make changelog`).
+            if ( ( pr.labels || [] ).some( ( l ) => l.name === 'No Changelog' ) ) {
+              return core.setOutput( 'generate', 'false' );
+            }
+            const files = await github.paginate( github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            } );
+            if ( files.some( ( f ) => /^changelog\/[^.]/.test( f.filename ) ) ) {
+              return core.setOutput( 'generate', 'false' );
+            }
+
+            // Otherwise an entry must be auto-generated from the opt-in section.
+            if ( ! /\[(?:x|X)\] Automatically create a changelog/m.test( pr.body || '' ) ) {
+              return core.setFailed(
+                'No changelog entry found. Run `make changelog`, tick "Automatically create a changelog entry" in the PR description, or apply the "No Changelog" label.'
+              );
+            }
+            core.setOutput( 'generate', 'true' );
+
+      # Everything below runs only when we need to generate an entry.
+      - name: Check out the PR branch
+        if: steps.gate.outputs.generate == 'true'
+        uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parse the structured "Changelog entry" section and write the file.
+      - name: Generate the changelog entry
+        if: steps.gate.outputs.generate == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require( 'node:fs' );
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Pick exactly one checked option from a list, or fail the job.
+            const pickOne = ( regex, label ) => {
+              const matches = [ ...body.matchAll( regex ) ];
+              if ( matches.length === 0 ) {
+                throw new Error( `No changelog ${ label } selected. Tick exactly one option in the PR description.` );
+              }
+              if ( matches.length > 1 ) {
+                throw new Error( `Multiple changelog ${ label }s selected. Tick only one option.` );
+              }
+              return matches[ 0 ][ 1 ].toLowerCase();
+            };
+
+            const significance = pickOne( /\[(?:x|X)\] (Patch|Minor|Major)\b/gm, 'significance' );
+            const type = pickOne( /\[(?:x|X)\] (Added|Changed|Fixed|Deprecated|Removed|Security|Development)\b/gm, 'type' );
+
+            const messageMatch = /#### Message ?(<!--.*?-->)?(.*?)<\/details>/gms.exec( body );
+            if ( ! messageMatch ) {
+              throw new Error( 'Could not find the "#### Message" block in the Changelog Entry Details.' );
+            }
+            const message = messageMatch[ 2 ].trim().replace( /\r\n|\n/g, ' ' );
+            if ( ! message ) {
+              throw new Error( 'Changelog message is empty. Add a message under "#### Message".' );
+            }
+
+            // Mirror jetpack-changelogger's default filename: branch name with
+            // filesystem-unsafe characters replaced by hyphens.
+            const filename = pr.head.ref.replace( /[<>:"/\\|?*]/g, '-' );
+            const content = `Significance: ${ significance }\nType: ${ type }\n\n${ message }\n`;
+            fs.writeFileSync( `changelog/${ filename }`, content );
+            core.info( `Wrote changelog/${ filename }:\n${ content }` );
+
+      - name: Commit and push the entry
+        if: steps.gate.outputs.generate == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain changelog/)" ]; then
+              git add changelog/
+              git commit -m "Add changelog entry from PR description"
+              git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          else
+              echo "No changelog changes to commit."
+          fi

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -107,6 +107,8 @@ jobs:
             // Mirror jetpack-changelogger's default filename: branch name with
             // filesystem-unsafe characters replaced by hyphens.
             const filename = pr.head.ref.replace( /[<>:"/\\|?*]/g, '-' );
+            const content = `Significance: ${ significance }\nType: ${ type }\n\n${ message }\n`;
+            fs.writeFileSync( `changelog/${ filename }`, content );
             core.info( `Wrote changelog/${ filename }.` );
 
       - name: Commit and push the entry

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -64,7 +64,7 @@ jobs:
       # Everything below runs only when we need to generate an entry.
       - name: Check out the PR branch
         if: steps.gate.outputs.generate == 'true'
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -99,13 +99,16 @@ jobs:
 
       - name: Commit and push the entry
         if: steps.gate.outputs.generate == 'true'
+        # HEAD_REF via env (not ${{ }} in the script) so a crafted branch name can't inject shell.
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if [ -n "$(git status --porcelain changelog/)" ]; then
               git add changelog/
               git commit -m "Add changelog entry from PR description"
-              git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+              git push origin "HEAD:$HEAD_REF"
           else
               echo "No changelog changes to commit."
           fi

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -26,10 +26,20 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
 
-            // No entry needed if exempted by label or one is already present (e.g. `make changelog`).
+            // Exempt via the "No Changelog" label.
             if ( ( pr.labels || [] ).some( ( l ) => l.name === 'No Changelog' ) ) {
               return core.setOutput( 'generate', 'false' );
             }
+
+            // Opt-in: (re)generate from the description on every run, so edits to the
+            // section propagate even after an entry was already generated. The description
+            // is the source of truth; an unchanged description regenerates identical content
+            // and commits nothing.
+            if ( /\[(?:x|X)\] Automatically create a changelog/m.test( pr.body || '' ) ) {
+              return core.setOutput( 'generate', 'true' );
+            }
+
+            // A changelog entry is already present in this PR (e.g. from `make changelog`).
             const files = await github.paginate( github.rest.pulls.listFiles, {
               ...context.repo,
               pull_number: pr.number,
@@ -39,13 +49,10 @@ jobs:
               return core.setOutput( 'generate', 'false' );
             }
 
-            // Otherwise an entry must be auto-generated from the opt-in section.
-            if ( ! /\[(?:x|X)\] Automatically create a changelog/m.test( pr.body || '' ) ) {
-              return core.setFailed(
-                'No changelog entry found. Run `make changelog`, tick "Automatically create a changelog entry" in the PR description, or apply the "No Changelog" label.'
-              );
-            }
-            core.setOutput( 'generate', 'true' );
+            // Nothing satisfies the changelog requirement.
+            return core.setFailed(
+              'No changelog entry found. Run `make changelog`, tick "Automatically create a changelog entry" in the PR description, or apply the "No Changelog" label.'
+            );
 
       # Everything below runs only when we need to generate an entry.
       - name: Check out the PR branch

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -107,9 +107,7 @@ jobs:
             // Mirror jetpack-changelogger's default filename: branch name with
             // filesystem-unsafe characters replaced by hyphens.
             const filename = pr.head.ref.replace( /[<>:"/\\|?*]/g, '-' );
-            const content = `Significance: ${ significance }\nType: ${ type }\n\n${ message }\n`;
-            fs.writeFileSync( `changelog/${ filename }`, content );
-            core.info( `Wrote changelog/${ filename }:\n${ content }` );
+            core.info( `Wrote changelog/${ filename }.` );
 
       - name: Commit and push the entry
         if: steps.gate.outputs.generate == 'true'

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -106,7 +106,6 @@ jobs:
 
       - name: Commit and push the entry
         if: steps.gate.outputs.generate == 'true'
-        # HEAD_REF via env (not ${{ }} in the script) so a crafted branch name can't inject shell.
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |


### PR DESCRIPTION
## Proposed Changes

Adds auto-generation of a changelog entry from the PR description:
* New "Changelog entry" section in the PR template (with opt-in checkbox + Significance / Type / Message, using Sensei's native changelogger types)
* `changelogger.yml` is rewritten into a single `pull_request_target` workflow that is both the gate and the generator. A read-only gate decides: 
  * `No Changelog` label → exempt
  *  opt-in box ticked → (re)generate from the description; 
  * existing `changelog/` entry (e.g. from `make changelog`) → pass; 
  * otherwise → fail with guidance. 


**The description is the source of truth when the box is ticked**: the entry is regenerated on every run, so editing the section updates the file. Hand-edits to the committed `changelog/<branch>` get overwritten.

Closes https://linear.app/a8c/issue/SEN-61/auto-generate-change-log-from-pr-description

## Testing Instructions

⚠️ Already manually tested in this fork https://github.com/albarin/sensei/pull/4

1. Create a fork of the repo with this branch merged into `trunk`.
2. Create a new PR in the repo with any change to a file.
3. Follow the next steps and check that the expectations are met.

Step | Action | Expected
-- | -- | -- |
1 | (initial state) | ❌ red — "No changelog entry found…" |
2 | Add the No Changelog label | ✅ green, no commit (re-runs on labeled) |
3 | Remove the label | ❌ red again |
4 | Tick the box + fill Significance + Type + Message | ✅ Bot commits changelog/branch |
5 | Edit the section (change the Type or Message) | ✅ green, file regenerated to match |
6 | Push a trivial commit, leave the description unchanged | ✅ green, no duplicate (regenerates identical → nothing to commit) |
7 | Break the section (tick two Types, or clear the Message) | ❌ red, specific message |
8 | Fix the section back to valid | ✅ green, regenerates |
9 | Untick the box (the generated file stays) | ✅ green, no new commit — passes via the existing-entry check |
10 | Hand-edit the committed changelog/<branch> to different text, then re-tick the box (valid section) | ✅ green, file overwritten to match the description |
