### PR TITLE
Align the Grading reset filter button with the filter dropdowns

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -832,14 +832,17 @@ table.wp_list_table_sensei_learner_admins {
 .sensei-grading-filters__reset-button {
 	width: 200px;
 	margin-bottom: 10px;
+	box-sizing: border-box;
+	text-align: center;
 
-	&.disabled {
-		margin-bottom: 10px;
+	// Match the 30px height of the filter dropdowns next to it.
+	.wrap & {
+		min-height: 30px;
+		line-height: 28px;
 	}
 
 	@media screen and (min-width: 782px) {
 		width: auto;
-		margin-bottom: auto;
 	}
 }
 

--- a/changelog/fix-grading-reset-filter-alignment
+++ b/changelog/fix-grading-reset-filter-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the misaligned Reset filter button on the Grading screen.


### PR DESCRIPTION
## Proposed Changes

On the Grading screen, the Reset filter button rendered noticeably taller than the two filter dropdowns next to it (the admin styling system sizes buttons at 40px while the dropdowns are 30px), leaving the filter row misaligned. The button now matches the dropdowns' height and bottom margin.

| Before | After |
|--------|--------|
| <img width="602" height="482" alt="Screenshot 2026-07-29 at 09 29 04" src="https://github.com/user-attachments/assets/8385a3ba-dcfe-42ea-8516-7f951350ae15" /> | <img width="581" height="450" alt="Screenshot 2026-07-29 at 09 28 32" src="https://github.com/user-attachments/assets/3df46dea-684e-4594-a76d-8ac7e279e852" /> |

## Testing Instructions

1. Go to Sensei LMS → Grading on a site with at least one course.
2. Look at the filter row above the table: the Reset filter button should have the same height as the two dropdowns and align with them.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message
Fix the misaligned Reset filter button on the Grading screen.

</details>