### PR TITLE
Only reset quiz progress when retakes are enabled

### DIFF
--- a/changelog/fix-quiz-reset-retake-enforcement
+++ b/changelog/fix-quiz-reset-retake-enforcement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure quiz resets are only allowed when retakes are enabled for the quiz.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2506,7 +2506,7 @@ class Sensei_Quiz {
 			return $block->render_contact_teacher_block( [], $button );
 		}
 
-		$prev_next_urls  = sensei_get_prev_next_lessons( $lesson_id );
+		$prev_next_urls  = sensei_get_prev_next_lessons( (int) $lesson_id );
 		$next_lesson_url = $prev_next_urls['next']['url'] ?? null;
 
 		if ( $next_lesson_url ) {

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -515,6 +515,11 @@ class Sensei_Quiz {
 		$current_quiz_id = $post->ID;
 		$lesson_id       = $this->get_lesson_id( $current_quiz_id );
 
+		// Bail if quiz resets are disabled for this quiz.
+		if ( ! self::is_reset_allowed( $lesson_id ) ) {
+			return;
+		}
+
 		// reset all user data
 		$this->reset_user_lesson_data( $lesson_id, get_current_user_id() );
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -515,8 +515,8 @@ class Sensei_Quiz {
 		$current_quiz_id = $post->ID;
 		$lesson_id       = $this->get_lesson_id( $current_quiz_id );
 
-		// Bail if quiz resets are disabled for this quiz.
-		if ( ! self::is_reset_allowed( $lesson_id ) ) {
+		// Bail if the quiz has no lesson, or resets are disabled for this quiz.
+		if ( ! $lesson_id || ! self::is_reset_allowed( $lesson_id ) ) {
 			return;
 		}
 

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -698,6 +698,91 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set up a user with a graded quiz attempt for reset listener tests.
+	 *
+	 * @param bool $reset_enabled Whether quiz resets are enabled for the quiz.
+	 *
+	 * @return array {
+	 *     @type int $user_id
+	 *     @type int $lesson_id
+	 *     @type int $quiz_id
+	 * }
+	 */
+	private function setup_graded_quiz_attempt( $reset_enabled ) {
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		update_post_meta( $quiz_id, '_enable_quiz_reset', $reset_enabled ? 'on' : '' );
+
+		$user_id = $this->factory->user->create();
+
+		$user_quiz_answers = $this->factory->generate_user_quiz_answers( $quiz_id );
+		$user_quiz_grades  = $this->factory->generate_user_quiz_grades( $user_quiz_answers );
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+		Sensei()->quiz->save_user_answers( $user_quiz_answers, array(), $lesson_id, $user_id );
+		Sensei()->quiz->set_user_grades( $user_quiz_grades, $lesson_id, $user_id );
+
+		return array(
+			'user_id'   => $user_id,
+			'lesson_id' => $lesson_id,
+			'quiz_id'   => $quiz_id,
+		);
+	}
+
+	public function testResetButtonClickListener_WhenResetDisabled_DoesNotResetLessonData() {
+		/* Arrange. */
+		$ids = $this->setup_graded_quiz_attempt( false );
+		wp_set_current_user( $ids['user_id'] );
+
+		global $post;
+		$post = get_post( $ids['quiz_id'] );
+
+		$_POST['quiz_reset']                        = '';
+		$_POST['woothemes_sensei_reset_quiz_nonce'] = wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' );
+
+		/* Act. */
+		Sensei()->quiz->reset_button_click_listener();
+
+		/* Assert. */
+		$this->assertNotEmpty(
+			Sensei()->quiz->get_user_answers( $ids['lesson_id'], $ids['user_id'] ),
+			'Quiz answers should be preserved when resets are disabled for the quiz.'
+		);
+
+		unset( $_POST['quiz_reset'], $_POST['woothemes_sensei_reset_quiz_nonce'] );
+	}
+
+	public function testResetButtonClickListener_WhenResetEnabled_ResetsLessonData() {
+		/* Arrange. */
+		$ids = $this->setup_graded_quiz_attempt( true );
+		wp_set_current_user( $ids['user_id'] );
+
+		global $post;
+		$post = get_post( $ids['quiz_id'] );
+
+		$_POST['quiz_reset']                        = '';
+		$_POST['woothemes_sensei_reset_quiz_nonce'] = wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' );
+
+		$this->prevent_wp_redirect();
+
+		/* Act. */
+		try {
+			Sensei()->quiz->reset_button_click_listener();
+		} catch ( \Sensei_WP_Redirect_Exception $e ) {
+			// The listener redirects and exits after a successful reset.
+			$redirected = true;
+		}
+
+		/* Assert. */
+		$this->assertTrue( $redirected ?? false, 'The listener should redirect after a successful reset.' );
+		$this->assertEmpty(
+			Sensei()->quiz->get_user_answers( $ids['lesson_id'], $ids['user_id'] ),
+			'Quiz answers should be cleared when resets are enabled for the quiz.'
+		);
+
+		unset( $_POST['quiz_reset'], $_POST['woothemes_sensei_reset_quiz_nonce'] );
+	}
+
+	/**
 	 * This tests Woothemes_Sensei()->quiz->prepare_form_submitted_answers.
 	 */
 	public function testPrepareFormSubmittedAnswers() {

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -732,9 +732,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$ids = $this->setup_graded_quiz_attempt( false );
 		wp_set_current_user( $ids['user_id'] );
-
-		global $post;
-		$post = get_post( $ids['quiz_id'] );
+		$this->go_to( get_permalink( $ids['quiz_id'] ) );
 
 		$_POST['quiz_reset']                        = '';
 		$_POST['woothemes_sensei_reset_quiz_nonce'] = wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' );
@@ -747,17 +745,13 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			Sensei()->quiz->get_user_answers( $ids['lesson_id'], $ids['user_id'] ),
 			'Quiz answers should be preserved when resets are disabled for the quiz.'
 		);
-
-		unset( $_POST['quiz_reset'], $_POST['woothemes_sensei_reset_quiz_nonce'] );
 	}
 
 	public function testResetButtonClickListener_WhenResetEnabled_ResetsLessonData() {
 		/* Arrange. */
 		$ids = $this->setup_graded_quiz_attempt( true );
 		wp_set_current_user( $ids['user_id'] );
-
-		global $post;
-		$post = get_post( $ids['quiz_id'] );
+		$this->go_to( get_permalink( $ids['quiz_id'] ) );
 
 		$_POST['quiz_reset']                        = '';
 		$_POST['woothemes_sensei_reset_quiz_nonce'] = wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' );
@@ -778,8 +772,6 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			Sensei()->quiz->get_user_answers( $ids['lesson_id'], $ids['user_id'] ),
 			'Quiz answers should be cleared when resets are enabled for the quiz.'
 		);
-
-		unset( $_POST['quiz_reset'], $_POST['woothemes_sensei_reset_quiz_nonce'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The frontend quiz reset handler resets a learner's lesson and quiz progress after verifying the reset nonce, but did not check the quiz's own retake setting. This aligns the handler with the rest of the UI, which only offers the reset action when retakes are enabled for the quiz.

## Changes

- Gate `Sensei_Quiz::reset_button_click_listener()` on `Sensei_Quiz::is_reset_allowed()` before resetting, reusing the same predicate the templates use to render the reset button.
- Add unit coverage for the handler with retakes disabled and enabled.

## Testing

- `make test-php-filter FILTER="Sensei_Class_Quiz_Test::testResetButtonClickListener"`

Closes https://linear.app/a8c/issue/SEN-78