### PR TITLE
Unblock Dependabot PRs from changelog and milestone checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    labels:
+      - "No Changelog"
     groups:
       actions-minor-patch:
         patterns:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR milestone
+        if: github.actor != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR milestone
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Changes

- **`.github/dependabot.yml`** — set `labels:` to only `No Changelog` on the `github-actions` update block. This replaces Dependabot's default labels (`dependencies`, `github_actions`) and makes the **Changelogger** check pass, since it exempts PRs carrying the `No Changelog` label.
- **`.github/workflows/pr-validation.yml`** — add `if: github.event.pull_request.user.login != 'dependabot[bot]'` to the `Check PR milestone` step. The step is skipped for Dependabot PRs while the job still reports success, so the required **Check Milestone** status is satisfied without assigning a milestone. Gating on the PR author (rather than `github.actor`) keeps the exemption stable across workflow re-runs and pushes to the branch.

## Why

Dependabot PRs were stuck in a `BLOCKED` merge state because the required `Changelogger used` and `Check Milestone` checks both failed — Dependabot adds no changelog entry and assigns no milestone.

## Not covered

The required-review rule still blocks auto-merge. That needs a separate auto-approve + auto-merge workflow.

## Test plan

1. Wait for the next Dependabot PR (or trigger one).
2. Confirm only the `No Changelog` label is applied.
3. Confirm `Changelogger used` and `Check Milestone` both report success.