### PR TITLE
Fix the Grading quiz link and row titles for WPML admin languages

### DIFF
--- a/changelog/fix-wpml-grading-quiz-link
+++ b/changelog/fix-wpml-grading-quiz-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the Grading screen Grade button and row titles when the admin uses a secondary language on multilingual sites.

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -343,7 +343,13 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 
 		$title = Sensei_Learner::get_full_name( $user_id );
 
-		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id, 'any' );
+		// Resolve the quiz from the lesson meta rather than a post query:
+		// language plugins (e.g. WPML) filter post queries to the current admin
+		// language, which can differ from the lesson's and return nothing.
+		$quiz_id = (int) get_post_meta( $lesson_id, '_lesson_quiz', true );
+		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
+			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id, 'any' );
+		}
 		$quiz_link = add_query_arg(
 			array(
 				'page'    => $this->page_slug,

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -343,13 +343,12 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 
 		$title = Sensei_Learner::get_full_name( $user_id );
 
-		// Resolve the quiz from the lesson meta rather than a post query:
-		// language plugins (e.g. WPML) filter post queries to the current admin
-		// language, which can differ from the lesson's and return nothing.
+		// Post queries can be language-filtered by multilingual plugins and miss the quiz; the meta is not.
 		$quiz_id = (int) get_post_meta( $lesson_id, '_lesson_quiz', true );
 		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
 			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id, 'any' );
 		}
+		
 		$quiz_link = add_query_arg(
 			array(
 				'page'    => $this->page_slug,

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -343,11 +343,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 
 		$title = Sensei_Learner::get_full_name( $user_id );
 
-		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
-		$quiz_id = (int) get_post_meta( $lesson_id, '_lesson_quiz', true );
-		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
-			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id, 'any' );
-		}
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		$quiz_link = add_query_arg(
 			array(

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -343,7 +343,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 
 		$title = Sensei_Learner::get_full_name( $user_id );
 
-		// Post queries can be language-filtered by multilingual plugins and miss the quiz; the meta is not.
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
 		$quiz_id = (int) get_post_meta( $lesson_id, '_lesson_quiz', true );
 		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
 			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id, 'any' );

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -348,7 +348,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
 			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id, 'any' );
 		}
