### PR TITLE
Fix Gutenberg infinite save loop when Polylang Pro is active

### DIFF
--- a/changelog/fix-lesson-quiz-rest-response-isolation
+++ b/changelog/fix-lesson-quiz-rest-response-isolation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix infinite save loop in the block editor when Polylang Pro is active. Third-party plugins that inject extra fields (e.g. lang, translations) into REST responses via WordPress lifecycle filters caused Gutenberg's block-state comparison to detect phantom unsaved changes, triggering repeated save cycles. The lesson-quiz REST endpoint now strips any top-level fields not defined by Sensei before the response reaches Gutenberg.

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -124,7 +124,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		// These are not Sensei-defined response fields, so they are not in the
 		// sensei_lesson_quiz_rest_response_keys filter, but they must not be stripped.
 		foreach ( array_keys( $result ) as $key ) {
-			if ( isset( $key[0] ) && '_' === $key[0] ) {
+			if ( is_string( $key ) && '_' === $key[0] ) {
 				$allowed[ $key ] = true;
 			}
 		}

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -117,7 +117,19 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 			return $result;
 		}
 
-		return array_intersect_key( $result, array_flip( $this->get_quiz_response_top_level_keys() ) );
+		$allowed = array_flip( $this->get_quiz_response_top_level_keys() );
+
+		// Preserve underscore-prefixed keys added by WordPress core before this filter
+		// runs (e.g. _links from response_to_data(), _embedded for ?_embed requests).
+		// These are not Sensei-defined response fields, so they are not in the
+		// sensei_lesson_quiz_rest_response_keys filter, but they must not be stripped.
+		foreach ( array_keys( $result ) as $key ) {
+			if ( isset( $key[0] ) && '_' === $key[0] ) {
+				$allowed[ $key ] = true;
+			}
+		}
+
+		return array_intersect_key( $result, $allowed );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -46,6 +46,10 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 	 * Register the REST API endpoints for quiz.
 	 */
 	public function register_routes() {
+		// Strip third-party injections from the response before Gutenberg reads it.
+		// Must be registered once, here, so it covers both GET and POST responses.
+		add_filter( 'rest_pre_echo_response', array( $this, 'isolate_lesson_quiz_response' ), PHP_INT_MAX, 3 );
+
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base . '/(?P<lesson_id>[0-9]+)',
@@ -83,6 +87,64 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
+		);
+	}
+
+	/**
+	 * Strips fields not defined by Sensei from the lesson-quiz REST response.
+	 *
+	 * Third-party plugins (e.g. Polylang Pro) may hook into WordPress REST API
+	 * lifecycle filters and inject extra top-level fields — such as `lang` and
+	 * `translations` — into every REST response they process. When these fields
+	 * reach Gutenberg's block-state comparison the editor sees unexpected data,
+	 * marks the post dirty, and triggers another save cycle, creating an infinite
+	 * loop (see issue #7861).
+	 *
+	 * Running at PHP_INT_MAX ensures this filter removes any additions made by
+	 * earlier-priority filters before the response is serialised and sent.
+	 *
+	 * @param mixed           $result  JSON-ready response data.
+	 * @param WP_REST_Server  $server  REST server instance.
+	 * @param WP_REST_Request $request Current REST request.
+	 * @return mixed Filtered response data.
+	 */
+	public function isolate_lesson_quiz_response( $result, WP_REST_Server $server, WP_REST_Request $request ) {
+		if ( ! is_array( $result ) ) {
+			return $result;
+		}
+
+		if ( 0 !== strpos( $request->get_route(), '/' . $this->namespace . '/' . $this->rest_base . '/' ) ) {
+			return $result;
+		}
+
+		return array_intersect_key( $result, array_flip( $this->get_quiz_response_top_level_keys() ) );
+	}
+
+	/**
+	 * Returns the top-level keys Sensei defines for lesson-quiz responses.
+	 *
+	 * Add a filter on sensei_lesson_quiz_rest_response_keys when you extend the
+	 * response via sensei_rest_api_lesson_quiz_response so that your additional
+	 * fields are not stripped by isolate_lesson_quiz_response().
+	 *
+	 * @return string[]
+	 */
+	private function get_quiz_response_top_level_keys(): array {
+		/**
+		 * Declares the top-level keys accepted in a lesson-quiz REST response.
+		 *
+		 * If you add custom top-level fields via the sensei_rest_api_lesson_quiz_response
+		 * filter, add their keys here so they are not removed before the response reaches
+		 * Gutenberg.
+		 *
+		 * @hook sensei_lesson_quiz_rest_response_keys
+		 *
+		 * @param {string[]} $keys Accepted top-level response keys.
+		 * @return {string[]} Filtered list of accepted keys.
+		 */
+		return apply_filters(
+			'sensei_lesson_quiz_rest_response_keys',
+			array( 'options', 'questions', 'lesson_title', 'lesson_status' )
 		);
 	}
 

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -1025,6 +1025,95 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	}
 
 	/**
+	 * Tests that isolate_lesson_quiz_response() strips top-level fields not in
+	 * Sensei's contract from the lesson-quiz REST response, preventing Gutenberg
+	 * save loops when third-party plugins (e.g. Polylang) inject extra fields.
+	 *
+	 * @covers Sensei_REST_API_Lesson_Quiz_Controller::isolate_lesson_quiz_response
+	 */
+	public function testIsolateLessonQuizResponse_ThirdPartyFieldsAreStripped(): void {
+		$controller = new Sensei_REST_API_Lesson_Quiz_Controller( 'sensei-internal/v1' );
+		$server     = rest_get_server();
+		$request    = new WP_REST_Request( 'POST', '/sensei-internal/v1/lesson-quiz/1' );
+
+		// Simulate what Polylang Pro injects into REST responses via rest_pre_echo_response.
+		$result = array(
+			'options'       => array( 'pass_required' => false ),
+			'questions'     => array(),
+			'lesson_title'  => 'Test Lesson',
+			'lesson_status' => 'draft',
+			'lang'          => 'en',             // Polylang field — must be stripped.
+			'translations'  => array( 'fr' => 2 ), // Polylang field — must be stripped.
+		);
+
+		$filtered = $controller->isolate_lesson_quiz_response( $result, $server, $request );
+
+		$this->assertArrayHasKey( 'options', $filtered, 'options must be present in the filtered response.' );
+		$this->assertArrayHasKey( 'questions', $filtered, 'questions must be present in the filtered response.' );
+		$this->assertArrayHasKey( 'lesson_title', $filtered, 'lesson_title must be present in the filtered response.' );
+		$this->assertArrayHasKey( 'lesson_status', $filtered, 'lesson_status must be present in the filtered response.' );
+		$this->assertArrayNotHasKey( 'lang', $filtered, 'Third-party "lang" field must be stripped from the lesson-quiz response.' );
+		$this->assertArrayNotHasKey( 'translations', $filtered, 'Third-party "translations" field must be stripped from the lesson-quiz response.' );
+	}
+
+	/**
+	 * Tests that isolate_lesson_quiz_response() does not modify responses for
+	 * routes outside the lesson-quiz endpoint.
+	 *
+	 * @covers Sensei_REST_API_Lesson_Quiz_Controller::isolate_lesson_quiz_response
+	 */
+	public function testIsolateLessonQuizResponse_OtherRoutesReturnedUnchanged(): void {
+		$controller = new Sensei_REST_API_Lesson_Quiz_Controller( 'sensei-internal/v1' );
+		$server     = rest_get_server();
+		$request    = new WP_REST_Request( 'GET', '/wp/v2/lessons/1' );
+
+		$data = array(
+			'id'           => 1,
+			'lang'         => 'en',
+			'translations' => array( 'fr' => 2 ),
+		);
+
+		$filtered = $controller->isolate_lesson_quiz_response( $data, $server, $request );
+
+		$this->assertSame( $data, $filtered, 'Responses for routes outside lesson-quiz must not be modified.' );
+	}
+
+	/**
+	 * Tests that custom top-level fields declared via sensei_lesson_quiz_rest_response_keys
+	 * are preserved by isolate_lesson_quiz_response().
+	 *
+	 * @covers Sensei_REST_API_Lesson_Quiz_Controller::isolate_lesson_quiz_response
+	 */
+	public function testIsolateLessonQuizResponse_CustomDeclaredFieldsArePreserved(): void {
+		$controller = new Sensei_REST_API_Lesson_Quiz_Controller( 'sensei-internal/v1' );
+		$server     = rest_get_server();
+		$request    = new WP_REST_Request( 'GET', '/sensei-internal/v1/lesson-quiz/1' );
+
+		// A third-party extension declares 'custom_field' as an accepted key.
+		$add_custom_key = function ( $keys ) {
+			$keys[] = 'custom_field';
+			return $keys;
+		};
+		add_filter( 'sensei_lesson_quiz_rest_response_keys', $add_custom_key );
+
+		$result = array(
+			'options'       => array(),
+			'questions'     => array(),
+			'lesson_title'  => 'Test',
+			'lesson_status' => 'draft',
+			'custom_field'  => 'keep me',   // Declared via filter — must survive.
+			'lang'          => 'en',         // Not declared — must be stripped.
+		);
+
+		$filtered = $controller->isolate_lesson_quiz_response( $result, $server, $request );
+
+		remove_filter( 'sensei_lesson_quiz_rest_response_keys', $add_custom_key );
+
+		$this->assertArrayHasKey( 'custom_field', $filtered, 'Fields declared via sensei_lesson_quiz_rest_response_keys must be preserved.' );
+		$this->assertArrayNotHasKey( 'lang', $filtered, '"lang" must be stripped even when custom fields are declared.' );
+	}
+
+	/**
 	 * Helper method to create a lesson with a quiz.
 	 *
 	 * @param array $quiz_args The quiz args.

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -1114,21 +1114,28 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	}
 
 	/**
-	 * Verifies that register_routes() wires isolate_lesson_quiz_response() into the
-	 * rest_pre_echo_response filter chain.
+	 * Integration test: dispatches a real GET to the lesson-quiz endpoint and
+	 * verifies that third-party fields injected via rest_pre_echo_response are
+	 * stripped before the response is serialised.
 	 *
-	 * This is the delete-the-fix test: removing the add_filter() call from
-	 * register_routes() means the callback is never registered, so Polylang-injected
-	 * fields survive apply_filters() and the assertArrayNotHasKey assertions fail.
+	 * WP_REST_Server::serve_request() applies rest_pre_echo_response to the
+	 * serialisation array after dispatch() returns.  This test replicates that
+	 * step so the full filter chain — including Sensei's PHP_INT_MAX handler
+	 * registered in register_routes() — is exercised against a real response.
+	 *
+	 * Delete-the-fix: removing the add_filter() call from register_routes() means
+	 * isolate_lesson_quiz_response() is absent from the hook chain.  The priority-10
+	 * Polylang stub adds 'lang'/'translations' and nothing strips them, so the
+	 * assertArrayNotHasKey calls fail.
 	 *
 	 * @covers Sensei_REST_API_Lesson_Quiz_Controller::register_routes
 	 * @covers Sensei_REST_API_Lesson_Quiz_Controller::isolate_lesson_quiz_response
 	 */
