### PR TITLE
Sync the translated quiz title with its translated lesson (WPML)

### DIFF
--- a/changelog/fix-wpml-translated-quiz-title
+++ b/changelog/fix-wpml-translated-quiz-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix translated quiz titles keeping the original-language title when using WPML.

--- a/includes/wpml/trait-quiz-translation-helper.php
+++ b/includes/wpml/trait-quiz-translation-helper.php
@@ -58,10 +58,8 @@ trait Quiz_Translation_Helper {
 		update_post_meta( $translated_quiz_id, '_quiz_lesson', $quiz_lesson_id );
 		update_post_meta( $quiz_lesson_id, '_lesson_quiz', $translated_quiz_id );
 
-		// The quiz copy above keeps the source lesson's title. Core's title sync
-		// (Sensei_Quiz::update_after_lesson_change) never repairs it: it only acts
-		// on classic-editor form saves ($_POST sniff), and even then its quiz
-		// lookup is language-filtered — both dead ends in translation contexts.
+		// The quiz copy keeps the source-language title and core's title sync
+		// never runs for translation saves; derive it from the translated lesson.
 		$quiz_lesson = $quiz_lesson_id ? get_post( $quiz_lesson_id ) : null;
 		if ( $quiz_lesson ) {
 			wp_update_post(

--- a/includes/wpml/trait-quiz-translation-helper.php
+++ b/includes/wpml/trait-quiz-translation-helper.php
@@ -58,6 +58,21 @@ trait Quiz_Translation_Helper {
 		update_post_meta( $translated_quiz_id, '_quiz_lesson', $quiz_lesson_id );
 		update_post_meta( $quiz_lesson_id, '_lesson_quiz', $translated_quiz_id );
 
+		// Sync the quiz title and slug from the translated lesson. The copy above
+		// carries the master lesson's title, and Sensei_Quiz::update_after_lesson_change
+		// cannot repair it in translation contexts because its quiz lookup is
+		// filtered to the current language.
+		$quiz_lesson = get_post( $quiz_lesson_id );
+		if ( $quiz_lesson ) {
+			wp_update_post(
+				array(
+					'ID'         => $translated_quiz_id,
+					'post_title' => $quiz_lesson->post_title,
+					'post_name'  => $quiz_lesson->post_name,
+				)
+			);
+		}
+
 		update_post_meta( $quiz_lesson_id, '_quiz_has_questions', count( $questions ) > 0 );
 
 		// Add relationship between quiz and questions.

--- a/includes/wpml/trait-quiz-translation-helper.php
+++ b/includes/wpml/trait-quiz-translation-helper.php
@@ -61,7 +61,7 @@ trait Quiz_Translation_Helper {
 		// The quiz copy keeps the source-language title and core's title sync
 		// never runs for translation saves; derive it from the translated lesson.
 		$quiz_lesson = $quiz_lesson_id ? get_post( $quiz_lesson_id ) : null;
-		if ( $quiz_lesson ) {
+		if ( $quiz_lesson instanceof \WP_Post ) {
 			wp_update_post(
 				array(
 					'ID'         => $translated_quiz_id,

--- a/includes/wpml/trait-quiz-translation-helper.php
+++ b/includes/wpml/trait-quiz-translation-helper.php
@@ -58,11 +58,11 @@ trait Quiz_Translation_Helper {
 		update_post_meta( $translated_quiz_id, '_quiz_lesson', $quiz_lesson_id );
 		update_post_meta( $quiz_lesson_id, '_lesson_quiz', $translated_quiz_id );
 
-		// Sync the quiz title and slug from the translated lesson. The copy above
-		// carries the master lesson's title, and Sensei_Quiz::update_after_lesson_change
-		// cannot repair it in translation contexts because its quiz lookup is
-		// filtered to the current language.
-		$quiz_lesson = get_post( $quiz_lesson_id );
+		// The quiz copy above keeps the source lesson's title. Core's title sync
+		// (Sensei_Quiz::update_after_lesson_change) never repairs it: it only acts
+		// on classic-editor form saves ($_POST sniff), and even then its quiz
+		// lookup is language-filtered — both dead ends in translation contexts.
+		$quiz_lesson = $quiz_lesson_id ? get_post( $quiz_lesson_id ) : null;
 		if ( $quiz_lesson ) {
 			wp_update_post(
 				array(

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -177,6 +177,8 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$lesson_translation->update_lesson_translations_on_lesson_translation_created( $translated_lesson_id );
 
 		/* Assert. */
-		$this->assertSame( 'Lección 1', get_post( $translated_quiz_id )->post_title, 'The translated quiz title should be synced from the translated lesson.' );
+		$translated_quiz = get_post( $translated_quiz_id );
+		$this->assertSame( 'Lección 1', $translated_quiz->post_title, 'The translated quiz title should be synced from the translated lesson.' );
+		$this->assertSame( 'leccion-1', $translated_quiz->post_name, 'The translated quiz slug should be synced from the translated lesson.' );
 	}
 }

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -107,7 +107,7 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( 8, $actual );
 	}
 
-	public function testUpdateLessonTranslationsOnLessonTranslationCreated_QuizTranslationCreated_SyncsQuizTitleFromTranslatedLesson() {
+	public function testUpdateLessonTranslationsOnLessonTranslationCreated_QuizNotYetTranslated_SyncsQuizTitleFromTranslatedLesson() {
 		/* Arrange. */
 		$course_with_lessons = $this->factory->get_course_with_lessons(
 			array(

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -106,4 +106,77 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$actual = count( array_unique( $created_duplicates ) );
 		$this->assertSame( 8, $actual );
 	}
+
+	public function testUpdateLessonTranslationsOnLessonTranslationCreated_QuizTranslationCreated_SyncsQuizTitleFromTranslatedLesson() {
+		/* Arrange. */
+		$course_with_lessons = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 1,
+			)
+		);
+		$master_lesson_id    = $course_with_lessons['lesson_ids'][0];
+		$master_quiz_id      = $course_with_lessons['quiz_ids'][0];
+
+		$translated_lesson_id = $this->factory->lesson->create(
+			array(
+				'post_title' => 'Lección 1',
+				'post_name'  => 'leccion-1',
+			)
+		);
+		// The quiz translation is a verbatim copy of the master, so it carries the master's title.
+		$translated_quiz_id     = $this->factory->quiz->create( array( 'post_title' => 'Lesson 1' ) );
+		$translated_question_id = $this->factory->post->create( array( 'post_type' => 'question' ) );
+
+		add_filter(
+			'wpml_element_language_details',
+			function () {
+				return array(
+					'language_code'        => 'es',
+					'source_language_code' => 'en',
+				);
+			},
+			10,
+			0
+		);
+
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id, $element_type ) use ( $translated_lesson_id, $master_lesson_id ) {
+				if ( 'lesson' === $element_type && $translated_lesson_id === $object_id ) {
+					return $master_lesson_id;
+				}
+				if ( 'lesson' === $element_type && $master_lesson_id === $object_id ) {
+					return $translated_lesson_id;
+				}
+				return 0;
+			},
+			10,
+			2
+		);
+
+		add_filter(
+			'wpml_copy_post_to_language',
+			function ( $post_id ) use ( $master_quiz_id, $translated_quiz_id, $translated_question_id ) {
+				return $master_quiz_id === $post_id ? $translated_quiz_id : $translated_question_id;
+			}
+		);
+
+		add_filter(
+			'wpml_post_duplicates',
+			function () {
+				return array();
+			},
+			10,
+			0
+		);
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_lesson_translations_on_lesson_translation_created( $translated_lesson_id );
+
+		/* Assert. */
+		$this->assertSame( 'Lección 1', get_post( $translated_quiz_id )->post_title, 'The translated quiz title should be synced from the translated lesson.' );
+	}
 }


### PR DESCRIPTION
## Proposed Changes

When Sensei's WPML integration creates a quiz translation (on course or lesson translation completion), the quiz is copied from the original and keeps the original-language title — students see an original-language quiz heading on an otherwise translated lesson.

This syncs the translated quiz's title and slug from its translated lesson right after the quiz is wired, matching how quiz titles are derived from lesson titles everywhere else in Sensei.

Related to https://linear.app/a8c/issue/SEN-103/

## Testing Instructions

**Reproduce the bug (on `trunk`):**

- [ ] With WPML active (two languages, e.g. English default + Spanish), create a course containing a lesson with a quiz (one question), and publish everything.
- [ ] Translate the **course**: go to Courses → All Courses (default language) → click the **⊕ icon** under the secondary-language flag for the course → WPML's Advanced Translation Editor opens (original strings left, translation fields right) → translate the fields until the progress bar reads 100% → click **Save and Complete**. This scaffolds the secondary-language lesson/quiz/question as copies.
- [ ] Translate the **lesson** the same way: Lessons → All Lessons → **⊕** under the secondary-language flag → give it a clearly translated title (e.g. "Lección F") → **Save and Complete**.
- [ ] Open the quiz in the secondary language: visit the site frontend, switch to the secondary language, open the lesson → **Take Quiz**. The quiz heading still shows the original-language title ("Lesson F") even though the lesson is translated — the bug.

**Verify the fix (on this branch):**

- [ ] Switch to this PR's branch.
- [ ] Re-open the lesson's translation (Lessons → All Lessons → the **pencil icon** under the secondary-language flag) and click **Save and Complete** again — any re-save re-runs the sync.
- [ ] Reload the quiz page in the secondary language: the heading now matches the translated lesson title ("Lección F").
- [ ] Optional: repeat the whole flow from scratch on this branch — the quiz title is correct from the very first translation, no re-save needed.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
<!-- Choose only one -->
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
<!-- Choose only one -->
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message <!-- Add the changelog message here -->
Fix translated quiz titles keeping the original-language title when using WPML.

</details>
