### PR TITLE
Exclude guest and preview users from course enrollment counts

### DIFF
--- a/changelog/fix-reports-courses-guest-preview-enrollment-count
+++ b/changelog/fix-reports-courses-guest-preview-enrollment-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude guest and preview users from the enrollment counts on Reports > Courses.

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -206,6 +206,8 @@ class Sensei_Reports_Overview_Service_Courses {
 	/**
 	 * Get students count by courses.
 	 *
+	 * Guest and preview users are excluded, same as the grading counts.
+	 *
 	 * @since  4.4.1
 	 *
 	 * @param array $course_ids The array of courses ids.
@@ -214,14 +216,25 @@ class Sensei_Reports_Overview_Service_Courses {
 	private function get_students_count_in_courses( array $course_ids ): array {
 
 		global $wpdb;
+
+		$excluded_login_patterns = array(
+			$wpdb->esc_like( Sensei_Guest_User::LOGIN_PREFIX ) . '%',
+			$wpdb->esc_like( Sensei_Preview_User::LOGIN_PREFIX ) . '%',
+		);
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe direct sql.
 		return $wpdb->get_results(
-			"SELECT c.comment_post_ID as course_id, count(c.comment_post_ID) as students_count
-				FROM {$wpdb->comments} c
-				WHERE c.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )'  // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			. " AND c.comment_type = 'sensei_course_status'
-				AND c.comment_approved IN ( 'in-progress', 'complete' )
-				GROUP BY c.comment_post_ID",
+			$wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Sniff miscounts %s across the concatenated query string.
+				"SELECT c.comment_post_ID as course_id, count(c.comment_post_ID) as students_count
+					FROM {$wpdb->comments} c
+					WHERE c.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )'  // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				. " AND c.comment_type = 'sensei_course_status'
+					AND c.comment_approved IN ( 'in-progress', 'complete' )
+					AND c.comment_author NOT LIKE %s
+					AND c.comment_author NOT LIKE %s
+					GROUP BY c.comment_post_ID",
+				$excluded_login_patterns
+			),
 			'OBJECT_K'
 		);
 	}

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
@@ -243,6 +243,39 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests that guest and preview user enrollments do not skew the average progress denominator.
+	 *
+	 * @covers Sensei_Reports_Overview_Service_Courses::get_total_average_progress
+	 */
+	public function testTotalAverageProgress_WhenGuestOrPreviewUsersAreEnrolled_ExcludesThemFromCalculation() {
+		// Create a course with 1 lesson.
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$regular_user_id = $this->factory->user->create();
+		$guest_user_id   = $this->factory->user->create( [ 'user_login' => Sensei_Guest_User::LOGIN_PREFIX . '11111111_1' ] );
+		$preview_user_id = $this->factory->user->create( [ 'user_login' => Sensei_Preview_User::LOGIN_PREFIX . '22222222_1_1' ] );
+
+		$service = new Sensei_Reports_Overview_Service_Courses();
+
+		// Complete the lesson with the regular user.
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $regular_user_id, true );
+
+		// Enroll guest and preview users without completing the lesson.
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $guest_user_id );
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $preview_user_id );
+
+		/* Assert. */
+		$this->assertEquals(
+			100,
+			$service->get_total_average_progress( [ $course_id ] ),
+			'Average progress should be based on the regular student only.'
+		);
+	}
+
 
 	public function testGetAverageDaysToCompletionWhenOneCourseExistsReturnsMatchingValue() {
 		$user1_id  = $this->factory->user->create();
@@ -398,6 +431,31 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertSame( 2, $actual );
+	}
+
+	public function testGetTotalEnrollments_WhenGuestOrPreviewUsersAreEnrolled_ExcludesThemFromCount() {
+
+		/* Arrange */
+		$regular_user_id = $this->factory->user->create();
+		$guest_user_id   = $this->factory->user->create( [ 'user_login' => Sensei_Guest_User::LOGIN_PREFIX . '11111111_1' ] );
+		$preview_user_id = $this->factory->user->create( [ 'user_login' => Sensei_Preview_User::LOGIN_PREFIX . '22222222_1_1' ] );
+
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $regular_user_id );
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $guest_user_id );
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $preview_user_id );
+
+		$instance = new Sensei_Reports_Overview_Service_Courses();
+
+		/* Act. */
+		$actual = $instance->get_total_enrollments( [ $course_id ] );
+
+		/* Assert. */
+		self::assertSame( 1, $actual, 'Guest and preview user enrollments should not be counted.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Reports > Courses counts guest and preview users in the Enrolled column, the header total, and the average progress calculation. These are temporary accounts created for course previews, not real students, and they are already excluded from the grading counts elsewhere. This brings the enrollment count in line with that.

Fixes #7919

## Changes
### `includes/reports/overview/services/class-sensei-reports-overview-service-courses.php`
**Before:**
```php
return $wpdb->get_results(
    "SELECT c.comment_post_ID as course_id, count(c.comment_post_ID) as students_count
        FROM {$wpdb->comments} c
        WHERE c.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )'
    . " AND c.comment_type = 'sensei_course_status'
        AND c.comment_approved IN ( 'in-progress', 'complete' )
        GROUP BY c.comment_post_ID",
    'OBJECT_K'
);
```
**After:**
```php
$excluded_login_patterns = array(
    $wpdb->esc_like( Sensei_Guest_User::LOGIN_PREFIX ) . '%',
    $wpdb->esc_like( Sensei_Preview_User::LOGIN_PREFIX ) . '%',
);

return $wpdb->get_results(
    $wpdb->prepare(
        "SELECT c.comment_post_ID as course_id, count(c.comment_post_ID) as students_count
            FROM {$wpdb->comments} c
            WHERE c.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )'
        . " AND c.comment_type = 'sensei_course_status'
            AND c.comment_approved IN ( 'in-progress', 'complete' )
            AND c.comment_author NOT LIKE %s
            AND c.comment_author NOT LIKE %s
            GROUP BY c.comment_post_ID",
        $excluded_login_patterns
    ),
    'OBJECT_K'
);
```
**Why:** `comment_author` on `sensei_course_status` comments is set from the user's login (`Sensei_Utils::sensei_log_activity()`), so filtering on the guest/preview login prefixes keeps these temporary accounts out of the count without a join or subquery. Same approach `Comments_Based_Progress_Aggregation_Service::build_user_exclusion_clause()` already uses for grading stats.

## Testing
**Test 1: Enrollment count excludes guest/preview users**
1. Create a course with one lesson
2. Start the lesson as a regular user, a guest user (`sensei_guest_*` login), and a preview user (`sensei_preview_*` login)
3. Call `get_total_enrollments()` for that course
Result: returns 1 (regular user only), previously counted all 3

**Test 2: Average progress excludes guest/preview users**
1. Same setup, complete the lesson as the regular user only, leave guest/preview in-progress
2. Call `get_total_average_progress()` for that course
Result: returns 100 (based on the regular student only), previously skewed by the extra unfinished enrollments

Both added as automated tests in `tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php`, verified failing on the old query and passing with the fix. Full class (14 tests) and PHPCS both pass clean.

## Screenshot
<img width="1905" height="585" alt="SCR-20260707-dkyq" src="https://github.com/user-attachments/assets/506f8a0a-c04a-472d-abd8-3cb58cc44017" />
