### PR TITLE
Only flag course_welcome as sent once it is actually dispatched

### DIFF
--- a/changelog/fix-course-welcome-email-marked-sent-when-suppressed
+++ b/changelog/fix-course-welcome-email-marked-sent-when-suppressed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only flag the Welcome to Course email as sent once it has actually been dispatched, so a welcome that is deferred until course access starts is still delivered.

--- a/changelog/fix-course-welcome-email-marked-sent-when-suppressed
+++ b/changelog/fix-course-welcome-email-marked-sent-when-suppressed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Only flag the Welcome to Course email as sent once it has actually been dispatched, so a welcome that is deferred until course access starts is still delivered.

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -126,13 +126,32 @@ class Email_Sender {
 			 * For documentation of the filter check class-sensei-emails.php file.
 			 */
 			if ( apply_filters( 'sensei_send_emails', true, $recipient, $subject, $message, $email_name, $replacement ) ) {
-				wp_mail(
+				$sent = wp_mail(
 					$recipient,
 					$subject,
 					$message,
 					$this->get_email_headers()
 				);
 				sensei_log_event( 'email_send', [ 'type' => $usage_tracking_type ] );
+
+				if ( $sent ) {
+					/**
+					 * Fires after a Sensei email has been successfully handed off for a recipient.
+					 *
+					 * Fires only when the email passed the `sensei_send_emails` gate and `wp_mail()`
+					 * returned true, so listeners can react to real sends rather than attempts that
+					 * were suppressed or failed at the mailer.
+					 *
+					 * @since $$next-version$$
+					 *
+					 * @hook  sensei_email_sent
+					 *
+					 * @param {string} $email_name  The email identifier (e.g. 'course_welcome').
+					 * @param {string} $recipient   The recipient email address.
+					 * @param {array}  $replacement The per-recipient replacement values.
+					 */
+					do_action( 'sensei_email_sent', $email_name, $recipient, $replacement );
+				}
 			}
 		}
 

--- a/includes/internal/emails/class-email-sender.php
+++ b/includes/internal/emails/class-email-sender.php
@@ -136,11 +136,8 @@ class Email_Sender {
 
 				if ( $sent ) {
 					/**
-					 * Fires after a Sensei email has been successfully handed off for a recipient.
-					 *
-					 * Fires only when the email passed the `sensei_send_emails` gate and `wp_mail()`
-					 * returned true, so listeners can react to real sends rather than attempts that
-					 * were suppressed or failed at the mailer.
+					 * Fires after `wp_mail()` sends a Sensei email to a recipient, so listeners
+					 * can react to real sends rather than suppressed or failed attempts.
 					 *
 					 * @since $$next-version$$
 					 *

--- a/includes/internal/emails/generators/class-course-welcome.php
+++ b/includes/internal/emails/generators/class-course-welcome.php
@@ -46,6 +46,21 @@ class Course_Welcome extends Email_Generators_Abstract {
 	const META_PREFIX_WELCOME_SENT = 'sensei_course_welcome_email_sent_';
 
 	/**
+	 * Value stored in the welcome-sent flag when the upgrade backfill grandfathered a student
+	 * instead of this code dispatching the email. It makes no claim about actual delivery —
+	 * the student may have been welcomed before this flag existed, or never.
+	 *
+	 * A recorded dispatch stores a timestamp instead, so integrations can tell an assumed flag
+	 * apart from a real dispatch (e.g. to still deliver a welcome whose access period had not
+	 * started when the backfill ran).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const WELCOME_ASSUMED = 'assumed';
+
+	/**
 	 * Build the user meta key used to flag the welcome email as sent for a course.
 	 *
 	 * The key is blog-prefixed so it stays scoped to the current site on multisite,
@@ -74,6 +89,9 @@ class Course_Welcome extends Email_Generators_Abstract {
 
 		// Send welcome email on the day the student gets access to the course.
 		$this->maybe_add_action( 'sensei_pro_course_access_start_student_email_send', [ $this, 'welcome_to_course_for_student' ], 10, 2 );
+
+		// Flag the welcome email as sent only once it has actually been dispatched.
+		$this->maybe_add_action( 'sensei_email_sent', array( $this, 'mark_welcome_email_sent_on_dispatch' ), 10, 3 );
 	}
 
 	/**
@@ -135,11 +153,37 @@ class Course_Welcome extends Email_Generators_Abstract {
 				],
 			]
 		);
+	}
 
-		// Flag as sent regardless of delivery outcome. Sensei's email dispatch is a
-		// fire-and-forget action, so the result is not knowable here. We favour never
-		// re-welcoming an enrolled student over guaranteeing a single delivery.
-		$this->mark_welcome_email_sent( $student_id, $course_id );
+	/**
+	 * Flag the welcome email as sent once it has actually been dispatched.
+	 *
+	 * Hooked on `sensei_email_sent`, which only fires when the email passed the
+	 * `sensei_send_emails` gate. Marking here rather than at send-attempt time avoids
+	 * flagging suppressed emails as sent (e.g. when access to the course has not started
+	 * yet), which would otherwise block the deferred welcome from being delivered later.
+	 *
+	 * @internal
+	 *
+	 * @access private
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $email_name  The email identifier.
+	 * @param string $recipient   The recipient email address.
+	 * @param array  $replacement The per-recipient replacement values.
+	 */
+	public function mark_welcome_email_sent_on_dispatch( $email_name, $recipient, $replacement ) {
+		if ( self::IDENTIFIER_NAME !== $email_name ) {
+			return;
+		}
+
+		$student_id = isset( $replacement['student:id'] ) ? (int) $replacement['student:id'] : 0;
+		$course_id  = isset( $replacement['course:id'] ) ? (int) $replacement['course:id'] : 0;
+
+		if ( $student_id && $course_id ) {
+			$this->mark_welcome_email_sent( $student_id, $course_id );
+		}
 	}
 
 	/**

--- a/includes/internal/emails/generators/class-course-welcome.php
+++ b/includes/internal/emails/generators/class-course-welcome.php
@@ -150,12 +150,10 @@ class Course_Welcome extends Email_Generators_Abstract {
 	}
 
 	/**
-	 * Flag the welcome email as sent once it has actually been dispatched.
+	 * Flag the welcome email as sent, hooked on `sensei_email_sent`.
 	 *
-	 * Hooked on `sensei_email_sent`, which only fires when the email passed the
-	 * `sensei_send_emails` gate. Marking here rather than at send-attempt time avoids
-	 * flagging suppressed emails as sent (e.g. when access to the course has not started
-	 * yet), which would otherwise block the deferred welcome from being delivered later.
+	 * That hook only fires on actual dispatch, so a suppressed email (e.g. course
+	 * access has not started yet) is not flagged and can still be delivered later.
 	 *
 	 * @internal
 	 *

--- a/includes/internal/emails/generators/class-course-welcome.php
+++ b/includes/internal/emails/generators/class-course-welcome.php
@@ -46,13 +46,7 @@ class Course_Welcome extends Email_Generators_Abstract {
 	const META_PREFIX_WELCOME_SENT = 'sensei_course_welcome_email_sent_';
 
 	/**
-	 * Value stored in the welcome-sent flag when the upgrade backfill grandfathered a student
-	 * instead of this code dispatching the email. It makes no claim about actual delivery —
-	 * the student may have been welcomed before this flag existed, or never.
-	 *
-	 * A recorded dispatch stores a timestamp instead, so integrations can tell an assumed flag
-	 * apart from a real dispatch (e.g. to still deliver a welcome whose access period had not
-	 * started when the backfill ran).
+	 * Welcome-sent flag value written by the upgrade backfill, not a real dispatch. A real dispatch stores a timestamp, so integrations can tell the two apart.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/internal/emails/generators/class-course-welcome.php
+++ b/includes/internal/emails/generators/class-course-welcome.php
@@ -79,10 +79,10 @@ class Course_Welcome extends Email_Generators_Abstract {
 	 * @return void
 	 */
 	public function init() {
-		$this->maybe_add_action( 'sensei_course_enrolment_status_changed', [ $this, 'welcome_to_course_for_student' ], 10, 3 );
+		$this->maybe_add_action( 'sensei_course_enrolment_status_changed', array( $this, 'welcome_to_course_for_student' ), 10, 3 );
 
 		// Send welcome email on the day the student gets access to the course.
-		$this->maybe_add_action( 'sensei_pro_course_access_start_student_email_send', [ $this, 'welcome_to_course_for_student' ], 10, 2 );
+		$this->maybe_add_action( 'sensei_pro_course_access_start_student_email_send', array( $this, 'welcome_to_course_on_access_start' ), 10, 2 );
 
 		// Flag the welcome email as sent only once it has actually been dispatched.
 		$this->maybe_add_action( 'sensei_email_sent', array( $this, 'mark_welcome_email_sent_on_dispatch' ), 10, 3 );
@@ -102,6 +102,37 @@ class Course_Welcome extends Email_Generators_Abstract {
 			return;
 		}
 
+		$this->maybe_send_welcome_email( (int) $student_id, (int) $course_id, true );
+	}
+
+	/**
+	 * Send email to student on the day their access period starts.
+	 *
+	 * Access had not started until now, so lesson progress cannot mean the student was
+	 * previously active — opening a locked lesson is enough to record it. Only completing
+	 * the course proves earlier access.
+	 *
+	 * @access private
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $student_id The student ID.
+	 * @param int $course_id  The course ID.
+	 */
+	public function welcome_to_course_on_access_start( $student_id, $course_id ) {
+		$this->maybe_send_welcome_email( (int) $student_id, (int) $course_id, false );
+	}
+
+	/**
+	 * Send the welcome email to a student for a course, if it is warranted.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int  $student_id            The student ID.
+	 * @param int  $course_id             The course ID.
+	 * @param bool $started_lessons_count Whether started lessons disqualify the student.
+	 */
+	private function maybe_send_welcome_email( int $student_id, int $course_id, bool $started_lessons_count ): void {
 		$course = get_post( $course_id );
 		if ( ! $course || 'publish' !== $course->post_status ) {
 			return;
@@ -115,7 +146,7 @@ class Course_Welcome extends Email_Generators_Abstract {
 		// Safeguard: don't re-welcome students who already have history in the course.
 		if (
 			\Sensei_Utils::user_completed_course( $course_id, $student_id )
-			|| \Sensei_Utils::user_started_lesson_count( $course_id, $student_id ) > 0
+			|| ( $started_lessons_count && \Sensei_Utils::user_started_lesson_count( $course_id, $student_id ) > 0 )
 		) {
 			return;
 		}
@@ -135,8 +166,8 @@ class Course_Welcome extends Email_Generators_Abstract {
 		$course_url = get_permalink( $course_id );
 
 		$this->send_email_action(
-			[
-				$recipient => [
+			array(
+				$recipient => array(
 					'teacher:id'          => $teacher->ID,
 					'teacher:displayname' => $teacher->display_name,
 					'student:id'          => $student->ID,
@@ -144,8 +175,8 @@ class Course_Welcome extends Email_Generators_Abstract {
 					'course:id'           => $course->ID,
 					'course:name'         => $course->post_title,
 					'course:url'          => $course_url,
-				],
-			]
+				),
+			)
 		);
 	}
 

--- a/includes/update-tasks/class-sensei-update-backfill-course-welcome-email-sent.php
+++ b/includes/update-tasks/class-sensei-update-backfill-course-welcome-email-sent.php
@@ -72,9 +72,11 @@ class Sensei_Update_Backfill_Course_Welcome_Email_Sent extends Sensei_Background
 			$meta_key = Course_Welcome::get_welcome_sent_meta_key( $course_id );
 
 			// Only add the flag for relationships that don't already have it, so
-			// re-runs never overwrite an existing value.
+			// re-runs never overwrite an existing value. The backfill stores the "assumed"
+			// sentinel (not a timestamp) so a grandfathered flag stays distinguishable from a
+			// recorded dispatch — it makes no claim about whether an email was ever delivered.
 			if ( ! metadata_exists( 'user', $user_id, $meta_key ) ) {
-				update_user_meta( $user_id, $meta_key, gmdate( 'Y-m-d H:i:s' ) );
+				update_user_meta( $user_id, $meta_key, Course_Welcome::WELCOME_ASSUMED );
 			}
 		}
 

--- a/includes/update-tasks/class-sensei-update-backfill-course-welcome-email-sent.php
+++ b/includes/update-tasks/class-sensei-update-backfill-course-welcome-email-sent.php
@@ -71,10 +71,8 @@ class Sensei_Update_Backfill_Course_Welcome_Email_Sent extends Sensei_Background
 
 			$meta_key = Course_Welcome::get_welcome_sent_meta_key( $course_id );
 
-			// Only add the flag for relationships that don't already have it, so
-			// re-runs never overwrite an existing value. The backfill stores the "assumed"
-			// sentinel (not a timestamp) so a grandfathered flag stays distinguishable from a
-			// recorded dispatch — it makes no claim about whether an email was ever delivered.
+			// Skip relationships that already have the flag so re-runs never overwrite
+			// an existing value.
 			if ( ! metadata_exists( 'user', $user_id, $meta_key ) ) {
 				update_user_meta( $user_id, $meta_key, Course_Welcome::WELCOME_ASSUMED );
 			}

--- a/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
@@ -75,7 +75,7 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 		do_action( 'sensei_email_sent', 'course_welcome', 'test@a.com', array() );
 
 		$priority_for_immediate_start = has_action( 'sensei_course_enrolment_status_changed', [ $generator, 'welcome_to_course_for_student' ] );
-		$priority_for_access_start    = has_action( 'sensei_pro_course_access_start_student_email_send', [ $generator, 'welcome_to_course_for_student' ] );
+		$priority_for_access_start    = has_action( 'sensei_pro_course_access_start_student_email_send', [ $generator, 'welcome_to_course_on_access_start' ] );
 		$priority_for_mark_on_sent    = has_action( 'sensei_email_sent', array( $generator, 'mark_welcome_email_sent_on_dispatch' ) );
 		self::assertSame( 10, $priority_for_immediate_start );
 		self::assertSame( 10, $priority_for_access_start );
@@ -291,6 +291,73 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertSame( array(), $actual_data, 'Welcome email should not be sent to a student who already started a lesson in the course.' );
+	}
+
+	public function testWelcomeToCourseOnAccessStart_StudentOnlyStartedLessonInCourse_SendsEmail() {
+		/* Arrange. */
+		$factory    = new \Sensei_Factory();
+		$student_id = $factory->user->create( array( 'user_email' => 'access-start-partway@a.com' ) );
+		$course_id  = $factory->course->create();
+		$lesson_id  = $factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $course_id ) ) );
+
+		\Sensei_Utils::update_lesson_status( $student_id, $lesson_id, 'in-progress' );
+
+		$email_repository = $this->createMock( Email_Repository::class );
+		$email_repository->method( 'get' )->with( 'course_welcome' )->willReturn( new \WP_Post( (object) array( 'post_status' => 'publish' ) ) );
+
+		$generator = new Course_Welcome( $email_repository );
+
+		$actual_data = array();
+		$filter      = function ( $email, $options ) use ( &$actual_data ) {
+			$actual_data = array(
+				'email'   => $email,
+				'options' => $options,
+			);
+		};
+		add_filter( 'sensei_email_send', $filter, 10, 2 );
+
+		/* Act. */
+		$generator->welcome_to_course_on_access_start( $student_id, $course_id );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_email_send', $filter, 10 );
+		$factory->tearDown();
+
+		/* Assert. */
+		self::assertNotSame( array(), $actual_data, 'Opening a lesson marks it in-progress even before access starts, so it must not stop the deferred welcome email.' );
+	}
+
+	public function testWelcomeToCourseOnAccessStart_StudentAlreadyCompletedCourse_DoesNotSendEmail() {
+		/* Arrange. */
+		$factory    = new \Sensei_Factory();
+		$student_id = $factory->user->create( array( 'user_email' => 'access-start-completed@a.com' ) );
+		$course_id  = $factory->course->create();
+
+		\Sensei_Utils::update_course_status( $student_id, $course_id, 'complete' );
+
+		$email_repository = $this->createMock( Email_Repository::class );
+		$email_repository->method( 'get' )->with( 'course_welcome' )->willReturn( new \WP_Post( (object) array( 'post_status' => 'publish' ) ) );
+
+		$generator = new Course_Welcome( $email_repository );
+
+		$actual_data = array();
+		$filter      = function ( $email, $options ) use ( &$actual_data ) {
+			$actual_data = array(
+				'email'   => $email,
+				'options' => $options,
+			);
+		};
+		add_filter( 'sensei_email_send', $filter, 10, 2 );
+
+		/* Act. */
+		$generator->welcome_to_course_on_access_start( $student_id, $course_id );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_email_send', $filter, 10 );
+		$factory->tearDown();
+
+		/* Assert. */
+		self::assertSame( array(), $actual_data, 'Completing a course proves earlier access, so a completed student should not be re-welcomed when a new access period starts.' );
 	}
 
 	public function testWelcomeToCourseForStudent_WelcomeAlreadyMarkedSent_DoesNotSendEmail() {

--- a/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
@@ -72,11 +72,14 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		do_action( 'sensei_course_enrolment_status_changed', 1, 1 );
 		do_action( 'sensei_pro_course_access_start_student_email_send', 1, 1 );
+		do_action( 'sensei_email_sent', 'course_welcome', 'test@a.com', array() );
 
 		$priority_for_immediate_start = has_action( 'sensei_course_enrolment_status_changed', [ $generator, 'welcome_to_course_for_student' ] );
 		$priority_for_access_start    = has_action( 'sensei_pro_course_access_start_student_email_send', [ $generator, 'welcome_to_course_for_student' ] );
+		$priority_for_mark_on_sent    = has_action( 'sensei_email_sent', array( $generator, 'mark_welcome_email_sent_on_dispatch' ) );
 		self::assertSame( 10, $priority_for_immediate_start );
 		self::assertSame( 10, $priority_for_access_start );
+		self::assertSame( 10, $priority_for_mark_on_sent );
 	}
 
 	public function testWelcomeToCourseForStudent_WhenCalled_CallsSenseiEmailSendFilterWithMatchingArguments() {
@@ -323,10 +326,10 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 		self::assertSame( array(), $actual_data, 'Welcome email should not be sent when it has already been marked as sent for the course.' );
 	}
 
-	public function testWelcomeToCourseForStudent_EmailSent_MarksWelcomeAsSent() {
+	public function testWelcomeToCourseForStudent_WhenCalled_DoesNotMarkWelcomeSentByItself() {
 		/* Arrange. */
 		$factory    = new \Sensei_Factory();
-		$student_id = $factory->user->create( array( 'user_email' => 'marks-flag@a.com' ) );
+		$student_id = $factory->user->create( array( 'user_email' => 'attempt-only@a.com' ) );
 		$course_id  = $factory->course->create();
 
 		$email_repository = $this->createMock( Email_Repository::class );
@@ -335,11 +338,68 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 		$generator = new Course_Welcome( $email_repository );
 
 		/* Act. */
+		// A send attempt alone must not flag the email as sent; the flag is only written once
+		// the email has actually been dispatched (via the sensei_email_sent action). Otherwise a
+		// suppressed send (e.g. access not started) would block the deferred welcome.
 		$generator->welcome_to_course_for_student( $student_id, $course_id );
 
 		/* Assert. */
 		$flag = get_user_meta( $student_id, Course_Welcome::get_welcome_sent_meta_key( $course_id ), true );
-		self::assertNotEmpty( $flag, 'The welcome email sent flag should be set after the email is sent.' );
+		self::assertEmpty( $flag, 'The welcome email sent flag should not be set on a send attempt alone.' );
+
+		/* Cleanup. */
+		$factory->tearDown();
+	}
+
+	public function testMarkWelcomeEmailSentOnDispatch_ForCourseWelcome_MarksWelcomeAsSent() {
+		/* Arrange. */
+		$factory    = new \Sensei_Factory();
+		$student_id = $factory->user->create( array( 'user_email' => 'dispatched@a.com' ) );
+		$course_id  = $factory->course->create();
+
+		$email_repository = $this->createMock( Email_Repository::class );
+		$generator        = new Course_Welcome( $email_repository );
+
+		/* Act. */
+		$generator->mark_welcome_email_sent_on_dispatch(
+			'course_welcome',
+			'dispatched@a.com',
+			array(
+				'student:id' => $student_id,
+				'course:id'  => $course_id,
+			)
+		);
+
+		/* Assert. */
+		$flag = get_user_meta( $student_id, Course_Welcome::get_welcome_sent_meta_key( $course_id ), true );
+		self::assertNotEmpty( $flag, 'The welcome email sent flag should be set once the email has been dispatched.' );
+
+		/* Cleanup. */
+		$factory->tearDown();
+	}
+
+	public function testMarkWelcomeEmailSentOnDispatch_ForOtherEmail_DoesNotMark() {
+		/* Arrange. */
+		$factory    = new \Sensei_Factory();
+		$student_id = $factory->user->create( array( 'user_email' => 'other-email@a.com' ) );
+		$course_id  = $factory->course->create();
+
+		$email_repository = $this->createMock( Email_Repository::class );
+		$generator        = new Course_Welcome( $email_repository );
+
+		/* Act. */
+		$generator->mark_welcome_email_sent_on_dispatch(
+			'some_other_email',
+			'other-email@a.com',
+			array(
+				'student:id' => $student_id,
+				'course:id'  => $course_id,
+			)
+		);
+
+		/* Assert. */
+		$flag = get_user_meta( $student_id, Course_Welcome::get_welcome_sent_meta_key( $course_id ), true );
+		self::assertEmpty( $flag, 'The welcome email sent flag should not be set for a different email identifier.' );
 
 		/* Cleanup. */
 		$factory->tearDown();
@@ -364,7 +424,17 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		// Simulate the enrolment status changing more than once (e.g. enrol, unenrol, re-enrol).
+		// The first attempt is dispatched (the sender fires sensei_email_sent, which flags it),
+		// so the second attempt must be skipped by the already-sent guard.
 		$generator->welcome_to_course_for_student( $student_id, $course_id );
+		$generator->mark_welcome_email_sent_on_dispatch(
+			'course_welcome',
+			'once@a.com',
+			array(
+				'student:id' => $student_id,
+				'course:id'  => $course_id,
+			)
+		);
 		$generator->welcome_to_course_for_student( $student_id, $course_id );
 
 		/* Cleanup. */

--- a/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
+++ b/tests/unit-tests/internal/emails/generators/test-class-course-welcome.php
@@ -326,10 +326,10 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 		self::assertSame( array(), $actual_data, 'Welcome email should not be sent when it has already been marked as sent for the course.' );
 	}
 
-	public function testWelcomeToCourseForStudent_WhenCalled_DoesNotMarkWelcomeSentByItself() {
+	public function testWelcomeToCourseForStudent_CalledTwice_SendsEmailOnlyOnce() {
 		/* Arrange. */
 		$factory    = new \Sensei_Factory();
-		$student_id = $factory->user->create( array( 'user_email' => 'attempt-only@a.com' ) );
+		$student_id = $factory->user->create( array( 'user_email' => 'once@a.com' ) );
 		$course_id  = $factory->course->create();
 
 		$email_repository = $this->createMock( Email_Repository::class );
@@ -337,18 +337,30 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 
 		$generator = new Course_Welcome( $email_repository );
 
+		$send_count = 0;
+		$filter     = function () use ( &$send_count ) {
+			++$send_count;
+		};
+		add_filter( 'sensei_email_send', $filter );
+
 		/* Act. */
-		// A send attempt alone must not flag the email as sent; the flag is only written once
-		// the email has actually been dispatched (via the sensei_email_sent action). Otherwise a
-		// suppressed send (e.g. access not started) would block the deferred welcome.
+		$generator->welcome_to_course_for_student( $student_id, $course_id );
+		$generator->mark_welcome_email_sent_on_dispatch(
+			'course_welcome',
+			'once@a.com',
+			array(
+				'student:id' => $student_id,
+				'course:id'  => $course_id,
+			)
+		);
 		$generator->welcome_to_course_for_student( $student_id, $course_id );
 
-		/* Assert. */
-		$flag = get_user_meta( $student_id, Course_Welcome::get_welcome_sent_meta_key( $course_id ), true );
-		self::assertEmpty( $flag, 'The welcome email sent flag should not be set on a send attempt alone.' );
-
 		/* Cleanup. */
+		remove_filter( 'sensei_email_send', $filter, 10 );
 		$factory->tearDown();
+
+		/* Assert. */
+		self::assertSame( 1, $send_count, 'The welcome email should be sent only once even when the enrolment status changes repeatedly.' );
 	}
 
 	public function testMarkWelcomeEmailSentOnDispatch_ForCourseWelcome_MarksWelcomeAsSent() {
@@ -403,45 +415,5 @@ class Course_Welcome_Test extends \WP_UnitTestCase {
 
 		/* Cleanup. */
 		$factory->tearDown();
-	}
-
-	public function testWelcomeToCourseForStudent_CalledTwice_SendsEmailOnlyOnce() {
-		/* Arrange. */
-		$factory    = new \Sensei_Factory();
-		$student_id = $factory->user->create( array( 'user_email' => 'once@a.com' ) );
-		$course_id  = $factory->course->create();
-
-		$email_repository = $this->createMock( Email_Repository::class );
-		$email_repository->method( 'get' )->with( 'course_welcome' )->willReturn( new \WP_Post( (object) array( 'post_status' => 'publish' ) ) );
-
-		$generator = new Course_Welcome( $email_repository );
-
-		$send_count = 0;
-		$filter     = function () use ( &$send_count ) {
-			++$send_count;
-		};
-		add_filter( 'sensei_email_send', $filter );
-
-		/* Act. */
-		// Simulate the enrolment status changing more than once (e.g. enrol, unenrol, re-enrol).
-		// The first attempt is dispatched (the sender fires sensei_email_sent, which flags it),
-		// so the second attempt must be skipped by the already-sent guard.
-		$generator->welcome_to_course_for_student( $student_id, $course_id );
-		$generator->mark_welcome_email_sent_on_dispatch(
-			'course_welcome',
-			'once@a.com',
-			array(
-				'student:id' => $student_id,
-				'course:id'  => $course_id,
-			)
-		);
-		$generator->welcome_to_course_for_student( $student_id, $course_id );
-
-		/* Cleanup. */
-		remove_filter( 'sensei_email_send', $filter, 10 );
-		$factory->tearDown();
-
-		/* Assert. */
-		self::assertSame( 1, $send_count, 'The welcome email should be sent only once even when the enrolment status changes repeatedly.' );
 	}
 }

--- a/tests/unit-tests/internal/emails/test-class-email-sender.php
+++ b/tests/unit-tests/internal/emails/test-class-email-sender.php
@@ -472,4 +472,94 @@ class Email_Sender_Test extends \WP_UnitTestCase {
 		self::assertStringContainsString( 'From: Test Blog <admin@example.org>', $last_email->header );
 	}
 
+	public function testSendEmail_WhenEmailIsSent_FiresSenseiEmailSentAction() {
+		/* Arrange. */
+		$fired    = array();
+		$callback = function ( $email_name, $recipient, $replacement ) use ( &$fired ) {
+			$fired[] = array(
+				'email_name'  => $email_name,
+				'recipient'   => $recipient,
+				'replacement' => $replacement,
+			);
+		};
+		add_action( 'sensei_email_sent', $callback, 10, 3 );
+
+		/* Act. */
+		$this->email_sender->send_email(
+			'student_starts_course',
+			array(
+				'a@a.test' => array(
+					'student:displayname' => 'Test Student',
+				),
+			),
+			self::USAGE_TRACKING_TYPE
+		);
+
+		/* Cleanup. */
+		remove_action( 'sensei_email_sent', $callback, 10 );
+
+		/* Assert. */
+		self::assertCount( 1, $fired, 'The sensei_email_sent action should fire once per dispatched recipient.' );
+		self::assertSame( 'student_starts_course', $fired[0]['email_name'], 'The action should receive the email identifier.' );
+		self::assertSame( 'a@a.test', $fired[0]['recipient'], 'The action should receive the recipient address.' );
+		self::assertSame( array( 'student:displayname' => 'Test Student' ), $fired[0]['replacement'], 'The action should receive the recipient replacements.' );
+	}
+
+	public function testSendEmail_WhenWpMailReturnsFalse_DoesNotFireSenseiEmailSentAction() {
+		/* Arrange. */
+		add_filter( 'pre_wp_mail', '__return_false' );
+
+		$fired    = 0;
+		$callback = function () use ( &$fired ) {
+			++$fired;
+		};
+		add_action( 'sensei_email_sent', $callback );
+
+		/* Act. */
+		$this->email_sender->send_email(
+			'student_starts_course',
+			array(
+				'a@a.test' => array(
+					'student:displayname' => 'Test Student',
+				),
+			),
+			self::USAGE_TRACKING_TYPE
+		);
+
+		/* Cleanup. */
+		remove_filter( 'pre_wp_mail', '__return_false' );
+		remove_action( 'sensei_email_sent', $callback );
+
+		/* Assert. */
+		self::assertSame( 0, $fired, 'The sensei_email_sent action must not fire when wp_mail() fails.' );
+	}
+
+	public function testSendEmail_WhenSendIsSuppressed_DoesNotFireSenseiEmailSentAction() {
+		/* Arrange. */
+		add_filter( 'sensei_send_emails', '__return_false' );
+
+		$fired    = 0;
+		$callback = function () use ( &$fired ) {
+			++$fired;
+		};
+		add_action( 'sensei_email_sent', $callback );
+
+		/* Act. */
+		$this->email_sender->send_email(
+			'student_starts_course',
+			array(
+				'a@a.test' => array(
+					'student:displayname' => 'Test Student',
+				),
+			),
+			self::USAGE_TRACKING_TYPE
+		);
+
+		/* Cleanup. */
+		remove_filter( 'sensei_send_emails', '__return_false' );
+		remove_action( 'sensei_email_sent', $callback );
+
+		/* Assert. */
+		self::assertSame( 0, $fired, 'The sensei_email_sent action must not fire when the send is suppressed.' );
+	}
 }

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-backfill-course-welcome-email-sent.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-backfill-course-welcome-email-sent.php
@@ -38,7 +38,7 @@ class Sensei_Update_Backfill_Course_Welcome_Email_Sent_Test extends WP_UnitTestC
 		/* Assert. */
 		foreach ( $relationships as $relationship ) {
 			$flag = get_user_meta( $relationship['user_id'], Course_Welcome::get_welcome_sent_meta_key( $relationship['course_id'] ), true );
-			self::assertNotEmpty( $flag, 'Every existing course progress relationship should be flagged as welcomed.' );
+			self::assertSame( Course_Welcome::WELCOME_ASSUMED, $flag, 'Every existing course progress relationship should be flagged with the assumed-welcomed sentinel.' );
 		}
 	}
 

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-backfill-course-welcome-email-sent.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-backfill-course-welcome-email-sent.php
@@ -38,7 +38,7 @@ class Sensei_Update_Backfill_Course_Welcome_Email_Sent_Test extends WP_UnitTestC
 		/* Assert. */
 		foreach ( $relationships as $relationship ) {
 			$flag = get_user_meta( $relationship['user_id'], Course_Welcome::get_welcome_sent_meta_key( $relationship['course_id'] ), true );
-			self::assertSame( Course_Welcome::WELCOME_ASSUMED, $flag, 'Every existing course progress relationship should be flagged with the assumed-welcomed sentinel.' );
+			self::assertSame( Course_Welcome::WELCOME_ASSUMED, $flag, 'Every existing course progress relationship should be flagged with the sentinel.' );
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

The `course_welcome` "send at most once" guard writes its per-student/per-course "sent" flag unconditionally, right after asking the email sender to send — before the `sensei_send_emails` filter (evaluated downstream in `Email_Sender`) has decided whether the email actually goes out. So when a listener suppresses the send, the student is still flagged as welcomed.

Sensei Pro depends on this exact path: for a course/group whose access period starts in the future, it suppresses the immediate welcome and re-sends it on the access-start day. Because the flag was set at enrolment, that deferred welcome hits the already-sent guard and is skipped — **the student never receives their welcome email**.

This change flags the welcome as sent only when it is genuinely dispatched, and makes the upgrade backfill's mark distinguishable from a real send:

- `Email_Sender` fires a new `sensei_email_sent` action after `wp_mail()` returns `true`, inside the `sensei_send_emails` gate — so listeners react to real sends, not suppressed or failed ones.
- `Course_Welcome` marks its sent flag on `sensei_email_sent` instead of on every attempt. The already-sent guard and the course-history safeguard are unchanged.
- The one-time upgrade backfill stores an **assumed** sentinel value (`Course_Welcome::WELCOME_ASSUMED`) instead of a timestamp. A real dispatch stores a timestamp, so an integration can tell a grandfathered flag apart from a genuine delivery and still deliver a welcome whose access period had not started when the backfill ran. The sentinel makes no claim about actual delivery — an existing student may have been welcomed before the flag existed, or never — it only means "not dispatched under this tracking."

User impact: students enrolled with a deferred/future-access welcome now receive it when access begins, instead of it being silently dropped. The prior "mark regardless of delivery" behaviour is intentionally dropped — a suppressed or failed send must not count as sent.

## Testing Instructions

Use Mailpit (or equivalent) to observe delivery. The welcome-sent flag is user meta `..._sensei_course_welcome_email_sent_<course_id>`.

**A. Email enabled — happy path**

- [x] Sensei LMS → Settings → Emails: enable (publish) **Welcome to Course**. Publish a course.
- [x] Enrol a student. Confirm the welcome is delivered **once** and the flag row now exists as a **timestamp**.
- [x] Recalculate enrolment (e.g. Tools → re-run enrolment calculation, or toggle the student out and back in). Confirm the welcome is **not** re-sent (send-once guard).

**B. Email disabled — no send, no flag**

- [x] Disable **Welcome to Course** (Settings → Emails). Enrol a fresh student in a published course.
- [x] Confirm **no** welcome is sent and **no** flag row is written.

**C. Suppressed while the email stays enabled**

- [x] Keep **Welcome to Course** enabled. Edit the student's **WP user profile** and uncheck the *Welcome to Course* email subscription (unsubscribes that recipient; the email stays published).
- [x] Enrol that student. Confirm **no** welcome is sent **and no** flag row is written.
- [x] Re-check the subscription on the profile, then recalculate enrolment (or re-enrol). Confirm the welcome is now delivered **once** and the flag row exists as a timestamp.

**D. Backfill sentinel (upgrade path)**

- [x] On a site with existing enrolments, force the upgrade path (set the stored `sensei-version` option below the release carrying this change so `run_updates()` re-fires) and let `Sensei_Update_Backfill_Course_Welcome_Email_Sent` run via Scheduled Actions.
- [x] Confirm existing enrolments now hold the flag with the **`assumed`** sentinel value (`Course_Welcome::WELCOME_ASSUMED`), not a timestamp — this is what lets an integration tell a grandfathered mark from a real delivery.

## New/Updated Hooks

- **`sensei_email_sent`** (action) — fires after a Sensei email is successfully handed off (passed the `sensei_send_emails` gate and `wp_mail()` returned `true`). Args: `$email_name` (string identifier, e.g. `course_welcome`), `$recipient` (string email address), `$replacement` (array of per-recipient replacement values).

## Changelog entry

- [ ] Automatically create a changelog entry from the details below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
