### PR TITLE
Accept private status when importing lessons and questions

### DIFF
--- a/changelog/fix-8067-import-private-status
+++ b/changelog/fix-8067-import-private-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Preserve the private status when importing lessons and questions so an export then import round-trip no longer drops private content.

--- a/includes/data-port/models/class-sensei-data-port-lesson-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-lesson-schema.php
@@ -65,7 +65,7 @@ class Sensei_Data_Port_Lesson_Schema extends Sensei_Data_Port_Schema {
 			self::COLUMN_STATUS         => [
 				'type'    => 'string',
 				'default' => 'draft',
-				'pattern' => '/^(publish|pending|draft|)$/',
+				'pattern' => '/^(publish|pending|private|draft|)$/',
 			],
 			self::COLUMN_MODULE         => [
 				'type' => 'string',

--- a/includes/data-port/models/class-sensei-data-port-question-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-question-schema.php
@@ -68,7 +68,7 @@ class Sensei_Data_Port_Question_Schema extends Sensei_Data_Port_Schema {
 			self::COLUMN_STATUS          => [
 				'type'    => 'string',
 				'default' => 'draft',
-				'pattern' => '/^(publish|pending|draft|)$/',
+				'pattern' => '/^(publish|pending|private|draft|)$/',
 			],
 			self::COLUMN_TYPE            => [
 				'type'    => 'string',

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -282,6 +282,26 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A 'private' status must survive import. The exporter writes the raw
+	 * post_status, so without 'private' in the status pattern an export then
+	 * import round-trip silently drops private lessons. Regression guard for #8067.
+	 */
+	public function testPrivateStatusIsAccepted() {
+		$task  = new Sensei_Import_Lessons( Sensei_Import_Job::create( 'test', 0 ) );
+		$model = Sensei_Import_Lesson_Model::from_source_array(
+			1,
+			[ Sensei_Data_Port_Lesson_Schema::COLUMN_STATUS => 'private' ],
+			new Sensei_Data_Port_Lesson_Schema(),
+			$task
+		);
+
+		$this->assertEquals(
+			'private',
+			$model->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_STATUS )
+		);
+	}
+
+	/**
 	 * Tests creating a lesson and updating all its values.
 	 */
 	public function testLessonIsInsertedAndUpdated() {

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -268,6 +268,24 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A 'private' status must survive import. The exporter writes the raw
+	 * post_status, so without 'private' in the status pattern an export then
+	 * import round-trip silently drops private questions. Regression guard for #8067.
+	 */
+	public function testPrivateStatusIsAccepted() {
+		$model = Sensei_Import_Question_Model::from_source_array(
+			1,
+			[ Sensei_Data_Port_Question_Schema::COLUMN_STATUS => 'private' ],
+			new Sensei_Data_Port_Question_Schema()
+		);
+
+		$this->assertEquals(
+			'private',
+			$model->get_value( Sensei_Data_Port_Question_Schema::COLUMN_STATUS )
+		);
+	}
+
+	/**
 	 * Check to make sure post is fully created.
 	 */
 	public function testValidFullPostCreated() {


### PR DESCRIPTION
Resolves #8067

## Proposed Changes

Exporting a lesson or question set to `private` and importing it back drops the status. The exporter writes the raw `post_status`, but the lesson and question import schemas only accept `publish`, `pending`, `draft`, or empty, so a `private` row fails the status pattern. `Sensei_Import_Model` then sets the non-matching value to null and the content imports as the default `draft` — an export then import round-trip silently downgrades private content.

* Add `private` to the status pattern in the lesson and question data-port schemas. The exporter already emits the raw status, so nothing changes there.
* Add a regression test to each model that imports a `private` row and asserts the status survives.

## Testing Instructions

1. Create a private lesson and a private question, then export lessons and questions to CSV from Tools then Export.
2. Import that CSV back via Tools then Import.
3. Before this change the imported item is `draft`; with it, the item stays `private`.
4. Automated: `npx wp-env run tests-cli -- phpunit --filter testPrivateStatusIsAccepted` covers both models. Removing `private` from either schema pattern makes the value null and the test fails, which is the delete-the-fix guard.

## Changelog entry

Included in this branch as `changelog/fix-8067-import-private-status` (Significance: patch, Type: fixed).

I verified the fix with `php -l` and a standalone harness reproducing the schema's `preg_match` path (`private` is dropped to null without the change, kept with it). I don't have a local wp-env, so the PHPUnit cases are written to match the existing model tests and run on CI.

(full disclosure: AI helped me identify the issue and verify my work)
