### PR TITLE
fix(lesson): duplicate quiz questions when duplicating lesson

### DIFF
--- a/changelog/fix-duplicate-lesson-quiz-questions
+++ b/changelog/fix-duplicate-lesson-quiz-questions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Duplicate quiz question posts when duplicating a lesson, so the original and duplicate have fully independent quizzes.

--- a/includes/admin/content-duplicators/class-lesson-quiz-duplicator.php
+++ b/includes/admin/content-duplicators/class-lesson-quiz-duplicator.php
@@ -66,16 +66,97 @@ class Lesson_Quiz_Duplicator {
 			)
 		);
 
+		$old_to_new_question_map = array();
+
 		foreach ( $old_quiz_questions as $question ) {
 
-			// Copy the question order over to the new quiz.
-			$old_question_order = get_post_meta( $question->ID, '_quiz_question_order' . $old_quiz_id, true );
-			$new_question_order = str_ireplace( (string) $old_quiz_id, (string) $new_quiz->ID, $old_question_order );
-			add_post_meta( $question->ID, '_quiz_question_order' . $new_quiz->ID, $new_question_order );
+			// Duplicate the question post so edits don't affect the original.
+			$new_question = $this->post_duplicator->duplicate( $question, '' );
 
-			// Add question to quiz.
-			add_post_meta( $question->ID, '_quiz_id', $new_quiz->ID, false );
+			if ( $new_question ) {
+				$old_to_new_question_map[ $question->ID ] = $new_question->ID;
 
+				// Set the quiz association on the new question.
+				add_post_meta( $new_question->ID, '_quiz_id', $new_quiz->ID, true );
+
+				// Copy the question order for the new quiz.
+				$old_question_order = get_post_meta( $question->ID, '_quiz_question_order' . $old_quiz_id, true );
+				$new_question_order = str_ireplace( (string) $old_quiz_id, (string) $new_quiz->ID, $old_question_order );
+				add_post_meta( $new_question->ID, '_quiz_question_order' . $new_quiz->ID, $new_question_order );
+			}
+		}
+
+		// Update the question order meta on the new quiz to reference new question IDs.
+		$old_question_order = get_post_meta( $old_quiz_id, '_question_order', true );
+		if ( is_array( $old_question_order ) ) {
+			$new_question_order = array();
+			foreach ( $old_question_order as $old_q_id ) {
+				$old_q_id = (int) $old_q_id;
+				if ( isset( $old_to_new_question_map[ $old_q_id ] ) ) {
+					$new_question_order[] = (string) $old_to_new_question_map[ $old_q_id ];
+				}
+			}
+			update_post_meta( $new_quiz->ID, '_question_order', $new_question_order );
+		}
+
+		// Update the duplicated lesson's post_content to reference the new quiz ID
+		// in the quiz block, and new question IDs in question blocks.
+		$this->update_lesson_content_with_new_ids( $new_lesson_id, $old_quiz_id, $new_quiz->ID, $old_to_new_question_map );
+	}
+
+	/**
+	 * Replace old quiz/question IDs in the lesson's post_content block markup.
+	 *
+	 * @param int   $lesson_id              The duplicated lesson ID.
+	 * @param int   $old_quiz_id            The original quiz ID.
+	 * @param int   $new_quiz_id            The new quiz ID.
+	 * @param array $old_to_new_question_map Map of old question ID => new question ID.
+	 */
+	private function update_lesson_content_with_new_ids( int $lesson_id, int $old_quiz_id, int $new_quiz_id, array $old_to_new_question_map ): void {
+		$lesson = get_post( $lesson_id );
+		if ( ! $lesson || empty( $lesson->post_content ) ) {
+			return;
+		}
+
+		$content = $lesson->post_content;
+
+		// Replace the quiz block id attribute.
+		$content = preg_replace_callback(
+			'/<!-- wp:sensei-lms\/quiz\s+(\{[^}]*\})\s+-->/',
+			function ( $matches ) use ( $old_quiz_id, $new_quiz_id ) {
+				$attrs = json_decode( $matches[1], true );
+				if ( isset( $attrs['id'] ) && (int) $attrs['id'] === (int) $old_quiz_id ) {
+					$attrs['id'] = $new_quiz_id;
+					return '<!-- wp:sensei-lms/quiz ' . wp_json_encode( $attrs ) . ' -->';
+				}
+				return $matches[0];
+			},
+			$content
+		);
+
+		// Replace question block id attributes.
+		foreach ( $old_to_new_question_map as $old_id => $new_id ) {
+			$content = preg_replace_callback(
+				'/<!-- wp:sensei-lms\/quiz-question\s+(\{[^}]*\})\s+-->/',
+				function ( $matches ) use ( $old_id, $new_id ) {
+					$attrs = json_decode( $matches[1], true );
+					if ( isset( $attrs['id'] ) && (int) $attrs['id'] === (int) $old_id ) {
+						$attrs['id'] = $new_id;
+						return '<!-- wp:sensei-lms/quiz-question ' . wp_json_encode( $attrs ) . ' -->';
+					}
+					return $matches[0];
+				},
+				$content
+			);
+		}
+
+		if ( $content !== $lesson->post_content ) {
+			wp_update_post(
+				array(
+					'ID'           => $lesson_id,
+					'post_content' => $content,
+				)
+			);
 		}
 	}
 }

