### PR TITLE
Fix Learning Mode admin CSS path for Divi theme

### DIFF
--- a/changelog/fix-divi-learning-mode-admin-css-path
+++ b/changelog/fix-divi-learning-mode-admin-css-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Learning Mode admin editor stylesheet path for the Divi theme, which pointed at a non-existent "div" directory instead of "divi".

--- a/includes/3rd-party/themes/divi.php
+++ b/includes/3rd-party/themes/divi.php
@@ -123,7 +123,7 @@ function sensei_admin_load_learning_mode_style_for_divi_theme() {
 	if ( $is_lesson_editor || $is_site_editor ) {
 		Sensei()->assets->enqueue(
 			'divi-learning-mode',
-			'css/3rd-party/themes/div/learning-mode.css'
+			'css/3rd-party/themes/divi/learning-mode.css'
 		);
 
 		Sensei()->assets->enqueue(


### PR DESCRIPTION
Closes #7863.

The Learning Mode admin stylesheet for the Divi theme was enqueued from `css/3rd-party/themes/div/learning-mode.css` — a directory that doesn't exist (the `i` is missing), so Learning Mode styles fail to load in the lesson editor and site editor with Divi active. The front-end enqueue and the Divi editor stylesheet already use the correct `divi/` directory, which is why only the admin editor view was affected.

### Fix
One-character path correction: `div/` → `divi/` in `sensei_admin_load_learning_mode_style_for_divi_theme()`.

### Testing
The change only corrects an asset path (no unit-testable state). Verified `css/3rd-party/themes/divi/learning-mode.css` is the path the front-end enqueue and the Divi editor stylesheet already reference, and that no other `div/` reference remains.

Changelog entry added (Significance: patch, Type: fixed).

Props @thisismyurl.

(full disclosure: AI helped me identify the issue and verify my work)
