### PR TITLE
Translate quiz questions when a WPML lesson translation is delivered

### DIFF
--- a/changelog/fix-wpml-translated-quiz-questions
+++ b/changelog/fix-wpml-translated-quiz-questions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix quiz question titles and answers not being translated on WPML-translated lessons.

--- a/includes/wpml/class-lesson-translation.php
+++ b/includes/wpml/class-lesson-translation.php
@@ -32,6 +32,8 @@ class Lesson_Translation {
 	public function init() {
 		// Update lesson properties on lesson translation created in UI.
 		add_action( 'wpml_pro_translation_completed', array( $this, 'update_lesson_translations_on_lesson_translation_created' ) );
+		// Run the deferred question sync when WPML writes the translated lesson content.
+		add_action( 'wp_after_insert_post', array( $this, 'update_question_translations_on_lesson_content_written' ), 10, 2 );
 	}
 
 	/**
@@ -64,6 +66,6 @@ class Lesson_Translation {
 
 		$this->update_translated_lesson_properties( $new_lesson_id, $master_lesson_id );
 		$this->update_quiz_translations( $master_lesson_id, $details['language_code'] );
-		$this->update_question_translations_from_lesson( $new_lesson_id );
+		$this->defer_question_translations_update( $new_lesson_id );
 	}
 }

--- a/includes/wpml/trait-question-translation-helper.php
+++ b/includes/wpml/trait-question-translation-helper.php
@@ -125,11 +125,15 @@ trait Question_Translation_Helper {
 				);
 			}
 
-			// The translated answers live in the block, split into correct and incorrect.
+			// The translated answers live in the block, split into correct and
+			// incorrect. Recompute the answer order (the md5 of each label, in
+			// block order) and the counts so they match the translated labels,
+			// mirroring how the editor stores them.
 			$answers = $block['attrs']['answer']['answers'] ?? array();
 			if ( ! empty( $answers ) ) {
 				$right_answers = array();
 				$wrong_answers = array();
+				$answer_order  = array();
 				foreach ( $answers as $answer ) {
 					if ( ! isset( $answer['label'] ) ) {
 						continue;
@@ -139,9 +143,13 @@ trait Question_Translation_Helper {
 					} else {
 						$wrong_answers[] = $answer['label'];
 					}
+					$answer_order[] = \Sensei()->lesson->get_answer_id( $answer['label'] );
 				}
 				update_post_meta( $question_id, '_question_right_answer', $right_answers );
 				update_post_meta( $question_id, '_question_wrong_answers', $wrong_answers );
+				update_post_meta( $question_id, '_answer_order', implode( ',', $answer_order ) );
+				update_post_meta( $question_id, '_right_answer_count', count( $right_answers ) );
+				update_post_meta( $question_id, '_wrong_answer_count', count( $wrong_answers ) );
 			}
 		}
 	}

--- a/includes/wpml/trait-question-translation-helper.php
+++ b/includes/wpml/trait-question-translation-helper.php
@@ -22,6 +22,59 @@ trait Question_Translation_Helper {
 	use WPML_API;
 
 	/**
+	 * Translated lessons whose question sync is waiting for WPML to write the
+	 * translated lesson content.
+	 *
+	 * @var array<int, bool>
+	 */
+	private $lessons_pending_question_sync = array();
+
+	/**
+	 * Defer the question sync until WPML writes the translated lesson content.
+	 *
+	 * When the translation-completed hook fires for a block-based lesson the
+	 * translated content does not exist yet; WPML assembles and writes it later
+	 * in the same request. Mark the lesson so the sync runs when that write
+	 * happens.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $lesson_id Translated lesson ID.
+	 */
+	private function defer_question_translations_update( $lesson_id ) {
+		$this->lessons_pending_question_sync[ (int) $lesson_id ] = true;
+	}
+
+	/**
+	 * Run the deferred question sync once the translated lesson content lands.
+	 *
+	 * Hooked to `wp_after_insert_post`, which fires once a post is fully written
+	 * (content, meta, and terms). Only acts on lessons marked by
+	 * defer_question_translations_update(), and only once the write carries
+	 * content.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object as written.
+	 */
+	public function update_question_translations_on_lesson_content_written( $post_id, $post ) {
+		if ( empty( $this->lessons_pending_question_sync[ $post_id ] ) ) {
+			return;
+		}
+
+		if ( '' === $post->post_content ) {
+			return;
+		}
+
+		unset( $this->lessons_pending_question_sync[ $post_id ] );
+
+		$this->update_question_translations_from_lesson( $post_id );
+	}
+
+	/**
 	 * Update question translations from lesson.
 	 *
 	 * @param int $lesson_id Lesson ID.
@@ -51,31 +104,66 @@ trait Question_Translation_Helper {
 			return;
 		}
 
-		foreach ( $blocks as $block ) {
-			if ( 'sensei-lms/question-block' !== $block['blockName'] ) {
-				continue;
-			}
-
+		foreach ( $this->find_question_blocks( $blocks ) as $block ) {
 			$question_id = $block['attrs']['id'] ?? 0;
 			if ( empty( $question_id ) ) {
 				continue;
 			}
 
-			$question_block = render_block( $block );
-
 			$question_id = $this->get_object_id( $question_id, 'question', false, $details['language_code'] );
-
 			if ( empty( $question_id ) ) {
 				continue;
 			}
 
-			// Update question content.
-			wp_update_post(
-				array(
-					'ID'           => (int) $question_id,
-					'post_content' => $question_block,
-				)
-			);
+			// The translated title lives in the block attribute.
+			if ( ! empty( $block['attrs']['title'] ) ) {
+				wp_update_post(
+					array(
+						'ID'         => (int) $question_id,
+						'post_title' => (string) $block['attrs']['title'],
+					)
+				);
+			}
+
+			// The translated answers live in the block, split into correct and incorrect.
+			$answers = $block['attrs']['answer']['answers'] ?? array();
+			if ( ! empty( $answers ) ) {
+				$right_answers = array();
+				$wrong_answers = array();
+				foreach ( $answers as $answer ) {
+					if ( ! isset( $answer['label'] ) ) {
+						continue;
+					}
+					if ( ! empty( $answer['correct'] ) ) {
+						$right_answers[] = $answer['label'];
+					} else {
+						$wrong_answers[] = $answer['label'];
+					}
+				}
+				update_post_meta( $question_id, '_question_right_answer', $right_answers );
+				update_post_meta( $question_id, '_question_wrong_answers', $wrong_answers );
+			}
 		}
+	}
+
+	/**
+	 * Collect quiz-question blocks at any nesting depth. They are nested inside
+	 * the quiz block in the lesson content.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 * @return array Question blocks.
+	 */
+	private function find_question_blocks( $blocks ) {
+		$question_blocks = array();
+		foreach ( $blocks as $block ) {
+			if ( 'sensei-lms/quiz-question' === ( $block['blockName'] ?? null ) ) {
+				$question_blocks[] = $block;
+				continue;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$question_blocks = array_merge( $question_blocks, $this->find_question_blocks( $block['innerBlocks'] ) );
+			}
+		}
+		return $question_blocks;
 	}
 }

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -106,4 +106,125 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$actual = count( array_unique( $created_duplicates ) );
 		$this->assertSame( 8, $actual );
 	}
