### PR TITLE
Fix: Add allow-popups to grading answer iframe sandbox

### DIFF
--- a/changelog/fix-8026-grading-iframe-sandbox-popups
+++ b/changelog/fix-8026-grading-iframe-sandbox-popups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix answer links not opening from grading screen by adding allow-popups to the answer iframe sandbox.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -88,7 +88,7 @@ class Sensei_Grading_User_Quiz {
 	 * `target="_blank"` can open in a new tab. Content is sanitized via
 	 * `wp_kses_post()` before being passed here.
 	 *
-	 * @since  4.27.0
+	 * @since  4.26.2
 	 *
 	 * @param string $html Sanitized HTML to render inside the iframe.
 	 * @return string The iframe element HTML.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -356,7 +356,8 @@ class Sensei_Grading_User_Quiz {
 							$html = '<html><head><title></title></head><body>' . $html . '</body></html>';
 							?>
 							<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped within render_answer_iframe().
-							echo self::render_answer_iframe( $html ); ?>
+							echo self::render_answer_iframe( $html );
+							?>
 							<?php
 						}
 						?>

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -93,7 +93,7 @@ class Sensei_Grading_User_Quiz {
 	 * @param string $html Sanitized HTML to render inside the iframe.
 	 * @return string The iframe element HTML.
 	 */
-	public static function render_answer_iframe( string $html ): string {
+	private static function render_answer_iframe( $html ) {
 		return '<iframe class="user-answer" srcdoc="' . esc_attr( $html ) . '" sandbox="allow-same-origin allow-popups" height="auto"></iframe>';
 	}
 

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -81,6 +81,23 @@ class Sensei_Grading_User_Quiz {
 	}
 
 	/**
+	 * Returns the HTML for a student answer iframe with appropriate sandbox attributes.
+	 *
+	 * The sandbox allows `allow-same-origin` (required for srcdoc access) and
+	 * `allow-popups` so that links inside sanitized answer content with
+	 * `target="_blank"` can open in a new tab. Content is sanitized via
+	 * `wp_kses_post()` before being passed here.
+	 *
+	 * @since  4.27.0
+	 *
+	 * @param string $html Sanitized HTML to render inside the iframe.
+	 * @return string The iframe element HTML.
+	 */
+	public static function render_answer_iframe( string $html ): string {
+		return '<iframe class="user-answer" srcdoc="' . esc_attr( $html ) . '" sandbox="allow-same-origin allow-popups" height="auto"></iframe>';
+	}
+
+	/**
 	 * Display output to the admin view
 	 *
 	 * This view is shown when grading a quiz for a single user in admin under grading
@@ -338,7 +355,8 @@ class Sensei_Grading_User_Quiz {
 							$html = wp_kses_post( $_user_answer );
 							$html = '<html><head><title></title></head><body>' . $html . '</body></html>';
 							?>
-							<iframe class="user-answer" srcdoc="<?php echo esc_attr( $html ); ?>" sandbox="allow-same-origin" height="auto"></iframe>
+							<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped within render_answer_iframe().
+							echo self::render_answer_iframe( $html ); ?>
 							<?php
 						}
 						?>

--- a/tests/unit-tests/test-class-sensei-grading-user-quiz.php
+++ b/tests/unit-tests/test-class-sensei-grading-user-quiz.php
@@ -43,4 +43,26 @@ class Sensei_Grading_User_Quiz_Test extends WP_UnitTestCase {
 			'unknown quiz, wrong'  => array( '', 0, 'ungraded' ),
 		);
 	}
+
+	/**
+	 * The answer iframe sandbox must include allow-popups.
+	 *
+	 * Without allow-popups, a target="_blank" link inside the sandboxed srcdoc
+	 * is silently blocked — teachers cannot open submitted file-upload answers.
+	 *
+	 * Delete-the-fix test: remove allow-popups from render_answer_iframe() and
+	 * this assertion fails because the sandbox value no longer contains the token.
+	 *
+	 * @covers Sensei_Grading_User_Quiz::render_answer_iframe
+	 */
+	public function test_answer_iframe_sandbox_includes_allow_popups() {
+		$html   = '<html><head><title></title></head><body><a href="http://example.com" target="_blank">View file</a></body></html>';
+		$output = Sensei_Grading_User_Quiz::render_answer_iframe( $html );
+
+		$this->assertStringContainsString(
+			'sandbox="allow-same-origin allow-popups"',
+			$output,
+			'Answer iframe must allow popups so target="_blank" links open for graders.'
+		);
+	}
 }

--- a/tests/unit-tests/test-class-sensei-grading-user-quiz.php
+++ b/tests/unit-tests/test-class-sensei-grading-user-quiz.php
@@ -56,8 +56,11 @@ class Sensei_Grading_User_Quiz_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Grading_User_Quiz::render_answer_iframe
 	 */
 	public function test_answer_iframe_sandbox_includes_allow_popups() {
+		$method = new ReflectionMethod( Sensei_Grading_User_Quiz::class, 'render_answer_iframe' );
+		$method->setAccessible( true );
+
 		$html   = '<html><head><title></title></head><body><a href="http://example.com" target="_blank">View file</a></body></html>';
-		$output = Sensei_Grading_User_Quiz::render_answer_iframe( $html );
+		$output = $method->invoke( null, $html );
 
 		$this->assertStringContainsString(
 			'sandbox="allow-same-origin allow-popups"',


### PR DESCRIPTION
Resolves #8026

## Proposed Changes
* Add `allow-popups` to the grading answer iframe sandbox so `target="_blank"` links in student answers open correctly for teachers.
* Extract the iframe HTML to a private static `render_answer_iframe()` method, allowing the sandbox attribute to be unit-tested directly via ReflectionMethod.

## Testing Instructions
1. Create a course with a file-upload question type.
2. As a student, enroll and submit an answer that includes a `target="_blank"` link (e.g. a URL to a document).
3. As a teacher or admin, navigate to Sensei > Grading and open that student's quiz submission.
4. Observe: before this fix, clicking the link in the answer iframe does nothing (sandboxed). After this fix, the link opens in a new tab.

Unit test: `tests/unit-tests/test-class-sensei-grading-user-quiz.php::test_answer_iframe_sandbox_includes_allow_popups`

Note: unable to run the test suite locally (fork, no local clone) — relying on CI for PHPUnit and PHPCS confirmation.

## New/Updated Hooks
* New private static method: `Sensei_Grading_User_Quiz::render_answer_iframe( $html )` — renders the student answer iframe with the correct sandbox attributes (`allow-same-origin allow-popups`). Extracted from `display()` for testability; `$html` must be pre-sanitized via `wp_kses_post()`.

## Deprecated Code
None.

## Pre-Merge Checklist
- [ ] PR title and description contain sufficient detail and accurately describe the changes
- [ ] Adheres to coding standards (PHP, JavaScript, CSS, HTML)
- [ ] All strings are translatable (without concatenation, handles plurals)
- [ ] Follows our naming conventions
- [ ] Hooks and functions are documented
- [ ] New UIs are responsive and use a mobile-first approach
- [ ] Code is tested on the minimum supported PHP and WordPress versions

## Changelog entry
Changelog file created manually: `changelog/fix-8026-grading-iframe-sandbox-popups` (fork — CI auto-create not available for forks; file matches Jetpack Changelogger format).

Note: External contributors cannot set milestones — please assign the appropriate milestone before merging.

(full disclosure: AI helped me identify the issue and verify my work)