### PR TITLE
Open course outline AI upsell in a new tab

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -105,7 +105,11 @@ const OutlineEdit = ( props ) => {
 		if ( removeCourseOutlineGeneratorUpsell ) {
 			window.location.hash = 'generate-course-outline-using-ai';
 		} else {
-			window.location.href = getSenseiProUpsellUrl( 'outline_edit' );
+			window.open(
+				getSenseiProUpsellUrl( 'outline_edit' ),
+				'_blank',
+				'noopener'
+			);
 		}
 	}, [ removeCourseOutlineGeneratorUpsell ] );
 

--- a/changelog/fix-course-outline-upsell-new-tab
+++ b/changelog/fix-course-outline-upsell-new-tab
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Open course outline AI upsell in a new tab.


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SEN-62

## Proposed Changes
* When Sensei Pro isn't installed, the course outline *Generate with AI* button now opens the Sensei Pro upsell page in a new tab (`window.open` with `noopener`) instead of redirecting the current tab. This keeps the editor and the in-progress course open behind it rather than leaving the user stranded on the checkout/order-confirmation page with no way back.
* Matches the behavior of every other Sensei Pro upsell in the plugin, which already open in a new tab.

## Testing Instructions
On a site **without** an active Sensei Pro installation:
1. Create a new course and open the editor.
2. Delete all lessons so the Course Outline shows the placeholder with *Start with blank* and *Generate with AI*.
3. Click *Generate with AI*.
4. Confirm the Sensei Pro upsell page opens in a **new browser tab**, and the course editor remains open in the original tab.

Regression check on a site **with** an active Sensei Pro installation:
1. Repeat steps 1-2 above.
2. Click *Generate with AI*.
3. Confirm the AI generation modal still opens in place (no new tab, editor context preserved).

## Pre-Merge Checklist
- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [x] Code is tested on the minimum supported PHP and WordPress versions
- [x] Includes a changelog entry (or the `No Changelog` label)


## Changelog entry
<!-- Tick the box below to have CI create the changelog/ entry from the details here (only available for branches in this repository; forks should run `make changelog`).
Otherwise run `make changelog` locally, or apply the "No Changelog" label for internal-only changes. -->

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
<!-- Choose only one -->
- [x] Patch - Backwards-compatible bug fixes
- [ ] Minor - Added or deprecated functionality in a backwards-compatible manner
- [ ] Major - Broke backwards compatibility in some way

#### Type
<!-- Choose only one -->
- [ ] Added - Adds new functionality
- [x] Changed - Changes existing functionality
- [ ] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message <!-- Add the changelog message here -->
Open course outline AI upsell in a new tab.
</details>