-	public function testRegisterRoutes_IsolationFilterIsWiredOnRestPreEchoResponse(): void {
-		// setUp() already fired do_action('rest_api_init'), which called register_routes()
-		// and should have registered isolate_lesson_quiz_response on rest_pre_echo_response.
+	public function testGetQuizEndpoint_PolylangInjectedFieldsAreStrippedBeforeSerialization(): void {
+		$this->login_as_teacher();
+		list( $lesson_id ) = $this->create_lesson_with_quiz();
 
-		// Simulate Polylang Pro injecting fields at a lower priority (as it does in production).
+		// Simulate Polylang Pro hooking rest_pre_echo_response at its default priority.
 		$polylang_stub = static function ( $result ) {
 			if ( is_array( $result ) ) {
 				$result['lang']         = 'en';
@@ -1138,25 +1145,22 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 		};
 		add_filter( 'rest_pre_echo_response', $polylang_stub, 10 );
 
-		$data    = array(
-			'options'       => array( 'pass_required' => false ),
-			'questions'     => array(),
-			'lesson_title'  => 'Test',
-			'lesson_status' => 'draft',
-		);
-		$request = new WP_REST_Request( 'GET', '/sensei-internal/v1/lesson-quiz/1' );
+		// Dispatch through the real REST server so the controller runs.
+		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . $lesson_id );
+		$response = $this->server->dispatch( $request );
 
-		// Reproduce what WP_REST_Server::serve_request() does before serialisation:
-		// apply the rest_pre_echo_response filter chain.  Priority 10 (Polylang stub)
-		// injects fields; PHP_INT_MAX (Sensei, if registered) strips them.
-		$filtered = apply_filters( 'rest_pre_echo_response', $data, rest_get_server(), $request );
+		// serve_request() passes response_to_data() output through rest_pre_echo_response
+		// before json_encode().  Replicate that step to exercise the full filter chain.
+		$filtered = apply_filters( 'rest_pre_echo_response', $response->get_data(), $this->server, $request );
 
 		remove_filter( 'rest_pre_echo_response', $polylang_stub, 10 );
 
-		$this->assertIsArray( $filtered, 'Filtered result must be an array.' );
-		$this->assertArrayHasKey( 'options', $filtered, 'options must survive the filter chain.' );
-		$this->assertArrayNotHasKey( 'lang', $filtered, '"lang" injected by Polylang must be stripped by the registered filter.' );
-		$this->assertArrayNotHasKey( 'translations', $filtered, '"translations" injected by Polylang must be stripped by the registered filter.' );
+		$this->assertEquals( 200, $response->get_status(), 'Endpoint must return 200.' );
+		$this->assertIsArray( $filtered, 'Serialisation data must be an array.' );
+		$this->assertArrayHasKey( 'options', $filtered, 'options must be present in the serialised response.' );
+		$this->assertArrayHasKey( 'questions', $filtered, 'questions must be present in the serialised response.' );
+		$this->assertArrayNotHasKey( 'lang', $filtered, '"lang" injected by Polylang must be stripped before serialisation.' );
+		$this->assertArrayNotHasKey( 'translations', $filtered, '"translations" injected by Polylang must be stripped before serialisation.' );
 	}
 
 	/**

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -1114,6 +1114,52 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	}
 
 	/**
+	 * Verifies that register_routes() wires isolate_lesson_quiz_response() into the
+	 * rest_pre_echo_response filter chain.
+	 *
+	 * This is the delete-the-fix test: removing the add_filter() call from
+	 * register_routes() means the callback is never registered, so Polylang-injected
+	 * fields survive apply_filters() and the assertArrayNotHasKey assertions fail.
+	 *
+	 * @covers Sensei_REST_API_Lesson_Quiz_Controller::register_routes
+	 * @covers Sensei_REST_API_Lesson_Quiz_Controller::isolate_lesson_quiz_response
+	 */
+	public function testRegisterRoutes_IsolationFilterIsWiredOnRestPreEchoResponse(): void {
+		// setUp() already fired do_action('rest_api_init'), which called register_routes()
+		// and should have registered isolate_lesson_quiz_response on rest_pre_echo_response.
+
+		// Simulate Polylang Pro injecting fields at a lower priority (as it does in production).
+		$polylang_stub = static function ( $result ) {
+			if ( is_array( $result ) ) {
+				$result['lang']         = 'en';
+				$result['translations'] = array( 'fr' => 2 );
+			}
+			return $result;
+		};
+		add_filter( 'rest_pre_echo_response', $polylang_stub, 10 );
+
+		$data    = array(
+			'options'       => array( 'pass_required' => false ),
+			'questions'     => array(),
+			'lesson_title'  => 'Test',
+			'lesson_status' => 'draft',
+		);
+		$request = new WP_REST_Request( 'GET', '/sensei-internal/v1/lesson-quiz/1' );
+
+		// Reproduce what WP_REST_Server::serve_request() does before serialisation:
+		// apply the rest_pre_echo_response filter chain.  Priority 10 (Polylang stub)
+		// injects fields; PHP_INT_MAX (Sensei, if registered) strips them.
+		$filtered = apply_filters( 'rest_pre_echo_response', $data, rest_get_server(), $request );
+
+		remove_filter( 'rest_pre_echo_response', $polylang_stub, 10 );
+
+		$this->assertIsArray( $filtered, 'Filtered result must be an array.' );
+		$this->assertArrayHasKey( 'options', $filtered, 'options must survive the filter chain.' );
+		$this->assertArrayNotHasKey( 'lang', $filtered, '"lang" injected by Polylang must be stripped by the registered filter.' );
+		$this->assertArrayNotHasKey( 'translations', $filtered, '"translations" injected by Polylang must be stripped by the registered filter.' );
+	}
+
+	/**
 	 * Helper method to create a lesson with a quiz.
 	 *
 	 * @param array $quiz_args The quiz args.

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -1135,6 +1135,16 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 		$this->login_as_teacher();
 		list( $lesson_id ) = $this->create_lesson_with_quiz();
 
+		// Simulate WP core adding an underscore-prefixed key (like _links from
+		// response_to_data()) at a priority lower than Polylang.
+		$wp_core_stub = static function ( $result ) {
+			if ( is_array( $result ) ) {
+				$result['_links'] = array( array( 'href' => 'http://example.com' ) );
+			}
+			return $result;
+		};
+		add_filter( 'rest_pre_echo_response', $wp_core_stub, 9 );
+
 		// Simulate Polylang Pro hooking rest_pre_echo_response at its default priority.
 		$polylang_stub = static function ( $result ) {
 			if ( is_array( $result ) ) {
@@ -1149,16 +1159,19 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . $lesson_id );
 		$response = $this->server->dispatch( $request );
 
-		// serve_request() passes response_to_data() output through rest_pre_echo_response
-		// before json_encode().  Replicate that step to exercise the full filter chain.
-		$filtered = apply_filters( 'rest_pre_echo_response', $response->get_data(), $this->server, $request );
+		// WP_REST_Server::serve_request() calls response_to_data() before rest_pre_echo_response.
+		// Replicate both steps to exercise the exact serve_request() path.
+		$data     = rest_get_server()->response_to_data( $response, false );
+		$filtered = apply_filters( 'rest_pre_echo_response', $data, $this->server, $request );
 
 		remove_filter( 'rest_pre_echo_response', $polylang_stub, 10 );
+		remove_filter( 'rest_pre_echo_response', $wp_core_stub, 9 );
 
 		$this->assertEquals( 200, $response->get_status(), 'Endpoint must return 200.' );
 		$this->assertIsArray( $filtered, 'Serialisation data must be an array.' );
 		$this->assertArrayHasKey( 'options', $filtered, 'options must be present in the serialised response.' );
 		$this->assertArrayHasKey( 'questions', $filtered, 'questions must be present in the serialised response.' );
+		$this->assertArrayHasKey( '_links', $filtered, '_-prefixed keys (e.g. _links from WP core) must survive filtering.' );
 		$this->assertArrayNotHasKey( 'lang', $filtered, '"lang" injected by Polylang must be stripped before serialisation.' );
 		$this->assertArrayNotHasKey( 'translations', $filtered, '"translations" injected by Polylang must be stripped before serialisation.' );
 	}


### PR DESCRIPTION
Closes #7861

## Description

When Polylang Pro is active it hooks into `rest_pre_echo_response` — a WordPress REST lifecycle filter that fires for _every_ REST response before serialisation — and injects `lang` and `translations` into any response it processes, including Sensei's lesson-quiz endpoint.

Gutenberg's `structure-store.js` uses a deep equality check (`isEqual(newStructure, state.editorStructure)`) to detect unsaved changes. The injected fields change the response shape so the check fails, `hasUnsavedServerUpdates` is set to `true`, another save fires — and the cycle repeats indefinitely.

### Fix

`isolate_lesson_quiz_response()` is registered on `rest_pre_echo_response` at `PHP_INT_MAX` priority. `PHP_INT_MAX` is required (not merely late) because the injector (Polylang Pro at its default priority) must have already run before we strip; we cannot anticipate what priority Polylang or any future injector will choose, so running last is the only guarantee.

The callback strips any non-underscore-prefixed top-level key not in Sensei's contract. Underscore-prefixed keys (`_links`, `_embedded`, etc.) are always preserved: they are WordPress HAL conventions injected by `response_to_data()` _before_ `rest_pre_echo_response` fires, and stripping them would break REST clients that follow links.

**Why `rest_pre_echo_response` rather than a per-route filter?** Sensei exposes both a GET (`get_quiz`) and a POST (`save_quiz`) on the same route. `rest_pre_echo_response` covers both in one registration. The callback self-limits via a route-prefix `strpos` guard, so it returns `$result` unchanged for every non-lesson-quiz response — the site-wide registration has O(1) overhead per unrelated request.

**Escape hatch for extensions:** third-party extensions that add custom top-level fields via `sensei_rest_api_lesson_quiz_response` can declare those keys on the `sensei_lesson_quiz_rest_response_keys` filter and they will not be stripped.

### Testing

- [ ] With Polylang Pro active, open a Lesson in the block editor — the editor no longer enters an infinite save loop.
- [ ] Without Polylang Pro, the lesson-quiz endpoint returns exactly the same fields as before this patch.
- [ ] A third-party extension using `add_filter('sensei_lesson_quiz_rest_response_keys', fn($k)=>[...$k,'my_field'])` has its field preserved.

### Checklist

- [x] Changelog entry added (`changelog/fix-lesson-quiz-rest-response-isolation`)
- [x] 4 tests, 16 assertions, all passing
- [x] PHPCS clean on all modified files
- [x] Delete-the-fix confirmed: removing `add_filter()` from `register_routes()` fails `testGetQuizEndpoint_PolylangInjectedFieldsAreStrippedBeforeSerialization`; direct unit tests still pass

props @thisismyurl

(full disclosure: AI helped me identify the issue and verify my work)