### PR TITLE
Enforce long array() syntax in phpcs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,29 +21,12 @@
 
 	<!-- Rules -->
 	<rule ref="PHPCompatibilityWP"/>
-	<rule ref="WordPress">
-		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
-	</rule>
+	<rule ref="WordPress" />
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 
 	<rule ref="WordPress.Security.ValidatedSanitizedInput" />
 	<rule ref="WordPress.DB.DirectDatabaseQuery" />
-
-	<!-- Array Syntax (disabled until we transition to short-array) -->
-<!--
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
-		<include-pattern>/sensei-lms.php</include-pattern>
-		<include-pattern>/uninstall.php</include-pattern>
-		<include-pattern>/includes/class-sensei-dependency-checker.php</include-pattern>
-	</rule>
-
-	<rule ref="Universal.Arrays.DisallowShortArraySyntax">
-		<include-pattern>/sensei-lms.php</include-pattern>
-		<include-pattern>/uninstall.php</include-pattern>
-		<include-pattern>/includes/class-sensei-dependency-checker.php</include-pattern>
-	</rule>
--->
 
 	<!-- Temporary Rule Exclusions -->
 	<rule ref="VariableAnalysis">


### PR DESCRIPTION
## Proposed Changes

Sensei's coding conventions (AGENTS.md) and the WordPress standards call for long `array()` syntax, but `phpcs.xml.dist` excluded `Universal.Arrays.DisallowShortArraySyntax` from the `WordPress` ruleset, so short `[ ]` arrays passed lint. A stale commented-out block below it referenced an abandoned "transition to short-array" direction and added confusion (it also held two mutually contradictory rules).

This removes the exclude so short arrays are flagged, and deletes the dead commented block. The diff-based CI linter only compares violations on changed files against trunk, so this enforces long `array()` on **new/changed** code only — no mass-conversion of existing arrays.

## Testing Instructions

This PR changes only `phpcs.xml.dist` — no PHP source — so the diff-based CI linter finds no `.php` changes and is a no-op on this branch. Verify the rule itself instead:

- [x] Run `./vendor/bin/phpcs --sniffs=Universal.Arrays.DisallowShortArraySyntax` against a file containing both syntaxes and confirm short `[ ]` arrays report `Universal.Arrays.DisallowShortArraySyntax.Found` while long `array()` is clean.

Note on the diff-based linter (`make lint` / CI): the cancellation of pre-existing `[ ]` in touched files only holds **once this merges**, when both the branch and its trunk baseline share the new config. On this branch the merge-base still carries the old (excluded) config, so a touched legacy file would surface its pre-existing short arrays as "new". Not exercised here since no PHP changes.