--- a/includes/admin/content-duplicators/class-lesson-quiz-duplicator.php
+++ b/includes/admin/content-duplicators/class-lesson-quiz-duplicator.php
@@ -125,9 +125,13 @@ class Lesson_Quiz_Duplicator {
 			'/<!-- wp:sensei-lms\/quiz\s+(\{[^}]*\})\s+-->/',
 			function ( $matches ) use ( $old_quiz_id, $new_quiz_id ) {
 				$attrs = json_decode( $matches[1], true );
-				if ( isset( $attrs['id'] ) && (int) $attrs['id'] === (int) $old_quiz_id ) {
+				if ( isset( $attrs['id'] ) && (int) $attrs['id'] === $old_quiz_id ) {
 					$attrs['id'] = $new_quiz_id;
-					return '<!-- wp:sensei-lms/quiz ' . wp_json_encode( $attrs ) . ' -->';
+					$json        = wp_json_encode( $attrs );
+					if ( false === $json ) {
+						return $matches[0];
+					}
+					return '<!-- wp:sensei-lms/quiz ' . $json . ' -->';
 				}
 				return $matches[0];
 			},
@@ -142,7 +146,11 @@ class Lesson_Quiz_Duplicator {
 					$attrs = json_decode( $matches[1], true );
 					if ( isset( $attrs['id'] ) && (int) $attrs['id'] === (int) $old_id ) {
 						$attrs['id'] = $new_id;
-						return '<!-- wp:sensei-lms/quiz-question ' . wp_json_encode( $attrs ) . ' -->';
+						$json        = wp_json_encode( $attrs );
+						if ( false === $json ) {
+							return $matches[0];
+						}
+						return '<!-- wp:sensei-lms/quiz-question ' . $json . ' -->';
 					}
 					return $matches[0];
 				},

--- a/tests/unit-tests/admin/content-duplicators/test-class-lesson-quiz-duplicator.php
+++ b/tests/unit-tests/admin/content-duplicators/test-class-lesson-quiz-duplicator.php
@@ -42,4 +42,123 @@ class Lesson_Quiz_Duplicator_Test extends \WP_UnitTestCase {
 		$new_quiz_id = Sensei()->lesson->lesson_quizzes( $new_lesson_id );
 		$this->assertNotNull( $new_quiz_id );
 	}
+
+	public function testDuplicate_LessonWithQuizQuestions_CreatesSeparateQuestionPosts(): void {
+		/* Arrange */
+		$old_lesson_id = $this->factory->get_lesson_with_quiz_and_questions();
+		$old_quiz_id   = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+		$old_questions = Sensei()->quiz->get_questions( $old_quiz_id );
+
+		$new_lesson_id = $this->factory->lesson->create();
+
+		$duplicator = new Lesson_Quiz_Duplicator();
+
+		/* Act */
+		$duplicator->duplicate( $old_lesson_id, $new_lesson_id );
+
+		/* Assert */
+		$new_quiz_id   = Sensei()->lesson->lesson_quizzes( $new_lesson_id );
+		$new_questions = Sensei()->quiz->get_questions( $new_quiz_id );
+
+		$this->assertCount( count( $old_questions ), $new_questions, 'New quiz should have the same number of questions.' );
+
+		// Verify question IDs are different (not shared).
+		$old_question_ids = wp_list_pluck( $old_questions, 'ID' );
+		$new_question_ids = wp_list_pluck( $new_questions, 'ID' );
+
+		$this->assertEmpty(
+			array_intersect( $old_question_ids, $new_question_ids ),
+			'Duplicated quiz should have its own question posts, not shared with the original.'
+		);
+	}
+
+	public function testDuplicate_QuestionsEditedInDuplicate_DoNotAffectOriginal(): void {
+		/* Arrange */
+		$old_lesson_id = $this->factory->get_lesson_with_quiz_and_questions();
+		$old_quiz_id   = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+		$old_questions = Sensei()->quiz->get_questions( $old_quiz_id );
+		$first_question = reset( $old_questions );
+		$original_title = $first_question->post_title;
+
+		$new_lesson_id = $this->factory->lesson->create();
+
+		$duplicator = new Lesson_Quiz_Duplicator();
+		$duplicator->duplicate( $old_lesson_id, $new_lesson_id );
+
+		/* Act — modify a question in the new quiz. */
+		$new_quiz_id   = Sensei()->lesson->lesson_quizzes( $new_lesson_id );
+		$new_questions = Sensei()->quiz->get_questions( $new_quiz_id );
+		$new_question  = reset( $new_questions );
+
+		wp_update_post(
+			array(
+				'ID'         => $new_question->ID,
+				'post_title' => 'Modified Question Title',
+			)
+		);
+
+		/* Assert — original question is unchanged. */
+		$original_question = get_post( $first_question->ID );
+		$this->assertSame( $original_title, $original_question->post_title, 'Original question should not be affected by edits to the duplicate.' );
+	}
+
+	public function testDuplicate_QuestionMetaCopiedToNewQuestions(): void {
+		/* Arrange */
+		$old_lesson_id = $this->factory->get_lesson_with_quiz_and_questions();
+		$old_quiz_id   = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+		$old_questions = Sensei()->quiz->get_questions( $old_quiz_id );
+		$first_question = reset( $old_questions );
+		$original_grade = get_post_meta( $first_question->ID, '_question_grade', true );
+
+		$new_lesson_id = $this->factory->lesson->create();
+
+		$duplicator = new Lesson_Quiz_Duplicator();
+
+		/* Act */
+		$duplicator->duplicate( $old_lesson_id, $new_lesson_id );
+
+		/* Assert */
+		$new_quiz_id   = Sensei()->lesson->lesson_quizzes( $new_lesson_id );
+		$new_questions = Sensei()->quiz->get_questions( $new_quiz_id );
+		$new_question  = reset( $new_questions );
+		$new_grade     = get_post_meta( $new_question->ID, '_question_grade', true );
+
+		$this->assertSame( $original_grade, $new_grade, 'Question grade meta should be copied to the new question.' );
+	}
+
+	public function testDuplicate_QuizBlockInPostContent_ReferencesNewQuizId(): void {
+		/* Arrange */
+		$old_lesson_id = $this->factory->get_lesson_with_quiz_and_questions();
+		$old_quiz_id   = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+
+		// Add quiz block with old quiz ID to lesson content.
+		wp_update_post(
+			array(
+				'ID'           => $old_lesson_id,
+				'post_content' => '<!-- wp:sensei-lms/quiz {"id":' . $old_quiz_id . '} -->
+<!-- /wp:sensei-lms/quiz -->',
+			)
+		);
+
+		$new_lesson_id = $this->factory->lesson->create(
+			array(
+				'post_content' => '<!-- wp:sensei-lms/quiz {"id":' . $old_quiz_id . '} -->
+<!-- /wp:sensei-lms/quiz -->',
+			)
+		);
+
+		$duplicator = new Lesson_Quiz_Duplicator();
+
+		/* Act */
+		$duplicator->duplicate( $old_lesson_id, $new_lesson_id );
+
+		/* Assert */
+		$new_quiz_id      = Sensei()->lesson->lesson_quizzes( $new_lesson_id );
+		$new_lesson       = get_post( $new_lesson_id );
+		$has_old_quiz_id  = strpos( $new_lesson->post_content, '"id":' . $old_quiz_id ) !== false;
+		$has_new_quiz_id  = strpos( $new_lesson->post_content, '"id":' . $new_quiz_id ) !== false;
+
+		$this->assertFalse( $has_old_quiz_id, 'Duplicated lesson content should not reference the old quiz ID.' );
+		$this->assertTrue( $has_new_quiz_id, 'Duplicated lesson content should reference the new quiz ID.' );
+	}
 }

--- a/tests/unit-tests/admin/content-duplicators/test-class-lesson-quiz-duplicator.php
+++ b/tests/unit-tests/admin/content-duplicators/test-class-lesson-quiz-duplicator.php
@@ -74,9 +74,9 @@ class Lesson_Quiz_Duplicator_Test extends \WP_UnitTestCase {
 
 	public function testDuplicate_QuestionsEditedInDuplicate_DoNotAffectOriginal(): void {
 		/* Arrange */
-		$old_lesson_id = $this->factory->get_lesson_with_quiz_and_questions();
-		$old_quiz_id   = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
-		$old_questions = Sensei()->quiz->get_questions( $old_quiz_id );
+		$old_lesson_id  = $this->factory->get_lesson_with_quiz_and_questions();
+		$old_quiz_id    = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+		$old_questions  = Sensei()->quiz->get_questions( $old_quiz_id );
 		$first_question = reset( $old_questions );
 		$original_title = $first_question->post_title;
 
@@ -104,9 +104,9 @@ class Lesson_Quiz_Duplicator_Test extends \WP_UnitTestCase {
 
 	public function testDuplicate_QuestionMetaCopiedToNewQuestions(): void {
 		/* Arrange */
-		$old_lesson_id = $this->factory->get_lesson_with_quiz_and_questions();
-		$old_quiz_id   = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
-		$old_questions = Sensei()->quiz->get_questions( $old_quiz_id );
+		$old_lesson_id  = $this->factory->get_lesson_with_quiz_and_questions();
+		$old_quiz_id    = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+		$old_questions  = Sensei()->quiz->get_questions( $old_quiz_id );
 		$first_question = reset( $old_questions );
 		$original_grade = get_post_meta( $first_question->ID, '_question_grade', true );
 
@@ -153,10 +153,10 @@ class Lesson_Quiz_Duplicator_Test extends \WP_UnitTestCase {
 		$duplicator->duplicate( $old_lesson_id, $new_lesson_id );
 
 		/* Assert */
-		$new_quiz_id      = Sensei()->lesson->lesson_quizzes( $new_lesson_id );
-		$new_lesson       = get_post( $new_lesson_id );
-		$has_old_quiz_id  = strpos( $new_lesson->post_content, '"id":' . $old_quiz_id ) !== false;
-		$has_new_quiz_id  = strpos( $new_lesson->post_content, '"id":' . $new_quiz_id ) !== false;
+		$new_quiz_id     = Sensei()->lesson->lesson_quizzes( $new_lesson_id );
+		$new_lesson      = get_post( $new_lesson_id );
+		$has_old_quiz_id = strpos( $new_lesson->post_content, '"id":' . $old_quiz_id ) !== false;
+		$has_new_quiz_id = strpos( $new_lesson->post_content, '"id":' . $new_quiz_id ) !== false;
 
 		$this->assertFalse( $has_old_quiz_id, 'Duplicated lesson content should not reference the old quiz ID.' );
 		$this->assertTrue( $has_new_quiz_id, 'Duplicated lesson content should reference the new quiz ID.' );


### PR DESCRIPTION
Resolves #7890

## Proposed Changes

When a lesson with a quiz is duplicated, the duplicated lesson's quiz block still references the original quiz ID, and question posts are shared between the original and duplicate. Editing questions in the duplicate (adding, removing, or modifying) affects the original lesson's quiz as well.

This fix duplicates each question post during lesson duplication so that the two lessons have fully independent quizzes. It also updates the quiz block `id` attribute in the duplicated lesson's `post_content` to reference the new quiz ID.

### Changes in `Lesson_Quiz_Duplicator` (`includes/admin/content-duplicators/class-lesson-quiz-duplicator.php`)

- Each question post is now duplicated via `Post_Duplicator` instead of sharing via non-unique `_quiz_id` meta.
- A `_question_order` meta remapping ensures the new quiz references the correct new question IDs.
- A `post_content` cleanup pass replaces stale quiz/question block `id` attributes in the duplicated lesson content.

## Testing Instructions

1. Create a lesson with a quiz containing 2+ questions, save/publish.
2. Duplicate the lesson.
3. Open the duplicate, remove all questions and add a new one.
4. Save the duplicate.
5. Open the original lesson's quiz.
6. Verify: Original quiz is unchanged, still has its original questions.
7. Edit a question title in the duplicate's quiz, save, then check the original lesson.
8. Verify: Original question title is unchanged.

## Pre-Merge Checklist

- [x] PR title and description contain sufficient detail and accurately describe the changes
- [x] Adheres to coding standards ([PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/))
- [x] Hooks and functions are documented
- [x] Code is tested on the minimum supported PHP and WordPress versions

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch - Backwards-compatible bug fixes

#### Type

- [x] Fixed - Fixes a bug

#### Message

Duplicate quiz question posts when duplicating a lesson, so the original and duplicate have fully independent quizzes.

</details>