### PR TITLE
fix(learning-mode): prevent long course title hiding mobile menu toggle

### DIFF
--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -18,6 +18,17 @@ $breakpoint: 783px;
 		.sensei-course-theme-header-content {
 			gap: 0;
 			transition: all 300ms;
+
+			// Let the title group shrink so a long course title
+			// ellipses instead of pushing the menu toggle off-screen.
+			> .wp-block-group:first-child {
+				flex: 1 1 auto;
+				min-width: 0;
+			}
+
+			> .wp-block-group:last-child {
+				flex: 0 0 auto;
+			}
 		}
 
 		&__focus-mode-toggle {

--- a/changelog/fix-7888-mobile-menu-hidden-long-title
+++ b/changelog/fix-7888-mobile-menu-hidden-long-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Long course title on mobile Learning Mode no longer pushes hamburger menu toggle off-screen.


### PR DESCRIPTION
## Summary
On mobile Learning Mode, long course titles push the hamburger menu toggle off-screen, making lesson navigation unreachable. The flex row had no constraint on the left group's min-width, so the nowrap title expanded past the viewport.

Fixes #7888

## Changes

### assets/css/sensei-course-theme/mobile.scss

**Before:**
```scss
.sensei-course-theme-header-content {
    gap: 0;
    transition: all 300ms;
}
```

**After:**
```scss
.sensei-course-theme-header-content {
    gap: 0;
    transition: all 300ms;

    // Let the title group shrink so a long course title
    // ellipses instead of pushing the menu toggle off-screen.
    > .wp-block-group:first-child {
        flex: 1 1 auto;
        min-width: 0;
    }

    > .wp-block-group:last-child {
        flex: 0 0 auto;
    }
}
```

**Why:** The left group (logo + course title) now shrinks when space is tight, so the existing `text-overflow: ellipsis` on the title finally works. The right group (toggle button) stays fixed-width and pinned to the right edge. Scoped to the mobile media query only.

## Testing

**Test 1: Mobile viewport with long title**
1. Create a course with a title longer than 300px wide
2. Enable Learning Mode, create a lesson
3. View the lesson, resize viewport to <= 782px
4. Result: Hamburger menu visible top-right, long title truncates with ellipsis

**Test 2: Short title (regression check)**
1. View a lesson with a short title on mobile
2. Result: Title displays fully, no layout change

**Test 3: Desktop viewport**
1. View any Learning Mode lesson on desktop (>= 783px)
2. Result: No change (toggle hidden on desktop as designed)

## Screenshot
| Before                                                                                             | After                                                                                            |
|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
| ![Before](https://github.com/user-attachments/assets/bbd2b358-588b-41cf-b149-dc04316bf60c)       | ![After](https://github.com/user-attachments/assets/b0201b5c-39c0-4d39-9252-a307af5a85ed)        |
