### PR TITLE
Limit module editing, deletion, and course assignment to the owner

### DIFF
--- a/changelog/fix-module-ownership-authorization
+++ b/changelog/fix-module-ownership-authorization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Limit editing, deleting, and course assignment of a module to the module's owner.

--- a/changelog/fix-module-ownership-authorization
+++ b/changelog/fix-module-ownership-authorization
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: security
 
 Limit editing, deleting, and course assignment of a module to the module's owner.

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -152,8 +152,8 @@ class Sensei_Course_Structure {
 			'id'          => $module_term->term_id,
 			'title'       => $module_term->name,
 			'description' => $module_term->description,
-			'teacher'     => user_can( $author, 'manage_options' ) ? '' : $author->display_name,
-			'teacherId'   => $author->ID,
+			'teacher'     => $author instanceof WP_User && ! user_can( $author, 'manage_options' ) ? $author->display_name : '',
+			'teacherId'   => $author instanceof WP_User ? $author->ID : 0,
 			'lastTitle'   => $module_term->name,
 			'slug'        => $module_term->slug === $default_slug ? '' : $module_term->slug,
 			'lessons'     => [],
@@ -830,7 +830,8 @@ class Sensei_Course_Structure {
 					);
 				}
 
-				if ( Sensei_Core_Modules::get_term_author( $item['slug'] )->ID !== wp_get_current_user()->ID &&
+				$term_author = Sensei_Core_Modules::get_term_author( $item['slug'] );
+				if ( ( ! $term_author instanceof WP_User || wp_get_current_user()->ID !== $term_author->ID ) &&
 					! current_user_can( 'manage_options' ) &&
 					get_term_by( 'slug', $item['slug'], 'module' )
 				) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2259,7 +2259,7 @@ class Sensei_Core_Modules {
 		}
 
 		$term = get_term( $args[0], 'module' );
-		if ( ! $term instanceof WP_Term || 'module' !== $term->taxonomy ) {
+		if ( ! $term instanceof WP_Term ) {
 			return $caps;
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -648,7 +648,7 @@ class Sensei_Core_Modules {
 		// Remove module from existing courses the current user is allowed to edit.
 		if ( isset( $courses ) && is_array( $courses ) ) {
 			foreach ( $courses as $course ) {
-				if ( ! current_user_can( 'edit_post', $course->ID ) ) {
+				if ( ! Sensei_Course::can_current_user_edit_course( $course->ID ) ) {
 					continue;
 				}
 				wp_remove_object_terms( $course->ID, (int) $module_id, $this->taxonomy );
@@ -666,7 +666,7 @@ class Sensei_Core_Modules {
 
 				$course_id = absint( $course_id );
 
-				if ( ! $course_id || ! current_user_can( 'edit_post', $course_id ) ) {
+				if ( ! $course_id || ! Sensei_Course::can_current_user_edit_course( $course_id ) ) {
 					continue;
 				}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -28,6 +28,9 @@ class Sensei_Core_Modules {
 		// setup taxonomy
 		add_action( 'init', array( $this, 'setup_modules_taxonomy' ), 10 );
 
+		// Restrict editing and deleting modules to their owner.
+		add_filter( 'map_meta_cap', array( $this, 'restrict_module_term_management' ), 10, 4 );
+
 		// Manage lesson meta boxes for taxonomy
 		add_action( 'add_meta_boxes', array( $this, 'modules_metaboxes' ), 20, 2 );
 
@@ -2219,6 +2222,49 @@ class Sensei_Core_Modules {
 
 		register_taxonomy( 'module', array( 'course', 'lesson' ), $args );
 
+	}
+
+	/**
+	 * Restrict editing and deleting a module to its owner.
+	 *
+	 * The module taxonomy grants the `manage_modules` capability to teachers so
+	 * they can manage their own modules. WordPress maps the `edit_term` and
+	 * `delete_term` meta capabilities to that primitive capability without any
+	 * ownership consideration, which would otherwise let a teacher edit or delete
+	 * modules belonging to administrators or other teachers. Limit those
+	 * operations to the module's owner; administrators are unaffected.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 *
+	 * @param string[] $caps    The mapped primitive capabilities.
+	 * @param string   $cap     The meta capability being checked.
+	 * @param int      $user_id The user ID the check is for.
+	 * @param array    $args    Context for the check; $args[0] is the term ID.
+	 *
+	 * @return string[] The filtered capabilities.
+	 */
+	public function restrict_module_term_management( $caps, $cap, $user_id, $args ) {
+		if ( ( 'edit_term' !== $cap && 'delete_term' !== $cap ) || empty( $args[0] ) ) {
+			return $caps;
+		}
+
+		$term = get_term( $args[0] );
+		if ( ! $term instanceof WP_Term || 'module' !== $term->taxonomy ) {
+			return $caps;
+		}
+
+		// Administrators can manage every module.
+		if ( user_can( $user_id, 'manage_options' ) ) {
+			return $caps;
+		}
+
+		$author = self::get_term_author( $term->slug );
+		if ( (int) $author->ID !== (int) $user_id ) {
+			$caps[] = 'do_not_allow';
+		}
+
+		return $caps;
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2241,7 +2241,8 @@ class Sensei_Core_Modules {
 	 * `delete_term` meta capabilities to that primitive capability without any
 	 * ownership consideration, which would otherwise let a teacher edit or delete
 	 * modules belonging to administrators or other teachers. Limit those
-	 * operations to the module's owner; administrators are unaffected.
+	 * operations to the module's owner; users who can edit others' courses
+	 * (editors and administrators) are unaffected.
 	 *
 	 * @since $$next-version$$
 	 * @access private
@@ -2263,8 +2264,8 @@ class Sensei_Core_Modules {
 			return $caps;
 		}
 
-		// Administrators can manage every module.
-		if ( user_can( $user_id, 'manage_options' ) ) {
+		// Editors and administrators can manage every module.
+		if ( user_can( $user_id, 'edit_others_courses' ) ) {
 			return $caps;
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2258,7 +2258,7 @@ class Sensei_Core_Modules {
 			return $caps;
 		}
 
-		$term = get_term( $args[0] );
+		$term = get_term( $args[0], 'module' );
 		if ( ! $term instanceof WP_Term || 'module' !== $term->taxonomy ) {
 			return $caps;
 		}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2269,7 +2269,7 @@ class Sensei_Core_Modules {
 		}
 
 		$author = self::get_term_author( $term->slug );
-		if ( ! $author instanceof WP_User || (int) $author->ID !== (int) $user_id ) {
+		if ( (int) $author->ID !== (int) $user_id ) {
 			$caps[] = 'do_not_allow';
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2269,7 +2269,7 @@ class Sensei_Core_Modules {
 		}
 
 		$author = self::get_term_author( $term->slug );
-		if ( (int) $author->ID !== (int) $user_id ) {
+		if ( ! $author instanceof WP_User || (int) $author->ID !== (int) $user_id ) {
 			$caps[] = 'do_not_allow';
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -645,14 +645,17 @@ class Sensei_Core_Modules {
 		);
 		$courses = get_posts( $args );
 
-		// Remove module from existing courses
+		// Remove module from existing courses the current user is allowed to edit.
 		if ( isset( $courses ) && is_array( $courses ) ) {
 			foreach ( $courses as $course ) {
+				if ( ! current_user_can( 'edit_post', $course->ID ) ) {
+					continue;
+				}
 				wp_remove_object_terms( $course->ID, (int) $module_id, $this->taxonomy );
 			}
 		}
 
-		// Add module to selected courses
+		// Add module to selected courses the current user is allowed to edit.
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_POST['module_courses'] ) && ! empty( $_POST['module_courses'] ) ) {
 
@@ -661,7 +664,13 @@ class Sensei_Core_Modules {
 
 			foreach ( $course_ids as $course_id ) {
 
-				wp_set_object_terms( absint( $course_id ), $module_id, $this->taxonomy, true );
+				$course_id = absint( $course_id );
+
+				if ( ! $course_id || ! current_user_can( 'edit_post', $course_id ) ) {
+					continue;
+				}
+
+				wp_set_object_terms( $course_id, $module_id, $this->taxonomy, true );
 
 			}
 		}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2270,7 +2270,7 @@ class Sensei_Core_Modules {
 		}
 
 		$author = self::get_term_author( $term->slug );
-		if ( (int) $author->ID !== (int) $user_id ) {
+		if ( ! $author instanceof WP_User || (int) $author->ID !== (int) $user_id ) {
 			$caps[] = 'do_not_allow';
 		}
 
@@ -2397,7 +2397,7 @@ class Sensei_Core_Modules {
 	 * @since 1.8.0
 	 *
 	 * @param $slug
-	 * @return WP_User $author if no author is found or invalid term is passed the admin user will be returned.
+	 * @return WP_User|false $author if no author is found or invalid term is passed the admin user will be returned, or `false` when no admin user can be resolved either.
 	 */
 	public static function get_term_author( $slug = '' ) {
 
@@ -2718,7 +2718,7 @@ class Sensei_Core_Modules {
 
 			$author = self::get_term_author( $term->slug );
 
-			if ( $user_id == $author->ID ) {
+			if ( $author instanceof WP_User && (int) $user_id === (int) $author->ID ) {
 				// add the term to the teachers terms
 				$users_terms[] = $term;
 			}
@@ -2783,7 +2783,7 @@ class Sensei_Core_Modules {
 
 			$author = self::get_term_author( $term->slug );
 
-			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) ) {
+			if ( $author instanceof WP_User && ! user_can( $author, 'manage_options' ) ) {
 				$term->name = $term->name . ' (' . $author->display_name . ') ';
 			}
 

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -298,7 +298,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$this->assertSame( absint( get_term_meta( $module['term_id'], 'module_author', true ) ), wp_get_current_user()->ID, 'Module teacher ID meta not set to the updated Author ID' );
 	}
 
-	public function testModuleAdminList_WhenViewedByTeacher_ExcludesOtherUsersModules() {
+	public function testFilterModuleTerms_WhenViewedByTeacher_ExcludesOtherUsersModules() {
 		/* Arrange */
 		set_current_screen( 'edit-module' );
 
@@ -329,7 +329,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		set_current_screen( 'front' );
 	}
 
-	public function testEditAndDeleteTermCaps_WhenTeacherDoesNotOwnModule_AreDenied() {
+	public function testRestrictModuleTermManagement_WhenTeacherDoesNotOwnModule_DeniesEditAndDelete() {
 		/* Arrange */
 		$teacher_a = $this->get_user_by_role( 'teacher' );
 		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );
@@ -348,7 +348,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function testEditAndDeleteTermCaps_WhenTeacherOwnsModule_AreAllowed() {
+	public function testRestrictModuleTermManagement_WhenTeacherOwnsModule_AllowsEditAndDelete() {
 		/* Arrange */
 		$teacher_a = $this->get_user_by_role( 'teacher' );
 		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );
@@ -367,7 +367,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function testEditAndDeleteTermCaps_WhenAdminDoesNotOwnModule_AreAllowed() {
+	public function testRestrictModuleTermManagement_WhenAdminDoesNotOwnModule_AllowsEditAndDelete() {
 		/* Arrange */
 		$teacher_a = $this->get_user_by_role( 'teacher' );
 		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );
@@ -386,7 +386,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function testEditAndDeleteTermCaps_WhenEditorDoesNotOwnModule_AreAllowed() {
+	public function testRestrictModuleTermManagement_WhenEditorDoesNotOwnModule_AllowsEditAndDelete() {
 		/* Arrange */
 		$teacher_a = $this->get_user_by_role( 'teacher' );
 		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -297,4 +297,92 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertSame( absint( get_term_meta( $module['term_id'], 'module_author', true ) ), wp_get_current_user()->ID, 'Module teacher ID meta not set to the updated Author ID' );
 	}
+
+	public function testModuleAdminList_WhenViewedByTeacher_ExcludesOtherUsersModules() {
+		/* Arrange */
+		set_current_screen( 'edit-module' );
+
+		$teacher_a  = $this->get_user_by_role( 'teacher' );
+		$admin_id   = $this->get_user_by_role( 'administrator' );
+		$own_module = wp_insert_term( 'Teacher A Module', 'module', array( 'slug' => 'teacher-a-module' ) );
+		update_term_meta( $own_module['term_id'], 'module_author', $teacher_a );
+		$admin_module = wp_insert_term( 'Admin Module', 'module', array( 'slug' => 'admin-module' ) );
+		update_term_meta( $admin_module['term_id'], 'module_author', $admin_id );
+
+		$this->login_as( $teacher_a );
+
+		/* Act */
+		$names = wp_list_pluck(
+			get_terms(
+				array(
+					'taxonomy'   => 'module',
+					'hide_empty' => false,
+				)
+			),
+			'name'
+		);
+
+		/* Assert */
+		self::assertContains( 'Teacher A Module', $names, 'The teacher should see their own module.' );
+		self::assertNotContains( 'Admin Module', $names, 'The teacher should not see another user\'s module in the admin list.' );
+
+		set_current_screen( 'front' );
+	}
+
+	public function testEditAndDeleteTermCaps_WhenTeacherDoesNotOwnModule_AreDenied() {
+		/* Arrange */
+		$teacher_a = $this->get_user_by_role( 'teacher' );
+		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );
+		update_term_meta( $module['term_id'], 'module_author', $teacher_a );
+
+		$this->login_as_teacher_b();
+
+		/* Act & Assert */
+		self::assertFalse(
+			current_user_can( 'edit_term', $module['term_id'] ),
+			'A teacher should not be able to edit a module owned by another user.'
+		);
+		self::assertFalse(
+			current_user_can( 'delete_term', $module['term_id'] ),
+			'A teacher should not be able to delete a module owned by another user.'
+		);
+	}
+
+	public function testEditAndDeleteTermCaps_WhenTeacherOwnsModule_AreAllowed() {
+		/* Arrange */
+		$teacher_a = $this->get_user_by_role( 'teacher' );
+		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );
+		update_term_meta( $module['term_id'], 'module_author', $teacher_a );
+
+		$this->login_as_teacher();
+
+		/* Act & Assert */
+		self::assertTrue(
+			current_user_can( 'edit_term', $module['term_id'] ),
+			'A teacher should be able to edit a module they own.'
+		);
+		self::assertTrue(
+			current_user_can( 'delete_term', $module['term_id'] ),
+			'A teacher should be able to delete a module they own.'
+		);
+	}
+
+	public function testEditAndDeleteTermCaps_WhenAdminDoesNotOwnModule_AreAllowed() {
+		/* Arrange */
+		$teacher_a = $this->get_user_by_role( 'teacher' );
+		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );
+		update_term_meta( $module['term_id'], 'module_author', $teacher_a );
+
+		$this->login_as_admin();
+
+		/* Act & Assert */
+		self::assertTrue(
+			current_user_can( 'edit_term', $module['term_id'] ),
+			'An administrator should be able to edit any module.'
+		);
+		self::assertTrue(
+			current_user_can( 'delete_term', $module['term_id'] ),
+			'An administrator should be able to delete any module.'
+		);
+	}
 }

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -385,4 +385,93 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 			'An administrator should be able to delete any module.'
 		);
 	}
+
+	public function testSaveModuleCourse_WhenTeacherAssignsModuleToCourseTheyCannotEdit_DoesNotAttach() {
+		/* Arrange */
+		$admin_id     = $this->get_user_by_role( 'administrator' );
+		$admin_course = $this->factory->course->create( array( 'post_author' => $admin_id ) );
+
+		$this->login_as_teacher();
+		$module = wp_insert_term( 'Teacher Module', 'module', array( 'slug' => 'teacher-module' ) );
+
+		/* Act */
+		$_POST['module_courses'] = array( $admin_course );
+		Sensei()->modules->save_module_course( $module['term_id'] );
+		unset( $_POST['module_courses'] );
+
+		/* Assert */
+		$module_terms = wp_get_object_terms( $admin_course, 'module', array( 'fields' => 'ids' ) );
+		self::assertNotContains(
+			$module['term_id'],
+			$module_terms,
+			'A teacher should not be able to attach a module to a course they cannot edit.'
+		);
+	}
+
+	public function testSaveModuleCourse_WhenTeacherRemovesModuleFromCourseTheyCannotEdit_DoesNotDetach() {
+		/* Arrange */
+		$admin_id     = $this->get_user_by_role( 'administrator' );
+		$admin_course = $this->factory->course->create( array( 'post_author' => $admin_id ) );
+
+		$this->login_as_teacher();
+		$module = wp_insert_term( 'Teacher Module', 'module', array( 'slug' => 'teacher-module' ) );
+
+		$this->login_as_admin();
+		wp_set_object_terms( $admin_course, array( $module['term_id'] ), 'module' );
+
+		/* Act */
+		$this->login_as_teacher();
+		$_POST['module_courses'] = array();
+		Sensei()->modules->save_module_course( $module['term_id'] );
+		unset( $_POST['module_courses'] );
+
+		/* Assert */
+		$module_terms = wp_get_object_terms( $admin_course, 'module', array( 'fields' => 'ids' ) );
+		self::assertContains(
+			$module['term_id'],
+			$module_terms,
+			'A teacher should not be able to detach a module from a course they cannot edit.'
+		);
+	}
+
+	public function testSaveModuleCourse_WhenTeacherAssignsModuleToCourseTheyOwn_Attaches() {
+		/* Arrange */
+		$this->login_as_teacher();
+		$own_course = $this->factory->course->create( array( 'post_author' => get_current_user_id() ) );
+		$module     = wp_insert_term( 'Teacher Module', 'module', array( 'slug' => 'teacher-module' ) );
+
+		/* Act */
+		$_POST['module_courses'] = array( $own_course );
+		Sensei()->modules->save_module_course( $module['term_id'] );
+		unset( $_POST['module_courses'] );
+
+		/* Assert */
+		$module_terms = wp_get_object_terms( $own_course, 'module', array( 'fields' => 'ids' ) );
+		self::assertContains(
+			$module['term_id'],
+			$module_terms,
+			'A teacher should be able to attach a module to a course they own.'
+		);
+	}
+
+	public function testSaveModuleCourse_WhenTeacherRemovesModuleFromCourseTheyOwn_Detaches() {
+		/* Arrange */
+		$this->login_as_teacher();
+		$own_course = $this->factory->course->create( array( 'post_author' => get_current_user_id() ) );
+		$module     = wp_insert_term( 'Teacher Module', 'module', array( 'slug' => 'teacher-module' ) );
+		wp_set_object_terms( $own_course, array( $module['term_id'] ), 'module' );
+
+		/* Act */
+		$_POST['module_courses'] = array();
+		Sensei()->modules->save_module_course( $module['term_id'] );
+		unset( $_POST['module_courses'] );
+
+		/* Assert */
+		$module_terms = wp_get_object_terms( $own_course, 'module', array( 'fields' => 'ids' ) );
+		self::assertNotContains(
+			$module['term_id'],
+			$module_terms,
+			'A teacher should be able to detach a module from a course they own.'
+		);
+	}
 }

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -386,6 +386,25 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function testEditAndDeleteTermCaps_WhenEditorDoesNotOwnModule_AreAllowed() {
+		/* Arrange */
+		$teacher_a = $this->get_user_by_role( 'teacher' );
+		$module    = wp_insert_term( 'Owned by A', 'module', array( 'slug' => 'owned-by-a' ) );
+		update_term_meta( $module['term_id'], 'module_author', $teacher_a );
+
+		$this->login_as_editor();
+
+		/* Act & Assert */
+		self::assertTrue(
+			current_user_can( 'edit_term', $module['term_id'] ),
+			'An editor should be able to edit any module.'
+		);
+		self::assertTrue(
+			current_user_can( 'delete_term', $module['term_id'] ),
+			'An editor should be able to delete any module.'
+		);
+	}
+
 	public function testSaveModuleCourse_WhenTeacherAssignsModuleToCourseTheyCannotEdit_DoesNotAttach() {
 		/* Arrange */
 		$admin_id     = $this->get_user_by_role( 'administrator' );

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -432,7 +432,6 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$admin_id     = $this->get_user_by_role( 'administrator' );
 		$admin_course = $this->factory->course->create( array( 'post_author' => $admin_id ) );
 
-		$this->login_as_teacher();
 		$module = wp_insert_term( 'Teacher Module', 'module', array( 'slug' => 'teacher-module' ) );
 
 		$this->login_as_admin();


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SEN-79

## Proposed Changes

Teachers hold the `manage_modules` capability so they can manage their own
modules, but that capability was applied without any per-module ownership
check. This restricts two operations to the module's owner:

- **Editing / deleting a module**: WordPress maps the `edit_term` and
  `delete_term` meta capabilities straight to `manage_modules`, ignoring which
  module it is. A `map_meta_cap` filter now denies those operations on a module
  the current non-admin user does not own.
- **Assigning a module to courses**: The "Course(s)" field on the
  module edit screen synced a module's course associations from the submitted
  IDs with no permission check. `save_module_course()` now skips any course the
  current user cannot edit, in both the attach and detach loops.

Administrators are unaffected. The restriction applies to **all non-admin
holders of `manage_modules`, teachers and editors** (editors were already
scoped to their own modules on the read side, so this aligns write access with
what they could already see).

> [!TIP]
> Might be easier to review commit by commit, since they are quite self-contained. 

## Testing instructions

Manual testing instructions can be found in the Linear issue

### Automated tests

```sh
make test-php-filter FILTER="Sensei_Class_Modules_Test"
```