+
+	public function testUpdateLessonTranslationsOnLessonTranslationCreated_TranslatedContentWrittenAfterCreation_UpdatesTranslatedQuestion() {
+		/* Arrange. */
+		$course_with_lessons = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 1,
+			)
+		);
+
+		$master_lesson_id   = $course_with_lessons['lesson_ids'][0];
+		$master_quiz_id     = $course_with_lessons['quiz_ids'][0];
+		$master_question_id = \Sensei()->quiz->get_questions( $master_quiz_id )[0]->ID;
+
+		// WPML creates the translated posts empty at the start of a delivery; the
+		// question begins as a copy that still holds the source-language strings.
+		$translated_lesson_id   = $this->factory->lesson->create( array( 'post_content' => '' ) );
+		$translated_quiz_id     = $this->factory->quiz->create();
+		$translated_question_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'question',
+				'post_title' => 'Question',
+			)
+		);
+
+		$this->simulate_wpml_translation(
+			$master_lesson_id,
+			$translated_lesson_id,
+			$master_quiz_id,
+			$translated_quiz_id,
+			$master_question_id,
+			$translated_question_id
+		);
+
+		$lesson_translation = new Lesson_Translation();
+		$lesson_translation->init();
+
+		/* Act. */
+		// WPML fires the completion hook while the lesson is still empty, then
+		// writes the translated block content later in the same request.
+		$lesson_translation->update_lesson_translations_on_lesson_translation_created( $translated_lesson_id );
+		wp_update_post(
+			array(
+				'ID'           => $translated_lesson_id,
+				'post_content' => $this->translated_lesson_content( $master_question_id ),
+			)
+		);
+
+		/* Assert. */
+		$translated_question = get_post( $translated_question_id );
+		$this->assertSame( 'Pregunta', $translated_question->post_title, 'The translated question title should be updated from the lesson content.' );
+		$this->assertSame( array( 'sí' ), get_post_meta( $translated_question_id, '_question_right_answer', true ), 'The right answer should be updated from the lesson content.' );
+		$this->assertSame( array( 'no' ), get_post_meta( $translated_question_id, '_question_wrong_answers', true ), 'The wrong answers should be updated from the lesson content.' );
+	}
+
+	/**
+	 * Register the WPML hooks that stand in for a real lesson translation: the
+	 * language details, the source/translation id map, and quiz duplication.
+	 *
+	 * @param int $source_lesson_id       Source (original language) lesson ID.
+	 * @param int $translated_lesson_id   Translated lesson ID.
+	 * @param int $source_quiz_id         Source quiz ID.
+	 * @param int $translated_quiz_id     Translated quiz ID.
+	 * @param int $source_question_id     Source question ID.
+	 * @param int $translated_question_id Translated question ID.
+	 */
+	private function simulate_wpml_translation( $source_lesson_id, $translated_lesson_id, $source_quiz_id, $translated_quiz_id, $source_question_id, $translated_question_id ) {
+		add_filter(
+			'wpml_element_language_details',
+			function () {
+				return array(
+					'language_code'        => 'es',
+					'source_language_code' => 'en',
+				);
+			},
+			10,
+			0
+		);
+
+		// Map a post to its counterpart in the other language, per element type.
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id, $element_type ) use ( $source_lesson_id, $translated_lesson_id, $source_question_id, $translated_question_id ) {
+				$map = array(
+					'lesson'   => array(
+						$translated_lesson_id => $source_lesson_id,
+						$source_lesson_id     => $translated_lesson_id,
+					),
+					'question' => array(
+						$source_question_id => $translated_question_id,
+					),
+				);
+				return $map[ $element_type ][ $object_id ] ?? 0;
+			},
+			10,
+			2
+		);
+
+		// Duplicating the quiz (or a question) into Spanish returns the
+		// translated post created for the test instead of making a new one.
+		add_filter(
+			'wpml_copy_post_to_language',
+			function ( $post_id ) use ( $source_quiz_id, $translated_quiz_id, $translated_question_id ) {
+				return $source_quiz_id === $post_id ? $translated_quiz_id : $translated_question_id;
+			}
+		);
+	}
+
+	/**
+	 * Translated lesson content: a quiz holding one translated question. The
+	 * question block still references the source-language question id.
+	 *
+	 * @param int $source_question_id Source question ID referenced by the block.
+	 * @return string Serialized block content.
+	 */
+	private function translated_lesson_content( $source_question_id ) {
+		return '<!-- wp:sensei-lms/quiz -->' . "\n" .
+			'<!-- wp:sensei-lms/quiz-question {"id":' . $source_question_id . ',"title":"Pregunta","answer":{"answers":[{"label":"sí","correct":true},{"label":"no","correct":false}]},"options":{"grade":1}} -->' . "\n" .
+			'<!-- /wp:sensei-lms/quiz-question -->' . "\n" .
+			'<!-- /wp:sensei-lms/quiz -->';
+	}
 }

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -121,7 +121,8 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$master_question_id = \Sensei()->quiz->get_questions( $master_quiz_id )[0]->ID;
 
 		// WPML creates the translated posts empty at the start of a delivery; the
