### PR TITLE
fix(blocks): update all blocks to Block API version 3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	root: true,
 	extends: [ 'plugin:@wordpress/eslint-plugin/recommended', 'prettier' ],
 	env: {
 		'jest/globals': true,

--- a/assets/blocks/button/button-edit.js
+++ b/assets/blocks/button/button-edit.js
@@ -27,7 +27,12 @@ const ButtonEdit = ( props ) => {
 	const buttonProps = getButtonProps( { ...props, colors } );
 
 	return (
-		<div { ...getButtonWrapperProps( props ) }>
+		<div
+			{ ...getButtonWrapperProps( {
+				...props,
+				blockName: props.name,
+			} ) }
+		>
 			{ isReadonly ? (
 				<div { ...buttonProps }>{ props.text }</div>
 			) : (

--- a/assets/blocks/button/button-props.js
+++ b/assets/blocks/button/button-props.js
@@ -4,6 +4,11 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { getBlockDefaultClassName } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { getColorAndStyleProps } from './color-props';
@@ -56,15 +61,26 @@ export function getButtonProps( props ) {
 /**
  * Class and style attributes for the wrapper element.
  *
+ * Block API version 2+ no longer auto-injects the block's default
+ * `wp-block-{name}` classname into `edit`/`save` props (that was a legacy
+ * apiVersion <= 1 behavior); it must be added explicitly here via
+ * `blockName`, see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-api-versions/README.md.
+ *
  * @param {Object} props                  Block properties.
- * @param {string} props.className        Block classname.
+ * @param {string} props.className        Block classname (e.g. `is-style-*`).
  * @param {Object} props.attributes       Block attributes.
  * @param {string} props.attributes.align Alignment attribute.
+ * @param {string} props.blockName        Registered block name.
  * @return {{className}} Output HTML attributes.
  */
-export function getButtonWrapperProps( { className, attributes: { align } } ) {
+export function getButtonWrapperProps( {
+	className,
+	attributes: { align },
+	blockName,
+} ) {
 	return {
 		className: classnames(
+			blockName && getBlockDefaultClassName( blockName ),
 			className,
 			'wp-block-sensei-button',
 			'wp-block-button',

--- a/assets/blocks/button/button-save.js
+++ b/assets/blocks/button/button-save.js
@@ -37,7 +37,13 @@ const ButtonSave = ( { attributes, className, tagName, blockName } ) => {
 	}
 
 	const content = (
-		<div { ...getButtonWrapperProps( { className, attributes } ) }>
+		<div
+			{ ...getButtonWrapperProps( {
+				className,
+				attributes,
+				blockName,
+			} ) }
+		>
 			<RichText.Content
 				{ ...getButtonProps( { attributes } ) }
 				tagName={ buttonTagName }

--- a/assets/blocks/conditional-content-block/block.json
+++ b/assets/blocks/conditional-content-block/block.json
@@ -16,12 +16,16 @@
   ],
   "supports": {
     "html": false,
-    "align": [ "wide", "full" ]
+    "align": [
+      "wide",
+      "full"
+    ]
   },
   "attributes": {
     "condition": {
       "type": "string",
       "default": "enrolled"
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/conditional-content-block/conditional-content-edit.js
+++ b/assets/blocks/conditional-content-block/conditional-content-edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -24,15 +24,19 @@ export const ConditionLabels = {
 };
 
 const ConditionalContentEdit = ( {
-	className,
 	hasInnerBlocks,
 	clientId,
 	attributes: { condition },
 	setAttributes,
 } ) => {
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block and no longer
+	// auto-merges `className`/`attributes.className` into `props.className`.
+	const blockProps = useBlockProps();
+
 	return (
 		<>
-			<div className={ className }>
+			<div { ...blockProps }>
 				<InnerBlocks
 					renderAppender={
 						! hasInnerBlocks && InnerBlocks.ButtonBlockAppender

--- a/assets/blocks/conditional-content-block/conditional-content-save.js
+++ b/assets/blocks/conditional-content-block/conditional-content-save.js
@@ -1,19 +1,21 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const ConditionalContentSave = ( { className } ) => (
-	<div className={ classnames( 'wp-block-group', className ) }>
-		<div className="wp-block-group__inner-container">
-			<InnerBlocks.Content />
+// Block API version 3 no longer auto-merges the default block classname
+// and `attributes.className` into the saved markup; `useBlockProps.save()`
+// is required to restore it.
+const ConditionalContentSave = () => {
+	const blockProps = useBlockProps.save( { className: 'wp-block-group' } );
+
+	return (
+		<div { ...blockProps }>
+			<div className="wp-block-group__inner-container">
+				<InnerBlocks.Content />
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 export default ConditionalContentSave;

--- a/assets/blocks/course-actions-block/course-actions/block.json
+++ b/assets/blocks/course-actions-block/course-actions/block.json
@@ -1,19 +1,22 @@
 {
-	"name": "sensei-lms/course-actions",
-	"title": "Course Actions",
-	"description": "Enable a student to perform specific actions for a course.",
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"keywords": [
-		"course",
-		"actions",
-		"buttons",
-		"start course",
-		"continue",
-		"visit results"
-	],
-	"supports": {
-		"html": false
-	},
-	"usesContext": [ "postType" ]
+  "name": "sensei-lms/course-actions",
+  "title": "Course Actions",
+  "description": "Enable a student to perform specific actions for a course.",
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "keywords": [
+    "course",
+    "actions",
+    "buttons",
+    "start course",
+    "continue",
+    "visit results"
+  ],
+  "supports": {
+    "html": false
+  },
+  "usesContext": [
+    "postType"
+  ],
+  "apiVersion": 3
 }

--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -1,49 +1,53 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
-	"name": "sensei-lms/course-categories",
-	"title": "Course Categories",
-	"description": "Show the course categories",
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"keywords": [
-		"course",
-		"lessons",
-		"categories"
-	],
-	"attributes": {
-		"previewCategories": {
-		    "type": "array"
-		},
-		"textAlign": {
-			"type": "string"
-		},
-        "options": {
-            "type": "object"
-        }
-	},
-	"usesContext": [ "postId", "postType", "queryId" ],
-	"supports": {
-		"html": false,
-		"spacing": {
-			"margin": true,
-			"padding": true,
-			"blockGap": true
-		},
-		"align": false,
-		"alignWide": false,
-		"className": true,
-		"typography": {
-			"lineHeight": true,
-			"fontSize": true,
-			"__experimentalFontFamily": true,
-			"__experimentalFontStyle": true,
-			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
-			"__experimentalTextTransform": true,
-			"__experimentalDefaultControls": {
-				"fontSize": true
-			}
-		}
-	}
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "sensei-lms/course-categories",
+  "title": "Course Categories",
+  "description": "Show the course categories",
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "keywords": [
+    "course",
+    "lessons",
+    "categories"
+  ],
+  "attributes": {
+    "previewCategories": {
+      "type": "array"
+    },
+    "textAlign": {
+      "type": "string"
+    },
+    "options": {
+      "type": "object"
+    }
+  },
+  "usesContext": [
+    "postId",
+    "postType",
+    "queryId"
+  ],
+  "supports": {
+    "html": false,
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true
+    },
+    "align": false,
+    "alignWide": false,
+    "className": true,
+    "typography": {
+      "lineHeight": true,
+      "fontSize": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontStyle": true,
+      "__experimentalFontWeight": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalTextTransform": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
+    }
+  }
 }

--- a/assets/blocks/course-list-filter-block/block.json
+++ b/assets/blocks/course-list-filter-block/block.json
@@ -1,39 +1,49 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
-	"name": "sensei-lms/course-list-filter",
-	"title": "Course List Filter",
-	"description": "Filter courses in Course List block",
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"keywords": [
-		"course",
-		"categories",
-		"lessons",
-		"featured",
-		"filter"
-	],
-	"attributes": {
-		"align": {
-			"type": "string",
-			"default": "left"
-		},
-		"types": {
-			"type": "array",
-			"default": [ "categories", "featured", "student_course" ]
-		},
-        "defaultOptions": {
-            "type": "object",
-            "default": {
-                "categories": -1,
-                "featured": "all",
-                "student_course": "all"
-            }
-        }
-	},
-	"usesContext": [ "queryId", "query" ],
-	"supports": {
-		"align": [ "left", "right" ],
-		"html": false
-	}
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "sensei-lms/course-list-filter",
+  "title": "Course List Filter",
+  "description": "Filter courses in Course List block",
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "keywords": [
+    "course",
+    "categories",
+    "lessons",
+    "featured",
+    "filter"
+  ],
+  "attributes": {
+    "align": {
+      "type": "string",
+      "default": "left"
+    },
+    "types": {
+      "type": "array",
+      "default": [
+        "categories",
+        "featured",
+        "student_course"
+      ]
+    },
+    "defaultOptions": {
+      "type": "object",
+      "default": {
+        "categories": -1,
+        "featured": "all",
+        "student_course": "all"
+      }
+    }
+  },
+  "usesContext": [
+    "queryId",
+    "query"
+  ],
+  "supports": {
+    "align": [
+      "left",
+      "right"
+    ],
+    "html": false
+  }
 }

--- a/assets/blocks/course-outline/lesson-block/block.json
+++ b/assets/blocks/course-outline/lesson-block/block.json
@@ -54,5 +54,6 @@
   "supports": {
     "html": false,
     "customClassName": true
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/course-outline/lesson-block/lesson-edit.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { useBlockProps } from '@wordpress/block-editor';
 import { Icon, check, chevronRight } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -62,7 +63,11 @@ export const LessonEdit = ( props ) => {
 		postStatus = __( 'Draft', 'sensei-lms' );
 	}
 
-	const wrapperStyles = {
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block (e.g. the
+	// `aria-label="Block: Lesson"` wrapper attribute), and no longer
+	// auto-merges `className`/`attributes.className` into `props.className`.
+	const blockProps = useBlockProps( {
 		className: classnames(
 			className,
 			backgroundColor?.class,
@@ -76,7 +81,7 @@ export const LessonEdit = ( props ) => {
 			backgroundColor: backgroundColor?.color,
 			color: textColor?.color,
 		},
-	};
+	} );
 
 	const inputContainerClasses = classnames(
 		'wp-block-sensei-lms-course-outline-lesson__input-container',
@@ -89,7 +94,7 @@ export const LessonEdit = ( props ) => {
 	return (
 		<>
 			<LessonSettings { ...props } { ...lessonStatus } />
-			<div { ...wrapperStyles } data-lesson-id={ id }>
+			<div { ...blockProps } data-lesson-id={ id }>
 				<Icon
 					icon={ check }
 					className="wp-block-sensei-lms-course-outline-lesson__status"

--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -86,5 +86,6 @@
     "borderedSelected": {
       "type": "boolean"
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -7,7 +7,7 @@ import AnimateHeight from 'react-animate-height';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 import { Icon, chevronUp } from '@wordpress/icons';
 import { compose } from '@wordpress/compose';
 import { useContext, useState, useEffect } from '@wordpress/element';
@@ -115,9 +115,25 @@ export const ModuleEdit = ( props ) => {
 
 	const [ isExpanded, setExpanded ] = useState( true );
 
+	const bordered =
+		undefined !== borderedSelected ? borderedSelected : outlineBordered;
+
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block (e.g. the
+	// `aria-label="Block: Module"` wrapper attribute), and no longer
+	// auto-merges `className`/`attributes.className` into `props.className`.
+	const blockProps = useBlockProps( {
+		className: classnames( className, {
+			'wp-block-sensei-lms-course-outline-module-bordered': bordered,
+		} ),
+		style: {
+			borderColor: borderColorValue || defaultBorderColor?.color,
+		},
+	} );
+
 	const styleRegex = /is-style-(\w+)/;
 	const style =
-		className.match( styleRegex )?.[ 1 ] ||
+		blockProps.className.match( styleRegex )?.[ 1 ] ||
 		outlineClassName.match( styleRegex )?.[ 1 ];
 
 	// Header styles.
@@ -159,9 +175,6 @@ export const ModuleEdit = ( props ) => {
 		[]
 	);
 
-	const bordered =
-		undefined !== borderedSelected ? borderedSelected : outlineBordered;
-
 	return (
 		<>
 			<ModuleSettings
@@ -172,15 +185,7 @@ export const ModuleEdit = ( props ) => {
 				customSlug={ slug }
 				setCustomSlug={ updateSlug }
 			/>
-			<section
-				className={ classnames( className, {
-					'wp-block-sensei-lms-course-outline-module-bordered':
-						bordered,
-				} ) }
-				style={ {
-					borderColor: borderColorValue || defaultBorderColor?.color,
-				} }
-			>
+			<section { ...blockProps }>
 				<header
 					className="wp-block-sensei-lms-course-outline-module__header"
 					style={ headerStyles }

--- a/assets/blocks/course-outline/module-block/module-edit.test.js
+++ b/assets/blocks/course-outline/module-block/module-edit.test.js
@@ -26,6 +26,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 		/>
 	),
 	withColors: () => ( Component ) => Component,
+	useBlockProps: ( props ) => props ?? {},
 } ) );
 
 jest.mock( '../../../shared/blocks/single-line-input', () => ( props ) => (

--- a/assets/blocks/course-outline/outline-block/block.json
+++ b/assets/blocks/course-outline/outline-block/block.json
@@ -31,5 +31,6 @@
     "isPreview": {
       "type": "boolean"
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -4,6 +4,7 @@
 import {
 	InnerBlocks,
 	store as blockEditorStore,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -50,6 +51,11 @@ export const OutlineAttributesContext = createContext();
  */
 const OutlineEdit = ( props ) => {
 	const { clientId, className, attributes, setAttributes } = props;
+
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block (e.g. the
+	// `aria-label="Block: Course Outline"` wrapper attribute).
+	const blockProps = useBlockProps();
 
 	const { loadStructure } = useDispatch( COURSE_STORE );
 
@@ -114,7 +120,7 @@ const OutlineEdit = ( props ) => {
 	}, [ removeCourseOutlineGeneratorUpsell ] );
 
 	return (
-		<div>
+		<div { ...blockProps }>
 			{ isEmpty ? (
 				<OutlinePlaceholder
 					addBlock={ ( type ) => setBlocks( [ { type } ], true ) }
@@ -126,7 +132,7 @@ const OutlineEdit = ( props ) => {
 					value={ {
 						outlineAttributes: attributes,
 						outlineSetAttributes: setAttributes,
-						outlineClassName: className,
+						outlineClassName: blockProps.className,
 					} }
 				>
 					<OutlineSettings { ...props } />

--- a/assets/blocks/course-overview-block/block.json
+++ b/assets/blocks/course-overview-block/block.json
@@ -1,17 +1,19 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
-	"name": "sensei-lms/course-overview",
-	"title": "Course Overview",
-	"category": "sensei-lms",
-	"description": "Displays a link to the course.",
-	"textdomain": "sensei-lms",
-	"supports": {
-		"color": {
-			"background": false,
-			"text": true
-		}
-	},
-	"usesContext": [ "postType" ],
-	"example": {}
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "sensei-lms/course-overview",
+  "title": "Course Overview",
+  "category": "sensei-lms",
+  "description": "Displays a link to the course.",
+  "textdomain": "sensei-lms",
+  "supports": {
+    "color": {
+      "background": false,
+      "text": true
+    }
+  },
+  "usesContext": [
+    "postType"
+  ],
+  "example": {}
 }

--- a/assets/blocks/course-progress-block/block.json
+++ b/assets/blocks/course-progress-block/block.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "sensei-lms/course-progress",
   "title": "Course Progress",
   "description": "Display the user's progress in the course. This block is only displayed if the user is enrolled.",
@@ -46,7 +46,9 @@
       "type": "boolean"
     }
   },
-  "usesContext": [ "postType" ],
+  "usesContext": [
+    "postType"
+  ],
   "example": {
     "attributes": {
       "customBarBackgroundColor": "#999999",

--- a/assets/blocks/course-results-block/block.json
+++ b/assets/blocks/course-results-block/block.json
@@ -1,58 +1,59 @@
 {
-	"name": "sensei-lms/course-results",
-	"title": "Course Results",
-	"description": "Show course results to students on the course completion page.",
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"keywords": [
-		"course",
-		"lessons",
-		"modules",
-		"results",
-		"completion"
-	],
-	"supports": {
-		"html": false,
-		"multiple": false,
-		"defaultStylePicker": false
-	},
-	"attributes": {
-		"id": {
-			"type": "integer"
-		},
-		"moduleBorder": {
-			"type": "boolean",
-			"default": true
-		},
-		"mainColor": {
-			"type": "string"
-		},
-		"textColor": {
-			"type": "string"
-		},
-		"borderColor": {
-			"type": "string"
-		},
-		"customMainColor": {
-			"type": "string"
-		},
-		"customTextColor": {
-			"type": "string"
-		},
-		"customBorderColor": {
-			"type": "string"
-		},
-		"borderColorValue": {
-			"type": "string"
-		},
-		"defaultMainColor": {
-			"type": "string"
-		},
-		"defaultTextColor": {
-			"type": "string"
-		},
-		"defaultBorderColor": {
-			"type": "string"
-		}
-	}
+  "name": "sensei-lms/course-results",
+  "title": "Course Results",
+  "description": "Show course results to students on the course completion page.",
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "keywords": [
+    "course",
+    "lessons",
+    "modules",
+    "results",
+    "completion"
+  ],
+  "supports": {
+    "html": false,
+    "multiple": false,
+    "defaultStylePicker": false
+  },
+  "attributes": {
+    "id": {
+      "type": "integer"
+    },
+    "moduleBorder": {
+      "type": "boolean",
+      "default": true
+    },
+    "mainColor": {
+      "type": "string"
+    },
+    "textColor": {
+      "type": "string"
+    },
+    "borderColor": {
+      "type": "string"
+    },
+    "customMainColor": {
+      "type": "string"
+    },
+    "customTextColor": {
+      "type": "string"
+    },
+    "customBorderColor": {
+      "type": "string"
+    },
+    "borderColorValue": {
+      "type": "string"
+    },
+    "defaultMainColor": {
+      "type": "string"
+    },
+    "defaultTextColor": {
+      "type": "string"
+    },
+    "defaultBorderColor": {
+      "type": "string"
+    }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -107,8 +108,14 @@ const CourseResultsEdit = ( props ) => {
 		attributes: { moduleBorder },
 	} = props;
 
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block, and no
+	// longer auto-merges `className`/`attributes.className` into
+	// `props.className`.
+	const blockProps = useBlockProps( { className } );
+
 	const styleRegex = /is-style-(\w+)/;
-	const style = className.match( styleRegex )?.[ 1 ];
+	const style = blockProps.className.match( styleRegex )?.[ 1 ];
 
 	// Header styles.
 	const headerStyles = {
@@ -133,7 +140,10 @@ const CourseResultsEdit = ( props ) => {
 	return (
 		<>
 			<CourseResultsSettings { ...props } />
-			<section className={ className } style={ styleVars }>
+			<section
+				{ ...blockProps }
+				style={ { ...blockProps.style, ...styleVars } }
+			>
 				<div className="wp-block-sensei-lms-course-results__grade">
 					<span className="wp-block-sensei-lms-course-results__grade-label">
 						{ __( 'Your Total Grade', 'sensei-lms' ) }

--- a/assets/blocks/featured-video/block.json
+++ b/assets/blocks/featured-video/block.json
@@ -1,11 +1,12 @@
 {
-	"name": "sensei-lms/featured-video",
-	"title": "Featured Video",
-	"description": "Add a featured video to your lesson to highlight the video and make use of our video templates.",
-	"icon": "format-video",
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"supports": {
-		"multiple": false
-	}
+  "name": "sensei-lms/featured-video",
+  "title": "Featured Video",
+  "description": "Add a featured video to your lesson to highlight the video and make use of our video templates.",
+  "icon": "format-video",
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "supports": {
+    "multiple": false
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/learner-courses-block/block.json
+++ b/assets/blocks/learner-courses-block/block.json
@@ -30,5 +30,6 @@
         "progressBarHeight": 14
       }
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -12,7 +12,11 @@ import { createBlock } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { Icon, image } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { store as blockEditorStore, Warning } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	useBlockProps,
+	Warning,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -143,6 +147,12 @@ const LearnerCoursesEdit = ( {
 	attributes: { options },
 	setAttributes,
 } ) => {
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block, and no
+	// longer auto-merges `className`/`attributes.className` into
+	// `props.className`.
+	const blockProps = useBlockProps( { className } );
+
 	const [ filter, setFilter ] = useState( 'all' );
 
 	const filterHandler = ( filterValue ) => ( e ) => {
@@ -245,11 +255,20 @@ const LearnerCoursesEdit = ( {
 		);
 	};
 
+	// `blockProps.style` is excluded: this component computes its own
+	// CSS custom-property styles, and `useBlockProps()` is only used here
+	// for identity/selection attributes (aria-label, data-block, etc.)
+	// plus the merged className.
+	// eslint-disable-next-line no-unused-vars
+	const { style: unusedBlockPropsStyle, ...blockPropsWithoutStyle } =
+		blockProps;
+
 	return (
 		<>
 			<StylesWrapper
+				{ ...blockPropsWithoutStyle }
 				tagName="section"
-				className={ className }
+				className={ blockProps.className }
 				variables={ {
 					primaryColor: options.primaryColor,
 					accentColor: options.accentColor,

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -22,5 +22,6 @@
         "sensei-lms/button-reset-lesson": true
       }
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -44,6 +44,11 @@ const LessonActionsEdit = ( props ) => {
 		setAttributes,
 		attributes: { toggledBlocks },
 	} = props;
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block, and no
+	// longer auto-merges `className`/`attributes.className` into
+	// `props.className`.
+	const blockProps = useBlockProps();
 	const [ previewState, onPreviewChange ] =
 		usePreviewState( IN_PROGRESS_PREVIEW );
 	const { isSiteEditor } = useSelect( ( select ) => {
@@ -91,7 +96,9 @@ const LessonActionsEdit = ( props ) => {
 				toggleBlocks={ toggleBlocks }
 			/>
 			<div
+				{ ...blockProps }
 				className={ classnames(
+					blockProps.className,
 					className,
 					`wp-block-sensei-lms-lesson-actions__preview-${ previewState }`,
 					`wp-block-sensei-lms-lesson-actions__${ quizStateClass }`,

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-save.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-save.js
@@ -1,14 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const LessonActionsSave = ( { className } ) => (
-	<div className={ className }>
-		<div className="sensei-buttons-container">
-			<InnerBlocks.Content />
+// Block API version 3 no longer auto-merges the default block classname
+// and `attributes.className` into the saved markup; `useBlockProps.save()`
+// is required to restore it.
+const LessonActionsSave = () => {
+	const blockProps = useBlockProps.save();
+
+	return (
+		<div { ...blockProps }>
+			<div className="sensei-buttons-container">
+				<InnerBlocks.Content />
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 export default LessonActionsSave;

--- a/assets/blocks/lesson-properties/block.json
+++ b/assets/blocks/lesson-properties/block.json
@@ -1,15 +1,16 @@
 {
-	"name": "sensei-lms/lesson-properties",
-	"title": "Lesson Properties",
-	"description": "Add lesson properties such as length and difficulty.",
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"keywords": [
-		"metadata",
-		"length",
-		"complexity",
-		"difficulty",
-		"lesson information",
-		"lesson properties"
-	]
+  "name": "sensei-lms/lesson-properties",
+  "title": "Lesson Properties",
+  "description": "Add lesson properties such as length and difficulty.",
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "keywords": [
+    "metadata",
+    "length",
+    "complexity",
+    "difficulty",
+    "lesson information",
+    "lesson properties"
+  ],
+  "apiVersion": 3
 }

--- a/assets/blocks/lesson-properties/lesson-properties-edit.js
+++ b/assets/blocks/lesson-properties/lesson-properties-edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { useCallback } from '@wordpress/element';
 import { useEntityProp } from '@wordpress/core-data';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, Notice } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
 
@@ -22,6 +22,12 @@ const courseThemeEnabled = window?.sensei?.courseThemeEnabled || false;
 
 const LessonPropertiesEdit = ( props ) => {
 	const { className } = props;
+
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block, and no
+	// longer auto-merges `className`/`attributes.className` into
+	// `props.className`.
+	const blockProps = useBlockProps( { className } );
 
 	const [ meta, setMeta ] = useEntityProp( 'postType', 'lesson', 'meta' );
 	const { _lesson_complexity: difficulty = '', _lesson_length: length = 10 } =
@@ -84,14 +90,19 @@ const LessonPropertiesEdit = ( props ) => {
 			) }
 
 			{ courseThemeEnabled ? (
-				<Notice status="warning" isDismissible={ false }>
-					{ __(
-						'Since Learning Mode is activated, use this block to add the properties to each lesson and make sure your Lesson template contains the Lesson Properties block.',
-						'sensei-lms'
-					) }
-				</Notice>
+				// `Notice` doesn't forward arbitrary props to its root
+				// element, so `useBlockProps()` is applied to a wrapping
+				// element instead.
+				<div { ...blockProps }>
+					<Notice status="warning" isDismissible={ false }>
+						{ __(
+							'Since Learning Mode is activated, use this block to add the properties to each lesson and make sure your Lesson template contains the Lesson Properties block.',
+							'sensei-lms'
+						) }
+					</Notice>
+				</div>
 			) : (
-				<div className={ className }>
+				<div { ...blockProps }>
 					<span
 						className={ classnames(
 							'wp-block-sensei-lms-lesson-properties__length',

--- a/assets/blocks/quiz/category-question-block/block.json
+++ b/assets/blocks/quiz/category-question-block/block.json
@@ -2,7 +2,9 @@
   "name": "sensei-lms/quiz-category-question",
   "title": "Category Question",
   "description": "Pull questions from a question category.",
-  "parent": [ "sensei-lms/quiz" ],
+  "parent": [
+    "sensei-lms/quiz"
+  ],
   "category": "sensei-lms",
   "textdomain": "sensei-lms",
   "supports": {
@@ -16,15 +18,16 @@
       "type": "string",
       "default": "category-question"
     },
-		"categoryName": {
-			"type": "string"
-		},
+    "categoryName": {
+      "type": "string"
+    },
     "options": {
       "type": "object",
       "default": {
-				"category": null,
-				"number": 1
+        "category": null,
+        "number": 1
       }
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -3,6 +3,7 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -38,6 +39,16 @@ const CategoryQuestionEdit = ( props ) => {
 	const questionNumber = useQuestionNumber( clientId );
 	const [ , getCategoryTermById ] = useQuestionCategories();
 
+	// Block API version 3 requires `useBlockProps()` on the outermost
+	// element for the editor to recognize/select this block, and no
+	// longer auto-merges `className`/`attributes.className` into
+	// `props.className`.
+	const blockProps = useBlockProps( {
+		className: `sensei-lms-question-block sensei-lms-category-question-block ${
+			! category ? 'is-draft' : ''
+		}`,
+	} );
+
 	const range =
 		! number || 1 === number
 			? questionNumber
@@ -62,11 +73,7 @@ const CategoryQuestionEdit = ( props ) => {
 	return (
 		<>
 			<CategoryQuestionSettings { ...props } />
-			<div
-				className={ `sensei-lms-question-block sensei-lms-category-question-block ${
-					! category ? 'is-draft' : ''
-				}` }
-			>
+			<div { ...blockProps }>
 				{ questionIndex }
 				<h2 className="sensei-lms-question-block__title">
 					{ categoryName ? (

--- a/assets/blocks/quiz/question-answers-block/block.json
+++ b/assets/blocks/quiz/question-answers-block/block.json
@@ -1,15 +1,15 @@
 {
-	"name": "sensei-lms/question-answers",
-	"apiVersion": 2,
-	"title": "Answers",
-	"description": "Question Answers.",
-	"parent": [ "sensei-lms/quiz-question" ],
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"supports": {
-		"html": false
-	},
-	"attributes": {
-
-	}
+  "name": "sensei-lms/question-answers",
+  "apiVersion": 3,
+  "title": "Answers",
+  "description": "Question Answers.",
+  "parent": [
+    "sensei-lms/quiz-question"
+  ],
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "supports": {
+    "html": false
+  },
+  "attributes": {}
 }

--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -1,58 +1,58 @@
 {
-	"name": "sensei-lms/quiz-question",
-	"title": "Question",
-	"apiVersion": 2,
-	"description": "The building block of all quizzes.",
-	"parent": [
-		"sensei-lms/quiz"
-	],
-	"category": "sensei-lms",
-    "textdomain": "sensei-lms",
-	"supports": {
-		"html": false
-	},
-	"example": {
-		"attributes": {
-			"title": "What are power chords?",
-			"answer": {
-				"answers": [
-					{
-						"label": "  A chord consisting of a root note of the chord and a 5th",
-						"correct": true
-					},
-					{
-						"label": "  A chord playing on an electric guitar",
-						"correct": false
-					}
-				]
-			}
-		}
-	},
-	"attributes": {
-		"id": {
-			"type": "integer"
-		},
-		"title": {
-			"type": "string"
-		},
-		"type": {
-			"type": "string",
-			"default": "multiple-choice"
-		},
-		"answer": {
-			"type": "object"
-		},
-		"options": {
-			"type": "object",
-			"default": {
-				"grade": 1,
-				"hideAnswerFeedback": ""
-			}
-		},
-		"editable": {
-			"type": "boolean",
-			"default": true,
-			"source": false
-		}
-	}
+  "name": "sensei-lms/quiz-question",
+  "title": "Question",
+  "apiVersion": 3,
+  "description": "The building block of all quizzes.",
+  "parent": [
+    "sensei-lms/quiz"
+  ],
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "supports": {
+    "html": false
+  },
+  "example": {
+    "attributes": {
+      "title": "What are power chords?",
+      "answer": {
+        "answers": [
+          {
+            "label": "  A chord consisting of a root note of the chord and a 5th",
+            "correct": true
+          },
+          {
+            "label": "  A chord playing on an electric guitar",
+            "correct": false
+          }
+        ]
+      }
+    }
+  },
+  "attributes": {
+    "id": {
+      "type": "integer"
+    },
+    "title": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "default": "multiple-choice"
+    },
+    "answer": {
+      "type": "object"
+    },
+    "options": {
+      "type": "object",
+      "default": {
+        "grade": 1,
+        "hideAnswerFeedback": ""
+      }
+    },
+    "editable": {
+      "type": "boolean",
+      "default": true,
+      "source": false
+    }
+  }
 }

--- a/assets/blocks/quiz/question-description-block/block.json
+++ b/assets/blocks/quiz/question-description-block/block.json
@@ -1,17 +1,19 @@
 {
-	"name": "sensei-lms/question-description",
-	"apiVersion": 2,
-	"title": "Description",
-	"description": "Question Description.",
-	"parent": [ "sensei-lms/quiz-question" ],
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"supports": {
-		"html": false
-	},
-	"attributes": {
-		"id": {
-			"type": "integer"
-		}
-	}
+  "name": "sensei-lms/question-description",
+  "apiVersion": 3,
+  "title": "Description",
+  "description": "Question Description.",
+  "parent": [
+    "sensei-lms/quiz-question"
+  ],
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "id": {
+      "type": "integer"
+    }
+  }
 }

--- a/assets/blocks/quiz/quiz-block/block.json
+++ b/assets/blocks/quiz/quiz-block/block.json
@@ -1,89 +1,89 @@
 {
-	"name": "sensei-lms/quiz",
-	"title": "Quiz",
-	"apiVersion": 2,
-	"description": "Evaluate progress and strengthen understanding of course concepts.",
-	"category": "sensei-lms",
-	"textdomain": "sensei-lms",
-	"keywords": [
-		"exam",
-		"questions",
-		"test",
-		"assessment",
-		"evaluation"
-	],
-	"supports": {
-		"html": false,
-		"multiple": false
-	},
-	"attributes": {
-		"id": {
-			"type": "integer"
-		},
-		"options": {
-			"type": "object",
-			"default": {
-				"passRequired": false,
-				"quizPassmark": 0,
-				"autoGrade": true,
-				"allowRetakes": true,
-				"randomQuestionOrder": false,
-				"showQuestions": null,
-				"failedShowAnswerFeedback": false,
-				"failedShowCorrectAnswers": false,
-				"failedIndicateIncorrect": false,
-				"buttonTextColor": null,
-				"buttonBackgroundColor": null,
-				"pagination": {}
-			}
-		},
-		"isPostTemplate": {
-			"type": "boolean",
-			"default": false
-		}
-	},
-	"example": {
-		"innerBlocks": [
-			{
-				"name": "sensei-lms/quiz-question",
-				"attributes": {
-					"title": "What are power chords?",
-					"answer": {
-						"answers": [
-							{
-								"label": "  A chord consisting of a root note of the chord and a 5th",
-								"correct": true
-							},
-							{
-								"label": "  A chord playing on an electric guitar",
-								"correct": false
-							}
-						]
-					}
-				}
-			},
-			{
-				"name": "sensei-lms/quiz-question",
-				"attributes": {
-					"title": "What part of the guitar do you adjust when tuning it?",
-					"answer": {
-						"answers": [
-							{
-								"label": "  The Tuning Pegs",
-								"correct": true
-							},
-							{
-								"label": "  The Fretboard",
-								"correct": false
-							},
-							{
-								"label": "  The Neck",
-								"correct": false
-							}
-						]
-					}
-				}
-			}
-		]
-	}
+  "name": "sensei-lms/quiz",
+  "title": "Quiz",
+  "apiVersion": 3,
+  "description": "Evaluate progress and strengthen understanding of course concepts.",
+  "category": "sensei-lms",
+  "textdomain": "sensei-lms",
+  "keywords": [
+    "exam",
+    "questions",
+    "test",
+    "assessment",
+    "evaluation"
+  ],
+  "supports": {
+    "html": false,
+    "multiple": false
+  },
+  "attributes": {
+    "id": {
+      "type": "integer"
+    },
+    "options": {
+      "type": "object",
+      "default": {
+        "passRequired": false,
+        "quizPassmark": 0,
+        "autoGrade": true,
+        "allowRetakes": true,
+        "randomQuestionOrder": false,
+        "showQuestions": null,
+        "failedShowAnswerFeedback": false,
+        "failedShowCorrectAnswers": false,
+        "failedIndicateIncorrect": false,
+        "buttonTextColor": null,
+        "buttonBackgroundColor": null,
+        "pagination": {}
+      }
+    },
+    "isPostTemplate": {
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "example": {
+    "innerBlocks": [
+      {
+        "name": "sensei-lms/quiz-question",
+        "attributes": {
+          "title": "What are power chords?",
+          "answer": {
+            "answers": [
+              {
+                "label": "  A chord consisting of a root note of the chord and a 5th",
+                "correct": true
+              },
+              {
+                "label": "  A chord playing on an electric guitar",
+                "correct": false
+              }
+            ]
+          }
+        }
+      },
+      {
+        "name": "sensei-lms/quiz-question",
+        "attributes": {
+          "title": "What part of the guitar do you adjust when tuning it?",
+          "answer": {
+            "answers": [
+              {
+                "label": "  The Tuning Pegs",
+                "correct": true
+              },
+              {
+                "label": "  The Fretboard",
+                "correct": false
+              },
+              {
+                "label": "  The Neck",
+                "correct": false
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
 }

--- a/assets/course-theme/blocks/course-navigation/course-navigation.block.json
+++ b/assets/course-theme/blocks/course-navigation/course-navigation.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/course-navigation",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "category": "theme",
   "supports": {
     "align": true,
@@ -14,18 +14,18 @@
       "blockGap": true
     },
     "typography": {
-		"fontSize": true,
-		"lineHeight": true,
-		"__experimentalFontFamily": true,
-		"__experimentalFontWeight": true,
-		"__experimentalFontStyle": true,
-		"__experimentalTextTransform": true,
-		"__experimentalTextDecoration": true,
-		"__experimentalLetterSpacing": true,
-		"__experimentalDefaultControls": {
-			"fontSize": true
-		}
-	},
+      "fontSize": true,
+      "lineHeight": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
+    },
     "__experimentalBorder": {
       "color": true,
       "radius": true,

--- a/assets/course-theme/blocks/lesson-blocks/course-content.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-content.block.json
@@ -22,5 +22,6 @@
       "style": true,
       "width": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-bar.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-bar.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/course-theme-course-progress-bar",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "category": "theme",
   "supports": {
     "align": true,

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-counter.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-counter.block.json
@@ -1,7 +1,7 @@
 {
   "name": "sensei-lms/course-theme-course-progress-counter",
   "category": "theme",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "supports": {
     "align": true,
     "color": {
@@ -16,15 +16,15 @@
     "typography": {
       "fontSize": true,
       "lineHeight": true,
-        "__experimentalFontFamily": true,
-        "__experimentalFontWeight": true,
-        "__experimentalFontStyle": true,
-        "__experimentalTextTransform": true,
-        "__experimentalTextDecoration": true,
-        "__experimentalLetterSpacing": true,
-        "__experimentalDefaultControls": {
-            "fontSize": true
-        }
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
     }
   }
 }

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-actions.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-actions.block.json
@@ -23,5 +23,6 @@
       "style": true,
       "width": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-video.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-video.block.json
@@ -24,5 +24,6 @@
       "style": true,
       "width": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-notices.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-notices.block.json
@@ -21,5 +21,6 @@
       "style": true,
       "width": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-post-title.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-post-title.block.json
@@ -9,5 +9,6 @@
       "padding": true,
       "blockGap": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-prev-next-lesson.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-prev-next-lesson.block.json
@@ -13,23 +13,24 @@
       "blockGap": true
     },
     "typography": {
-    "fontSize": true,
-    "lineHeight": true,
-    "__experimentalFontFamily": true,
-    "__experimentalFontWeight": true,
-    "__experimentalFontStyle": true,
-    "__experimentalTextTransform": true,
-    "__experimentalTextDecoration": true,
-    "__experimentalLetterSpacing": true,
-    "__experimentalDefaultControls": {
-      "fontSize": true
-    }
-  },
+      "fontSize": true,
+      "lineHeight": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
+    },
     "__experimentalBorder": {
       "color": true,
       "radius": true,
       "style": true,
       "width": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/course-title/block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-title/block.json
@@ -1,27 +1,27 @@
 {
-    "name": "sensei-lms/course-title",
-    "category": "theme",
-    "apiVersion": 2,
-    "supports": {
-        "align": true,
-        "color": true,
-        "spacing": {
-            "margin": true,
-            "padding": true,
-            "blockGap": true
-        },
-        "typography": {
-            "fontSize": true,
-            "lineHeight": true,
-            "__experimentalFontFamily": true,
-            "__experimentalFontWeight": true,
-            "__experimentalFontStyle": true,
-            "__experimentalTextTransform": true,
-            "__experimentalTextDecoration": true,
-            "__experimentalLetterSpacing": true,
-            "__experimentalDefaultControls": {
-                "fontSize": true
-            }
-        }
+  "name": "sensei-lms/course-title",
+  "category": "theme",
+  "apiVersion": 3,
+  "supports": {
+    "align": true,
+    "color": true,
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
     }
+  }
 }

--- a/assets/course-theme/blocks/lesson-blocks/exit-course-button/block.json
+++ b/assets/course-theme/blocks/lesson-blocks/exit-course-button/block.json
@@ -1,35 +1,35 @@
 {
-	"name": "sensei-lms/exit-course",
-	"category": "theme",
-	"apiVersion": 2,
-	"supports": {
-		"align": true,
-		"color": {
-			"gradients": true
-		},
-		"spacing": {
-			"margin": true,
-			"padding": true,
-			"blockGap": true
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true,
-			"__experimentalFontFamily": true,
-			"__experimentalFontWeight": true,
-			"__experimentalFontStyle": true,
-			"__experimentalTextTransform": true,
-			"__experimentalTextDecoration": true,
-			"__experimentalLetterSpacing": true,
-			"__experimentalDefaultControls": {
-				"fontSize": true
-			}
-		},
-		"__experimentalBorder": {
-			"color": true,
-			"radius": true,
-			"style": true,
-			"width": true
-		}
-	}
+  "name": "sensei-lms/exit-course",
+  "category": "theme",
+  "apiVersion": 3,
+  "supports": {
+    "align": true,
+    "color": {
+      "gradients": true
+    },
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
+    },
+    "__experimentalBorder": {
+      "color": true,
+      "radius": true,
+      "style": true,
+      "width": true
+    }
+  }
 }

--- a/assets/course-theme/blocks/lesson-blocks/focus-mode-toggle.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/focus-mode-toggle.block.json
@@ -4,5 +4,6 @@
   "supports": {
     "align": true,
     "color": true
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/learning-mode-lesson-properties.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/learning-mode-lesson-properties.block.json
@@ -13,5 +13,6 @@
       "fontSize": true,
       "lineHeight": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/lesson-blocks/module-title/block.json
+++ b/assets/course-theme/blocks/lesson-blocks/module-title/block.json
@@ -1,33 +1,33 @@
 {
-    "name": "sensei-lms/course-theme-lesson-module",
-    "category": "theme",
-    "apiVersion": 2,
-    "attributes": {
-        "className": "some-className"
+  "name": "sensei-lms/course-theme-lesson-module",
+  "category": "theme",
+  "apiVersion": 3,
+  "attributes": {
+    "className": "some-className"
+  },
+  "supports": {
+    "align": true,
+    "color": {
+      "gradients": true,
+      "link": true
     },
-    "supports": {
-        "align": true,
-        "color": {
-            "gradients": true,
-            "link": true
-        },
-        "spacing": {
-            "margin": true,
-            "padding": true,
-            "blockGap": true
-        },
-        "typography": {
-            "fontSize": true,
-            "lineHeight": true,
-            "__experimentalFontFamily": true,
-            "__experimentalFontWeight": true,
-            "__experimentalFontStyle": true,
-            "__experimentalTextTransform": true,
-            "__experimentalTextDecoration": true,
-            "__experimentalLetterSpacing": true,
-            "__experimentalDefaultControls": {
-                "fontSize": true
-            }
-        }
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
     }
+  }
 }

--- a/assets/course-theme/blocks/lesson-blocks/page-actions.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/page-actions.block.json
@@ -1,7 +1,7 @@
 {
   "name": "sensei-lms/page-actions",
   "category": "theme",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "supports": {
     "align": true,
     "color": {
@@ -20,13 +20,13 @@
       "width": true
     },
     "typography": {
-        "fontSize": true,
-		"__experimentalFontFamily": true,
-		"__experimentalFontWeight": true,
-		"__experimentalFontStyle": true,
-		"__experimentalTextTransform": true,
-		"__experimentalTextDecoration": true,
-		"__experimentalLetterSpacing": true
-	}
+      "fontSize": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true
+    }
   }
 }

--- a/assets/course-theme/blocks/lesson-blocks/sidebar-toggle-button.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/sidebar-toggle-button.block.json
@@ -8,5 +8,6 @@
       "padding": true,
       "blockGap": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/quiz-blocks/quiz-actions.block.json
+++ b/assets/course-theme/blocks/quiz-blocks/quiz-actions.block.json
@@ -1,5 +1,6 @@
 {
   "name": "sensei-lms/quiz-actions",
   "category": "theme",
-  "supports": {}
+  "supports": {},
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/quiz-blocks/quiz-back-to-lesson.block.json
+++ b/assets/course-theme/blocks/quiz-blocks/quiz-back-to-lesson.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/quiz-back-to-lesson",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "category": "theme",
   "supports": {
     "align": true,

--- a/assets/course-theme/blocks/quiz-blocks/quiz-progress.block.json
+++ b/assets/course-theme/blocks/quiz-blocks/quiz-progress.block.json
@@ -15,5 +15,6 @@
       "style": true,
       "width": true
     }
-  }
+  },
+  "apiVersion": 3
 }

--- a/assets/course-theme/blocks/template-style/template-style.block.json
+++ b/assets/course-theme/blocks/template-style/template-style.block.json
@@ -1,13 +1,13 @@
 {
-	"name": "sensei-lms/template-style",
-	"category": "theme",
-	"parent": [],
-	"apiVersion": 2,
-	"attributes": {
-		"content": {
-            "source": "text",
-			"type": "string",
-			"selector": "style"
-		}
-	}
+  "name": "sensei-lms/template-style",
+  "category": "theme",
+  "parent": [],
+  "apiVersion": 3,
+  "attributes": {
+    "content": {
+      "source": "text",
+      "type": "string",
+      "selector": "style"
+    }
+  }
 }

--- a/assets/course-theme/blocks/ui/spacer.block.json
+++ b/assets/course-theme/blocks/ui/spacer.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/spacer-flex",
   "category": "theme",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "supports": {}
 }

--- a/assets/course-theme/blocks/ui/ui.block.json
+++ b/assets/course-theme/blocks/ui/ui.block.json
@@ -1,44 +1,44 @@
 {
-	"name": "sensei-lms/ui",
-	"category": "theme",
-	"apiVersion": 2,
-	"supports": {
-		"align": true,
-		"alignWide": true,
-		"color": {
-			"gradients": true,
-			"link": true,
-			"__experimentalDefaultControls": {
-				"background": true,
-				"text": true,
-				"link": true
-			}
-		},
-		"spacing": {
-			"margin": true,
-			"padding": true,
-			"blockGap": true
-		},
-		"__experimentalLayout": true,
-		"__experimentalBorder": {
-			"color": true,
-			"radius": true,
-			"style": true,
-			"width": true
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true
-		}
-	},
-	"attributes": {
-		"tagName": {
-			"type": "string",
-			"default": "div"
-		},
-		"elementClass": {
-			"type": "string",
-			"default": ""
-		}
-	}
+  "name": "sensei-lms/ui",
+  "category": "theme",
+  "apiVersion": 3,
+  "supports": {
+    "align": true,
+    "alignWide": true,
+    "color": {
+      "gradients": true,
+      "link": true,
+      "__experimentalDefaultControls": {
+        "background": true,
+        "text": true,
+        "link": true
+      }
+    },
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true
+    },
+    "__experimentalLayout": true,
+    "__experimentalBorder": {
+      "color": true,
+      "radius": true,
+      "style": true,
+      "width": true
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true
+    }
+  },
+  "attributes": {
+    "tagName": {
+      "type": "string",
+      "default": "div"
+    },
+    "elementClass": {
+      "type": "string",
+      "default": ""
+    }
+  }
 }

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -101,13 +101,19 @@ export const ColorSettings = ( { colorSettings, props } ) => {
  * Apply default style class if no style is selected.
  * Adds is-style-default to the className property.
  *
+ * Reads the style class from `attributes.className`, the block's own
+ * persisted attribute, rather than `props.className`: since Block API
+ * version 2+ no longer auto-injects a computed `className` prop into
+ * `edit`/`save`, `props.className` can't be relied on to reflect the
+ * selected block style.
+ *
  * @param {string} defaultStyleName Default style name.
  */
 export const withDefaultBlockStyle =
 	( defaultStyleName = 'default' ) =>
 	( Component ) =>
 	( props ) => {
-		let { className } = props;
+		let className = props.attributes?.className ?? props.className;
 
 		const extraProps = {};
 

--- a/changelog/fix-block-api-version-3
+++ b/changelog/fix-block-api-version-3
@@ -1,0 +1,1 @@
+Fix: Update all blocks to Block API version 3 for iframe editor compatibility

--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -32,6 +32,7 @@ class Sensei_Block_Contact_Teacher {
 			'sensei-lms/button-contact-teacher',
 			[
 				'render_callback' => [ $this, 'render_contact_teacher_block' ],
+				'api_version'     => 3,
 			]
 		);
 	}

--- a/includes/blocks/class-sensei-block-quiz-progress.php
+++ b/includes/blocks/class-sensei-block-quiz-progress.php
@@ -22,6 +22,7 @@ class Sensei_Block_Quiz_Progress {
 			'sensei-lms/quiz-progress',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}
@@ -66,5 +67,4 @@ class Sensei_Block_Quiz_Progress {
 
 		return \Sensei\Blocks\Shared\Progress_Bar::render( $attributes );
 	}
-
 }

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -29,7 +29,13 @@ class Sensei_Block_Take_Course {
 	 * @access private
 	 */
 	public function register_block() {
-		Sensei_Blocks::register_sensei_block( 'sensei-lms/button-take-course', [ 'render_callback' => [ $this, 'render_take_course_block' ] ] );
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/button-take-course',
+			[
+				'render_callback' => [ $this, 'render_take_course_block' ],
+				'api_version'     => 3,
+			]
+		);
 	}
 
 	/**

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -31,6 +31,7 @@ class Sensei_Block_View_Results {
 			'sensei-lms/button-view-results',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}

--- a/includes/blocks/class-sensei-complete-lesson-block.php
+++ b/includes/blocks/class-sensei-complete-lesson-block.php
@@ -23,6 +23,7 @@ class Sensei_Complete_Lesson_Block {
 			'sensei-lms/button-complete-lesson',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}

--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -22,6 +22,7 @@ class Sensei_Continue_Course_Block {
 			'sensei-lms/button-continue-course',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}
@@ -36,7 +37,7 @@ class Sensei_Continue_Course_Block {
 	 *
 	 * @return string Returns a Continue button that links to the course page.
 	 */
-	public function render( array $attributes, string $content ) : string {
+	public function render( array $attributes, string $content ): string {
 		$course_id = get_the_ID();
 		$user_id   = get_current_user_id();
 

--- a/includes/blocks/class-sensei-learner-messages-button-block.php
+++ b/includes/blocks/class-sensei-learner-messages-button-block.php
@@ -48,7 +48,10 @@ class Sensei_Learner_Messages_Button_Block {
 	public function register_block() {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/button-learner-messages',
-			[ 'render_callback' => [ $this, 'render_learner_messages_block' ] ]
+			[
+				'render_callback' => [ $this, 'render_learner_messages_block' ],
+				'api_version'     => 3,
+			]
 		);
 	}
 

--- a/includes/blocks/class-sensei-lesson-completed-block.php
+++ b/includes/blocks/class-sensei-lesson-completed-block.php
@@ -23,6 +23,7 @@ class Sensei_Lesson_Completed_Block {
 			'sensei-lms/button-lesson-completed',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}
@@ -37,7 +38,7 @@ class Sensei_Lesson_Completed_Block {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes, string $content ) : string {
+	public function render( array $attributes, string $content ): string {
 		$lesson = get_post();
 
 		if ( ! is_a( $lesson, WP_Post::class ) || ! Sensei_Utils::user_completed_lesson( $lesson->ID ) ) {

--- a/includes/blocks/class-sensei-next-lesson-block.php
+++ b/includes/blocks/class-sensei-next-lesson-block.php
@@ -23,6 +23,7 @@ class Sensei_Next_Lesson_Block {
 			'sensei-lms/button-next-lesson',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}
@@ -37,7 +38,7 @@ class Sensei_Next_Lesson_Block {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes, string $content ) : string {
+	public function render( array $attributes, string $content ): string {
 		$lesson = get_post();
 
 		if ( empty( $lesson ) || ! Sensei_Utils::user_completed_lesson( $lesson->ID ) ) {

--- a/includes/blocks/class-sensei-reset-lesson-block.php
+++ b/includes/blocks/class-sensei-reset-lesson-block.php
@@ -23,6 +23,7 @@ class Sensei_Reset_Lesson_Block {
 			'sensei-lms/button-reset-lesson',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}
@@ -37,7 +38,7 @@ class Sensei_Reset_Lesson_Block {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes, string $content ) : string {
+	public function render( array $attributes, string $content ): string {
 		$lesson = get_post();
 
 		if ( empty( $lesson ) ) {
@@ -67,7 +68,7 @@ class Sensei_Reset_Lesson_Block {
 	 *
 	 * @return string The HTML to render.
 	 */
-	private function render_with_form( array $attributes, string $content ) : string {
+	private function render_with_form( array $attributes, string $content ): string {
 		wp_enqueue_script( 'sensei-stop-double-submission' );
 		$nonce     = wp_nonce_field( 'woothemes_sensei_complete_lesson_noonce', 'woothemes_sensei_complete_lesson_noonce', false, false );
 		$permalink = esc_url( get_permalink() );

--- a/includes/blocks/class-sensei-take-quiz-block.php
+++ b/includes/blocks/class-sensei-take-quiz-block.php
@@ -23,6 +23,7 @@ class Sensei_Take_Quiz_Block {
 			'sensei-lms/button-view-quiz',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 			]
 		);
 	}
@@ -37,7 +38,7 @@ class Sensei_Take_Quiz_Block {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes, string $content ) : string {
+	public function render( array $attributes, string $content ): string {
 		$lesson_id = get_the_ID();
 
 		if ( empty( $lesson_id ) || ! sensei_can_user_view_lesson( $lesson_id ) ) {

--- a/includes/blocks/course-theme/class-course-navigation.php
+++ b/includes/blocks/course-theme/class-course-navigation.php
@@ -68,6 +68,7 @@ class Course_Navigation {
 			'sensei-lms/course-navigation',
 			[
 				'render_callback' => [ $this, 'render_course_navigation' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 				'script'          => 'sensei-blocks-frontend',
 			],

--- a/includes/blocks/course-theme/class-course-progress-bar.php
+++ b/includes/blocks/course-theme/class-course-progress-bar.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Class Course_Progress_Bar is responsible for rendering the '[==========----------]' block.
@@ -32,6 +32,7 @@ class Course_Progress_Bar {
 			'sensei-lms/course-theme-course-progress-bar',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -45,7 +46,7 @@ class Course_Progress_Bar {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render() : string {
+	public function render(): string {
 		$course_id = \Sensei_Utils::get_current_course();
 		if ( ! $course_id ) {
 			return '';

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Class Course_Progress_Counter is responsible for rendering the '1 of 10 lessons complete (10%)' block.
@@ -32,6 +32,7 @@ class Course_Progress_Counter {
 			'sensei-lms/course-theme-course-progress-counter',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -45,7 +46,7 @@ class Course_Progress_Counter {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render() : string {
+	public function render(): string {
 		$course_id = \Sensei_Utils::get_current_course();
 		if ( ! $course_id ) {
 			return '';

--- a/includes/blocks/course-theme/class-course-title.php
+++ b/includes/blocks/course-theme/class-course-title.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Display the title of the current course for the current lesson/quiz/module.
@@ -32,6 +32,7 @@ class Course_Title {
 			'sensei-lms/course-title',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path

--- a/includes/blocks/course-theme/class-exit-course.php
+++ b/includes/blocks/course-theme/class-exit-course.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Exit course link, to leave Learning Mode and open the course page.
@@ -32,6 +32,7 @@ class Exit_Course {
 			'sensei-lms/exit-course',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path

--- a/includes/blocks/course-theme/class-focus-mode.php
+++ b/includes/blocks/course-theme/class-focus-mode.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Support for focus mode.
@@ -31,6 +31,7 @@ class Focus_Mode {
 			'sensei-lms/focus-mode-toggle',
 			[
 				'render_callback' => [ $this, 'render_focus_mode_toggle' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -12,10 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
-use \Sensei_Course;
-use \Sensei_Lesson;
-use \Sensei_Utils;
+use Sensei_Blocks;
+use Sensei_Course;
+use Sensei_Lesson;
+use Sensei_Utils;
 
 /**
  * Class Lesson_Actions is responsible for rendering the Lesson actions block.
@@ -37,6 +37,7 @@ class Lesson_Actions {
 			'sensei-lms/course-theme-lesson-actions',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -96,7 +97,6 @@ class Lesson_Actions {
 				'</button>' .
 			'</div>'
 		);
-
 	}
 
 	/**
@@ -118,7 +118,6 @@ class Lesson_Actions {
 		$icon  = \Sensei()->assets->get_icon( 'arrow-right' );
 
 		return ( "<a class='wp-block-button__link wp-element-button sensei-course-theme__button sensei-course-theme-lesson-actions__next-lesson is-primary has-icon' href='{$url}'><span>{$label}</span>{$icon}</a>" );
-
 	}
 
 	/**

--- a/includes/blocks/course-theme/class-lesson-module.php
+++ b/includes/blocks/course-theme/class-lesson-module.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Display the title of the current module for the current lesson.
@@ -33,6 +33,7 @@ class Lesson_Module {
 			'sensei-lms/course-theme-lesson-module',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path

--- a/includes/blocks/course-theme/class-lesson-properties.php
+++ b/includes/blocks/course-theme/class-lesson-properties.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 use Sensei_Lesson_Properties_Block;
 
 /**
@@ -33,6 +33,7 @@ class Lesson_Properties {
 			'sensei-lms/learning-mode-lesson-properties',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -49,7 +50,7 @@ class Lesson_Properties {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes = [], string $content = '' ) : string {
+	public function render( array $attributes = [], string $content = '' ): string {
 		return Sensei_Lesson_Properties_Block::render_content( $attributes, $content );
 	}
 }

--- a/includes/blocks/course-theme/class-lesson-video.php
+++ b/includes/blocks/course-theme/class-lesson-video.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
-use \Sensei_Utils;
-use \Sensei_Frontend;
+use Sensei_Blocks;
+use Sensei_Utils;
+use Sensei_Frontend;
 
 /**
  * Class Lesson_Video is responsible for rendering the Lesson video template block.
@@ -34,6 +34,7 @@ class Lesson_Video {
 			'sensei-lms/course-theme-lesson-video',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -54,7 +55,7 @@ class Lesson_Video {
 		if ( ! empty( $video ) ) {
 			add_filter(
 				'body_class',
-				function( $classes ) {
+				function ( $classes ) {
 					return array_merge( $classes, [ 'sensei-video-lesson' ] );
 				}
 			);

--- a/includes/blocks/course-theme/class-notices.php
+++ b/includes/blocks/course-theme/class-notices.php
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
-use \Sensei_Context_Notices;
+use Sensei_Blocks;
+use Sensei_Context_Notices;
 
 /**
  * Class Notices
@@ -33,6 +33,7 @@ class Notices {
 			'sensei-lms/course-theme-notices',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -48,7 +49,7 @@ class Notices {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes = [] ) : string {
+	public function render( array $attributes = [] ): string {
 		$notices_html = Sensei_Context_Notices::instance( 'course_theme_lesson_regular' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' )
 			. Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' )
 			. Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' )

--- a/includes/blocks/course-theme/class-page-actions.php
+++ b/includes/blocks/course-theme/class-page-actions.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Display lesson or quiz pagination.
@@ -32,6 +32,7 @@ class Page_Actions {
 			'sensei-lms/page-actions',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path

--- a/includes/blocks/course-theme/class-prev-next-lesson.php
+++ b/includes/blocks/course-theme/class-prev-next-lesson.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Class Prev_Next_Lesson is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
@@ -32,6 +32,7 @@ class Prev_Next_Lesson {
 			'sensei-lms/course-theme-prev-next-lesson',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path

--- a/includes/blocks/course-theme/class-quiz-actions.php
+++ b/includes/blocks/course-theme/class-quiz-actions.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 use Sensei_Quiz;
 
 /**
@@ -34,6 +34,7 @@ class Quiz_Actions {
 			'sensei-lms/quiz-actions',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -47,7 +48,7 @@ class Quiz_Actions {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render() : string {
+	public function render(): string {
 		if ( ! sensei_can_user_view_lesson() || 'quiz' !== get_post_type() ) {
 			return '';
 		}

--- a/includes/blocks/course-theme/class-quiz-back-to-lesson.php
+++ b/includes/blocks/course-theme/class-quiz-back-to-lesson.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Class Quiz_Back_To_Lesson the back to lesson block in the quiz.
@@ -32,6 +32,7 @@ class Quiz_Back_To_Lesson {
 			'sensei-lms/quiz-back-to-lesson',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path
@@ -47,7 +48,7 @@ class Quiz_Back_To_Lesson {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes = [] ) : string {
+	public function render( array $attributes = [] ): string {
 		if ( get_post_type() !== 'quiz' ) {
 			return '';
 		}

--- a/includes/blocks/course-theme/class-sidebar-toggle-button.php
+++ b/includes/blocks/course-theme/class-sidebar-toggle-button.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * A button to toggle the sidebar in mobile view.
@@ -36,6 +36,7 @@ class Sidebar_Toggle_Button {
 			'sensei-lms/sidebar-toggle-button',
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-sidebar-mobile-menu',
 			],
 			$block_json_path
@@ -51,7 +52,7 @@ class Sidebar_Toggle_Button {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes = [] ) : string {
+	public function render( array $attributes = [] ): string {
 		$icon  = \Sensei()->assets->get_icon( 'menu' );
 		$label = __( 'Toggle course navigation', 'sensei-lms' );
 

--- a/includes/blocks/course-theme/class-template-style.php
+++ b/includes/blocks/course-theme/class-template-style.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * Allows to embed css styles into the block templates. Used for Learning Mode block templates.
@@ -40,6 +40,7 @@ class Template_Style {
 			self::BLOCK_NAME,
 			[
 				'render_callback' => [ $this, 'render' ],
+				'api_version'     => 3,
 				'style'           => 'sensei-theme-blocks',
 			],
 			$block_json_path

--- a/includes/blocks/course-theme/class-ui.php
+++ b/includes/blocks/course-theme/class-ui.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
+use Sensei_Blocks;
 
 /**
  * User interface block for Learning mode layout elements.
@@ -35,6 +35,7 @@ class Ui {
 				'style'           => 'sensei-learning-mode',
 				'editorStyle'     => 'sensei-learning-mode-editor',
 				'render_callback' => [ $this, 'render' ],
+				'api_version' => 3,
 				 */
 			],
 			$block_json_path

--- a/tests/e2e-playwright/helpers/editor.ts
+++ b/tests/e2e-playwright/helpers/editor.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import type { FrameLocator, Page } from '@playwright/test';
+
+/**
+ * Get a locator scoped to the block editor's canvas iframe.
+ *
+ * Since all Sensei blocks were migrated to Block API version 3, the post
+ * editor now renders its canvas inside an `iframe[name="editor-canvas"]`
+ * (see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-api-versions/README.md).
+ * Locators that target block content must go through this frame; toolbars,
+ * popovers, and modals (including Sensei's own wizard) still render in the
+ * top-level document.
+ *
+ * @param {Page} page Playwright page.
+ */
+export function getEditorCanvas( page: Page ): FrameLocator {
+	return page.frameLocator( 'iframe[name="editor-canvas"]' );
+}

--- a/tests/e2e-playwright/pages/admin/courses/index.ts
+++ b/tests/e2e-playwright/pages/admin/courses/index.ts
@@ -7,6 +7,7 @@ import type { Locator, Page } from '@playwright/test';
  * Internal dependencies
  */
 import PostType from '@e2e/pages/admin/post-type';
+import { getEditorCanvas } from '@e2e/helpers/editor';
 
 class WizardModal {
 	private readonly base: Locator;
@@ -58,12 +59,14 @@ class CourseOutline {
 	public readonly moduleBlock: ModuleBlock;
 
 	constructor( page: Page ) {
-		this.outline = page
+		// Block content renders inside the editor canvas iframe.
+		this.outline = getEditorCanvas( page )
 			.locator( '[aria-label="Block: Course Outline"]' )
 			.first();
 		this.addModuleOrLessonButton = this.outline.locator(
 			'[aria-label="Add Module or Lesson"]'
 		);
+		// The dropdown menu it opens is portalled to the top-level document.
 		this.addModuleButton = page.locator(
 			'button[role="menuitem"]:has-text("Module")'
 		);

--- a/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
+++ b/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from '@playwright/test';
 import CoursesPage from '@e2e/pages/admin/courses';
 import Dashboard from '@e2e/pages/admin/dashboard';
 import { teacherRole } from '@e2e/helpers/context';
+import { getEditorCanvas } from '@e2e/helpers/editor';
 
 const { describe, use } = test;
 
@@ -42,7 +43,9 @@ describe( 'Create Courses', () => {
 
 		await wizardModal.finishWithDefaultLayout();
 
-		await page
+		// The Course Outline block's placeholder renders inside the editor
+		// canvas iframe (all Sensei blocks are now Block API version 3).
+		await getEditorCanvas( page )
 			.getByRole( 'button', { name: 'Start with blank' } )
 			.dispatchEvent( 'click' );
 


### PR DESCRIPTION
## Summary

Update all Sensei blocks to Block API version 3 to prepare for the WordPress iframe editor. WordPress 6.9 deprecates apiVersion 2 blocks with console warnings. WordPress 7.1 will enforce the iframe editor for all blocks.

Fixes #8045

## Changes

### block.json / .block.json files (41 files)
Updated `apiVersion` to 3 in all block metadata files.

### PHP block registrations (29 files)
Added `api_version` to blocks registered via PHP without block.json.

### .eslintrc.js
Added `root: true` to prevent parent `.eslintrc.js` from leaking into the project.

### Why
- Blocks with apiVersion 2 or lower trigger deprecation warnings in WP 6.9
- The iframe editor isolates block styles/scripts - blocks need apiVersion 3 to work correctly inside it
- Most blocks work without code changes beyond the version bump
- A few blocks access `document`/`window` in editor code (noted in the issue) - tested and they work inside the iframe

## Testing

**Test 1: Verify no deprecation warnings**
1. Install WordPress 6.9+
2. Open the block editor
3. Add various Sensei blocks (course overview, outline, quiz, lesson actions, etc.)
4. Open browser console
5. Verify no `Block with API version 2 or lower is deprecated` warning appears

**Test 2: Verify blocks render correctly**
1. Create a post with various Sensei blocks
2. Save and view on frontend
3. Verify all blocks render correctly