### PR TITLE
Return 0 instead of false for a wrong autograded answer

### DIFF
--- a/changelog/fix-autograde-wrong-answer-false-grade
+++ b/changelog/fix-autograde-wrong-answer-false-grade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed auto-graded quizzes showing an inflated total on the admin Review Grade screen when a student answered questions incorrectly.

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1222,7 +1222,7 @@ class Sensei_Grading {
 
 		}
 
-		return $question_grade;
+		return (int) $question_grade;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -282,6 +282,25 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A wrong answer to an autogradable question must be recorded as a numeric zero grade,
+	 * not boolean false. Storing false makes get_user_question_grade() report the question as
+	 * "not graded" on the Review Grade screen, so a wrong answer renders as ungraded and the
+	 * displayed total is inflated.
+	 *
+	 * @covers Sensei_Grading::grade_question_auto
+	 */
+	public function testGradeQuestionAuto_WrongMultipleChoiceAnswerGiven_ReturnsZeroGrade(): void {
+		/* Arrange. */
+		$question_id = $this->getTestQuestion( 'multiple-choice' );
+
+		/* Act. */
+		$grade = Sensei_Grading::grade_question_auto( $question_id, 'multiple-choice', 'wrong1', 0 );
+
+		/* Assert. */
+		$this->assertSame( 0, $grade );
+	}
+
+	/**
 	 * Test that courses average grade is calculated correctly when there are no grades.
 	 *
 	 * @covers Sensei_Grading::get_courses_average_grade


### PR DESCRIPTION
## Proposed Changes

On the admin **Review Grade** screen, a student's total could display **higher than their actual grade** (up to 100%) for auto-graded quizzes — and the number varied between page loads.

Root cause: `grade_question_auto()` returned boolean `false` (not `0`) for a wrong answer to an autogradable question. `set_user_grades()` then caches that raw map in the `quiz_grades_<user>_<lesson>` **transient** with the `false` intact. (The persisted `quiz_grades` comment meta is unaffected — the grade repository's `int $points` signature already coerces `false`→`0` before the DB write, so this is a transient-vs-persisted inconsistency, not corrupted stored data.) `get_user_question_grade()` reads the transient, sees `false`, and reports the question as *not graded*. The Review Grade screen renders wrong answers as **ungraded** instead of **wrong**, and the on-load `autoGrade()` JS re-grades them by scraping the answer iframes — a race that intermittently marks wrong answers correct and inflates the total. (Once the transient expires it rebuilds from the repository as `0` and self-heals, which is part of why the symptom was intermittent.)

This casts the autogradable return to `int`, so a wrong answer is recorded as `0` (graded, incorrect) everywhere — the transient now matches the persisted value. It then renders as "wrong", `autoGrade()` skips it, and the total matches the student's real grade.

## Testing Instructions

**Setup**

- [ ] Create an **auto-graded** quiz with a couple of multiple-choice questions.
- [ ] As a student, submit it, answering **one question wrong**. Note the lesson ID, student user ID, and the wrong question's ID.

**Data check (deterministic)**

- [ ] Run: `wp eval 'var_dump( Sensei()->quiz->get_user_question_grade( LESSON_ID, WRONG_QUESTION_ID, USER_ID ) );'`
  - **Trunk (bug):** `bool(false)`
  - **With this fix:** `int(0)`

**UI check (deterministic — disable JavaScript so the on-load auto-grade script can't mask the state)**

- [ ] Open **Grading → Review Grade** for that student.
  - **Trunk (bug):** the wrong question is **unmarked** — neither *Right* nor *Wrong* selected, grade box blank.
  - **With this fix:** the wrong question is marked **Wrong**, grade `0`.

With JavaScript enabled, the bug instead surfaces as an **inflated total** at the top (up to 100%, varying on refresh), but that depends on page timing — use the checks above to verify reliably.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fixed auto-graded quizzes showing an inflated total on the admin Review Grade screen when a student answered questions incorrectly.

</details>