### PR TITLE
Display the module Course(s) field description below the select

### DIFF
--- a/changelog/fix-module-courses-field-description
+++ b/changelog/fix-module-courses-field-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the position of the Course(s) field description on the module add and edit screens.

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -540,9 +540,7 @@ class Sensei_Core_Modules {
 				</option>
 			<?php } ?>
 		</select>
-		<span
-			class="description"><?php echo esc_html__( 'Search for and select the courses that this module will belong to.', 'sensei-lms' ); ?>
-		</span>
+		<p class="description"><?php echo esc_html__( 'Search for and select the courses that this module will belong to.', 'sensei-lms' ); ?></p>
 		<?php
 	}
 


### PR DESCRIPTION
## Proposed Changes

On the module add and edit screens, the "Search for and select the courses…" description is rendered as an inline `<span>` right after the Course(s) select, so it flows beside the field and wraps awkwardly around it.

This renders it as a block-level `<p class="description">` instead, so it displays on its own line below the field. Both the "Add New Module" form and the module edit screen share this renderer, so both are fixed.

## Screenshots

| Before | After |
| --- | --- |
| <img width="804" height="744" alt="Screenshot 2026-07-14 at 18 59 29" src="https://github.com/user-attachments/assets/f3527812-cc17-4eef-a5c6-0a978842f588" /> | <img width="800" height="779" alt="Screenshot 2026-07-14 at 18 57 15" src="https://github.com/user-attachments/assets/e3429961-1649-4e0c-b9cf-4bce675c09e4" /> |

## Testing Instructions

1. Go to WP Admin → Sensei LMS → Modules.
2. In the **Add New Module** form, confirm the description "Search for and select the courses that this module will belong to." appears on its own line below the Course(s) field.
3. Click an existing module to open its edit screen and confirm the same  description appears below the courses select, not beside it.
