### PR TITLE
Scope the Students load-more-courses action to the teacher's own courses

### DIFF
--- a/changelog/fix-get-course-list-teacher-idor
+++ b/changelog/fix-get-course-list-teacher-idor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Scope the Students "load more courses" action to courses the current teacher can manage.

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -1761,9 +1761,7 @@
     <InvalidScalarArgument occurrences="1">
       <code>$user_id</code>
     </InvalidScalarArgument>
-    <PossiblyInvalidPropertyFetch occurrences="5">
-      <code>$course-&gt;ID</code>
-      <code>$course-&gt;post_title</code>
+    <PossiblyInvalidPropertyFetch occurrences="3">
       <code>$user-&gt;display_name</code>
       <code>$user-&gt;first_name</code>
       <code>$user-&gt;last_name</code>

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -804,15 +804,22 @@ class Sensei_Learner {
 		$base_query_args = [ 'posts_per_page' => -1 ];
 		$courses_query   = $learner_manager->get_enrolled_courses_query( $user_id, $base_query_args );
 
+		// Restrict to courses the current user can manage before dropping the three shown in the
+		// table, so the "load more" results line up with the visible (teacher-scoped) list.
+		$manageable_courses = array_values(
+			array_filter(
+				$courses_query->posts,
+				static function ( $course ) {
+					return Sensei_Abilities::can_manage_grades( array( 'course' => $course->ID ) );
+				}
+			)
+		);
+
 		// We only want to show courses after the third one in the UI.
-		$courses = array_slice( $courses_query->posts, 3 );
+		$courses = array_slice( $manageable_courses, 3 );
 
 		$html_items = [];
 		foreach ( $courses as $course ) {
-			if ( ! Sensei_Abilities::can_manage_grades( array( 'course' => $course->ID ) ) ) {
-				continue;
-			}
-
 			$html_items[] = '<a href="' . esc_url( $controller->get_learner_management_course_url( $course->ID ) ) .
 							'" class="sensei-students__enrolled-course" data-course-id="' . intval( $course->ID ) . '">' .
 							esc_html( $course->post_title ) .

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -790,6 +790,10 @@ class Sensei_Learner {
 			wp_send_json_error( array( 'error' => esc_html__( 'Insufficient Permissions.', 'sensei-lms' ) ) );
 		}
 
+		if ( ! current_user_can( 'manage_sensei_grades' ) ) {
+			wp_send_json_error( array( 'error' => esc_html__( 'Insufficient Permissions.', 'sensei-lms' ) ) );
+		}
+
 		$user_id         = isset( $_POST['user_id'] ) ? sanitize_text_field( wp_unslash( $_POST['user_id'] ) ) : '';
 		$learner_manager = self::instance();
 		$controller      = new Sensei_Learners_Admin_Bulk_Actions_Controller( new Sensei_Learner_Management( '' ), $learner_manager );
@@ -801,6 +805,10 @@ class Sensei_Learner {
 
 		$html_items = [];
 		foreach ( $courses as $course ) {
+			if ( ! Sensei_Abilities::can_manage_grades( array( 'course' => $course->ID ) ) ) {
+				continue;
+			}
+
 			$html_items[] = '<a href="' . esc_url( $controller->get_learner_management_course_url( $course->ID ) ) .
 							'" class="sensei-students__enrolled-course" data-course-id="' . intval( $course->ID ) . '">' .
 							esc_html( $course->post_title ) .

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -806,14 +806,12 @@ class Sensei_Learner {
 
 		// Restrict to courses the current user can manage before dropping the three shown in the
 		// table, so the "load more" results line up with the visible (teacher-scoped) list.
-		$manageable_courses = array_values(
-			array_filter(
-				$courses_query->posts,
-				static function ( $course ) {
-					return Sensei_Abilities::can_manage_grades( array( 'course' => $course->ID ) );
-				}
-			)
-		);
+		$manageable_courses = array();
+		foreach ( $courses_query->posts as $course ) {
+			if ( $course instanceof WP_Post && Sensei_Abilities::can_manage_grades( array( 'course' => $course->ID ) ) ) {
+				$manageable_courses[] = $course;
+			}
+		}
 
 		// We only want to show courses after the third one in the UI.
 		$courses = array_slice( $manageable_courses, 3 );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -794,7 +794,11 @@ class Sensei_Learner {
 			wp_send_json_error( array( 'error' => esc_html__( 'Insufficient Permissions.', 'sensei-lms' ) ) );
 		}
 
-		$user_id         = isset( $_POST['user_id'] ) ? sanitize_text_field( wp_unslash( $_POST['user_id'] ) ) : '';
+		$user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
+		if ( ! $user_id ) {
+			wp_send_json_error( array( 'error' => esc_html__( 'Invalid request.', 'sensei-lms' ) ) );
+		}
+
 		$learner_manager = self::instance();
 		$controller      = new Sensei_Learners_Admin_Bulk_Actions_Controller( new Sensei_Learner_Management( '' ), $learner_manager );
 		$base_query_args = [ 'posts_per_page' => -1 ];

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -808,7 +808,7 @@ class Sensei_Learner {
 		// table, so the "load more" results line up with the visible (teacher-scoped) list.
 		$manageable_courses = array();
 		foreach ( $courses_query->posts as $course ) {
-			if ( $course instanceof WP_Post && Sensei_Abilities::can_manage_grades( array( 'course' => $course->ID ) ) ) {
+			if ( $course instanceof WP_Post && Sensei_Course::can_current_user_edit_course( $course->ID ) ) {
 				$manageable_courses[] = $course;
 			}
 		}

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -7,16 +7,6 @@
 class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
 
-	public function setUp(): void {
-		parent::setUp();
-		add_filter( 'pre_http_request', '__return_empty_array' );
-	}
-
-	public function tearDown(): void {
-		remove_filter( 'pre_http_request', '__return_empty_array' );
-		parent::tearDown();
-	}
-
 	/**
 	 * Gets the manual enrolment manager.
 	 *

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -95,8 +95,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 
 		$response = json_decode( $this->_last_response );
 
-		$this->assertIsObject( $response );
-		$this->assertTrue( $response->success );
+		$this->assertIsObject( $response, 'The AJAX response should be a JSON object.' );
+		$this->assertTrue( $response->success, 'The request should succeed.' );
 		$this->assertEmpty( $response->data, 'Teacher A must not receive Teacher B courses.' );
 	}
 
@@ -135,13 +135,13 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 
 		$response = json_decode( $this->_last_response );
 
-		$this->assertIsObject( $response );
-		$this->assertTrue( $response->success );
+		$this->assertIsObject( $response, 'The AJAX response should be a JSON object.' );
+		$this->assertTrue( $response->success, 'The request should succeed.' );
 		// Five courses enrolled, first three are shown in the table, so two remain for the "More" call.
-		$this->assertCount( 2, $response->data );
+		$this->assertCount( 2, $response->data, 'Two courses should remain for the "More" call.' );
 
 		foreach ( $response->data as $item ) {
-			$this->assertStringContainsString( 'Teacher Own Course', $item );
+			$this->assertStringContainsString( 'Teacher Own Course', $item, 'Each returned course should belong to the teacher.' );
 		}
 	}
 
@@ -165,7 +165,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 
 		$response = json_decode( $this->_last_response );
 
-		$this->assertIsObject( $response );
+		$this->assertIsObject( $response, 'The AJAX response should be a JSON object.' );
 		$this->assertFalse( $response->success, 'A non-numeric user_id must not be queried.' );
 	}
 
@@ -217,10 +217,12 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 		}
 
 		$response = json_decode( $this->_last_response );
-		$body     = implode( "\n", $response->data );
 
-		$this->assertIsObject( $response );
-		$this->assertTrue( $response->success );
+		$this->assertIsObject( $response, 'The AJAX response should be a JSON object.' );
+		$this->assertTrue( $response->success, 'The request should succeed.' );
+
+		$body = implode( "\n", $response->data );
+
 		// Only Teacher A's two courses from the remainder; the visible three and the unmanageable remainder are excluded.
 		$this->assertCount( 2, $response->data, 'Only the manageable remaining courses should be returned.' );
 		$this->assertStringContainsString( 'Teacher A Remaining 1', $body, 'Manageable remaining course should be present.' );

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -58,4 +58,90 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 			$this->assertStringContainsString( 'Course title', $item );
 		}
 	}
+
+	/**
+	 * The get_course_list action only returns courses the current user can manage.
+	 */
+	public function testGetCourseList_ExcludesCoursesTheUserCannotManage() {
+		$this->factory = new Sensei_Factory();
+		Sensei()->teacher->create_role();
+
+		$teacher_a = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		$teacher_b = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		$student   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$provider  = $this->getManualEnrolmentProvider();
+
+		// Enroll the student in five courses owned by teacher B.
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$course_id = $this->factory->course->create(
+				array(
+					'post_author' => $teacher_b,
+					'post_title'  => 'Teacher B Hidden Course ' . $i,
+				)
+			);
+			$provider->enrol_learner( $student, $course_id );
+		}
+
+		wp_set_current_user( $teacher_a );
+
+		$_POST['nonce']   = wp_create_nonce( 'get_course_list' );
+		$_POST['user_id'] = $student;
+
+		try {
+			$this->_handleAjax( 'get_course_list' );
+		} catch ( \WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertIsObject( $response );
+		$this->assertTrue( $response->success );
+		$this->assertEmpty( $response->data, 'Teacher A must not receive Teacher B courses.' );
+	}
+
+	/**
+	 * A teacher should still receive their own enrolled courses beyond the third one.
+	 */
+	public function testGetCourseList_AsTeacherForOwnCourses_ReturnsThem() {
+		$this->factory = new Sensei_Factory();
+		Sensei()->teacher->create_role();
+
+		$teacher  = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		$student  = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$provider = $this->getManualEnrolmentProvider();
+
+		// Enroll the student in five courses owned by the teacher.
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$course_id = $this->factory->course->create(
+				array(
+					'post_author' => $teacher,
+					'post_title'  => 'Teacher Own Course ' . $i,
+				)
+			);
+			$provider->enrol_learner( $student, $course_id );
+		}
+
+		wp_set_current_user( $teacher );
+
+		$_POST['nonce']   = wp_create_nonce( 'get_course_list' );
+		$_POST['user_id'] = $student;
+
+		try {
+			$this->_handleAjax( 'get_course_list' );
+		} catch ( \WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertIsObject( $response );
+		$this->assertTrue( $response->success );
+		// Five courses enrolled, first three are shown in the table, so two remain for the "More" call.
+		$this->assertCount( 2, $response->data );
+
+		foreach ( $response->data as $item ) {
+			$this->assertStringContainsString( 'Teacher Own Course', $item );
+		}
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -170,12 +170,13 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 	}
 
 	/**
-	 * With a mixed enrolment, only the manageable courses after the first three visible ones are returned.
+	 * With a mixed enrolment, unmanageable courses are dropped before the first three are sliced off.
 	 *
-	 * The query orders by date DESC, so the three newest (unmanageable) courses occupy the visible
-	 * slots, and the "More" call must return only the current teacher's courses from the remainder.
+	 * Other teachers' courses are interleaved (including the newest), so a slice-before-filter approach
+	 * would skip the wrong courses or duplicate visible ones. The "More" call must return the current
+	 * teacher's courses that come after their own first three manageable courses.
 	 */
-	public function testGetCourseList_WithMixedEnrolment_ReturnsOnlyManageableAfterTheVisibleThree() {
+	public function testGetCourseList_WithMixedEnrolment_ReturnsManageableAfterTheirOwnFirstThree() {
 		$this->factory = new Sensei_Factory();
 		Sensei()->teacher->create_role();
 
@@ -184,15 +185,16 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 		$student   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		$provider  = $this->getManualEnrolmentProvider();
 
-		// Each row is [ author, title, date ]. Newest first by date: three Teacher B courses fill the
-		// visible three, then the remainder is a mix of Teacher A and Teacher B courses.
+		// Each row is [ author, title, date ]. Newest first by date; Teacher B courses are interleaved.
+		// After filtering to Teacher A's courses, the first three are "Visible" and the rest are "More".
 		$courses = array(
-			array( $teacher_b, 'Teacher B Visible 1', '2026-01-06 00:00:00' ),
-			array( $teacher_b, 'Teacher B Visible 2', '2026-01-05 00:00:00' ),
-			array( $teacher_b, 'Teacher B Visible 3', '2026-01-04 00:00:00' ),
-			array( $teacher_a, 'Teacher A Remaining 1', '2026-01-03 00:00:00' ),
-			array( $teacher_b, 'Teacher B Remaining', '2026-01-02 00:00:00' ),
-			array( $teacher_a, 'Teacher A Remaining 2', '2026-01-01 00:00:00' ),
+			array( $teacher_b, 'Teacher B Hidden 1', '2026-01-07 00:00:00' ),
+			array( $teacher_a, 'Teacher A Visible 1', '2026-01-06 00:00:00' ),
+			array( $teacher_a, 'Teacher A Visible 2', '2026-01-05 00:00:00' ),
+			array( $teacher_b, 'Teacher B Hidden 2', '2026-01-04 00:00:00' ),
+			array( $teacher_a, 'Teacher A Visible 3', '2026-01-03 00:00:00' ),
+			array( $teacher_a, 'Teacher A More 1', '2026-01-02 00:00:00' ),
+			array( $teacher_a, 'Teacher A More 2', '2026-01-01 00:00:00' ),
 		);
 		foreach ( $courses as $course ) {
 			$course_id = $this->factory->course->create(
@@ -223,10 +225,11 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 
 		$body = implode( "\n", $response->data );
 
-		// Only Teacher A's two courses from the remainder; the visible three and the unmanageable remainder are excluded.
-		$this->assertCount( 2, $response->data, 'Only the manageable remaining courses should be returned.' );
-		$this->assertStringContainsString( 'Teacher A Remaining 1', $body, 'Manageable remaining course should be present.' );
-		$this->assertStringContainsString( 'Teacher A Remaining 2', $body, 'Manageable remaining course should be present.' );
+		// Teacher A's two courses after their own first three; the visible three and all Teacher B courses are excluded.
+		$this->assertCount( 2, $response->data, 'Only the manageable courses after the first three should be returned.' );
+		$this->assertStringContainsString( 'Teacher A More 1', $body, 'Manageable course after the first three should be present.' );
+		$this->assertStringContainsString( 'Teacher A More 2', $body, 'Manageable course after the first three should be present.' );
+		$this->assertStringNotContainsString( 'Teacher A Visible', $body, 'The first three manageable courses are shown in the table, not the "More" call.' );
 		$this->assertStringNotContainsString( 'Teacher B', $body, 'No Teacher B course should leak.' );
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -168,4 +168,63 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 		$this->assertIsObject( $response );
 		$this->assertFalse( $response->success, 'A non-numeric user_id must not be queried.' );
 	}
+
+	/**
+	 * With a mixed enrolment, only the manageable courses after the first three visible ones are returned.
+	 *
+	 * The query orders by date DESC, so the three newest (unmanageable) courses occupy the visible
+	 * slots, and the "More" call must return only the current teacher's courses from the remainder.
+	 */
+	public function testGetCourseList_WithMixedEnrolment_ReturnsOnlyManageableAfterTheVisibleThree() {
+		$this->factory = new Sensei_Factory();
+		Sensei()->teacher->create_role();
+
+		$teacher_a = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		$teacher_b = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		$student   = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$provider  = $this->getManualEnrolmentProvider();
+
+		// Each row is [ author, title, date ]. Newest first by date: three Teacher B courses fill the
+		// visible three, then the remainder is a mix of Teacher A and Teacher B courses.
+		$courses = array(
+			array( $teacher_b, 'Teacher B Visible 1', '2026-01-06 00:00:00' ),
+			array( $teacher_b, 'Teacher B Visible 2', '2026-01-05 00:00:00' ),
+			array( $teacher_b, 'Teacher B Visible 3', '2026-01-04 00:00:00' ),
+			array( $teacher_a, 'Teacher A Remaining 1', '2026-01-03 00:00:00' ),
+			array( $teacher_b, 'Teacher B Remaining', '2026-01-02 00:00:00' ),
+			array( $teacher_a, 'Teacher A Remaining 2', '2026-01-01 00:00:00' ),
+		);
+		foreach ( $courses as $course ) {
+			$course_id = $this->factory->course->create(
+				array(
+					'post_author' => $course[0],
+					'post_title'  => $course[1],
+					'post_date'   => $course[2],
+				)
+			);
+			$provider->enrol_learner( $student, $course_id );
+		}
+
+		wp_set_current_user( $teacher_a );
+
+		$_POST['nonce']   = wp_create_nonce( 'get_course_list' );
+		$_POST['user_id'] = $student;
+
+		try {
+			$this->_handleAjax( 'get_course_list' );
+		} catch ( \WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response );
+		$body     = implode( "\n", $response->data );
+
+		$this->assertIsObject( $response );
+		$this->assertTrue( $response->success );
+		// Only Teacher A's two courses from the remainder; the visible three and the unmanageable remainder are excluded.
+		$this->assertCount( 2, $response->data, 'Only the manageable remaining courses should be returned.' );
+		$this->assertStringContainsString( 'Teacher A Remaining 1', $body, 'Manageable remaining course should be present.' );
+		$this->assertStringContainsString( 'Teacher A Remaining 2', $body, 'Manageable remaining course should be present.' );
+		$this->assertStringNotContainsString( 'Teacher B', $body, 'No Teacher B course should leak.' );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -7,6 +7,16 @@
 class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
 
+	public function setUp(): void {
+		parent::setUp();
+		add_filter( 'pre_http_request', '__return_empty_array' );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', '__return_empty_array' );
+		parent::tearDown();
+	}
+
 	/**
 	 * Gets the manual enrolment manager.
 	 *

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -8,6 +8,21 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 	use Sensei_Course_Enrolment_Test_Helpers;
 
 	/**
+	 * _handleAjax() fires admin_init, which runs WordPress's core/plugin/theme update
+	 * checks (requests to api.wordpress.org). Block them so the bootstrap's
+	 * prevent_requests guard doesn't fail these tests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		add_filter( 'pre_http_request', '__return_empty_array' );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', '__return_empty_array' );
+		parent::tearDown();
+	}
+
+	/**
 	 * Gets the manual enrolment manager.
 	 *
 	 * @return false|Sensei_Course_Manual_Enrolment_Provider

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -144,4 +144,28 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 			$this->assertStringContainsString( 'Teacher Own Course', $item );
 		}
 	}
+
+	/**
+	 * A non-numeric user_id is rejected before any learner query runs.
+	 */
+	public function testGetCourseList_WhenUserIdNotNumeric_ReturnsError() {
+		$this->factory = new Sensei_Factory();
+
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$_POST['nonce']   = wp_create_nonce( 'get_course_list' );
+		$_POST['user_id'] = 'foo';
+
+		try {
+			$this->_handleAjax( 'get_course_list' );
+		} catch ( \WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertIsObject( $response );
+		$this->assertFalse( $response->success, 'A non-numeric user_id must not be queried.' );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learners-admin-bulk-actions-ajax.php
@@ -156,16 +156,17 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 	}
 
 	/**
-	 * A non-numeric user_id is rejected before any learner query runs.
+	 * A user without the manage_sensei_grades capability is denied.
 	 */
-	public function testGetCourseList_WhenUserIdNotNumeric_ReturnsError() {
+	public function testGetCourseList_WhenUserLacksManageGradesCap_ReturnsError() {
 		$this->factory = new Sensei_Factory();
 
-		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $admin );
+		$subscriber = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$student    = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
 
 		$_POST['nonce']   = wp_create_nonce( 'get_course_list' );
-		$_POST['user_id'] = 'foo';
+		$_POST['user_id'] = $student;
 
 		try {
 			$this->_handleAjax( 'get_course_list' );
@@ -176,7 +177,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test extends WP_Ajax_UnitTest
 		$response = json_decode( $this->_last_response );
 
 		$this->assertIsObject( $response, 'The AJAX response should be a JSON object.' );
-		$this->assertFalse( $response->success, 'A non-numeric user_id must not be queried.' );
+		$this->assertFalse( $response->success, 'A user without manage_sensei_grades must be denied.' );
 	}
 
 	/**


### PR DESCRIPTION

## Proposed Changes

Makes the Students page "load more courses" AJAX action (`get_course_list()`) consistent with the rest of the learner-management surface: it now applies the same grading capability used elsewhere on the page before returning results, and filters the returned list to the courses the current user is allowed to manage.

* Apply the page's existing grading capability check to the action.
* Limit the results to courses the current user can manage, in line with the rest of the learner-management UI.
* Add test coverage for the action under `tests/unit-tests/admin/`.

## Testing

```bash
make test-php-filter FILTER="Sensei_Learners_Admin_Bulk_Actions_View_AJAX_Test"
```