-		// question begins as a copy that still holds the source-language strings.
+		// question begins as a copy that still holds the source-language strings
+		// and answer order.
 		$translated_lesson_id   = $this->factory->lesson->create( array( 'post_content' => '' ) );
 		$translated_quiz_id     = $this->factory->quiz->create();
 		$translated_question_id = $this->factory->post->create(
@@ -129,6 +130,11 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 				'post_type'  => 'question',
 				'post_title' => 'Question',
 			)
+		);
+		update_post_meta(
+			$translated_question_id,
+			'_answer_order',
+			\Sensei()->lesson->get_answer_id( 'yes' ) . ',' . \Sensei()->lesson->get_answer_id( 'no' )
 		);
 
 		$this->simulate_wpml_translation(
@@ -166,6 +172,7 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( 'Pregunta', $translated_question->post_title, 'The translated question title should be updated from the lesson content.' );
 		$this->assertSame( array( 'sí' ), get_post_meta( $translated_question_id, '_question_right_answer', true ), 'The right answer should be updated from the lesson content.' );
 		$this->assertSame( array( 'no' ), get_post_meta( $translated_question_id, '_question_wrong_answers', true ), 'The wrong answers should be updated from the lesson content.' );
+		$this->assertSame( \Sensei()->lesson->get_answer_id( 'sí' ) . ',' . \Sensei()->lesson->get_answer_id( 'no' ), get_post_meta( $translated_question_id, '_answer_order', true ), 'The answer order should be recomputed from the translated labels in block order.' );
 	}
 
 	/**

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -154,6 +154,13 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 			)
 		);
 
+		/* Clean up. */
+		remove_all_filters( 'wpml_element_language_details' );
+		remove_all_filters( 'wpml_object_id' );
+		remove_all_filters( 'wpml_copy_post_to_language' );
+		remove_action( 'wpml_pro_translation_completed', array( $lesson_translation, 'update_lesson_translations_on_lesson_translation_created' ) );
+		remove_action( 'wp_after_insert_post', array( $lesson_translation, 'update_question_translations_on_lesson_content_written' ) );
+
 		/* Assert. */
 		$translated_question = get_post( $translated_question_id );
 		$this->assertSame( 'Pregunta', $translated_question->post_title, 'The translated question title should be updated from the lesson content.' );


