### PR TITLE
Forward refs through quiz toolbar number controls

### DIFF
--- a/assets/blocks/editor-components/number-control/index.js
+++ b/assets/blocks/editor-components/number-control/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { BaseControl, Button } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -24,62 +25,68 @@ import { __ } from '@wordpress/i18n';
  * @param {string}   props.suffix              Input suffix.
  * @param {boolean}  props.hideLabelFromVision Hides label.
  */
-const NumberControl = ( {
-	className,
-	id,
-	label,
-	value,
-	help,
-	allowReset = false,
-	resetLabel,
-	onChange,
-	suffix,
-	hideLabelFromVision,
-	...props
-} ) => {
-	const setValue = ( e ) => {
-		onChange( parseInt( e.target.value, 10 ) || props.min || 0 );
-	};
+const NumberControl = forwardRef(
+	(
+		{
+			className,
+			id,
+			label,
+			value,
+			help,
+			allowReset = false,
+			resetLabel,
+			onChange,
+			suffix,
+			hideLabelFromVision,
+			...props
+		},
+		ref
+	) => {
+		const setValue = ( e ) => {
+			onChange( parseInt( e.target.value, 10 ) || props.min || 0 );
+		};
 
-	return (
-		<BaseControl
-			id={ id }
-			label={ label }
-			help={ help }
-			hideLabelFromVision={ hideLabelFromVision }
-		>
-			<div className="sensei-number-control">
-				<div className="sensei-number-control__input-container">
-					<input
-						className={ classnames(
-							'sensei-number-control__input components-text-control__input',
-							className
+		return (
+			<BaseControl
+				id={ id }
+				label={ label }
+				help={ help }
+				hideLabelFromVision={ hideLabelFromVision }
+			>
+				<div className="sensei-number-control">
+					<div className="sensei-number-control__input-container">
+						<input
+							ref={ ref }
+							className={ classnames(
+								'sensei-number-control__input components-text-control__input',
+								className
+							) }
+							type="number"
+							id={ id }
+							onChange={ setValue }
+							value={ null === value ? '' : value }
+							{ ...props }
+						/>
+						{ suffix && (
+							<span className="sensei-number-control__input-suffix">
+								{ suffix }
+							</span>
 						) }
-						type="number"
-						id={ id }
-						onChange={ setValue }
-						value={ null === value ? '' : value }
-						{ ...props }
-					/>
-					{ suffix && (
-						<span className="sensei-number-control__input-suffix">
-							{ suffix }
-						</span>
+					</div>
+					{ allowReset && (
+						<Button
+							className="sensei-number-control__button"
+							isSmall
+							isSecondary
+							onClick={ () => onChange( null ) }
+						>
+							{ resetLabel || __( 'Reset', 'sensei-lms' ) }
+						</Button>
 					) }
 				</div>
-				{ allowReset && (
-					<Button
-						className="sensei-number-control__button"
-						isSmall
-						isSecondary
-						onClick={ () => onChange( null ) }
-					>
-						{ resetLabel || __( 'Reset', 'sensei-lms' ) }
-					</Button>
-				) }
-			</div>
-		</BaseControl>
-	);
-};
+			</BaseControl>
+		);
+	}
+);
 
 export default NumberControl;

--- a/assets/blocks/editor-components/number-control/index.test.js
+++ b/assets/blocks/editor-components/number-control/index.test.js
@@ -4,6 +4,11 @@
 import { render, fireEvent } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { createRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import NumberControl from './index';
@@ -50,6 +55,15 @@ describe( '<NumberControl />', () => {
 		} );
 
 		expect( onChangeMock ).toBeCalledWith( 20 );
+	} );
+
+	it( 'Should forward the ref to the input element', () => {
+		const ref = createRef();
+		const { queryByDisplayValue } = render(
+			<NumberControl value={ 10 } ref={ ref } />
+		);
+
+		expect( ref.current ).toBe( queryByDisplayValue( '10' ) );
 	} );
 
 	it( 'Should call the change event with null when resetting', () => {

--- a/assets/blocks/editor-components/number-control/index.test.js
+++ b/assets/blocks/editor-components/number-control/index.test.js
@@ -4,11 +4,6 @@
 import { render, fireEvent } from '@testing-library/react';
 
 /**
- * WordPress dependencies
- */
-import { createRef } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import NumberControl from './index';
@@ -55,15 +50,6 @@ describe( '<NumberControl />', () => {
 		} );
 
 		expect( onChangeMock ).toBeCalledWith( 20 );
-	} );
-
-	it( 'Should forward the ref to the input element', () => {
-		const ref = createRef();
-		const { queryByDisplayValue } = render(
-			<NumberControl value={ 10 } ref={ ref } />
-		);
-
-		expect( ref.current ).toBe( queryByDisplayValue( '10' ) );
 	} );
 
 	it( 'Should call the change event with null when resetting', () => {

--- a/assets/blocks/quiz/question-block/question-grade-control.js
+++ b/assets/blocks/quiz/question-block/question-grade-control.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { forwardRef, useMemo } from '@wordpress/element';
 import { _n } from '@wordpress/i18n';
 /**
  * External dependencies
@@ -17,10 +17,11 @@ import NumberControl from '../../editor-components/number-control';
  *
  * @param {Object} props NumberControl props.
  */
-export const QuestionGradeControl = ( props ) => {
+export const QuestionGradeControl = forwardRef( ( props, ref ) => {
 	const id = useMemo( () => uuid(), [] );
 	return (
 		<NumberControl
+			ref={ ref }
 			id={ id }
 			min={ 0 }
 			step={ 1 }
@@ -28,4 +29,4 @@ export const QuestionGradeControl = ( props ) => {
 			suffix={ _n( 'Point', 'Points', props.value, 'sensei-lms' ) }
 		/>
 	);
-};
+} );

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -9,6 +9,7 @@ import {
 	ToolbarItem,
 	ToolbarGroup,
 } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
 import { __, _n } from '@wordpress/i18n';
 
 /**
@@ -44,32 +45,35 @@ const onDropdownChange = ( updatePagination ) => ( value ) => {
  * @param {Object}   props.settings         Pagination settings object.
  * @param {Function} props.updatePagination Update pagination options function.
  */
-const QuestionsControl = ( { settings, updatePagination, ...props } ) => {
-	const { paginationNumber } = settings;
+const QuestionsControl = forwardRef(
+	( { settings, updatePagination, ...props }, ref ) => {
+		const { paginationNumber } = settings;
 
-	return (
-		<>
-			<NumberControl
-				label={ __( 'Number of Questions', 'sensei-lms' ) }
-				min={ 1 }
-				step={ 1 }
-				hideLabelFromVision
-				suffix={ _n(
-					'question',
-					'questions',
-					paginationNumber,
-					'sensei-lms'
-				) }
-				value={ paginationNumber }
-				onChange={ ( value ) =>
-					updatePagination( { paginationNumber: value } )
-				}
-				{ ...props }
-			/>
-			<span>{ __( 'per page', 'sensei-lms' ) }</span>
-		</>
-	);
-};
+		return (
+			<>
+				<NumberControl
+					ref={ ref }
+					label={ __( 'Number of Questions', 'sensei-lms' ) }
+					min={ 1 }
+					step={ 1 }
+					hideLabelFromVision
+					suffix={ _n(
+						'question',
+						'questions',
+						paginationNumber,
+						'sensei-lms'
+					) }
+					value={ paginationNumber }
+					onChange={ ( value ) =>
+						updatePagination( { paginationNumber: value } )
+					}
+					{ ...props }
+				/>
+				<span>{ __( 'per page', 'sensei-lms' ) }</span>
+			</>
+		);
+	}
+);
 
 /**
  * Quiz sidebar settings.

--- a/changelog/fix-quiz-toolbar-forwardref
+++ b/changelog/fix-quiz-toolbar-forwardref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix React ref warning in the quiz block toolbar by forwarding refs through the number controls.


### PR DESCRIPTION
## Problem

Creating a lesson with a quiz logs a React console warning:

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
Check the render method of `ToolbarItem2`.
```

`ToolbarItem` passes a ref to its `as` component to drive the toolbar's roving tabindex. The quiz block's toolbar uses `as={ QuestionsControl }` (pagination) and `as={ QuestionGradeControl }` (question grade), both plain function components, so the ref was dropped — triggering the warning and leaving the controls unreachable via toolbar arrow-key navigation.

## Fix

Wrap the affected components in `forwardRef` and thread the ref down to the underlying `<input>`:

- `NumberControl` — forwards its ref to the `<input>`.
- `QuestionsControl` (quiz pagination toolbar) — forwards to `NumberControl`.
- `QuestionGradeControl` (question grade toolbar) — forwards to `NumberControl`.

## Test plan

1. Create or edit a lesson and add a Quiz block.
2. Open the browser console.
3. Set the quiz to multi-page pagination and add a question.
4. Confirm no "Function components cannot be given refs" warning appears.
5. Confirm the pagination question-count and question grade toolbar controls work, including arrow-key navigation within the toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
