### PR TITLE
Prevent duplicate export rows when the first batch reruns

### DIFF
--- a/changelog/fix-7969-export-reentrant-duplicate-rows
+++ b/changelog/fix-7969-export-reentrant-duplicate-rows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent the exporter from appending duplicate rows when the first batch runs again before its progress offset is persisted.

--- a/includes/data-port/export-tasks/class-sensei-export-task.php
+++ b/includes/data-port/export-tasks/class-sensei-export-task.php
@@ -121,7 +121,16 @@ abstract class Sensei_Export_Task extends Sensei_Data_Port_Task implements Sense
 				throw new Exception( 'Missing output file' );
 			}
 
-			$output_file = new SplFileObject( $this->file, 'a' );
+			$is_first_batch = 0 === $this->completed_posts;
+			$output_file    = new SplFileObject( $this->file, $is_first_batch ? 'w' : 'a' );
+
+			if ( $is_first_batch ) {
+				// Truncate and rewrite the header on the first batch so a re-entrant
+				// first run (e.g. a scheduler retry before the completed-posts offset
+				// was persisted) rewrites the file instead of appending rows it may
+				// have already written.
+				$output_file->fputcsv( $this->get_header_row() );
+			}
 		} catch ( Exception $e ) {
 			$this->is_aborted = true;
 
@@ -190,17 +199,23 @@ abstract class Sensei_Export_Task extends Sensei_Data_Port_Task implements Sense
 	 * @return string Temporary filename.
 	 */
 	private function create_csv_file() {
-		$columns = $this->get_type_schema()->get_schema();
-		$headers = array_map( 'ucwords', array_keys( $columns ) );
-
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
 		$filename = wp_tempnam( 'sensei-export-csv-' . $this->get_content_type() );
 		$file     = new SplFileObject( $filename, 'w' );
-		$file->fputcsv( $headers );
+		$file->fputcsv( $this->get_header_row() );
 		$file = null;
 
 		return $filename;
+	}
+
+	/**
+	 * Get the CSV header row for this content type.
+	 *
+	 * @return string[] The column headers.
+	 */
+	private function get_header_row() {
+		return array_map( 'ucwords', array_keys( $this->get_type_schema()->get_schema() ) );
 	}
 
 	/**

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
@@ -68,6 +68,32 @@ class Sensei_Export_Lessons_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A re-entrant first batch must not duplicate rows. If the completed-posts
+	 * offset is not advanced before the batch runs again (for example a
+	 * scheduler retry), the export must rewrite the file rather than append the
+	 * same rows a second time. Regression guard for #7969.
+	 */
+	public function testExport_FirstBatchRerunsWithoutAdvancing_DoesNotDuplicateRows() {
+		$this->factory->lesson->create();
+		$this->factory->lesson->create();
+
+		$job   = Sensei_Export_Job::create( 'test', 0 );
+		$class = $this->get_task_class();
+
+		// First batch writes its rows and records the completed-posts offset.
+		( new $class( $job ) )->run();
+
+		$type = ( new $class( $job ) )->get_content_type();
+
+		// Simulate the batch running again before the offset was persisted.
+		$job->set_state( $type, array( Sensei_Export_Task::STATE_COMPLETED_POSTS => 0 ) );
+		( new $class( $job ) )->run();
+
+		$rows = array_values( array_filter( self::read_csv( $job->get_file_path( $type ) ) ) );
+		$this->assertCount( 2, $rows, 'A re-entrant first batch should not duplicate exported rows.' );
+	}
+
+	/**
 	 * Test that lesson details are exported correctly.
 	 */
 	public function testLessonContentExported() {


### PR DESCRIPTION
Resolves #7969

## Proposed Changes

The export task always opened its CSV in append mode, so if the first batch runs again before its `completed-posts` offset is persisted (a scheduler retry, for instance) it appends the same rows a second time and the file ends up with duplicates. The report notes this is pre-existing on trunk.

* On the first batch (`completed_posts === 0`), open the file in write mode and rewrite the header, so a re-entrant first run rewrites the file instead of appending to it. Later batches still append.
* Extract the header row into a shared `get_header_row()` helper used by both the initial file creation and the first-batch rewrite, so the two can't drift.

The file is created once per job, so truncating and rewriting the header on the first batch is safe across batches.

## Testing Instructions

1. Export any content type to CSV from Tools then Export and note the row count.
2. Simulate a re-entrant first batch: run the first export batch, reset its `completed-posts` offset to 0 without advancing it, then run again. The added test does exactly this.
3. Before this change the CSV holds the first batch's rows twice; with it, once.
4. Automated: `npx wp-env run tests-cli -- phpunit --filter testExport_FirstBatchRerunsWithoutAdvancing_DoesNotDuplicateRows`. Reverting to append-always makes the row count double and the test fails.

## Changelog entry

Included in this branch as `changelog/fix-7969-export-reentrant-duplicate-rows` (Significance: patch, Type: fixed).

I verified the fix with `php -l` and a standalone `SplFileObject` harness (a re-entrant first batch yields 4 rows without the fix, 2 with). No local wp-env here, so the PHPUnit case is written to match the existing export-task tests and runs on CI.

(full disclosure: AI helped me identify the issue and verify my work)
