### PR TITLE
Prevent keyed frontend notices from printing more than once

### DIFF
--- a/changelog/fix-duplicate-notices-after-early-print
+++ b/changelog/fix-duplicate-notices-after-early-print
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix duplicate frontend notices when the same keyed notice is added multiple times on classic themes.

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -40,6 +40,13 @@ class Sensei_Notices {
 	protected $has_printed;
 
 	/**
+	 * Keys of notices that have already been printed during this request.
+	 *
+	 * @var array $printed_keys
+	 */
+	protected $printed_keys;
+
+	/**
 	 * The HTML allowed for message boxes.
 	 *
 	 * @var array The HTML allowed for message boxes.
@@ -53,6 +60,7 @@ class Sensei_Notices {
 		// initialize the notices variable.
 		$this->notices      = array();
 		$this->has_printed  = false;
+		$this->printed_keys = array();
 		$this->allowed_html = array_merge(
 			wp_kses_allowed_html( 'post' ),
 			array(
@@ -73,6 +81,8 @@ class Sensei_Notices {
 
 	/**
 	 *  Add a notice to the array of notices for display at a later stage.
+	 *
+	 * @since $$next-version$$ Keyed notices that have already been printed are not added again.
 	 *
 	 * @param string $content Content.
 	 * @param string $type    Defaults to alert options( alert, tick , download , info   ).
@@ -103,6 +113,11 @@ class Sensei_Notices {
 			return;
 		}
 
+		// Do not re-add a keyed notice that has already been printed during this request.
+		if ( ! empty( $notice['key'] ) && isset( $this->printed_keys[ $notice['key'] ] ) ) {
+			return;
+		}
+
 		// append the new notice.
 		if ( empty( $notice['key'] ) ) {
 			$this->notices[] = $notice;
@@ -125,6 +140,10 @@ class Sensei_Notices {
 		$this->maybe_load_notices();
 		if ( ! empty( $this->notices ) ) {
 			foreach ( $this->notices  as  $notice ) {
+				if ( ! empty( $notice['key'] ) ) {
+					$this->printed_keys[ $notice['key'] ] = true;
+				}
+
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in generate_notice
 				echo $this->generate_notice( $notice['type'], $notice['content'] );
 			}

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -82,8 +82,6 @@ class Sensei_Notices {
 	/**
 	 *  Add a notice to the array of notices for display at a later stage.
 	 *
-	 * @since $$next-version$$ Keyed notices that have already been printed are not added again.
-	 *
 	 * @param string $content Content.
 	 * @param string $type    Defaults to alert options( alert, tick , download , info   ).
 	 * @param string $key     Notices with the same key will be overwritten.

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -362,6 +362,10 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		$property = new ReflectionProperty( 'Sensei_Notices', 'has_printed' );
 		$property->setAccessible( true );
 		$property->setValue( Sensei()->notices, false );
+
+		$property = new ReflectionProperty( 'Sensei_Notices', 'printed_keys' );
+		$property->setAccessible( true );
+		$property->setValue( Sensei()->notices, array() );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-notices.php
+++ b/tests/unit-tests/test-class-sensei-notices.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Tests for Sensei_Notices class.
  *

--- a/tests/unit-tests/test-class-sensei-notices.php
+++ b/tests/unit-tests/test-class-sensei-notices.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for Sensei_Notices class.
+ *
+ * @group notices
+ */
+class Sensei_Notices_Test extends WP_UnitTestCase {
+
+	/**
+	 * Notices instance under test.
+	 *
+	 * @var Sensei_Notices
+	 */
+	private $notices;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->notices = new Sensei_Notices();
+	}
+
+	public function testMaybePrintNotices_KeyedNoticeAddedTwiceBeforePrinting_PrintsNoticeOnce() {
+		$this->notices->add_notice( 'Log in please.', 'info', 'login-notice' );
+		$this->notices->add_notice( 'Log in please.', 'info', 'login-notice' );
+
+		$output = $this->print_notices();
+
+		$this->assertSame( 1, substr_count( $output, 'Log in please.' ) );
+	}
+
+	public function testAddNotice_KeyedNoticeAddedTwiceAfterPrintingStarted_PrintsNoticeOnce() {
+		// Start printing with an empty queue, as happens on `wp_body_open` in classic themes.
+		$this->print_notices();
+
+		ob_start();
+		$this->notices->add_notice( 'Log in please.', 'info', 'login-notice' );
+		$this->notices->add_notice( 'Log in please.', 'info', 'login-notice' );
+		$output = ob_get_clean();
+
+		$this->assertSame( 1, substr_count( $output, 'Log in please.' ) );
+	}
+
+	public function testAddNotice_KeyedNoticeReAddedAfterItWasPrinted_DoesNotPrintAgain() {
+		$this->notices->add_notice( 'Log in please.', 'info', 'login-notice' );
+		$this->print_notices();
+
+		ob_start();
+		$this->notices->add_notice( 'Log in please.', 'info', 'login-notice' );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'Log in please.', $output );
+	}
+
+	public function testAddNotice_UnkeyedNoticesAddedAfterPrintingStarted_StillPrint() {
+		$this->print_notices();
+
+		ob_start();
+		$this->notices->add_notice( 'First message.' );
+		$this->notices->add_notice( 'Second message.' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'First message.', $output, 'First unkeyed notice should print immediately once printing has started.' );
+		$this->assertStringContainsString( 'Second message.', $output, 'Second unkeyed notice should print immediately once printing has started.' );
+	}
+
+	/**
+	 * Print the queued notices and return the output.
+	 *
+	 * @return string
+	 */
+	private function print_notices(): string {
+		ob_start();
+		$this->notices->maybe_print_notices();
+
+		return ob_get_clean();
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei-pro/issues/2650

## Proposed Changes

* Track the keys of notices that `Sensei_Notices` has already printed during the request, and skip re-adding a keyed notice once it has been printed.

On classic themes, `maybe_print_notices()` runs on `wp_body_open` before the content renders. Even with an empty queue it sets `has_printed`, so every later `add_notice()` prints immediately, bypassing the key-based dedupe that normally happens in the queue. A course with multiple purchase buttons (Sensei Pro) then prints one "Please log in to access your purchased courses." notice per button, since each block re-adds the same `sensei-take-course-login` key. Block themes are unaffected because they render content before `wp_body_open`.

Unkeyed notices are untouched: they still print immediately once printing has started (legacy course notices rely on this).

## Testing Instructions

Requires Sensei Pro (WooCommerce Paid Courses) and WooCommerce for the reported scenario.

1. Activate a classic theme, e.g. `wp theme install generatepress --activate`.
2. Create a simple WooCommerce product, then create a course and attach the product in the course settings.
3. Edit the course and add a second `Take Course` button (e.g. duplicate the `Course Actions` block, or add another button block at the bottom of the content).
4. In a logged-out window, view the course page.
   * Before: one "Please log in to access your purchased courses." notice per button.
   * After: a single notice.
5. Regression checks:
   * Switch to a block theme (e.g. Twenty Twenty-Five) and confirm the page still shows a single notice.
   * On the classic theme, add the course to the cart (click a purchase button) and reload logged out: the "Course added to cart…" notice shows once and still appears.

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] All strings are translatable (without concatenation, handles plurals)
- [x] Follows our naming conventions (P6rkRX-4oA-p2)
- [x] Hooks (p6rkRX-1uS-p2) and functions are documented
- [ ] New UIs are responsive and use a [mobile-first approach](https://zellwk.com/blog/how-to-write-mobile-first-css/)
- [ ] Code is tested on the minimum supported PHP and WordPress versions