-		
+
 		$quiz_link = add_query_arg(
 			array(
 				'page'    => $this->page_slug,

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3650,6 +3650,27 @@ class Sensei_Lesson {
 		return $quiz_id;
 	}
 
+	/**
+	 * Get the quiz ID for a lesson.
+	 *
+	 * Resolves the quiz from the lesson meta first: post queries can be
+	 * filtered by plugins and miss the quiz.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $lesson_id The lesson ID.
+	 *
+	 * @return int|null Quiz ID, or null when the lesson has no quiz.
+	 */
+	public function get_quiz_id( $lesson_id ) {
+		$quiz_id = (int) get_post_meta( $lesson_id, '_lesson_quiz', true );
+		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
+			$quiz_id = $this->lesson_quizzes( $lesson_id );
+		}
+
+		return $quiz_id;
+	}
+
 
 	/**
 	 * Get quiz permalink.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1159,11 +1159,7 @@ class Sensei_Quiz {
 			$user_id = get_current_user_id();
 		}
 
-		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
-		$quiz_id = (int) get_post_meta( $lesson_id, '_lesson_quiz', true );
-		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
-			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		}
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		if (
 			! intval( $lesson_id ) > 0

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1159,7 +1159,11 @@ class Sensei_Quiz {
 			$user_id = get_current_user_id();
 		}
 
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = (int) get_post_meta( $lesson_id, '_lesson_quiz', true );
+		if ( ! $quiz_id || 'quiz' !== get_post_type( $quiz_id ) ) {
+			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		}
 
 		if (
 			! intval( $lesson_id ) > 0

--- a/includes/wpml/class-grading.php
+++ b/includes/wpml/class-grading.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * File containing \Sensei\WPML\Grading class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\WPML;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Grading
+ *
+ * Compatibility code with WPML.
+ *
+ * @since $$next-version$$
+ *
+ * @internal
+ */
+class Grading {
+	use WPML_API;
+
+	/**
+	 * Init hooks.
+	 */
+	public function init() {
+		add_filter( 'sensei_grading_main_column_data', array( $this, 'translate_row_titles' ), 10, 3 );
+	}
+
+	/**
+	 * Show the lesson and course titles of a Grading row in the current admin language.
+	 *
+	 * Display only: the rebuilt links keep the original-language IDs, which is
+	 * what the listing filters expect.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param array  $column_data Column data for the row.
+	 * @param object $item        Grading item for the row.
+	 * @param int    $course_id   Course ID.
+	 * @return array
+	 */
+	public function translate_row_titles( $column_data, $item, $course_id ) {
+		$current_language = $this->get_current_language();
+		if ( ! $current_language ) {
+			return $column_data;
+		}
+
+		$lesson_id = (int) $item->lesson_id;
+		if ( ! empty( $column_data['lesson'] ) && $lesson_id ) {
+			$display_lesson_id = $this->get_object_id( $lesson_id, 'lesson', true, $current_language );
+			if ( $display_lesson_id !== $lesson_id ) {
+				$column_data['lesson'] = $this->build_title_link( 'lesson_id', $lesson_id, $display_lesson_id );
+			}
+		}
+
+		$course_id = (int) $course_id;
+		if ( ! empty( $column_data['course'] ) && $course_id ) {
+			$display_course_id = $this->get_object_id( $course_id, 'course', true, $current_language );
+			if ( $display_course_id !== $course_id ) {
+				$column_data['course'] = $this->build_title_link( 'course_id', $course_id, $display_course_id );
+			}
+		}
+
+		return $column_data;
+	}
+
+	/**
+	 * Build a Grading filter link with the original ID and the display post's title.
+	 *
+	 * @param string $query_key   Query argument name.
+	 * @param int    $original_id Original-language post ID for the link.
+	 * @param int    $display_id  Post ID to take the title from.
+	 * @return string
+	 */
+	private function build_title_link( $query_key, $original_id, $display_id ) {
+		return '<a href="' . esc_url(
+			add_query_arg(
+				array(
+					'page'     => 'sensei_grading',
+					$query_key => $original_id,
+				),
+				admin_url( 'admin.php' )
+			)
+		) . '">' . esc_html( get_the_title( $display_id ) ) . '</a>';
+	}
+}

--- a/includes/wpml/class-wpml.php
+++ b/includes/wpml/class-wpml.php
@@ -26,6 +26,7 @@ class WPML {
 		( new Course_Translation() )->init();
 		( new Custom_Fields() )->init();
 		( new Email() )->init();
+		( new Grading() )->init();
 		( new Language_Details() )->init();
 		( new Lesson_Progress() )->init();
 		( new Lesson_Translation() )->init();

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -33,6 +33,41 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the Grade link keeps the quiz ID even when quiz post queries
+	 * are filtered to another language, as WPML does in a secondary admin language.
+	 *
+	 * @covers Sensei_Grading_Main::get_row_data
+	 */
+	public function testGetRowData_QuizQueryFilteredToAnotherLanguage_BuildsGradeLinkWithQuizId(): void {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->quiz->create( array( 'post_parent' => $lesson_id ) );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		// Simulate WPML filtering quiz post queries to a different admin language.
+		$language_filter = function ( $where, $query ) {
+			if ( 'quiz' === $query->get( 'post_type' ) ) {
+				$where .= ' AND 1=0';
+			}
+			return $where;
+		};
+		add_filter( 'posts_where', $language_filter, 10, 2 );
+
+		$grading_main = new Sensei_Grading_Main( array( 'view' => 'ungraded' ) );
+		$item         = new \Sensei\Internal\Services\Grading_Item( 'ungraded', $user_id, $lesson_id, current_time( 'mysql' ), null );
+
+		/* Act. */
+		$method = new ReflectionMethod( Sensei_Grading_Main::class, 'get_row_data' );
+		$method->setAccessible( true );
+		$row = $method->invoke( $grading_main, $item );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertStringContainsString( 'quiz_id=' . $quiz_id, $row['action'], 'The Grade link should carry the quiz ID even when quiz queries are language filtered.' );
+	}
+
+	/**
 	 * Tests that prepare_items() applies sensei_count_statuses_args
 	 * restrictions to listing rows for tables-based storage.
 	 *

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -34,7 +34,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tests that the Grade link keeps the quiz ID even when quiz post queries
-	 * are filtered to another language, as WPML does in a secondary admin language.
+	 * are filtered to another language, as multilingual plugins do in a
+	 * secondary admin language.
 	 *
 	 * @covers Sensei_Grading_Main::get_row_data
 	 */
@@ -45,7 +46,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$quiz_id   = $this->factory->quiz->create( array( 'post_parent' => $lesson_id ) );
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
-		// Simulate WPML filtering quiz post queries to a different admin language.
+		// Simulate a multilingual plugin filtering quiz post queries to another language.
 		$language_filter = function ( $where, $query ) {
 			if ( 'quiz' === $query->get( 'post_type' ) ) {
 				$where .= ' AND 1=0';

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1076,6 +1076,42 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	/**
 	 * Testing $woothemes->quiz->get_user_grades.
 	 */
+	/**
+	 * Tests that stored grades survive quiz post queries being filtered
+	 * to another language by a multilingual plugin.
+	 *
+	 * @covers Sensei_Quiz::get_user_grades
+	 */
+	public function testGetUserGrades_QuizQueryFilteredToAnotherLanguage_ReturnsStoredGrades() {
+		/* Arrange. */
+		$user_id     = $this->factory->user->create();
+		$lesson_id   = $this->factory->get_random_lesson_id();
+		$quiz_id     = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		$question_id = Sensei()->quiz->get_questions( $quiz_id )[0]->ID;
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+		$submission = Sensei()->quiz_submission_repository->create( $quiz_id, $user_id );
+		$answer     = Sensei()->quiz_answer_repository->create( $submission, $question_id, 'Answer' );
+		Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, 1 );
+
+		// Simulate a multilingual plugin filtering quiz post queries to another language.
+		$language_filter = function ( $where, $query ) {
+			if ( 'quiz' === $query->get( 'post_type' ) ) {
+				$where .= ' AND 1=0';
+			}
+			return $where;
+		};
+		add_filter( 'posts_where', $language_filter, 10, 2 );
+
+		/* Act. */
+		$grades = Sensei()->quiz->get_user_grades( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertSame( array( $question_id => 1 ), $grades, 'Stored grades should survive language-filtered quiz queries.' );
+	}
+
 	public function testGetUserGrades() {
 
 		// Setup the data needed for the assertions in this test.

--- a/tests/unit-tests/wpml/test-class-grading.php
+++ b/tests/unit-tests/wpml/test-class-grading.php
@@ -6,6 +6,24 @@ use Sensei\Internal\Services\Grading_Item;
 use Sensei\WPML\Grading;
 
 class Grading_Test extends \WP_UnitTestCase {
+	/**
+	 * Sensei Factory.
+	 *
+	 * @var \Sensei_Factory
+	 */
+	protected $factory;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'wpml_current_language' );
+		remove_all_filters( 'wpml_object_id' );
+		parent::tear_down();
+		$this->factory->tearDown();
+	}
 
 	public function testInit_WhenCalled_AddsFilters() {
 		/* Arrange. */
@@ -57,10 +75,22 @@ class Grading_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'Curso ES', $actual['course'] );
 	}
 
+	public function testTranslateRowTitles_CourseTranslationExists_KeepsOriginalCourseIdInLink() {
+		/* Arrange. */
+		list( $column_data, $item, $course_id ) = $this->arrange_row_with_translations();
+
+		$grading = new Grading();
+
+		/* Act. */
+		$actual = $grading->translate_row_titles( $column_data, $item, $course_id );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'course_id=' . $course_id, $actual['course'] );
+	}
+
 	public function testTranslateRowTitles_NoTranslationExists_ReturnsColumnDataUnchanged() {
 		/* Arrange. */
-		$factory   = new \Sensei_Factory();
-		$lesson_id = $factory->lesson->create( array( 'post_title' => 'Lesson EN' ) );
+		$lesson_id = $this->factory->lesson->create( array( 'post_title' => 'Lesson EN' ) );
 
 		add_filter(
 			'wpml_current_language',
@@ -94,12 +124,10 @@ class Grading_Test extends \WP_UnitTestCase {
 	 * @return array{0: array, 1: Grading_Item, 2: int} Column data, item, and course ID.
 	 */
 	private function arrange_row_with_translations() {
-		$factory = new \Sensei_Factory();
-
-		$lesson_en = $factory->lesson->create( array( 'post_title' => 'Lesson EN' ) );
-		$lesson_es = $factory->lesson->create( array( 'post_title' => 'Lección ES' ) );
-		$course_en = $factory->course->create( array( 'post_title' => 'Course EN' ) );
-		$course_es = $factory->course->create( array( 'post_title' => 'Curso ES' ) );
+		$lesson_en = $this->factory->lesson->create( array( 'post_title' => 'Lesson EN' ) );
+		$lesson_es = $this->factory->lesson->create( array( 'post_title' => 'Lección ES' ) );
+		$course_en = $this->factory->course->create( array( 'post_title' => 'Course EN' ) );
+		$course_es = $this->factory->course->create( array( 'post_title' => 'Curso ES' ) );
 
 		add_filter(
 			'wpml_current_language',

--- a/tests/unit-tests/wpml/test-class-grading.php
+++ b/tests/unit-tests/wpml/test-class-grading.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace SenseiTest\WPML;
+
+use Sensei\Internal\Services\Grading_Item;
+use Sensei\WPML\Grading;
+
+class Grading_Test extends \WP_UnitTestCase {
+
+	public function testInit_WhenCalled_AddsFilters() {
+		/* Arrange. */
+		$grading = new Grading();
+
+		/* Act. */
+		$grading->init();
+
+		/* Assert. */
+		$this->assertEquals( 10, has_filter( 'sensei_grading_main_column_data', array( $grading, 'translate_row_titles' ) ) );
+	}
+
+	public function testTranslateRowTitles_LessonTranslationExists_ShowsCurrentLanguageLessonTitle() {
+		/* Arrange. */
+		list( $column_data, $item, $course_id ) = $this->arrange_row_with_translations();
+
+		$grading = new Grading();
+
+		/* Act. */
+		$actual = $grading->translate_row_titles( $column_data, $item, $course_id );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'Lección ES', $actual['lesson'] );
+	}
+
+	public function testTranslateRowTitles_LessonTranslationExists_KeepsOriginalLessonIdInLink() {
+		/* Arrange. */
+		list( $column_data, $item, $course_id ) = $this->arrange_row_with_translations();
+
+		$grading = new Grading();
+
+		/* Act. */
+		$actual = $grading->translate_row_titles( $column_data, $item, $course_id );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'lesson_id=' . $item->lesson_id, $actual['lesson'] );
+	}
+
+	public function testTranslateRowTitles_CourseTranslationExists_ShowsCurrentLanguageCourseTitle() {
+		/* Arrange. */
+		list( $column_data, $item, $course_id ) = $this->arrange_row_with_translations();
+
+		$grading = new Grading();
+
+		/* Act. */
+		$actual = $grading->translate_row_titles( $column_data, $item, $course_id );
+
+		/* Assert. */
+		$this->assertStringContainsString( 'Curso ES', $actual['course'] );
+	}
+
+	public function testTranslateRowTitles_NoTranslationExists_ReturnsColumnDataUnchanged() {
+		/* Arrange. */
+		$factory   = new \Sensei_Factory();
+		$lesson_id = $factory->lesson->create( array( 'post_title' => 'Lesson EN' ) );
+
+		add_filter(
+			'wpml_current_language',
+			function () {
+				return 'es';
+			},
+			10,
+			0
+		);
+		// No wpml_object_id filter: WPML returns the same ID it was given.
+
+		$column_data = array(
+			'lesson' => '<a href="#original">Lesson EN</a>',
+			'course' => '',
+		);
+		$item        = new Grading_Item( 'ungraded', 1, $lesson_id, current_time( 'mysql' ), null );
+
+		$grading = new Grading();
+
+		/* Act. */
+		$actual = $grading->translate_row_titles( $column_data, $item, 0 );
+
+		/* Assert. */
+		$this->assertSame( $column_data, $actual );
+	}
+
+	/**
+	 * Create an EN lesson/course pair with ES translations, register the WPML
+	 * filters linking them (current language es), and build the row inputs.
+	 *
+	 * @return array{0: array, 1: Grading_Item, 2: int} Column data, item, and course ID.
+	 */
+	private function arrange_row_with_translations() {
+		$factory = new \Sensei_Factory();
+
+		$lesson_en = $factory->lesson->create( array( 'post_title' => 'Lesson EN' ) );
+		$lesson_es = $factory->lesson->create( array( 'post_title' => 'Lección ES' ) );
+		$course_en = $factory->course->create( array( 'post_title' => 'Course EN' ) );
+		$course_es = $factory->course->create( array( 'post_title' => 'Curso ES' ) );
+
+		add_filter(
+			'wpml_current_language',
+			function () {
+				return 'es';
+			},
+			10,
+			0
+		);
+
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id, $type ) use ( $lesson_en, $lesson_es, $course_en, $course_es ) {
+				if ( 'lesson' === $type && $lesson_en === $object_id ) {
+					return $lesson_es;
+				}
+				if ( 'course' === $type && $course_en === $object_id ) {
+					return $course_es;
+				}
+				return $object_id;
+			},
+			10,
+			2
+		);
+
+		$column_data = array(
+			'lesson' => '<a href="#original">Lesson EN</a>',
+			'course' => '<a href="#original">Course EN</a>',
+		);
+		$item        = new Grading_Item( 'ungraded', 1, $lesson_en, current_time( 'mysql' ), null );
+
+		return array( $column_data, $item, $course_en );
+	}
+}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SEN-94/wpml-grading-does-not-respect-the-selected-admin-language
Closes #7574

## Proposed Changes

On multilingual sites, the Grading screen broke down when the admin was in a secondary language:

- The **Grade button did nothing**: the quiz for each row was resolved with a post query, which multilingual plugins filter to the current admin language. In a secondary language it returned nothing and the button linked back to the list without a quiz. The quiz is now resolved from the lesson meta, with the previous query as a fallback for lessons without it.
- The **grading detail screen showed every question as ungraded** in a secondary admin language: the stored grades were read through the same language-filtered quiz lookup, and the page's on-load auto-grading could then mis-mark the questions. The quiz is now resolved from the lesson meta there too.
- The **lesson and course titles always showed in the original language**. A new WPML compatibility class now displays them in the current admin language when a translation exists, using the existing column-data filter. Links keep the original-language IDs, so the course and lesson filters keep working.

Behavior on sites without a multilingual plugin is unchanged.

## Testing Instructions

1. On a site with WPML active (English as default, Spanish as secondary), create a course with one lesson and a quiz with at least one question, and translate the course, lesson and quiz into Spanish with the Advanced Translation Editor.
2. As an enrolled student, take and submit the quiz on the English frontend.
3. As a second enrolled student, switch the frontend to Spanish and take and submit the Spanish quiz, so Grading has one row per student.
4. In wp-admin, switch the admin-bar language to Spanish and go to **Sensei LMS → Grading**.
5. Check both rows show the lesson and course titles in Spanish.
6. Hover over the **Grade quiz** button of each row and check its URL contains `quiz_id`. Before this fix, in a secondary admin language the link had no `quiz_id` and clicking it reloaded the list.
7. Click the button on both rows: the grading screen should open for each submission. Note the questions and answers display in the language each quiz was taken in; that is existing behavior and out of scope for this PR.
8. Still in Spanish, check each submission shows its stored per-question grades and total correctly. Before this fix, every question displayed as ungraded and the page could auto-mark them wrong.
9. Switch the admin-bar language back to English and check the titles show in English and the buttons still work.
10. Deactivate WPML and check the Grading screen looks and works as before.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message
Fixed the Grading screen Grade button and row titles when the admin uses a secondary language on multilingual sites.

</details>

