### PR TITLE
Require enrolment to mark a course as complete

### DIFF
--- a/changelog/fix-complete-course-enrollment-authorization
+++ b/changelog/fix-complete-course-enrollment-authorization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only allow enrolled students to mark a course as complete.

--- a/changelog/fix-complete-course-enrollment-authorization
+++ b/changelog/fix-complete-course-enrollment-authorization
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: security
 
 Only allow enrolled students to mark a course as complete.

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -817,6 +817,11 @@ class Sensei_Frontend {
 			// Handle submit data.
 			switch ( $sanitized_submit ) {
 				case __( 'Mark as Complete', 'sensei-lms' ):
+					// Only students enrolled in the course may mark it as complete.
+					if ( ! Sensei_Course::is_user_enrolled( $sanitized_course_id, $current_user->ID ) ) {
+						break;
+					}
+
 					$course_progress = Sensei()->course_progress_repository->get( $sanitized_course_id, $current_user->ID );
 					if ( null === $course_progress ) {
 						$course_progress = Sensei()->course_progress_repository->create( $sanitized_course_id, $current_user->ID );

--- a/tests/unit-tests/test-class-frontend.php
+++ b/tests/unit-tests/test-class-frontend.php
@@ -44,7 +44,7 @@ class Sensei_Frontend_Test extends WP_UnitTestCase {
 	/**
 	 * An enrolled student can mark the course as complete.
 	 */
-	public function testEnrolledStudentCompletesCourse() {
+	public function testSenseiCompleteCourse_StudentEnrolled_CompletesCourse() {
 		$student_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		$course_id  = $this->factory->get_course_with_lessons(
 			array(
@@ -68,7 +68,7 @@ class Sensei_Frontend_Test extends WP_UnitTestCase {
 	/**
 	 * A student who is not enrolled cannot mark the course as complete.
 	 */
-	public function testNonEnrolledStudentCannotCompleteCourse() {
+	public function testSenseiCompleteCourse_StudentNotEnrolled_DoesNotCompleteCourse() {
 		$student_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		$course_id  = $this->factory->get_course_with_lessons(
 			array(

--- a/tests/unit-tests/test-class-frontend.php
+++ b/tests/unit-tests/test-class-frontend.php
@@ -1,0 +1,103 @@
+<?php
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
+
+/**
+ * Tests for Sensei_Frontend.
+ *
+ * @group frontend
+ */
+class Sensei_Frontend_Test extends WP_UnitTestCase {
+
+	use Sensei_Course_Enrolment_Test_Helpers;
+	use Sensei_Course_Enrolment_Manual_Test_Helpers;
+
+	/**
+	 * Test factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+		self::resetEnrolmentProviders();
+		$this->prepareEnrolmentManager();
+	}
+
+	public function tearDown(): void {
+		unset(
+			$_POST['course_complete'],
+			$_POST['course_complete_id'],
+			$_POST['woothemes_sensei_complete_course_noonce']
+		);
+
+		parent::tearDown();
+	}
+
+	public static function tearDownAfterClass(): void {
+		parent::tearDownAfterClass();
+		self::resetEnrolmentProviders();
+	}
+
+	/**
+	 * An enrolled student can mark the course as complete.
+	 */
+	public function testEnrolledStudentCompletesCourse() {
+		$student_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$course_id  = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 2,
+				'question_count' => 0,
+			)
+		)['course_id'];
+
+		wp_set_current_user( $student_id );
+		$this->manuallyEnrolStudentInCourse( $student_id, $course_id );
+		$this->submitCompletion( $course_id );
+
+		Sensei()->frontend->sensei_complete_course();
+
+		self::assertTrue(
+			Sensei_Utils::user_completed_course( $course_id, $student_id ),
+			'An enrolled student should be able to complete the course.'
+		);
+	}
+
+	/**
+	 * A student who is not enrolled cannot mark the course as complete.
+	 */
+	public function testNonEnrolledStudentCannotCompleteCourse() {
+		$student_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$course_id  = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 2,
+				'question_count' => 0,
+			)
+		)['course_id'];
+
+		wp_set_current_user( $student_id );
+		$this->submitCompletion( $course_id );
+
+		Sensei()->frontend->sensei_complete_course();
+
+		self::assertFalse(
+			Sensei_Utils::user_completed_course( $course_id, $student_id ),
+			'A student who is not enrolled should not be able to complete the course.'
+		);
+	}
+
+	/**
+	 * Populate the request as the "Mark as Complete" form submission does.
+	 *
+	 * The nonce is bound to the already-set current user.
+	 *
+	 * @param int $course_id Course being completed.
+	 */
+	private function submitCompletion( $course_id ) {
+		$_POST['course_complete']                         = 'Mark as Complete';
+		$_POST['course_complete_id']                      = $course_id;
+		$_POST['woothemes_sensei_complete_course_noonce'] = wp_create_nonce( 'woothemes_sensei_complete_course_noonce' );
+	}
+}


### PR DESCRIPTION
## Summary

The `Mark as Complete` handler (`Sensei_Frontend::sensei_complete_course()`) completes the target course for the current user and marks all of its lessons complete, but does not verify that the user is enrolled — even though the button that triggers it is only rendered for enrolled learners. This aligns the handler with that rendering condition by requiring enrolment before completing the course.

## Changes

- Gate `sensei_complete_course()` on `Sensei_Course::is_user_enrolled()` before creating progress and completing lessons.
- Add `Sensei_Frontend_Test` covering the enrolled (completes) and non-enrolled (no-op) cases.

## Testing

```
make test-php-filter FILTER="Sensei_Frontend_Test"
```

Closes [SEN-73](https://linear.app/a8c/issue/SEN-73)