### PR TITLE
Fix grade_quiz_auto() silently treating false-grade question IDs as zero-grade

### DIFF
--- a/changelog/fix-grade-quiz-auto-false-question-id
+++ b/changelog/fix-grade-quiz-auto-false-question-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix quiz grade being deflated when submitted answers include question IDs that are not a valid 'question' post type. PHP's loose `0 == false` comparison caused such IDs to be silently treated as zero-grade questions, potentially corrupting the per-question grade record. They are now skipped entirely.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -138,7 +138,7 @@ class Sensei_Grading_User_Quiz {
 				}
 
 				$question_grade_total = Sensei()->question->get_question_grade( $question_id );
-				$quiz_grade_total    += $question_grade_total;
+				$quiz_grade_total    += (int) $question_grade_total;
 
 				$right_answer        = get_post_meta( $question_id, '_question_right_answer', true );
 				$user_answer_content = Sensei()->quiz->get_user_question_answer( $lesson_id, $question_id, $user_id );

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1074,6 +1074,15 @@ class Sensei_Grading {
 			// check if the question is autogradable, either by type, or because the grade is 0
 			$question_type    = Sensei()->question->get_question_type( $question_id );
 			$achievable_grade = Sensei()->question->get_question_grade( $question_id );
+
+			// get_question_grade() returns false for non-'question' post types (e.g. deleted
+			// posts or multiple_question containers). Strict check must come before the loose
+			// 0 == comparison below, because PHP evaluates 0 == false as true, which would
+			// silently drop a correctly-answered question from grade_total.
+			if ( false === $achievable_grade ) {
+				continue;
+			}
+
 			// Question has a zero grade, so skip grading
 			if ( 0 == $achievable_grade ) {
 				$all_question_grades[ $question_id ] = $achievable_grade;

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -583,7 +583,7 @@ class Sensei_Question {
 	 *
 	 * @param int $question_id
 	 *
-	 * @return int $question_grade | bool
+	 * @return int|false
 	 */
 	public function get_question_grade( $question_id ) {
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1009,7 +1009,7 @@ class Sensei_Question {
 
 		$correct_answer = $show_correct_answers && ! $answer_correct ? self::get_correct_answer( $question_id ) : false;
 
-		$grade = Sensei()->view_helper->format_question_points( $answer_grade . '/' . $question_grade );
+		$grade = Sensei()->view_helper->format_question_points( $answer_grade . '/' . (int) $question_grade );
 
 		/**
 		 * Filter the learner grade displayed.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -746,7 +746,7 @@ class Sensei_Utils {
 			$question_grade = 0;
 			foreach ( $questions as $question ) {
 				$question_grade = Sensei()->question->get_question_grade( $question->ID );
-				$quiz_total    += $question_grade;
+				$quiz_total    += (int) $question_grade;
 			}
 		}
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -731,6 +731,62 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that grade_quiz_auto() ignores question IDs whose post type is not
+	 * 'question' (e.g. deleted posts or multiple_question containers) instead of
+	 * silently treating them as zero-grade via PHP's loose 0 == false comparison.
+	 *
+	 * Before the fix, such IDs were stored with grade `false` in the per-question
+	 * grade map, which could corrupt the grade record held by set_user_grades().
+	 * After the fix they are skipped entirely (continue), so they do not appear in
+	 * the stored per-question grades returned by get_user_grades().
+	 *
+	 * @covers Sensei_Grading::grade_quiz_auto
+	 */
+	public function testGradeQuizAuto_InvalidQuestionIdInSubmitted_IsSkippedAndNotStoredInGrades(): void {
+		/* Arrange. */
+		$user_id   = wp_create_user( 'grading_invalid_q', 'pass', 'grading_invalid_q@example.com' );
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		update_post_meta( $quiz_id, '_quiz_grade_type', 'auto' );
+
+		// One valid boolean question where 'true' is the correct answer.
+		$question_args = $this->factory->question->get_sample_question_data( 'boolean' );
+		$question_args['quiz_id']     = $quiz_id;
+		$question_args['post_author'] = get_post( $quiz_id )->post_author;
+		// Ensure the right answer is 'true' so we can submit a known correct answer.
+		$question_args['question_right_answer_boolean'] = 'true';
+		$valid_question_id = Sensei()->lesson->lesson_save_question( $question_args );
+
+		// A regular post (not a 'question' post type): get_question_grade() returns false for it.
+		$invalid_question_id = $this->factory->post->create();
+
+		wp_set_current_user( $user_id );
+		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
+
+		// Both IDs are submitted — the valid one answered correctly, the invalid one with anything.
+		$submitted = [
+			$valid_question_id   => 'true',
+			$invalid_question_id => 'true',
+		];
+		Sensei_Quiz::save_user_answers( $submitted, [], $lesson_id, $user_id );
+
+		/* Act. */
+		$grade = Sensei_Grading::grade_quiz_auto( $quiz_id, $submitted, 0, 'auto' );
+
+		/* Assert: grade is computed (not a WP_Error) and the invalid ID is not in stored grades. */
+		$this->assertIsNumeric( $grade, 'grade_quiz_auto() should return a numeric grade when all valid questions can be auto-graded.' );
+
+		$stored_grades = Sensei()->quiz->get_user_grades( $lesson_id, $user_id );
+		$this->assertIsArray( $stored_grades, 'get_user_grades() should return an array.' );
+		$this->assertArrayNotHasKey(
+			$invalid_question_id,
+			$stored_grades,
+			'An invalid question ID (non-\'question\' post type) must not be stored in per-question grades.'
+		);
+	}
+
+	/**
 	 * Add lesson status for a given student.
 	 *
 	 * @param int    $lesson_id Lesson ID.

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -874,7 +874,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$user_id   = wp_create_user( 'grading_invalid_q', 'pass', 'grading_invalid_q@example.com' );
 		$lesson_id = $this->factory->lesson->create();
-		$quiz_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+		$quiz_id   = $this->factory->quiz->create( array( 'post_parent' => $lesson_id ) );
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $quiz_id, '_quiz_grade_type', 'auto' );
 
@@ -897,11 +897,11 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
 
 		// Both IDs are submitted — the valid one answered correctly, the invalid one with anything.
-		$submitted = [
+		$submitted = array(
 			$valid_question_id   => 'true',
 			$invalid_question_id => 'true',
-		];
-		Sensei_Quiz::save_user_answers( $submitted, [], $lesson_id, $user_id );
+		);
+		Sensei_Quiz::save_user_answers( $submitted, array(), $lesson_id, $user_id );
 
 		/* Act. */
 		$grade = Sensei_Grading::grade_quiz_auto( $quiz_id, $submitted, 0, 'auto' );

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -254,6 +254,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test grade_gap_fill_question with regex patterns.
+	 *
 	 * @dataProvider gradeGapFillQuestions
 	 * @covers Sensei_Grading::grade_gap_fill_question
 	 * @since 1.9.18
@@ -753,11 +755,11 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		update_post_meta( $quiz_id, '_quiz_grade_type', 'auto' );
 
 		// One valid boolean question where 'true' is the correct answer (grade = 1 by default).
-		$question_args = $this->factory->question->get_sample_question_data( 'boolean' );
-		$question_args['quiz_id']     = $quiz_id;
-		$question_args['post_author'] = get_post( $quiz_id )->post_author;
+		$question_args                                  = $this->factory->question->get_sample_question_data( 'boolean' );
+		$question_args['quiz_id']                       = $quiz_id;
+		$question_args['post_author']                   = get_post( $quiz_id )->post_author;
 		$question_args['question_right_answer_boolean'] = 'true';
-		$valid_question_id = Sensei()->lesson->lesson_save_question( $question_args );
+		$valid_question_id                              = Sensei()->lesson->lesson_save_question( $question_args );
 
 		// Precondition: the valid question must exist as a 'question' post type.
 		$this->assertSame( 'question', get_post_type( $valid_question_id ), 'Precondition: valid question must be of post type "question".' );

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -735,10 +735,12 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 * 'question' (e.g. deleted posts or multiple_question containers) instead of
 	 * silently treating them as zero-grade via PHP's loose 0 == false comparison.
 	 *
-	 * Before the fix, such IDs were stored with grade `false` in the per-question
-	 * grade map, which could corrupt the grade record held by set_user_grades().
-	 * After the fix they are skipped entirely (continue), so they do not appear in
-	 * the stored per-question grades returned by get_user_grades().
+	 * Before the fix, get_question_grade() returns false for a non-'question' post type,
+	 * but `0 == false` evaluated to true in PHP, so the ID fell through to the zero-grade
+	 * branch and was stored with grade false via set_user_grades(). After the fix the
+	 * strict false === $achievable_grade guard skips the ID entirely (continue), so it
+	 * does not appear in the stored per-question grades and the percentage reflects only
+	 * valid questions.
 	 *
 	 * @covers Sensei_Grading::grade_quiz_auto
 	 */
@@ -750,16 +752,20 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $quiz_id, '_quiz_grade_type', 'auto' );
 
-		// One valid boolean question where 'true' is the correct answer.
+		// One valid boolean question where 'true' is the correct answer (grade = 1 by default).
 		$question_args = $this->factory->question->get_sample_question_data( 'boolean' );
 		$question_args['quiz_id']     = $quiz_id;
 		$question_args['post_author'] = get_post( $quiz_id )->post_author;
-		// Ensure the right answer is 'true' so we can submit a known correct answer.
 		$question_args['question_right_answer_boolean'] = 'true';
 		$valid_question_id = Sensei()->lesson->lesson_save_question( $question_args );
 
+		// Precondition: the valid question must exist as a 'question' post type.
+		$this->assertSame( 'question', get_post_type( $valid_question_id ), 'Precondition: valid question must be of post type "question".' );
+
 		// A regular post (not a 'question' post type): get_question_grade() returns false for it.
 		$invalid_question_id = $this->factory->post->create();
+		$this->assertNotSame( 'question', get_post_type( $invalid_question_id ), 'Precondition: invalid question must NOT be of post type "question".' );
+		$this->assertFalse( Sensei()->question->get_question_grade( $invalid_question_id ), 'Precondition: get_question_grade() must return false for the invalid ID.' );
 
 		wp_set_current_user( $user_id );
 		Sensei_Utils::user_start_lesson( $user_id, $lesson_id );
@@ -774,11 +780,22 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		/* Act. */
 		$grade = Sensei_Grading::grade_quiz_auto( $quiz_id, $submitted, 0, 'auto' );
 
-		/* Assert: grade is computed (not a WP_Error) and the invalid ID is not in stored grades. */
-		$this->assertIsNumeric( $grade, 'grade_quiz_auto() should return a numeric grade when all valid questions can be auto-graded.' );
+		/* Assert. */
 
+		// The returned grade must be 100 — the valid question was answered correctly and the
+		// invalid ID must not inflate the denominator or corrupt the numerator.
+		$this->assertSame( 100, (int) $grade, 'grade_quiz_auto() should return 100 when the only valid question is answered correctly.' );
+
+		// The valid question must appear in stored grades with a passing mark.
 		$stored_grades = Sensei()->quiz->get_user_grades( $lesson_id, $user_id );
 		$this->assertIsArray( $stored_grades, 'get_user_grades() should return an array.' );
+		$this->assertArrayHasKey(
+			$valid_question_id,
+			$stored_grades,
+			'The valid question ID must be stored in per-question grades.'
+		);
+
+		// The invalid ID must not appear in stored grades at all.
 		$this->assertArrayNotHasKey(
 			$invalid_question_id,
 			$stored_grades,


### PR DESCRIPTION
Resolves #7818

## Proposed Changes

`get_question_grade()` returns `false` — not `0` — for any post ID that is not of the `'question'` post type (such as `multiple_question` container IDs or deleted-post remnants). In `grade_quiz_auto()`, the existing check `if ( 0 == $achievable_grade )` uses PHP's loose comparison operator, which evaluates `0 == false` as `true`. This caused those IDs to silently fall into the zero-grade branch and be written to the per-question grade map as `false` via `set_user_grades()`, corrupting the per-question grade record and potentially deflating the computed percentage.

This PR adds a strict `false === $achievable_grade` guard before the existing loose check. Invalid IDs are now skipped entirely (`continue`) — no grade entry is created for them.

## Testing Instructions

1. Run the new unit test:
   ```
   make test-php-filter FILTER="testGradeQuizAuto_InvalidQuestionIdInSubmitted_IsSkippedAndNotStoredInGrades"
   ```
2. To reproduce manually: create a quiz with at least one boolean question (correct answer `true`). As a student, submit the quiz with the correct answer plus an answer keyed to a non-`'question'` post ID (simulating a `multiple_question` container or deleted-post remnant in the submitted array). Check the stored per-question grades — the invalid ID must not appear, and the percentage must reflect only the valid questions.

## New/Updated Hooks

*None*

## Deprecated Code

*None*

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards (PHP)
- [x] All strings are translatable (no user-facing strings added)
- [x] New UIs are responsive (no UI changes)
- [x] Code is tested on the minimum supported PHP and WordPress versions

## Changelog entry

A `changelog/fix-grade-quiz-auto-false-question-id` file is included (patch/fixed).

---

(full disclosure: AI helped me identify the issue and verify my work)
