### PR TITLE
Scope modules course search to the current user's courses

### DIFF
--- a/changelog/fix-modules-course-search-authorization
+++ b/changelog/fix-modules-course-search-authorization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Limit the modules course search to courses the current user is allowed to edit.

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -705,7 +705,7 @@ class Sensei_Core_Modules {
 
 		// Return nothing if term is empty
 		if ( empty( $term ) ) {
-			die();
+			wp_die();
 		}
 
 		// Set a default if none is given
@@ -715,13 +715,19 @@ class Sensei_Core_Modules {
 		$found_courses = array( '' => $default );
 
 		// Fetch results
-		$args    = array(
+		$args = array(
 			'post_type'      => 'course',
 			'post_status'    => array( 'publish', 'draft', 'future', 'private' ),
 			'posts_per_page' => -1,
 			'orderby'        => 'title',
 			's'              => $term,
 		);
+
+		// Ensure that the user either has permission to edit other's courses or is the author of the course.
+		if ( ! current_user_can( 'edit_others_courses' ) ) {
+			$args['author'] = get_current_user_id();
+		}
+
 		$courses = get_posts( $args );
 
 		// Add results to array
@@ -733,7 +739,7 @@ class Sensei_Core_Modules {
 
 		// Encode and return results for processing & selection.
 		echo wp_json_encode( $found_courses );
-		die();
+		wp_die();
 	}
 
 	public function sensei_course_preview_titles( $title, $lesson_id ) {

--- a/tests/unit-tests/test-class-modules-search-courses-ajax.php
+++ b/tests/unit-tests/test-class-modules-search-courses-ajax.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * AJAX tests for the modules course search endpoint (`sensei_json_search_courses`).
+ *
+ * @group ajax-calls
+ */
+class Sensei_Modules_Search_Courses_AJAX_Test extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Factory for creating test data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+		add_filter( 'pre_http_request', '__return_empty_array' );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	public function testSearchCoursesJson_WhenUserCannotEditOthersCourses_ExcludesOtherAuthorsCourses() {
+		/* Arrange. */
+		$teacher_a = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		$this->factory->course->create(
+			array(
+				'post_title'  => 'Secret Course Alpha',
+				'post_status' => 'private',
+				'post_author' => $teacher_a,
+			)
+		);
+
+		// Search as a different teacher, who lacks the edit_others_courses capability.
+		$teacher_b = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		wp_set_current_user( $teacher_b );
+
+		/* Act. */
+		$results = $this->search_for_courses( 'Secret' );
+
+		/* Assert. */
+		$this->assertNotContains( 'Secret Course Alpha', $results, "A teacher should not see another author's private course." );
+	}
+
+	public function testSearchCoursesJson_WhenUserCannotEditOthersCourses_IncludesOwnCourses() {
+		/* Arrange. */
+		// Search as the teacher who authored the course.
+		$teacher = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		wp_set_current_user( $teacher );
+		$this->factory->course->create(
+			array(
+				'post_title'  => 'Secret Course Beta',
+				'post_status' => 'private',
+				'post_author' => $teacher,
+			)
+		);
+
+		/* Act. */
+		$results = $this->search_for_courses( 'Secret' );
+
+		/* Assert. */
+		$this->assertContains( 'Secret Course Beta', $results, 'A teacher should still see their own course.' );
+	}
+
+	public function testSearchCoursesJson_WhenUserCanEditOthersCourses_IncludesAllAuthorsCourses() {
+		/* Arrange. */
+		$teacher_a = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		$this->factory->course->create(
+			array(
+				'post_title'  => 'Secret Course Gamma',
+				'post_status' => 'private',
+				'post_author' => $teacher_a,
+			)
+		);
+
+		// Search as a different user: an admin, who has the edit_others_courses capability.
+		$admin = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		/* Act. */
+		$results = $this->search_for_courses( 'Secret' );
+
+		/* Assert. */
+		$this->assertContains( 'Secret Course Gamma', $results, "An admin should see other authors' courses." );
+	}
+
+	/**
+	 * Dispatch the `sensei_json_search_courses` AJAX action and return the decoded results.
+	 *
+	 * @param string $term Search term.
+	 * @return array Map of course ID => title.
+	 */
+	private function search_for_courses( string $term ): array {
+		$nonce                = wp_create_nonce( 'search-courses' );
+		$_GET['security']     = $nonce;
+		$_REQUEST['security'] = $nonce;
+		$_GET['term']         = $term;
+
+		try {
+			$this->_handleAjax( 'sensei_json_search_courses' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		return (array) json_decode( $this->_last_response, true );
+	}
+}


### PR DESCRIPTION
## Proposed Changes

The `sensei_json_search_courses` AJAX handler, used by the course selector on the Modules admin screens, returns courses from every author regardless of who is searching. This scopes it by author when the current user lacks the `edit_others_courses` capability, matching the other course pickers (`Sensei_Admin::lesson_order_screen()` and the courses-list ability), so teachers see their own courses while admins/editors continue to see all.

Adds `Sensei_Modules_Search_Courses_AJAX_Test` for the change:

```
make test-php-filter FILTER="Sensei_Modules_Search_Courses_AJAX_Test"
```

Closes [SEN-72](https://linear.app/a8c/issue/SEN-72/)