### PR TITLE
fix(command-palette): surface Course, Lesson, Question in Command Palette

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	root: true,
 	extends: [ 'plugin:@wordpress/eslint-plugin/recommended', 'prettier' ],
 	env: {
 		'jest/globals': true,

--- a/assets/admin/command-palette/command-palette.js
+++ b/assets/admin/command-palette/command-palette.js
@@ -1,0 +1,151 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useCommand, useCommandLoader } from '@wordpress/commands';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+import { plus, page } from '@wordpress/icons';
+
+const COURSE = { slug: 'course', label: __( 'Course', 'sensei-lms' ) };
+const LESSON = { slug: 'lesson', label: __( 'Lesson', 'sensei-lms' ) };
+const QUESTION = { slug: 'question', label: __( 'Question', 'sensei-lms' ) };
+
+/**
+ * Registers an "Add new <post type>" command. `useCommand` has no built-in
+ * visibility check, so this is only rendered by `PostTypeCommands` for users
+ * who can create that post type.
+ *
+ * @param {Object} postType       Post type descriptor.
+ * @param {string} postType.slug  Registered post type slug.
+ * @param {string} postType.label Post type label used in the command label.
+ */
+function AddNewCommand( { slug, label } ) {
+	useCommand( {
+		name: `sensei-lms/add-new-${ slug }`,
+		label: sprintf(
+			/* translators: %s: Post type label, e.g. "Course". */
+			__( 'Add new %s', 'sensei-lms' ),
+			label
+		),
+		icon: plus,
+		callback: ( { close } ) => {
+			close();
+			document.location.href = `post-new.php?post_type=${ slug }`;
+		},
+	} );
+
+	return null;
+}
+
+/**
+ * Registers a command loader that searches existing posts of the given type
+ * and navigates to their edit screen.
+ *
+ * @param {Object} postType       Post type descriptor.
+ * @param {string} postType.slug  Registered post type slug.
+ * @param {string} postType.label Post type label used in the command label.
+ */
+function SearchCommand( { slug, label } ) {
+	/**
+	 * Searches posts of `slug` matching the palette's current search term.
+	 *
+	 * @param {Object} args        Loader args from the command palette.
+	 * @param {string} args.search Current search term.
+	 */
+	function useSenseiSearchLoader( { search } ) {
+		const { records, isLoading } = useSelect(
+			( select ) => {
+				const { getEntityRecords, hasFinishedResolution } =
+					select( coreStore );
+				const query = { search: search || undefined, per_page: 10 };
+
+				return {
+					records: getEntityRecords( 'postType', slug, query ),
+					isLoading: ! hasFinishedResolution( 'getEntityRecords', [
+						'postType',
+						slug,
+						query,
+					] ),
+				};
+			},
+			[ search ]
+		);
+
+		return useMemo(
+			() => ( {
+				isLoading,
+				commands: ( records ?? [] ).map( ( record ) => ( {
+					name: `sensei-lms/${ slug }-${ record.id }`,
+					label: sprintf(
+						/* translators: 1: Post type label, 2: Post title. */
+						__( '%1$s: %2$s', 'sensei-lms' ),
+						label,
+						record.title?.rendered ||
+							__( '(no title)', 'sensei-lms' )
+					),
+					icon: page,
+					callback: ( { close } ) => {
+						close();
+						document.location.href = addQueryArgs( 'post.php', {
+							post: record.id,
+							action: 'edit',
+						} );
+					},
+				} ) ),
+			} ),
+			[ records, isLoading ]
+		);
+	}
+
+	useCommandLoader( {
+		name: `sensei-lms/search-${ slug }`,
+		hook: useSenseiSearchLoader,
+	} );
+
+	return null;
+}
+
+/**
+ * Registers both commands for a Sensei post type. The "Add new" command is
+ * only rendered for users who can create that post type — `AddNewCommand`
+ * is conditionally mounted rather than conditionally calling `useCommand`,
+ * since hooks can't be called conditionally.
+ *
+ * @param {Object} postType       Post type descriptor.
+ * @param {string} postType.slug  Registered post type slug.
+ * @param {string} postType.label Post type label used in the command label.
+ */
+function PostTypeCommands( postType ) {
+	const canCreate = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: postType.slug,
+			} ),
+		[ postType.slug ]
+	);
+
+	return (
+		<>
+			{ canCreate && <AddNewCommand { ...postType } /> }
+			<SearchCommand { ...postType } />
+		</>
+	);
+}
+
+/**
+ * Registers Course, Lesson and Question commands with the block editor
+ * Command Palette (Cmd/Ctrl+K).
+ */
+export default function CommandPalette() {
+	return (
+		<>
+			<PostTypeCommands { ...COURSE } />
+			<PostTypeCommands { ...LESSON } />
+			<PostTypeCommands { ...QUESTION } />
+		</>
+	);
+}

