### PR TITLE
Update logic for lesson completion check

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1828,7 +1828,7 @@ class Sensei_Utils {
 					$quiz_progress = Sensei()->quiz_progress_repository->get( $lesson_quiz_id, $user_id );
 					if ( $quiz_progress ) {
 						$user_lesson_status = $quiz_progress->get_status();
-					} elseif ( $user_lesson_status !== 'complete' ) {
+					} elseif ( 'complete' !== $user_lesson_status ) {
 						// A lesson already marked complete is authoritative: no quiz row exists for manual
 						// completions and lessons migrated from the comments-based system.
 						return false;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1820,7 +1820,7 @@ class Sensei_Utils {
 			}
 
 			// In the comments-based progress we use one entry to store both the lesson progress and the quiz progress.
-			// In the tables-based progress we split them. Here is important to use the quiz proress if the quiz pass is required.
+			// In the tables-based progress we split them. Here is important to use the quiz progess if the quiz pass is required.
 			$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 			if ( $lesson_quiz_id ) {
 				$pass_required = get_post_meta( $lesson_quiz_id, '_pass_required', true );
@@ -1828,7 +1828,9 @@ class Sensei_Utils {
 					$quiz_progress = Sensei()->quiz_progress_repository->get( $lesson_quiz_id, $user_id );
 					if ( $quiz_progress ) {
 						$user_lesson_status = $quiz_progress->get_status();
-					} else {
+					} elseif ( $user_lesson_status !== 'complete' ) {
+						// A lesson already marked complete is authoritative: no quiz row exists for manual
+						// completions and lessons migrated from the comments-based system.
 						return false;
 					}
 				}


### PR DESCRIPTION
Resolves #

## Proposed Changes

- Fix `user_completed_lesson()` incorrectly returning `false` for lessons manually marked complete when using HPPS (tables-based progress storage).

In the comments-based system a single `sensei_lesson_status` comment serves as both lesson progress and quiz progress. In HPPS these are stored as separate rows (`type = 'lesson'` and `type = 'quiz'` in `sensei_lms_progress`). When a lesson is manually marked complete (bypassing the normal quiz submission flow) only a `type = 'lesson'` row is created but no `type = 'quiz'` row exists.

Previously, when `_pass_required` was `true` and `quiz_progress_repository->get()` returned `null`, the code unconditionally returned `false`, even when the lesson progress row already held `status = 'complete'`. The fix adds an `elseif` so that if a lesson is marked as complete, the function continues rather than returning early.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the changes.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable HPPS (tables-based student progress storage) in Sensei settings.
2. Create a lesson that has a quiz with **Pass Required** enabled.
3. Manually mark the lesson as complete for a student (e.g. via the Sensei admin learner management screen) without the student submitting the quiz.
4. Confirm that `Sensei_Utils::user_completed_lesson( $lesson_id, $user_id )` returns `true` for that student.
5. Confirm the student's course progress reflects the lesson as complete.

**Before fix:** step 4 returns `false` with HPPS enabled; the same scenario returns `true` with comments-based storage.
**After fix:** step 4 returns `true` in both storage modes.

## New/Updated Hooks

-

## Deprecated Code

-

## Pre-Merge Checklist

<!-- Complete applicable items on this checklist **before** merging. Items that are not applicable can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed. -->

- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions (P6rkRX-4oA-p2)
- [ ] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions

## Changelog entry

<!-- Tick the box below to have CI create the changelog/ entry from the details here (only available for branches in this repository; forks should run `make changelog`).
Otherwise run `make changelog` locally, or apply the "No Changelog" label for internal-only changes. -->

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

### Significance

<!-- Choose only one -->

- [x] Patch - Backwards-compatible bug fixes
- [ ] Minor - Added or deprecated functionality in a backwards-compatible manner
- [ ] Major - Broke backwards compatibility in some way

### Type

<!-- Choose only one -->

- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

### Message <!-- Add the changelog message here -->

Fix `user_completed_lesson()` returning false for manually-completed lessons when using HPPS (tables-based progress storage) with Pass Required enabled.

</details>
