### PR TITLE
Update bug report labels for consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "[Status] Needs Triage, [Status] Bug"
+labels: "[Status] Needs Triage, [Type] Bug"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "[Status] Needs Triage, Bug"
+labels: "[Status] Needs Triage, [Status] Bug"
 assignees: ''
 
 ---


### PR DESCRIPTION
Matching the Bug label to use [Status] Bug

This is a quick update to match the bug report label's formatting.
