### PR TITLE
Fix Notices block color settings in Learning Mode

### DIFF
--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -198,9 +198,13 @@ export default [
 			'Display Sensei notices about the current lesson or quiz.',
 			'sensei-lms'
 		),
-		edit() {
+		edit: function NoticesEdit() {
+			const blockProps = useBlockProps( {
+				className:
+					'sensei-course-theme__frame sensei-lms-notice sensei-course-theme-lesson-quiz-notice',
+			} );
 			return (
-				<div className="sensei-course-theme__frame sensei-lms-notice sensei-course-theme-lesson-quiz-notice">
+				<div { ...blockProps }>
 					<div className="sensei-course-theme-lesson-quiz-notice__content">
 						{ __( 'Notice', 'sensei-lms' ) }
 					</div>

--- a/assets/css/sensei-course-theme/notices.scss
+++ b/assets/css/sensei-course-theme/notices.scss
@@ -8,9 +8,14 @@ body.sensei-course-theme {
 }
 
 /* All notices */
-.sensei-course-theme .sensei-lms-notice {
+.sensei-course-theme .wp-block-sensei-lms-course-theme-notices {
 	background-color: var(--wp--preset--color--foreground, #f6f7f7);
 	color: var(--wp--preset--color--background, #1e1e1e);
+}
+
+.sensei-course-theme .sensei-lms-notice {
+	background-color: inherit;
+	color: inherit;
 	padding: 24px;
 
 	@media (min-width: $break-medium) {

--- a/changelog/fix-7450-lm-notices-block-styling
+++ b/changelog/fix-7450-lm-notices-block-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Notices block color settings not applying in Learning Mode, in the editor or on the frontend.


### PR DESCRIPTION
Resolves #7450

## Proposed Changes

Learning Mode's Notices block exposes color settings in the editor, but changing them did nothing in the editor preview or on the frontend. The block never applied block-support props in `edit()`, and hardcoded notice colors on the nested `.sensei-lms-notice` element blocked any custom styles from cascading.

This wires up `useBlockProps` for the Notices block (same pattern as neighboring Learning Mode blocks) and moves the default background/text colors to the block wrapper so custom colors can cascade into the notice. Spacing, typography, and border supports are still only partially applied (styles land on the wrapper only) — this PR fixes the color path described in the issue.

## Screenshots

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/4e765dfc-99cd-430d-a075-9a889d4f5e72) | ![After](https://github.com/user-attachments/assets/16c94cc9-8611-41f6-adaa-0b277de9c301) |

## Testing Instructions

- [ ] Go to **Sensei LMS → Settings → Appearance**, enable Learning Mode if needed, then click **Customize** on the active Learning Mode template
- [ ] Select the Notices block (the block that shows "Notice" in the template preview)
- [ ] In the block sidebar, open **Color → Background** and pick a distinctive color (e.g. bright yellow)
- [ ] Confirm the Notices block preview updates to that color in the editor
- [ ] Save the template
- [ ] Open a frontend lesson that shows a notice (e.g. quiz in progress, or a locked lesson) and confirm the notice uses the custom background color
- [ ] Optional: check another notice type (e.g. "Awaiting grade" on a quiz) still picks up the color
- [ ] Confirm lessons not using Learning Mode are unchanged

## Changelog entry

Changelog file already committed at `changelog/fix-7450-lm-notices-block-styling` (fork cannot use auto-create).

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message
Fix Notices block color settings not applying in Learning Mode, in the editor or on the frontend.

</details>