### PR DESCRIPTION
## Proposed Changes

When a lesson is translated with WPML, its quiz questions kept the **source-language title and answers** on the translated site — a student opening the translated quiz saw the original-language question text even though the translation was complete.

Two causes: the routine that copies the translated strings onto the translated question posts looked for a block name that no longer exists (so it never matched a question), and — once that was corrected — it ran at the WPML "translation completed" moment, *before* WPML had written the translated block content into the lesson.

This matches the current `sensei-lms/quiz-question` block (searching nested blocks for it), and defers the sync until the translated content is actually written (`wp_after_insert_post`), so the translated question posts receive the translated title and answers. Freshly translated quizzes now display in the translated language.

## Testing Instructions

1. On a site with Sensei and WPML active and a second language configured (e.g. Spanish), create a course with a single lesson.
2. Add a quiz to that lesson with at least one question that has a recognisable title and distinct answer labels — for example a multiple-choice question titled "Question 1" with answers "Apple" and "Banana". Publish the lesson.
3. Enrol a test student in the course, and make sure you can log in as that student.
4. Send the lesson for translation into the second language (WPML → Translation Management, or the "+" translate icon on the lesson).
5. Open the job in the Advanced Translation Editor, translate the question title and every answer label into the second language, then complete and save the job so WPML delivers the translation.
6. Log in as the enrolled student (who has **not** yet taken the quiz), switch the site to the second language, and open the translated lesson's quiz on the frontend.
7. Confirm the question title and the answer labels are shown in the translated language, not the source language.
