### PR TITLE
Fix export content search to match titles only, ranked by relevance

### DIFF
--- a/assets/data-port/export/post-token-field.js
+++ b/assets/data-port/export/post-token-field.js
@@ -82,6 +82,9 @@ export const PostTokenField = ( {
 		} );
 		if ( debouncedInput ) {
 			params.set( 'search', debouncedInput );
+			params.append( 'search_columns[]', 'post_title' );
+			// WP core rejects `orderby=relevance` without a `search`.
+			params.set( 'orderby', 'relevance' );
 		}
 
 		apiFetch( {

--- a/assets/data-port/export/post-token-field.js
+++ b/assets/data-port/export/post-token-field.js
@@ -13,7 +13,7 @@ const REST_BASE_BY_TYPE = {
 	question: 'questions',
 };
 
-const SUGGESTION_LIMIT = 20;
+const SUGGESTION_LIMIT = 100;
 
 // `title.rendered` in `view` context, `title.raw` in `edit` — accept either.
 const titleOf = ( item ) =>

--- a/assets/data-port/export/post-token-field.test.js
+++ b/assets/data-port/export/post-token-field.test.js
@@ -76,6 +76,18 @@ describe( '<PostTokenField />', () => {
 		);
 	} );
 
+	it( 'does not request relevance ordering when there is no search term', async () => {
+		renderField( { type: 'lesson' } );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalled() );
+
+		// WP core rejects `orderby=relevance` without a `search` param, so the
+		// initial (empty-search) fetch must fall back to the default ordering.
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).not.toContain(
+			'orderby=relevance'
+		);
+	} );
+
 	it( 'renders pre-selected ids as their titles once the fetch resolves', async () => {
 		apiFetch.mockResolvedValueOnce( [ itemFor( 42, 'Course A' ) ] );
 

--- a/changelog/fix-export-search-relevance
+++ b/changelog/fix-export-search-relevance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix export content search missing matching lessons/courses/questions by searching titles only and ordering suggestions by relevance.

--- a/changelog/fix-export-search-relevance
+++ b/changelog/fix-export-search-relevance
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix export content search missing matching lessons/courses/questions by searching titles only and ordering suggestions by relevance.
+Fix export content search missing matching lessons/courses/questions.


### PR DESCRIPTION
## Problem

The Export Content tool's search field (Sensei LMS → Tools → Export Content) failed to find matching lessons/courses/questions. Fixes #8047.

Reported in #8047: searching for a lesson by title returned nothing even though it exists and is published.

`PostTokenField` fetched `/wp/v2/{type}?search=…&per_page=20` with WordPress core's **default date ordering** and searched **title + content + excerpt**. So:

- Results were the newest 20 matches, not the best 20.
- Posts matching only in their **body text** consumed slots.
- A matching post older than 20 such posts fell outside the window and was unselectable.

Confirmed against learn.wordpress.org data: a search returned 20 lessons, none matching in their title, all newer than the intended target — which was a title match but never appeared.

## Fix

When a search term is present, the suggestion fetch now:

- Adds `search_columns[]=post_title` — match titles only (this is a "pick a post by name" field; body matches shouldn't crowd it out).
- Adds `orderby=relevance` — rank by match quality instead of date, so a title match isn't pushed past the `per_page` cap.
- Raises the suggestion limit from 20 to 100 — relevance ordering alone still left broad matches unreachable (see below).

The first two are `@wordpress/api-fetch` query params — no server changes. `search_columns` is a WP core REST param since 6.5; Sensei requires 6.8, so it's always available. `orderby=relevance` is set only when searching, because WP core rejects it without a `search` param and the field fetches with no search term on mount.

Relevance ordering alone still wasn't enough. A broad term like "open so" matches 32 lessons; the intended title match ("What Is Open Source?") ranks ~27th, because titles that *lead* with the search terms score higher and equal scores fall back to date. With `per_page=20` the match stayed outside the window, so the limit is raised to 100 to keep lower-ranked title matches reachable.

## Testing

1. On a site with 20+ lessons, create a lesson whose **title** matches a term (e.g. "Open source basics") with an older publish date than 20+ other lessons that mention that term only in their **body**.
2. Sensei LMS → Tools → Export Content → select Lessons.
3. Search for the title term.
4. The lesson appears in the suggestions and is selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
