### PR TITLE
Fix React key warning on Sensei Home

### DIFF
--- a/assets/home/grid.js
+++ b/assets/home/grid.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
+import { Children, forwardRef } from '@wordpress/element';
 
 /**
  * Grid component.
@@ -18,7 +18,7 @@ import { forwardRef } from '@wordpress/element';
  */
 export const Grid = ( { as: Component = 'div', className, children } ) => (
 	<Component className={ classnames( className, 'sensei-home__grid' ) }>
-		{ children }
+		{ Children.toArray( children ) }
 	</Component>
 );
 


### PR DESCRIPTION
## Summary

Fixes a React `Each child in a list should have a unique "key" prop` console warning on the Sensei Home screen.

## Root cause

`main.js` passes multiple static children to `<Grid as="main">`. React hands those to `Grid` as an array prop, and `Grid` re-renders that array as a single child of its wrapper element (`{ children }`). React requires keys on runtime array children passed this way, so it logged a missing-key warning. (Other `<Grid>` usages pass an already-keyed `.map`, so they didn't warn.)

## Fix

Wrap the children in `Children.toArray()` in `grid.js`, which auto-assigns stable keys and drops `null`/`false` entries. No layout or behavior change.

## Test plan

1. Open **Sensei LMS → Home** with the browser devtools console open.
2. Confirm no `Each child in a list should have a unique "key" prop` warning appears.
3. Confirm the Home layout (header, tasks, quick links, sections) renders unchanged.
