### PR TITLE
Fix typo in My Courses Page setting description

### DIFF
--- a/changelog/fix-my-courses-page-typo
+++ b/changelog/fix-my-courses-page-typo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix typo in My Courses Page setting description

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -415,7 +415,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'name'        => __( 'My Courses Page', 'sensei-lms' ),
 			'description' => sprintf(
 				// translators: Placeholder is the docs link.
-				__( 'The <a href="%s" target="_blank">page</a> to use to display the courses that a user is currently taking as well as the courses a user has complete.', 'sensei-lms' ),
+				__( 'The <a href="%s" target="_blank">page</a> to use to display the courses that a user is currently taking as well as the courses a user has completed.', 'sensei-lms' ),
 				'https://senseilms.com/documentation/sensei-pages/#my-courses'
 			),
 			'type'        => 'select',

--- a/lang/sensei-lms.pot
+++ b/lang/sensei-lms.pot
@@ -5442,7 +5442,7 @@ msgstr ""
 #. translators: Placeholder is the docs link.
 #: includes/class-sensei-settings.php:418
 #, php-format
-msgid "The <a href=\"%s\" target=\"_blank\">page</a> to use to display the courses that a user is currently taking as well as the courses a user has complete."
+msgid "The <a href=\"%s\" target=\"_blank\">page</a> to use to display the courses that a user is currently taking as well as the courses a user has completed."
 msgstr ""
 
 #: includes/class-sensei-settings.php:429


### PR DESCRIPTION
## Proposed Changes
* Fix typo in My Courses Page setting description: "has complete" → "has completed".
* Update matching string in `lang/sensei-lms.pot`.

Resolves #8084

## Testing Instructions
- [ ] Open Sensei settings (`/wp-admin/admin.php?page=sensei-settings`)
- [ ] Confirm the My Courses Page description reads "...courses a user has completed."

## Changelog entry
- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message
Fix typo in My Courses Page setting description ("has completed").

</details>