### PR TITLE
Detect YouTube completion when the ended state is not emitted

### DIFF
--- a/assets/shared/helpers/player/youtube-adapter.js
+++ b/assets/shared/helpers/player/youtube-adapter.js
@@ -144,7 +144,17 @@ export const onTimeupdate = ( player, callback, w = window ) => {
 	// Update the current time based on an interval.
 	const interval = setInterval( () => {
 		if ( player.getPlayerState() !== w.YT.PlayerState.ENDED ) {
-			updateCurrentTime( player.getCurrentTime() );
+			const currentTime = player.getCurrentTime();
+			const duration = player.getDuration();
+
+			// YouTube doesn't always emit the ENDED state at the very end, so
+			// completion, which relies on reaching the duration, can be missed.
+			// Once we're within a second of the end, report the full duration.
+			if ( duration > 0 && currentTime >= duration - 1 ) {
+				updateCurrentTime( duration );
+			} else {
+				updateCurrentTime( currentTime );
+			}
 		}
 	}, timer );
 

--- a/assets/shared/helpers/player/youtube-adapter.test.js
+++ b/assets/shared/helpers/player/youtube-adapter.test.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { onTimeupdate } from './youtube-adapter';
+
+describe( 'youtube-adapter', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'reports the full duration once within a second of the end even if the ENDED state never fires', () => {
+		jest.useFakeTimers();
+
+		const duration = 100;
+		const w = { YT: { PlayerState: { ENDED: 0 } } };
+		const player = {
+			getPlayerState: () => 1, // PLAYING; the ENDED state (0) never arrives.
+			getCurrentTime: () => duration - 0.5,
+			getDuration: () => duration,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+		};
+		const callback = jest.fn();
+
+		const unsubscribe = onTimeupdate( player, callback, w );
+		jest.advanceTimersByTime( 250 );
+
+		expect( callback ).toHaveBeenCalledWith( duration );
+
+		unsubscribe();
+	} );
+} );

--- a/changelog/fix-7980-youtube-completion-tolerance
+++ b/changelog/fix-7980-youtube-completion-tolerance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Detect completion for YouTube videos when the player does not emit the ended state at the very end of playback.


### PR DESCRIPTION
Resolves #7980

## Proposed Changes

YouTube videos don't reliably register as complete. The adapter's time-update interval only reports progress while the player state isn't `ENDED`, and completion depends on the `ENDED` handler calling `updateCurrentTime(duration)`. YouTube doesn't always emit `ENDED` at the very end of playback, so the last reported time stays just short of the duration and the lesson never marks the video complete.

* In the time-update interval, once the current time is within a second of the duration, report the full duration. Completion is then detected even when `ENDED` never arrives; behaviour elsewhere is unchanged.

## Testing Instructions

1. Add a lesson with a YouTube video that requires completion to progress.
2. Watch it to the end. On some videos YouTube settles on a paused final frame without firing `ENDED`; before this change the video stays marked incomplete.
3. With this change the video registers as complete once playback reaches the final second.
4. Automated: `npm run test-js -- youtube-adapter`. The test advances the interval with a player that never reaches `ENDED` and asserts the callback receives the full duration; without the tolerance it receives `duration - 0.5` and the test fails.

## Changelog entry

Included in this branch as `changelog/fix-7980-youtube-completion-tolerance` (Significance: patch, Type: fixed).

I verified the fix with a standalone Node harness reproducing the interval (the reported time reaches the full duration only with the tolerance). npm install was blocked by an intermittent network error in my environment, so the jest case is written to match the repo's existing player tests (such as `round-with-decimals.test.js`) and runs on CI.

(full disclosure: AI helped me identify the issue and verify my work)
