### PR TITLE
Scope `GET sensei-messages` with `?sender=all` to message participants

### DIFF
--- a/changelog/fix-messages-rest-sender-all-scoping
+++ b/changelog/fix-messages-rest-sender-all-scoping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Align the sensei-messages REST endpoint results with documented message visibility.

--- a/includes/rest-api/class-sensei-rest-api-messages-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-messages-controller.php
@@ -152,14 +152,29 @@ class Sensei_REST_API_Messages_Controller extends WP_REST_Posts_Controller {
 	 * @return array The modified query args.
 	 */
 	public function exclude_others_comments( $args, $request ) {
-		if (
-			'all' === $request->get_param( 'sender' ) &&
-			( current_user_can( 'moderate_comments' ) || current_user_can( 'read_private_sensei_messages' ) )
-		) {
+		$current_user = wp_get_current_user();
+
+		if ( 'all' === $request->get_param( 'sender' ) ) {
+			// Site administrators may read every message thread.
+			if ( current_user_can( 'manage_options' ) ) {
+				return $args;
+			}
+
+			// Everyone else (e.g. a teacher) sees the messages they sent or received.
+			$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'relation' => 'OR',
+				array(
+					'key'   => '_sender',
+					'value' => $current_user->user_login,
+				),
+				array(
+					'key'   => '_receiver',
+					'value' => $current_user->user_login,
+				),
+			);
+
 			return $args;
 		}
-
-		$current_user = wp_get_current_user();
 
 		$args['meta_key']   = '_sender'; // phpcs:ignore  Slow query ok.
 		$args['meta_value'] = $current_user->user_login; // phpcs:ignore Slow query ok.

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-messages-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-messages-controller.php
@@ -331,10 +331,10 @@ class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Helper method to create a sensei message.
 	 *
-	 * @param string  $title The messager title.
-	 * @param string  $sender The username of the sender.
-	 * @param integer $course The course id.
-	 * @param string  $receiver The username of the receiver.
+	 * @param string      $title    The message title.
+	 * @param string      $sender   The username of the sender.
+	 * @param int|null    $course   The course ID.
+	 * @param string|null $receiver The username of the receiver.
 	 *
 	 * @return int The message id
 	 */

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-messages-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-messages-controller.php
@@ -73,17 +73,6 @@ class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
 
 		$this->create_sensei_message( 'Message title', 'login' );
 
-		// Test that a teacher can see all messages when sender=all.
-		$teacher_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
-		wp_set_current_user( $teacher_id );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
-		$request->set_param( 'sender', 'all' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertCount( 1, $response->get_data(), 'A teacher does not see exactly one message.' );
-		$this->assertEquals( 'Message title', $response->get_data()[0]['displayed_title'] );
-
 		// Test that an administrator can see all messages when sender=all.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -93,13 +82,87 @@ class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertCount( 1, $response->get_data(), 'An administrator does not see exactly one message.' );
-		$this->assertEquals( 'Message title', $response->get_data()[0]['displayed_title'] );
+		$this->assertEquals( 'Message title', $response->get_data()[0]['displayed_title'], 'An administrator should see the message.' );
 
 		// Test that an administrator does not see all messages when no sender argument is supplied.
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertCount( 0, $response->get_data(), 'Messages are returned for an administrator which didn\'t create any. ' );
+	}
+
+	/**
+	 * Tests that a teacher requesting all messages can only read the threads they participate
+	 * in (as sender or receiver), and never another teacher's private messages.
+	 *
+	 * @covers Sensei_REST_API_Messages_Controller::exclude_others_comments
+	 */
+	public function testTeacherCannotAccessOtherTeachersMessagesWithSenderAll() {
+
+		$this->factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'student',
+			)
+		);
+
+		$teacher_a = $this->factory->user->create(
+			array(
+				'role'       => 'teacher',
+				'user_login' => 'teacher_a',
+			)
+		);
+		$this->factory->user->create(
+			array(
+				'role'       => 'teacher',
+				'user_login' => 'teacher_b',
+			)
+		);
+
+		// The student sent a message to each teacher.
+		$this->create_sensei_message( 'For teacher A', 'student', null, 'teacher_a' );
+		$this->create_sensei_message( 'For teacher B', 'student', null, 'teacher_b' );
+
+		wp_set_current_user( $teacher_a );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
+		$request->set_param( 'sender', 'all' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertCount( 1, $data, 'Teacher A should only see the message addressed to them.' );
+		$this->assertEquals( 'For teacher A', $data[0]['displayed_title'], 'Teacher A must not see messages addressed to teacher B.' );
+	}
+
+	/**
+	 * Tests that a teacher requesting all messages sees threads they received as well as threads
+	 * they sent.
+	 *
+	 * @covers Sensei_REST_API_Messages_Controller::exclude_others_comments
+	 */
+	public function testTeacherSeesOwnSentAndReceivedMessagesWithSenderAll() {
+
+		$teacher_id = $this->factory->user->create(
+			array(
+				'role'       => 'teacher',
+				'user_login' => 'teacher',
+			)
+		);
+
+		// A message the teacher received, and one the teacher sent.
+		$this->create_sensei_message( 'Received message', 'student', null, 'teacher' );
+		$this->create_sensei_message( 'Sent message', 'teacher', null, 'other' );
+
+		wp_set_current_user( $teacher_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
+		$request->set_param( 'sender', 'all' );
+		$response = $this->server->dispatch( $request );
+		$titles   = wp_list_pluck( $response->get_data(), 'displayed_title' );
+
+		$this->assertCount( 2, $titles, 'The teacher should see both their received and sent messages.' );
+		$this->assertContains( 'Received message', $titles, 'The teacher should see the message they received.' );
+		$this->assertContains( 'Sent message', $titles, 'The teacher should see the message they sent.' );
 	}
 
 	/**
@@ -271,10 +334,11 @@ class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
 	 * @param string  $title The messager title.
 	 * @param string  $sender The username of the sender.
 	 * @param integer $course The course id.
+	 * @param string  $receiver The username of the receiver.
 	 *
 	 * @return int The message id
 	 */
-	private function create_sensei_message( $title, $sender, $course = null ) {
+	private function create_sensei_message( $title, $sender, $course = null, $receiver = null ) {
 		$message_args = array(
 			'post_type'   => 'sensei_message',
 			'post_status' => 'publish',
@@ -283,6 +347,10 @@ class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
 				'_sender' => $sender,
 			),
 		);
+
+		if ( null !== $receiver ) {
+			$message_args['meta_input']['_receiver'] = $receiver;
+		}
 
 		if ( null !== $course ) {
 			$message_args['meta_input']['_posttype'] = 'course';


### PR DESCRIPTION
## Proposed Changes

Aligns the `GET /wp/v2/sensei-messages?sender=all` filter with documented messages behaviour. Per the [docs](https://senseilms.com/documentation/messages/), messages are viewable only by "the teacher, the sender, and site administrators", so:

- **Site admins** (`manage_options`) see all messages.
- **Everyone else** is scoped to threads where they are the `_sender` or `_receiver`.

The `?sender=current` path is unchanged. Also tidied the existing unit test and added regression coverage for the scoping.

## Testing Instructions

1. Create two Teacher users (`teacherA`, `teacherB`) and a student user.
2. Create a course with the `Contact teacher` block, and assign **`teacherB`** as its teacher.
3. As the **student**, go to the course, `Start Course`, and use the **Contact Teacher** button to message `teacherB`.
4. Generate an application password for each teacher (Users → Profile → Application Passwords).
5. As **`teacherA`** request `GET /wp-json/wp/v2/sensei-messages?sender=all` → response is `[]`.
6. As **`teacherB`**, the same `?sender=all` request returns their own received message.
7. As an **administrator**, `?sender=all` returns all messages.

Automated: `make test-php-filter FILTER="Sensei_REST_API_Messages_Controller_Tests"` → 8 tests pass.