--- a/assets/admin/command-palette/command-palette.test.js
+++ b/assets/admin/command-palette/command-palette.test.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { render, renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useCommand, useCommandLoader } from '@wordpress/commands';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import CommandPalette from './command-palette';
+
+jest.mock( '@wordpress/commands' );
+jest.mock( '@wordpress/data' );
+
+describe( '<CommandPalette />', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useSelect.mockImplementation( ( selector ) =>
+			selector( () => ( {
+				canUser: () => true,
+				getEntityRecords: () => [],
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+	} );
+
+	it( 'registers an "Add new" command for Course, Lesson and Question', () => {
+		render( <CommandPalette /> );
+
+		const names = useCommand.mock.calls.map( ( [ args ] ) => args.name );
+
+		expect( names ).toEqual( [
+			'sensei-lms/add-new-course',
+			'sensei-lms/add-new-lesson',
+			'sensei-lms/add-new-question',
+		] );
+		expect( useCommand.mock.calls[ 0 ][ 0 ].label ).toBe(
+			'Add new Course'
+		);
+	} );
+
+	it( 'does not register an "Add new" command for a post type the user cannot create', () => {
+		useSelect.mockImplementation( ( selector ) =>
+			selector( () => ( {
+				canUser: ( action, { name } ) =>
+					! ( action === 'create' && name === 'course' ),
+				getEntityRecords: () => [],
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+
+		render( <CommandPalette /> );
+
+		const names = useCommand.mock.calls.map( ( [ args ] ) => args.name );
+
+		expect( names ).toEqual( [
+			'sensei-lms/add-new-lesson',
+			'sensei-lms/add-new-question',
+		] );
+	} );
+
+	it( 'registers a search command loader for Course, Lesson and Question', () => {
+		render( <CommandPalette /> );
+
+		const names = useCommandLoader.mock.calls.map(
+			( [ args ] ) => args.name
+		);
+
+		expect( names ).toEqual( [
+			'sensei-lms/search-course',
+			'sensei-lms/search-lesson',
+			'sensei-lms/search-question',
+		] );
+	} );
+
+	it( 'maps found posts to labeled, navigable commands', () => {
+		render( <CommandPalette /> );
+
+		const courseLoader = useCommandLoader.mock.calls.find(
+			( [ args ] ) => args.name === 'sensei-lms/search-course'
+		)[ 0 ].hook;
+
+		useSelect.mockImplementation( ( selector ) =>
+			selector( () => ( {
+				getEntityRecords: () => [
+					{ id: 12, title: { rendered: 'Intro to Testing' } },
+				],
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+
+		const { result } = renderHook( () =>
+			courseLoader( { search: 'testing' } )
+		);
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.commands ).toHaveLength( 1 );
+		expect( result.current.commands[ 0 ] ).toMatchObject( {
+			name: 'sensei-lms/course-12',
+			label: 'Course: Intro to Testing',
+		} );
+	} );
+} );

--- a/assets/admin/command-palette/index.js
+++ b/assets/admin/command-palette/index.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import CommandPalette from './command-palette';
+
+// Mounted directly (rather than via `registerPlugin`) so the commands
+// register regardless of the current screen. `registerPlugin` only renders
+// through a `<PluginArea>`, which the block editor provides but plain
+// wp-admin screens don't, so commands would never register outside the
+// editor. Wrapped in `domReady()` because this script is enqueued with
+// `in_footer` — matches the `assets/home/index.js` pattern — and the guard
+// keeps it correct even if the enqueue call ever drops the footer flag.
+domReady( () => {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	createRoot( container ).render( <CommandPalette /> );
+} );

--- a/changelog/fix-7748-command-palette
+++ b/changelog/fix-7748-command-palette
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Course, Lesson and Question to the block editor Command Palette (Cmd/Ctrl+K).

--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -35,6 +35,12 @@
       <code>DAY_IN_SECONDS</code>
     </UndefinedConstant>
   </file>
+  <file src="includes/admin/class-sensei-command-palette.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>! self::$instance</code>
+      <code>self::$instance</code>
+    </DocblockTypeContradiction>
+  </file>
   <file src="includes/admin/class-sensei-course-pre-publish-panel.php">
     <DocblockTypeContradiction occurrences="2">
       <code>! self::$instance</code>

--- a/includes/admin/class-sensei-command-palette.php
+++ b/includes/admin/class-sensei-command-palette.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * File containing the class Sensei_Command_Palette.
+ *
+ * @package sensei-lms
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class that registers Sensei post types with the block editor Command Palette.
+ *
+ * @since $$next-version$$
+ */
+class Sensei_Command_Palette {
+	/**
+	 * Instance of class.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Sensei_Command_Palette constructor. Prevents other instances from being created outside of `self::instance()`.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Fetches an instance of the class.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Initializes the class.
+	 */
+	public function init() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Enqueue command palette assets. Not scoped to a specific screen or post type
+	 * since the command palette is available everywhere in wp-admin.
+	 *
+	 * Loaded in the footer (`in_footer = true`) so the script executes after the
+	 * DOM is ready — matches the convention in `class-sensei-home.php`.
+	 */
+	public function enqueue_assets() {
+		Sensei()->assets->enqueue( 'sensei-command-palette', 'admin/command-palette/index.js', array(), true );
+	}
+}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -721,6 +721,9 @@ class Sensei_Main {
 
 		Sensei_Course_Pre_Publish_Panel::instance()->init();
 
+		// Command Palette.
+		Sensei_Command_Palette::instance()->init();
+
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
 			// Load Admin Class.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@wordpress/base-styles": "wp-6.7",
         "@wordpress/block-editor": "wp-6.7",
         "@wordpress/blocks": "wp-6.7",
+        "@wordpress/commands": "wp-6.7",
         "@wordpress/components": "wp-6.7",
         "@wordpress/compose": "wp-6.7",
         "@wordpress/core-data": "wp-6.7",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@wordpress/base-styles": "wp-6.7",
     "@wordpress/block-editor": "wp-6.7",
     "@wordpress/blocks": "wp-6.7",
+    "@wordpress/commands": "wp-6.7",
     "@wordpress/components": "wp-6.7",
     "@wordpress/compose": "wp-6.7",
     "@wordpress/core-data": "wp-6.7",

--- a/tests/unit-tests/admin/test-class-sensei-command-palette.php
+++ b/tests/unit-tests/admin/test-class-sensei-command-palette.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file contains the Sensei_Command_Palette_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Command_Palette class.
+ */
+class Sensei_Command_Palette_Test extends WP_UnitTestCase {
+	/**
+	 * The command palette script is enqueued on the block editor.
+	 *
+	 * @covers Sensei_Command_Palette::enqueue_assets
+	 */
+	public function testEnqueueAssets_BlockEditorHookFired_EnqueuesScript() {
+		Sensei_Command_Palette::instance()->init();
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		self::assertTrue( wp_script_is( 'sensei-command-palette' ) );
+	}
+
+	/**
+	 * The command palette script is enqueued on other wp-admin screens too,
+	 * since the palette isn't scoped to a single post type or screen.
+	 *
+	 * @covers Sensei_Command_Palette::enqueue_assets
+	 */
+	public function testEnqueueAssets_AdminEnqueueScriptsHookFired_EnqueuesScript() {
+		set_current_screen( 'dashboard' );
+
+		Sensei_Command_Palette::instance()->init();
+
+		do_action( 'admin_enqueue_scripts' );
+
+		self::assertTrue( wp_script_is( 'sensei-command-palette' ) );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,6 +91,7 @@ const files = [
 	'blocks/email-editor.js',
 	'css/email-notifications/email-editor-style.scss',
 	'css/email-notifications/email-style.scss',
+	'admin/command-palette/index.js',
 	'admin/course-pre-publish-panel/index.js',
 	'admin/editor-wizard/index.js',
 	'admin/editor-wizard/style.scss',


### PR DESCRIPTION
Registers Course, Lesson, and Question with the WP 6.3+ Command Palette (Cmd/Ctrl+K) via `@wordpress/commands`. Adds "Add new" commands (gated by capability) and per-item search/navigation commands for existing posts.

Fixes #7748

## Changes

**`includes/admin/class-sensei-command-palette.php`** (new) — Singleton enqueuing the JS on `enqueue_block_editor_assets` and `admin_enqueue_scripts`, so commands register on every admin screen.

**`assets/admin/command-palette/command-palette.js`** (new) — For each of `course` / `lesson` / `question`:
- `useCommand` for a static "Add new <type>" command, only rendered when `canUser('create', postType)` is true.
- `useCommandLoader` for a dynamic search loader over `getEntityRecords`, mapping records to navigation commands.

**`assets/admin/command-palette/index.js`** (new) — Entry point. Mounts `<CommandPalette />` via `createRoot()` wrapped in `domReady()`, matching the `assets/home/index.js` pattern.

**`webpack.config.js`, `package.json`, `includes/class-sensei.php`** — Wire up the new entry and singleton. Added `@wordpress/commands` (wp-6.7) dep.

**`changelog/fix-7748-command-palette`** — Changelog entry.

## Testing

**Test 1: "Add new" commands**
1. Log in as Administrator, open any wp-admin screen.
2. Press Cmd/Ctrl+K, type "Add new".
3. Result: "Add new Course", "Add new Lesson", "Add new Question" appear. Click one — opens the new-post editor for that type.

**Test 2: Search existing posts**
1. Create a Course titled "Intro to Testing".
2. Open palette, type "testing".
3. Result: Course shows as "Course: Intro to Testing", clicking navigates to its edit screen.

**Test 3: Capability gating**
1. Log in as a Subscriber.
2. Open palette.
3. Result: "Add new" commands hidden. Existing visible posts still searchable.

**Automated:** PHP and JS unit tests included (PHPUnit + Jest).

## Screenshots
<img width="1920" height="1050" alt="SCR-20260706-dnmr" src="https://github.com/user-attachments/assets/7fab39bf-8460-4a67-8b66-471023bf42eb" />

https://github.com/user-attachments/assets/e5bf45d5-9c68-4ed3-9f87-f51707ba053f

