### PR TITLE
Show quiz review questions in the viewer's language on WPML sites

### DIFF
--- a/changelog/fix-wpml-quiz-review-viewer-language
+++ b/changelog/fix-wpml-quiz-review-viewer-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the quiz results page showing questions in the language the quiz was taken in instead of the viewer's language on multilingual sites.

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -712,12 +712,12 @@ class Sensei_Question {
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @hook sensei_question_description_post_id
+		 * @hook sensei_question_description_question_id
 		 *
 		 * @param {int} $question_id Question ID.
 		 * @return {int} Question ID to render the description from.
 		 */
-		$question_id = (int) apply_filters( 'sensei_question_description_post_id', $question_id );
+		$question_id = (int) apply_filters( 'sensei_question_description_question_id', $question_id );
 
 		$question = $question_id > 0 ? get_post( $question_id ) : null;
 		if ( ! $question ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -717,9 +717,13 @@ class Sensei_Question {
 		 * @param {int} $question_id Question ID.
 		 * @return {int} Question ID to render the description from.
 		 */
-		$question_id = apply_filters( 'sensei_the_question_description_question_id', $question_id );
+		$question_id = (int) apply_filters( 'sensei_the_question_description_question_id', $question_id );
 
-		$question             = get_post( $question_id );
+		$question = $question_id > 0 ? get_post( $question_id ) : null;
+		if ( ! $question ) {
+			return '';
+		}
+
 		$question_description = $question->post_content;
 
 		if ( has_blocks( $question_description ) ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -701,12 +701,23 @@ class Sensei_Question {
 	}
 
 	/**
-	 * Tech the question description
+	 * Get the question description.
 	 *
 	 * @param $question_id
 	 * @return string
 	 */
 	public static function get_the_question_description( $question_id ) {
+		/**
+		 * Filter the question whose description is rendered.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @hook sensei_the_question_description_question_id
+		 *
+		 * @param {int} $question_id Question ID.
+		 * @return {int} Question ID to render the description from.
+		 */
+		$question_id = apply_filters( 'sensei_the_question_description_question_id', $question_id );
 
 		$question             = get_post( $question_id );
 		$question_description = $question->post_content;

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -712,12 +712,12 @@ class Sensei_Question {
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @hook sensei_the_question_description_question_id
+		 * @hook sensei_question_description_post_id
 		 *
 		 * @param {int} $question_id Question ID.
 		 * @return {int} Question ID to render the description from.
 		 */
-		$question_id = (int) apply_filters( 'sensei_the_question_description_question_id', $question_id );
+		$question_id = (int) apply_filters( 'sensei_question_description_post_id', $question_id );
 
 		$question = $question_id > 0 ? get_post( $question_id ) : null;
 		if ( ! $question ) {

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -31,9 +31,8 @@ class Question_Display {
 	 * Init hooks.
 	 */
 	public function init() {
-		// After the question-type loaders (priority 10): they compute selection and
-		// order in as-taken space, where stored answers match; this class only
-		// swaps what is displayed.
+		// Run after the question-type loaders (priority 10), so the student's
+		// selection is already resolved when the labels get translated.
 		add_filter( 'sensei_get_question_template_data', array( $this, 'translate_template_data' ), 15, 2 );
 		// The question heading is rendered from get_the_title(), outside the template data.
 		add_filter( 'the_title', array( $this, 'translate_question_title' ), 10, 2 );
@@ -49,10 +48,12 @@ class Question_Display {
 	/**
 	 * Show the question-authored answer feedback in the current language.
 	 *
-	 * The notes can also be per-student feedback written by the teacher while
-	 * grading; that has no translation and is shown as written. The two are
-	 * told apart by matching the notes against the taken question's own
-	 * feedback sources.
+	 * Runs when the feedback box of a graded question is rendered on the quiz
+	 * page. If the notes are the question's own feedback (the correct/incorrect
+	 * feedback blocks or the answer feedback field), it swaps them for the
+	 * translation's version. Notes written by the teacher for this student
+	 * while grading have no translation and are shown as written; they are
+	 * told apart because they match none of the question's feedback sources.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -100,8 +101,10 @@ class Question_Display {
 	/**
 	 * Show the "Right Answer:" reveal in the current language.
 	 *
-	 * Gap fill stays as taken on purpose: the right answer only makes sense
-	 * against the gap in its own language.
+	 * Runs when the feedback box of a failed question reveals the right answer
+	 * on the quiz page. It rebuilds the message from the question's
+	 * translation. Gap fill stays as taken on purpose: the right answer only
+	 * makes sense against the gap in its own language.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -132,7 +135,9 @@ class Question_Display {
 	/**
 	 * Take over the question-description renderer on the frontend.
 	 *
-	 * Only when the core renderer is found where expected: otherwise leave it
+	 * Runs right before a quiz renders its questions: it unhooks the core
+	 * renderer and puts render_question_description() in its place. Only when
+	 * the core renderer is found where expected: otherwise it leaves everything
 	 * alone rather than risk rendering the description twice.
 	 *
 	 * @since $$next-version$$
@@ -150,6 +155,10 @@ class Question_Display {
 	/**
 	 * Render the question description from the current-language question.
 	 *
+	 * Runs in each question's header in place of the core renderer. It renders
+	 * the translation's description; without a translation it renders the
+	 * question's own, exactly like core.
+	 *
 	 * @since $$next-version$$
 	 *
 	 * @internal
@@ -164,6 +173,10 @@ class Question_Display {
 
 	/**
 	 * Show a question's title in the current language on the frontend.
+	 *
+	 * Runs whenever a question title is fetched on the frontend (the quiz page
+	 * heading among others). In wp-admin, or without a translation, the title
+	 * is returned unchanged.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -187,11 +200,13 @@ class Question_Display {
 	}
 
 	/**
-	 * Resolve the current-language twin of a question.
+	 * Get the ID of the question's translation in the current language.
 	 *
 	 * @param int $question_id Question ID.
-	 * @return int Twin question ID, or 0 when there is nothing to translate to
-	 *             (no multilingual plugin, no translation, or same question).
+	 * @return int Translated question ID, or 0 when the question should render
+	 *             as is: no multilingual plugin is active, the question has no
+	 *             translation in the current language, or it already is the
+	 *             current-language version.
 	 */
 	private function get_display_question_id( $question_id ) {
 		$current_language = $this->get_current_language();
@@ -208,9 +223,14 @@ class Question_Display {
 	}
 
 	/**
-	 * Swap a question's template data for the current-language translation.
+	 * Show a question of a completed quiz in the current language.
 	 *
-	 * Display only: stored answers and grades are never modified.
+	 * Runs every time a question is rendered on the quiz page, after the type
+	 * loaders have built its template data. On a completed quiz it replaces the
+	 * title, content, and option labels with the ones from the question's
+	 * translation. While the quiz is open, or when the options cannot be
+	 * mapped, the question renders as taken. Display only: stored answers and
+	 * grades are never modified.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -35,7 +35,7 @@ class Question_Display {
 		// The question heading is rendered from get_the_title(), outside the template data.
 		add_filter( 'the_title', array( $this, 'translate_question_title' ), 10, 2 );
 		// The description renderer asks through this filter which question to read from.
-		add_filter( 'sensei_question_description_post_id', array( $this, 'translate_question_description_id' ) );
+		add_filter( 'sensei_question_description_question_id', array( $this, 'translate_question_description_id' ) );
 		// The "Right Answer:" reveal shown on failed questions.
 		add_filter( 'sensei_question_answer_message_correct_answer', array( $this, 'translate_correct_answer_message' ), 10, 3 );
 		// The feedback text shown under Correct/Incorrect.

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -36,9 +36,9 @@ class Question_Display {
 		add_filter( 'sensei_get_question_template_data', array( $this, 'translate_template_data' ), 15, 2 );
 		// The question heading is rendered from get_the_title(), outside the template data.
 		add_filter( 'the_title', array( $this, 'translate_question_title' ), 10, 2 );
-		// The description renderer has no filter carrying the question ID; swap
-		// the renderer itself right before a quiz renders its questions.
-		add_action( 'sensei_single_quiz_questions_before', array( $this, 'replace_question_description_renderer' ) );
+		// The description renderer asks through this filter which question to
+		// read from.
+		add_filter( 'sensei_the_question_description_question_id', array( $this, 'translate_question_description_id' ) );
 		// The "Right Answer:" reveal shown on failed questions.
 		add_filter( 'sensei_question_answer_message_correct_answer', array( $this, 'translate_correct_answer_message' ), 10, 3 );
 		// The feedback text shown under Correct/Incorrect.
@@ -133,42 +133,22 @@ class Question_Display {
 	}
 
 	/**
-	 * Take over the question-description renderer on the frontend.
-	 *
-	 * Runs right before a quiz renders its questions: it unhooks the core
-	 * renderer and puts render_question_description() in its place. Only when
-	 * the core renderer is found where expected: otherwise it leaves everything
-	 * alone rather than risk rendering the description twice.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @internal
-	 */
-	public function replace_question_description_renderer() {
-		if ( ! remove_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question', 'the_question_description' ), 20 ) ) {
-			return;
-		}
-
-		add_action( 'sensei_quiz_question_inside_before', array( $this, 'render_question_description' ), 20 );
-	}
-
-	/**
 	 * Render the question description from the current-language question.
 	 *
-	 * Runs in each question's header in place of the core renderer. It renders
-	 * the translation's description; without a translation it renders the
-	 * question's own, exactly like core.
+	 * Runs whenever a question description is rendered. Without a translation,
+	 * the question renders its own description, exactly like core.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @internal
 	 *
-	 * @param int $question_id Question ID the row was built from (as taken).
+	 * @param int $question_id Question ID the description would render from (as taken).
+	 * @return int
 	 */
-	public function render_question_description( $question_id ) {
+	public function translate_question_description_id( $question_id ) {
 		$display_question_id = $this->get_display_question_id( (int) $question_id );
 
-		\Sensei_Question::the_question_description( $display_question_id ? $display_question_id : $question_id );
+		return $display_question_id ? $display_question_id : (int) $question_id;
 	}
 
 	/**

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -35,9 +35,78 @@ class Question_Display {
 		// order in as-taken space, where stored answers match; this class only
 		// swaps what is displayed.
 		add_filter( 'sensei_get_question_template_data', array( $this, 'translate_template_data' ), 15, 2 );
-		// The question heading is rendered from get_the_title(), outside the
-		// template data.
+		// The question heading is rendered from get_the_title(), outside the template data.
 		add_filter( 'the_title', array( $this, 'translate_question_title' ), 10, 2 );
+		// The description renderer has no filter carrying the question ID; swap
+		// the renderer itself right before a quiz renders its questions.
+		add_action( 'sensei_single_quiz_questions_before', array( $this, 'replace_question_description_renderer' ) );
+		// The "Right Answer:" reveal shown on failed questions.
+		add_filter( 'sensei_question_answer_message_correct_answer', array( $this, 'translate_correct_answer_message' ), 10, 3 );
+	}
+
+	/**
+	 * Show the "Right Answer:" reveal in the current language.
+	 *
+	 * Gap fill stays as taken on purpose: the right answer only makes sense
+	 * against the gap in its own language.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param string|false $correct_answer Correct answer message, or false when hidden.
+	 * @param int          $lesson_id      Lesson ID.
+	 * @param int          $question_id    Question ID the row was built from (as taken).
+	 * @return string|false
+	 */
+	public function translate_correct_answer_message( $correct_answer, $lesson_id, $question_id ) {
+		if ( ! $correct_answer ) {
+			return $correct_answer;
+		}
+
+		if ( 'gap-fill' === Sensei()->question->get_question_type( $question_id ) ) {
+			return $correct_answer;
+		}
+
+		$display_question_id = $this->get_display_question_id( (int) $question_id );
+		if ( ! $display_question_id ) {
+			return $correct_answer;
+		}
+
+		return \Sensei_Question::get_correct_answer( $display_question_id );
+	}
+
+	/**
+	 * Take over the question-description renderer on the frontend.
+	 *
+	 * Only when the core renderer is found where expected: otherwise leave it
+	 * alone rather than risk rendering the description twice.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 */
+	public function replace_question_description_renderer() {
+		if ( ! remove_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question', 'the_question_description' ), 20 ) ) {
+			return;
+		}
+
+		add_action( 'sensei_quiz_question_inside_before', array( $this, 'render_question_description' ), 20 );
+	}
+
+	/**
+	 * Render the question description from the current-language question.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param int $question_id Question ID the row was built from (as taken).
+	 */
+	public function render_question_description( $question_id ) {
+		$display_question_id = $this->get_display_question_id( (int) $question_id );
+
+		\Sensei_Question::the_question_description( $display_question_id ? $display_question_id : $question_id );
 	}
 
 	/**
@@ -56,22 +125,33 @@ class Question_Display {
 			return $title;
 		}
 
+		$display_question_id = $this->get_display_question_id( (int) $post_id );
+		if ( ! $display_question_id ) {
+			return $title;
+		}
+
+		return get_post( $display_question_id )->post_title;
+	}
+
+	/**
+	 * Resolve the current-language twin of a question.
+	 *
+	 * @param int $question_id Question ID.
+	 * @return int Twin question ID, or 0 when there is nothing to translate to
+	 *             (no multilingual plugin, no translation, or same question).
+	 */
+	private function get_display_question_id( $question_id ) {
 		$current_language = $this->get_current_language();
 		if ( ! $current_language ) {
-			return $title;
+			return 0;
 		}
 
-		$display_question_id = $this->get_object_id( (int) $post_id, 'question', true, $current_language );
-		if ( ! $display_question_id || (int) $post_id === $display_question_id ) {
-			return $title;
+		$display_question_id = $this->get_object_id( $question_id, 'question', true, $current_language );
+		if ( ! $display_question_id || $question_id === $display_question_id || ! get_post( $display_question_id ) ) {
+			return 0;
 		}
 
-		$display_question = get_post( $display_question_id );
-		if ( ! $display_question ) {
-			return $title;
-		}
-
-		return $display_question->post_title;
+		return $display_question_id;
 	}
 
 	/**
@@ -88,20 +168,12 @@ class Question_Display {
 	 * @return array
 	 */
 	public function translate_template_data( $question_data, $question_id ) {
-		$current_language = $this->get_current_language();
-		if ( ! $current_language ) {
-			return $question_data;
-		}
-
-		$display_question_id = $this->get_object_id( (int) $question_id, 'question', true, $current_language );
-		if ( ! $display_question_id || (int) $question_id === $display_question_id ) {
+		$display_question_id = $this->get_display_question_id( (int) $question_id );
+		if ( ! $display_question_id ) {
 			return $question_data;
 		}
 
 		$display_question = get_post( $display_question_id );
-		if ( ! $display_question ) {
-			return $question_data;
-		}
 
 		$question_data['title']   = $display_question->post_title;
 		$question_data['content'] = $display_question->post_content;
@@ -115,13 +187,8 @@ class Question_Display {
 	 *
 	 * Multilingual plugins translate option labels in place, never reordering
 	 * them or moving them between the right and wrong lists, so same list + same
-	 * position is the same answer. All-or-nothing: on any mismatch (list size,
-	 * unknown label) the data is returned untouched and the question renders as
-	 * taken.
-	 *
-	 * The as-taken lists are read from the question's own meta: the type loaders
-	 * mutate the ones in the template data (the right answer is merged into the
-	 * wrong list to build the options).
+	 * position is the same answer. On any mismatch (list size, unknown label)
+	 * the data is returned untouched and the question renders as taken.
 	 *
 	 * @param array $question_data       Question template data, as left by the type loaders.
 	 * @param int   $question_id         As-taken question ID.

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -63,7 +63,7 @@ class Question_Display {
 	 * @return string|false
 	 */
 	public function translate_answer_notes( $answer_notes, $question_id ) {
-		if ( ! $answer_notes || ! is_string( $answer_notes ) ) {
+		if ( ! is_string( $answer_notes ) || '' === $answer_notes ) {
 			return $answer_notes;
 		}
 

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -181,7 +181,9 @@ class Question_Display {
 			return $title;
 		}
 
-		return get_post( $display_question_id )->post_title;
+		$display_question = get_post( $display_question_id );
+
+		return $display_question ? $display_question->post_title : $title;
 	}
 
 	/**

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -42,6 +42,59 @@ class Question_Display {
 		add_action( 'sensei_single_quiz_questions_before', array( $this, 'replace_question_description_renderer' ) );
 		// The "Right Answer:" reveal shown on failed questions.
 		add_filter( 'sensei_question_answer_message_correct_answer', array( $this, 'translate_correct_answer_message' ), 10, 3 );
+		// The feedback text shown under Correct/Incorrect.
+		add_filter( 'sensei_question_answer_notes', array( $this, 'translate_answer_notes' ), 10, 2 );
+	}
+
+	/**
+	 * Show the question-authored answer feedback in the current language.
+	 *
+	 * The notes can also be per-student feedback written by the teacher while
+	 * grading; that has no translation and is shown as written. The two are
+	 * told apart by matching the notes against the taken question's own
+	 * feedback sources.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param string|false $answer_notes Answer notes.
+	 * @param int          $question_id  Question ID the row was built from (as taken).
+	 * @return string|false
+	 */
+	public function translate_answer_notes( $answer_notes, $question_id ) {
+		if ( ! $answer_notes || ! is_string( $answer_notes ) ) {
+			return $answer_notes;
+		}
+
+		$display_question_id = $this->get_display_question_id( (int) $question_id );
+		if ( ! $display_question_id ) {
+			return $answer_notes;
+		}
+
+		$sources = array(
+			array(
+				\Sensei_Quiz::get_correct_answer_feedback( $question_id ),
+				\Sensei_Quiz::get_correct_answer_feedback( $display_question_id ),
+			),
+			array(
+				\Sensei_Quiz::get_incorrect_answer_feedback( $question_id ),
+				\Sensei_Quiz::get_incorrect_answer_feedback( $display_question_id ),
+			),
+			array(
+				get_post_meta( $question_id, '_answer_feedback', true ),
+				get_post_meta( $display_question_id, '_answer_feedback', true ),
+			),
+		);
+
+		foreach ( $sources as $source ) {
+			list( $taken_feedback, $display_feedback ) = $source;
+			if ( $taken_feedback && $answer_notes === $taken_feedback && $display_feedback ) {
+				return $display_feedback;
+			}
+		}
+
+		return $answer_notes;
 	}
 
 	/**

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -38,7 +38,7 @@ class Question_Display {
 		add_filter( 'the_title', array( $this, 'translate_question_title' ), 10, 2 );
 		// The description renderer asks through this filter which question to
 		// read from.
-		add_filter( 'sensei_the_question_description_question_id', array( $this, 'translate_question_description_id' ) );
+		add_filter( 'sensei_question_description_post_id', array( $this, 'translate_question_description_id' ) );
 		// The "Right Answer:" reveal shown on failed questions.
 		add_filter( 'sensei_question_answer_message_correct_answer', array( $this, 'translate_correct_answer_message' ), 10, 3 );
 		// The feedback text shown under Correct/Incorrect.

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -135,8 +135,9 @@ class Question_Display {
 	/**
 	 * Render the question description from the current-language question.
 	 *
-	 * Runs whenever a question description is rendered. Without a translation,
-	 * the question renders its own description, exactly like core.
+	 * Runs whenever a question description is rendered on the frontend. In
+	 * wp-admin (the grading screen renders descriptions too), or without a
+	 * translation, the question renders its own description, exactly like core.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -146,6 +147,10 @@ class Question_Display {
 	 * @return int
 	 */
 	public function translate_question_description_id( $question_id ) {
+		if ( is_admin() ) {
+			return $question_id;
+		}
+
 		$display_question_id = $this->get_display_question_id( (int) $question_id );
 
 		return $display_question_id ? $display_question_id : (int) $question_id;

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -221,17 +221,32 @@ class Question_Display {
 	 * @return array
 	 */
 	public function translate_template_data( $question_data, $question_id ) {
+		// Only translate once the quiz is completed (review mode). While it is
+		// open, the option labels are live form values: translating them would
+		// make the form submit display-language labels against the as-taken
+		// questions and corrupt the stored answers.
+		if ( empty( $question_data['quiz_is_completed'] ) ) {
+			return $question_data;
+		}
+
 		$display_question_id = $this->get_display_question_id( (int) $question_id );
 		if ( ! $display_question_id ) {
 			return $question_data;
 		}
 
+		// All-or-nothing per question: if this is a choice question and its
+		// options cannot be mapped, render the whole question as taken.
+		$translated = $this->translate_answer_options( $question_data, (int) $question_id, $display_question_id );
+		if ( null === $translated ) {
+			return $question_data;
+		}
+
 		$display_question = get_post( $display_question_id );
 
-		$question_data['title']   = $display_question->post_title;
-		$question_data['content'] = $display_question->post_content;
+		$translated['title']   = $display_question->post_title;
+		$translated['content'] = $display_question->post_content;
 
-		return $this->translate_answer_options( $question_data, (int) $question_id, $display_question_id );
+		return $translated;
 	}
 
 	/**
@@ -240,13 +255,14 @@ class Question_Display {
 	 *
 	 * Multilingual plugins translate option labels in place, never reordering
 	 * them or moving them between the right and wrong lists, so same list + same
-	 * position is the same answer. On any mismatch (list size, unknown label)
-	 * the data is returned untouched and the question renders as taken.
+	 * position is the same answer.
 	 *
 	 * @param array $question_data       Question template data, as left by the type loaders.
 	 * @param int   $question_id         As-taken question ID.
 	 * @param int   $display_question_id Current-language question ID.
-	 * @return array
+	 * @return array|null Translated data; the data untouched for questions
+	 *                    without options; null when options exist but cannot be
+	 *                    mapped (list size or label mismatch).
 	 */
 	private function translate_answer_options( $question_data, $question_id, $display_question_id ) {
 		if ( empty( $question_data['answer_options'] ) ) {
@@ -259,7 +275,7 @@ class Question_Display {
 		$display_wrong = (array) get_post_meta( $display_question_id, '_question_wrong_answers', true );
 
 		if ( count( $taken_right ) !== count( $display_right ) || count( $taken_wrong ) !== count( $display_wrong ) ) {
-			return $question_data;
+			return null;
 		}
 
 		$label_map = array_merge(
@@ -270,7 +286,7 @@ class Question_Display {
 		$translated_options = array();
 		foreach ( $question_data['answer_options'] as $key => $option ) {
 			if ( ! isset( $option['answer'], $label_map[ $option['answer'] ] ) ) {
-				return $question_data;
+				return null;
 			}
 
 			$option['answer']           = $label_map[ $option['answer'] ];

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -299,9 +299,34 @@ class Question_Display {
 		}
 
 		$question_data['answer_options']         = $translated_options;
-		$question_data['question_right_answer']  = get_post_meta( $display_question_id, '_question_right_answer', true );
-		$question_data['question_wrong_answers'] = $display_wrong;
+		$question_data['question_right_answer']  = $this->translate_answer_labels( $question_data['question_right_answer'] ?? '', $label_map );
+		$question_data['question_wrong_answers'] = $this->translate_answer_labels( $question_data['question_wrong_answers'] ?? array(), $label_map );
 
 		return $question_data;
+	}
+
+	/**
+	 * Translate answer labels through the label map, keeping the value's shape.
+	 *
+	 * The type loaders reshape these fields (the right answer gets merged into
+	 * the wrong list to build the options), so the existing values are mapped
+	 * in place rather than replaced with the translation's raw meta. Labels
+	 * missing from the map are kept as they are.
+	 *
+	 * @param string|array $labels    Label or list of labels, as the loaders left them.
+	 * @param array        $label_map As-taken label => display-language label.
+	 * @return string|array
+	 */
+	private function translate_answer_labels( $labels, $label_map ) {
+		if ( is_array( $labels ) ) {
+			$translated_labels = array();
+			foreach ( $labels as $key => $label ) {
+				$translated_labels[ $key ] = $label_map[ $label ] ?? $label;
+			}
+
+			return $translated_labels;
+		}
+
+		return $label_map[ $labels ] ?? $labels;
 	}
 }

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -16,9 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Compatibility code with WPML.
  *
- * Renders quiz questions in the viewer's language: submissions store the
- * questions as taken, and this class swaps the display data for the
- * current-language translation at render time.
+ * Renders quiz questions in the viewer's language: submissions store the questions as taken,
+ * and this class swaps the display data for the current-language translation at render time.
  *
  * @since $$next-version$$
  *
@@ -31,13 +30,11 @@ class Question_Display {
 	 * Init hooks.
 	 */
 	public function init() {
-		// Run after the question-type loaders (priority 10), so the student's
-		// selection is already resolved when the labels get translated.
+		// Run after the question-type loaders, so the student's selection is already resolved when the labels get translated.
 		add_filter( 'sensei_get_question_template_data', array( $this, 'translate_template_data' ), 15, 2 );
 		// The question heading is rendered from get_the_title(), outside the template data.
 		add_filter( 'the_title', array( $this, 'translate_question_title' ), 10, 2 );
-		// The description renderer asks through this filter which question to
-		// read from.
+		// The description renderer asks through this filter which question to read from.
 		add_filter( 'sensei_question_description_post_id', array( $this, 'translate_question_description_id' ) );
 		// The "Right Answer:" reveal shown on failed questions.
 		add_filter( 'sensei_question_answer_message_correct_answer', array( $this, 'translate_correct_answer_message' ), 10, 3 );
@@ -48,12 +45,12 @@ class Question_Display {
 	/**
 	 * Show the question-authored answer feedback in the current language.
 	 *
-	 * Runs when the feedback box of a graded question is rendered on the quiz
-	 * page. If the notes are the question's own feedback (the correct/incorrect
-	 * feedback blocks or the answer feedback field), it swaps them for the
-	 * translation's version. Notes written by the teacher for this student
-	 * while grading have no translation and are shown as written; they are
-	 * told apart because they match none of the question's feedback sources.
+	 * Runs when the feedback box of a graded question is rendered on the quiz page.
+	 * If the notes are the question's own feedback (the correct/incorrect feedback
+	 * blocks or the answer feedback field), it swaps them for the translation's version.
+	 * Notes written by the teacher for this student while grading have no translation
+	 * and are shown as written; they are told apart because they match none of the
+	 * question's feedback sources.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -101,10 +98,9 @@ class Question_Display {
 	/**
 	 * Show the "Right Answer:" reveal in the current language.
 	 *
-	 * Runs when the feedback box of a failed question reveals the right answer
-	 * on the quiz page. It rebuilds the message from the question's
-	 * translation. Gap fill stays as taken on purpose: the right answer only
-	 * makes sense against the gap in its own language.
+	 * Runs when the feedback box of a failed question reveals the right answer on the quiz page.
+	 * It rebuilds the message from the question's translation. Gap fill stays as taken on purpose:
+	 * the right answer only makes sense against the gap in its own language.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -135,8 +131,8 @@ class Question_Display {
 	/**
 	 * Render the question description from the current-language question.
 	 *
-	 * Runs whenever a question description is rendered on the frontend. In
-	 * wp-admin (the grading screen renders descriptions too), or without a
+	 * Runs whenever a question description is rendered on the frontend.
+	 * In wp-admin (the grading screen renders descriptions too), or without a
 	 * translation, the question renders its own description, exactly like core.
 	 *
 	 * @since $$next-version$$
@@ -159,9 +155,8 @@ class Question_Display {
 	/**
 	 * Show a question's title in the current language on the frontend.
 	 *
-	 * Runs whenever a question title is fetched on the frontend (the quiz page
-	 * heading among others). In wp-admin, or without a translation, the title
-	 * is returned unchanged.
+	 * Runs whenever a question title is fetched on the frontend (the quiz page heading among others).
+	 * In wp-admin, or without a translation, the title is returned unchanged.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -212,12 +207,11 @@ class Question_Display {
 	/**
 	 * Show a question of a completed quiz in the current language.
 	 *
-	 * Runs every time a question is rendered on the quiz page, after the type
-	 * loaders have built its template data. On a completed quiz it replaces the
-	 * title, content, and option labels with the ones from the question's
-	 * translation. While the quiz is open, or when the options cannot be
-	 * mapped, the question renders as taken. Display only: stored answers and
-	 * grades are never modified.
+	 * Runs every time a question is rendered on the quiz page, after the type loaders
+	 * have built its template data. On a completed quiz it replaces the title, content,
+	 * and option labels with the ones from the question's translation. While the quiz
+	 * is open, or when the options cannot be mapped, the question renders as taken.
+	 * Display only: stored answers and grades are never modified.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -228,10 +222,9 @@ class Question_Display {
 	 * @return array
 	 */
 	public function translate_template_data( $question_data, $question_id ) {
-		// Only translate once the quiz is completed (review mode). While it is
-		// open, the option labels are live form values: translating them would
-		// make the form submit display-language labels against the as-taken
-		// questions and corrupt the stored answers.
+		// Only translate once the quiz is completed (review mode). While it is open,
+		// the option labels are live form values: translating them would make the form
+		// submit display-language labels against the as-taken questions and corrupt the stored answers.
 		if ( empty( $question_data['quiz_is_completed'] ) ) {
 			return $question_data;
 		}
@@ -241,8 +234,8 @@ class Question_Display {
 			return $question_data;
 		}
 
-		// All-or-nothing per question: if this is a choice question and its
-		// options cannot be mapped, render the whole question as taken.
+		// All-or-nothing per question: if this is a choice question
+		// and its options cannot be mapped, render the whole question as taken.
 		$translated = $this->translate_answer_options( $question_data, (int) $question_id, $display_question_id );
 		if ( null === $translated ) {
 			return $question_data;
@@ -260,9 +253,8 @@ class Question_Display {
 	 * Swap the option labels of a choice question for the display question's,
 	 * matching right answers with right answers and wrong with wrong, by position.
 	 *
-	 * Multilingual plugins translate option labels in place, never reordering
-	 * them or moving them between the right and wrong lists, so same list + same
-	 * position is the same answer.
+	 * Multilingual plugins translate option labels in place, never reordering them
+	 * or moving them between the right and wrong lists, so same list + same position is the same answer.
 	 *
 	 * @param array $question_data       Question template data, as left by the type loaders.
 	 * @param int   $question_id         As-taken question ID.
@@ -310,10 +302,9 @@ class Question_Display {
 	/**
 	 * Translate answer labels through the label map, keeping the value's shape.
 	 *
-	 * The type loaders reshape these fields (the right answer gets merged into
-	 * the wrong list to build the options), so the existing values are mapped
-	 * in place rather than replaced with the translation's raw meta. Labels
-	 * missing from the map are kept as they are.
+	 * The type loaders reshape these fields (the right answer gets merged into the wrong list
+	 * to build the options), so the existing values are mapped in place rather than replaced
+	 * with the translation's raw meta. Labels missing from the map are kept as they are.
 	 *
 	 * @param string|array $labels    Label or list of labels, as the loaders left them.
 	 * @param array        $label_map As-taken label => display-language label.

--- a/includes/wpml/class-question-display.php
+++ b/includes/wpml/class-question-display.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * File containing \Sensei\WPML\Question_Display class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\WPML;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Question_Display
+ *
+ * Compatibility code with WPML.
+ *
+ * Renders quiz questions in the viewer's language: submissions store the
+ * questions as taken, and this class swaps the display data for the
+ * current-language translation at render time.
+ *
+ * @since $$next-version$$
+ *
+ * @internal
+ */
+class Question_Display {
+	use WPML_API;
+
+	/**
+	 * Init hooks.
+	 */
+	public function init() {
+		// After the question-type loaders (priority 10): they compute selection and
+		// order in as-taken space, where stored answers match; this class only
+		// swaps what is displayed.
+		add_filter( 'sensei_get_question_template_data', array( $this, 'translate_template_data' ), 15, 2 );
+		// The question heading is rendered from get_the_title(), outside the
+		// template data.
+		add_filter( 'the_title', array( $this, 'translate_question_title' ), 10, 2 );
+	}
+
+	/**
+	 * Show a question's title in the current language on the frontend.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param string $title   Post title.
+	 * @param int    $post_id Post ID.
+	 * @return string
+	 */
+	public function translate_question_title( $title, $post_id ) {
+		if ( is_admin() || 'question' !== get_post_type( $post_id ) ) {
+			return $title;
+		}
+
+		$current_language = $this->get_current_language();
+		if ( ! $current_language ) {
+			return $title;
+		}
+
+		$display_question_id = $this->get_object_id( (int) $post_id, 'question', true, $current_language );
+		if ( ! $display_question_id || (int) $post_id === $display_question_id ) {
+			return $title;
+		}
+
+		$display_question = get_post( $display_question_id );
+		if ( ! $display_question ) {
+			return $title;
+		}
+
+		return $display_question->post_title;
+	}
+
+	/**
+	 * Swap a question's template data for the current-language translation.
+	 *
+	 * Display only: stored answers and grades are never modified.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param array $question_data Question template data.
+	 * @param int   $question_id   Question ID the data was built from (as taken).
+	 * @return array
+	 */
+	public function translate_template_data( $question_data, $question_id ) {
+		$current_language = $this->get_current_language();
+		if ( ! $current_language ) {
+			return $question_data;
+		}
+
+		$display_question_id = $this->get_object_id( (int) $question_id, 'question', true, $current_language );
+		if ( ! $display_question_id || (int) $question_id === $display_question_id ) {
+			return $question_data;
+		}
+
+		$display_question = get_post( $display_question_id );
+		if ( ! $display_question ) {
+			return $question_data;
+		}
+
+		$question_data['title']   = $display_question->post_title;
+		$question_data['content'] = $display_question->post_content;
+
+		return $this->translate_answer_options( $question_data, (int) $question_id, $display_question_id );
+	}
+
+	/**
+	 * Swap the option labels of a choice question for the display question's,
+	 * matching right answers with right answers and wrong with wrong, by position.
+	 *
+	 * Multilingual plugins translate option labels in place, never reordering
+	 * them or moving them between the right and wrong lists, so same list + same
+	 * position is the same answer. All-or-nothing: on any mismatch (list size,
+	 * unknown label) the data is returned untouched and the question renders as
+	 * taken.
+	 *
+	 * The as-taken lists are read from the question's own meta: the type loaders
+	 * mutate the ones in the template data (the right answer is merged into the
+	 * wrong list to build the options).
+	 *
+	 * @param array $question_data       Question template data, as left by the type loaders.
+	 * @param int   $question_id         As-taken question ID.
+	 * @param int   $display_question_id Current-language question ID.
+	 * @return array
+	 */
+	private function translate_answer_options( $question_data, $question_id, $display_question_id ) {
+		if ( empty( $question_data['answer_options'] ) ) {
+			return $question_data;
+		}
+
+		$taken_right   = (array) get_post_meta( $question_id, '_question_right_answer', true );
+		$taken_wrong   = (array) get_post_meta( $question_id, '_question_wrong_answers', true );
+		$display_right = (array) get_post_meta( $display_question_id, '_question_right_answer', true );
+		$display_wrong = (array) get_post_meta( $display_question_id, '_question_wrong_answers', true );
+
+		if ( count( $taken_right ) !== count( $display_right ) || count( $taken_wrong ) !== count( $display_wrong ) ) {
+			return $question_data;
+		}
+
+		$label_map = array_merge(
+			array_combine( array_values( $taken_right ), array_values( $display_right ) ),
+			array_combine( array_values( $taken_wrong ), array_values( $display_wrong ) )
+		);
+
+		$translated_options = array();
+		foreach ( $question_data['answer_options'] as $key => $option ) {
+			if ( ! isset( $option['answer'], $label_map[ $option['answer'] ] ) ) {
+				return $question_data;
+			}
+
+			$option['answer']           = $label_map[ $option['answer'] ];
+			$translated_options[ $key ] = $option;
+		}
+
+		$question_data['answer_options']         = $translated_options;
+		$question_data['question_right_answer']  = get_post_meta( $display_question_id, '_question_right_answer', true );
+		$question_data['question_wrong_answers'] = $display_wrong;
+
+		return $question_data;
+	}
+}

--- a/includes/wpml/class-wpml.php
+++ b/includes/wpml/class-wpml.php
@@ -30,6 +30,7 @@ class WPML {
 		( new Language_Details() )->init();
 		( new Lesson_Progress() )->init();
 		( new Lesson_Translation() )->init();
+		( new Question_Display() )->init();
 		( new Quiz_Progress() )->init();
 		( new Quiz_Submission() )->init();
 		( new Page() )->init();

--- a/includes/wpml/trait-question-translation-helper.php
+++ b/includes/wpml/trait-question-translation-helper.php
@@ -115,14 +115,24 @@ trait Question_Translation_Helper {
 				continue;
 			}
 
+			$question_updates = array();
+
 			// The translated title lives in the block attribute.
 			if ( ! empty( $block['attrs']['title'] ) ) {
-				wp_update_post(
-					array(
-						'ID'         => (int) $question_id,
-						'post_title' => (string) $block['attrs']['title'],
-					)
-				);
+				$question_updates['post_title'] = (string) $block['attrs']['title'];
+			}
+
+			// A question post stores the question block's whole inner content
+			// (description, answers, and feedback blocks), mirroring how the
+			// editor saves it (see getBlockContent in the quiz editor and the
+			// REST question helpers).
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$question_updates['post_content'] = implode( '', array_map( 'serialize_block', $block['innerBlocks'] ) );
+			}
+
+			if ( $question_updates ) {
+				$question_updates['ID'] = (int) $question_id;
+				wp_update_post( $question_updates );
 			}
 
 			// The translated answers live in the block, split into correct and

--- a/includes/wpml/trait-question-translation-helper.php
+++ b/includes/wpml/trait-question-translation-helper.php
@@ -123,9 +123,8 @@ trait Question_Translation_Helper {
 			}
 
 			// A question post stores the question block's whole inner content
-			// (description, answers, and feedback blocks), mirroring how the
-			// editor saves it (see getBlockContent in the quiz editor and the
-			// REST question helpers).
+			// (description, answers, and feedback blocks), mirroring how the editor saves it
+			// (see getBlockContent in the quiz editor and the REST question helpers).
 			if ( ! empty( $block['innerBlocks'] ) ) {
 				$question_updates['post_content'] = implode( '', array_map( 'serialize_block', $block['innerBlocks'] ) );
 			}

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -248,6 +248,8 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( array( 'sí' ), get_post_meta( $translated_question_id, '_question_right_answer', true ), 'The right answer should be updated from the lesson content.' );
 		$this->assertSame( array( 'no' ), get_post_meta( $translated_question_id, '_question_wrong_answers', true ), 'The wrong answers should be updated from the lesson content.' );
 		$this->assertSame( \Sensei()->lesson->get_answer_id( 'sí' ) . ',' . \Sensei()->lesson->get_answer_id( 'no' ), get_post_meta( $translated_question_id, '_answer_order', true ), 'The answer order should be recomputed from the translated labels in block order.' );
+		$this->assertStringContainsString( 'Descripción ES', $translated_question->post_content, 'The question description should be updated from the lesson content.' );
+		$this->assertStringContainsString( 'Feedback correcto ES', \Sensei_Quiz::get_correct_answer_feedback( $translated_question_id ), 'The question feedback blocks should be updated from the lesson content.' );
 	}
 
 	/**
@@ -313,6 +315,12 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 	private function translated_lesson_content( $source_question_id ) {
 		return '<!-- wp:sensei-lms/quiz -->' . "\n" .
 			'<!-- wp:sensei-lms/quiz-question {"id":' . $source_question_id . ',"title":"Pregunta","answer":{"answers":[{"label":"sí","correct":true},{"label":"no","correct":false}]},"options":{"grade":1}} -->' . "\n" .
+			'<!-- wp:sensei-lms/question-description -->' . "\n" .
+			'<p>Descripción ES</p>' . "\n" .
+			'<!-- /wp:sensei-lms/question-description -->' . "\n" .
+			'<!-- wp:sensei-lms/quiz-question-feedback-correct -->' . "\n" .
+			'<p>Feedback correcto ES</p>' . "\n" .
+			'<!-- /wp:sensei-lms/quiz-question-feedback-correct -->' . "\n" .
 			'<!-- /wp:sensei-lms/quiz-question -->' . "\n" .
 			'<!-- /wp:sensei-lms/quiz -->';
 	}

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -274,10 +274,10 @@ class Question_Display_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Create a real ES multiple choice (taxonomy, metas, and answer order, so the
-	 * type loader runs on it), an EN twin question, and WPML simulated with the
+	 * type loader runs on it), an EN translation, and WPML simulated with the
 	 * viewer on EN.
 	 *
-	 * The ES question shows "Verde" (wrong) then "Azul" (right); the EN twin has
+	 * The ES question shows "Verde" (wrong) then "Azul" (right); the EN translation has
 	 * "Green"/"Blue" in the same buckets and positions.
 	 *
 	 * @return array{0: int, 1: int} As-taken question ID and quiz ID.
@@ -328,7 +328,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 	/**
 	 * Build the template data of an ES-taken multiple choice as the type loader
 	 * leaves it (as-taken labels, selection and order already resolved), with an
-	 * EN twin question and WPML simulated with the viewer on EN.
+	 * EN translation and WPML simulated with the viewer on EN.
 	 *
 	 * The student picked "Azul" (right answer, second position).
 	 *
@@ -394,7 +394,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Register the WPML simulation filters: viewer on EN, ES question mapped to
-	 * its EN twin.
+	 * its EN translation.
 	 *
 	 * @param int $taken_question_id   As-taken (ES) question ID.
 	 * @param int $display_question_id Display (EN) question ID.
@@ -421,5 +421,4 @@ class Question_Display_Test extends \WP_UnitTestCase {
 			2
 		);
 	}
-
 }

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -108,6 +108,26 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'EN description', $description );
 	}
 
+	public function testTranslateQuestionDescriptionId_InAdminContext_ReturnsQuestionIdUnchanged() {
+		/* Arrange. */
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		set_current_screen( 'edit-post' );
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$question_id = apply_filters( 'sensei_the_question_description_question_id', $taken_question_id );
+
+		/* Clean up. */
+		unset( $GLOBALS['current_screen'] );
+
+		/* Assert. */
+		$this->assertSame( $taken_question_id, $question_id, 'The grading screen should keep rendering the as-taken description.' );
+	}
+
 	public function testTranslateCorrectAnswerMessage_TranslationForMultipleChoiceExists_ShowsViewerLanguageRightAnswer() {
 		/* Arrange. */
 		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace SenseiTest\WPML;
+
+use Sensei\WPML\Question_Display;
+
+/**
+ * Class Question_Display_Test
+ *
+ * @covers \Sensei\WPML\Question_Display
+ */
+class Question_Display_Test extends \WP_UnitTestCase {
+	/**
+	 * Sensei Factory.
+	 *
+	 * @var \Sensei_Factory
+	 */
+	protected $factory;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'wpml_current_language' );
+		remove_all_filters( 'wpml_object_id' );
+		parent::tear_down();
+		$this->factory->tearDown();
+	}
+
+	public function testInit_WhenCalled_AddsFilters() {
+		/* Arrange. */
+		$question_display = new Question_Display();
+
+		/* Act. */
+		$question_display->init();
+
+		/* Assert. */
+		$this->assertEquals( 15, has_filter( 'sensei_get_question_template_data', array( $question_display, 'translate_template_data' ) ), 'The template data filter should be added after the type loaders.' );
+		$this->assertEquals( 10, has_filter( 'the_title', array( $question_display, 'translate_question_title' ) ), 'The title filter should be added.' );
+	}
+
+	public function testTranslateQuestionTitle_ViewerLanguageDiffersFromTakenQuestion_ShowsViewerLanguageTitle() {
+		/* Arrange. */
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$title = get_the_title( $taken_question_id );
+
+		/* Assert. */
+		$this->assertSame( 'What color is the sky?', $title );
+	}
+
+	public function testTranslateQuestionTitle_InAdminContext_ReturnsTitleUnchanged() {
+		/* Arrange. */
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		set_current_screen( 'edit-post' );
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$title = get_the_title( $taken_question_id );
+
+		/* Clean up. */
+		unset( $GLOBALS['current_screen'] );
+
+		/* Assert. */
+		$this->assertSame( '¿De qué color es el cielo?', $title );
+	}
+
+	public function testTranslateTemplateData_TranslationForMultipleChoiceExists_ShowsViewerLanguageOptionLabels() {
+		/* Arrange. */
+		list( $taken_question_id, $quiz_id ) = $this->arrange_real_taken_multiple_choice_with_translation();
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$question_data = \Sensei_Question::get_template_data( $taken_question_id, $quiz_id );
+
+		/* Assert. */
+		$this->assertSame( array( 'Green', 'Blue' ), array_values( array_column( $question_data['answer_options'], 'answer' ) ) );
+	}
+
+	public function testTranslateTemplateData_TranslationForMultipleChoiceExists_KeepsStudentSelectionByPosition() {
+		/* Arrange. */
+		list( $question_data, $taken_question_id ) = $this->arrange_loader_output_with_translation();
+
+		$question_display = new Question_Display();
+
+		/* Act. */
+		$actual = $question_display->translate_template_data( $question_data, $taken_question_id );
+
+		/* Assert. */
+		$checked_labels = array();
+		foreach ( $actual['answer_options'] as $option ) {
+			if ( '' !== $option['checked'] ) {
+				$checked_labels[] = $option['answer'];
+			}
+		}
+		$this->assertSame( array( 'Blue' ), $checked_labels, 'The option the student picked (Azul, second position) should stay checked as its translation (Blue).' );
+	}
+
+	public function testTranslateTemplateData_ViewerLanguageDiffersFromTakenQuestion_ShowsViewerLanguageTitle() {
+		/* Arrange. */
+		list( $taken_question_id, $quiz_id ) = $this->arrange_taken_question_with_translation();
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$question_data = \Sensei_Question::get_template_data( $taken_question_id, $quiz_id );
+
+		/* Assert. */
+		$this->assertSame( 'Is the sky blue?', $question_data['title'] );
+	}
+
+	/**
+	 * Create a real ES multiple choice (taxonomy, metas, and answer order, so the
+	 * type loader runs on it), an EN twin question, and WPML simulated with the
+	 * viewer on EN.
+	 *
+	 * The ES question shows "Verde" (wrong) then "Azul" (right); the EN twin has
+	 * "Green"/"Blue" in the same buckets and positions.
+	 *
+	 * @return array{0: int, 1: int} As-taken question ID and quiz ID.
+	 */
+	private function arrange_real_taken_multiple_choice_with_translation() {
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+
+		wp_set_object_terms( $taken_question_id, 'multiple-choice', 'question-type' );
+		update_post_meta(
+			$taken_question_id,
+			'_answer_order',
+			\Sensei()->lesson->get_answer_id( 'Verde' ) . ',' . \Sensei()->lesson->get_answer_id( 'Azul' )
+		);
+
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		return array( $taken_question_id, $this->factory->quiz->create() );
+	}
+
+	/**
+	 * Build the template data of an ES-taken multiple choice as the type loader
+	 * leaves it (as-taken labels, selection and order already resolved), with an
+	 * EN twin question and WPML simulated with the viewer on EN.
+	 *
+	 * The student picked "Azul" (right answer, second position).
+	 *
+	 * @return array{0: array, 1: int} Question data and as-taken question ID.
+	 */
+	private function arrange_loader_output_with_translation() {
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		$question_data = array(
+			'ID'                     => $taken_question_id,
+			'title'                  => '¿De qué color es el cielo?',
+			'content'                => '',
+			'question_right_answer'  => 'Azul',
+			// The type loader merges the right answer into the wrong list.
+			'question_wrong_answers' => array( 'Verde', 'Azul' ),
+			'user_answer_entry'      => 'Azul',
+			'answer_options'         => array(
+				md5( 'Verde' ) => array(
+					'ID'      => md5( 'Verde' ),
+					'answer'  => 'Verde',
+					'checked' => '',
+				),
+				md5( 'Azul' )  => array(
+					'ID'      => md5( 'Azul' ),
+					'answer'  => 'Azul',
+					'checked' => 'checked="checked"',
+				),
+			),
+		);
+
+		return array( $question_data, $taken_question_id );
+	}
+
+	/**
+	 * Create the ES/EN question pair with their right/wrong answer metas.
+	 *
+	 * @return array{0: int, 1: int} As-taken (ES) and display (EN) question IDs.
+	 */
+	private function create_question_pair() {
+		$taken_question_id   = $this->factory->post->create(
+			array(
+				'post_type'  => 'question',
+				'post_title' => '¿De qué color es el cielo?',
+			)
+		);
+		$display_question_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'question',
+				'post_title' => 'What color is the sky?',
+			)
+		);
+
+		update_post_meta( $taken_question_id, '_question_right_answer', 'Azul' );
+		update_post_meta( $taken_question_id, '_question_wrong_answers', array( 'Verde' ) );
+		update_post_meta( $display_question_id, '_question_right_answer', 'Blue' );
+		update_post_meta( $display_question_id, '_question_wrong_answers', array( 'Green' ) );
+
+		return array( $taken_question_id, $display_question_id );
+	}
+
+	/**
+	 * Register the WPML simulation filters: viewer on EN, ES question mapped to
+	 * its EN twin.
+	 *
+	 * @param int $taken_question_id   As-taken (ES) question ID.
+	 * @param int $display_question_id Display (EN) question ID.
+	 */
+	private function simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id ) {
+		add_filter(
+			'wpml_current_language',
+			function () {
+				return 'en';
+			},
+			10,
+			0
+		);
+
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id, $type ) use ( $taken_question_id, $display_question_id ) {
+				if ( 'question' === $type && $taken_question_id === $object_id ) {
+					return $display_question_id;
+				}
+				return $object_id;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Create an EN course whose quiz question has an ES twin, simulate WPML with
+	 * the viewer on EN, and return the as-taken (ES) question and the quiz.
+	 *
+	 * The scenario mirrors a student who took the quiz in ES and now views the
+	 * results with the site in EN: the page loop passes the stored ES question
+	 * to the template data builder.
+	 *
+	 * @return array{0: int, 1: int} As-taken question ID and quiz ID.
+	 */
+	private function arrange_taken_question_with_translation() {
+		$course_with_lessons = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 1,
+			)
+		);
+
+		$quiz_id             = $course_with_lessons['quiz_ids'][0];
+		$display_question_id = \Sensei()->quiz->get_questions( $quiz_id )[0]->ID;
+		wp_update_post(
+			array(
+				'ID'         => $display_question_id,
+				'post_title' => 'Is the sky blue?',
+			)
+		);
+
+		$taken_question_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'question',
+				'post_title' => '¿El cielo es azul?',
+			)
+		);
+
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		return array( $taken_question_id, $quiz_id );
+	}
+}

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -178,6 +178,19 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		$this->assertSame( $question_data, $actual, 'On an answer-list size mismatch the whole question should render as taken.' );
 	}
 
+	public function testTranslateTemplateData_TranslationForMultipleChoiceExists_KeepsAnswerListsShape() {
+		/* Arrange. */
+		list( $question_data, $taken_question_id ) = $this->arrange_loader_output_with_translation();
+
+		$question_display = new Question_Display();
+
+		/* Act. */
+		$actual = $question_display->translate_template_data( $question_data, $taken_question_id );
+
+		/* Assert. */
+		$this->assertSame( array( 'Green', 'Blue' ), $actual['question_wrong_answers'], 'The loader-merged wrong list should be translated in place, keeping its shape.' );
+	}
+
 	public function testTranslateTemplateData_NoTranslationExists_ReturnsQuestionDataUnchanged() {
 		/* Arrange. */
 		list( $question_data, $taken_question_id ) = $this->arrange_loader_output_with_translation();

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -39,7 +39,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals( 15, has_filter( 'sensei_get_question_template_data', array( $question_display, 'translate_template_data' ) ), 'The template data filter should be added after the type loaders.' );
 		$this->assertEquals( 10, has_filter( 'the_title', array( $question_display, 'translate_question_title' ) ), 'The title filter should be added.' );
-		$this->assertEquals( 10, has_filter( 'sensei_question_description_post_id', array( $question_display, 'translate_question_description_id' ) ), 'The description question filter should be added.' );
+		$this->assertEquals( 10, has_filter( 'sensei_question_description_question_id', array( $question_display, 'translate_question_description_id' ) ), 'The description question filter should be added.' );
 		$this->assertEquals( 10, has_filter( 'sensei_question_answer_message_correct_answer', array( $question_display, 'translate_correct_answer_message' ) ), 'The right-answer reveal filter should be added.' );
 		$this->assertEquals( 10, has_filter( 'sensei_question_answer_notes', array( $question_display, 'translate_answer_notes' ) ), 'The answer notes filter should be added.' );
 	}
@@ -119,7 +119,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		$question_display->init();
 
 		/* Act. */
-		$question_id = apply_filters( 'sensei_question_description_post_id', $taken_question_id );
+		$question_id = apply_filters( 'sensei_question_description_question_id', $taken_question_id );
 
 		/* Clean up. */
 		unset( $GLOBALS['current_screen'] );

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -39,6 +39,8 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals( 15, has_filter( 'sensei_get_question_template_data', array( $question_display, 'translate_template_data' ) ), 'The template data filter should be added after the type loaders.' );
 		$this->assertEquals( 10, has_filter( 'the_title', array( $question_display, 'translate_question_title' ) ), 'The title filter should be added.' );
+		$this->assertEquals( 10, has_filter( 'sensei_question_answer_message_correct_answer', array( $question_display, 'translate_correct_answer_message' ) ), 'The right-answer reveal filter should be added.' );
+		$this->assertEquals( 10, has_filter( 'sensei_question_answer_notes', array( $question_display, 'translate_answer_notes' ) ), 'The answer notes filter should be added.' );
 	}
 
 	public function testTranslateQuestionTitle_ViewerLanguageDiffersFromTakenQuestion_ShowsViewerLanguageTitle() {
@@ -138,6 +140,44 @@ class Question_Display_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertSame( 'Blue', $message );
+	}
+
+	public function testTranslateAnswerNotes_NotesMatchTakenQuestionGenericFeedback_ShowsViewerLanguageFeedback() {
+		/* Arrange. */
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+
+		update_post_meta( $taken_question_id, '_answer_feedback', 'Feedback ES' );
+		update_post_meta( $display_question_id, '_answer_feedback', 'Feedback EN' );
+
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$notes = apply_filters( 'sensei_question_answer_notes', 'Feedback ES', $taken_question_id, 0 );
+
+		/* Assert. */
+		$this->assertSame( 'Feedback EN', $notes );
+	}
+
+	public function testTranslateAnswerNotes_NotesAreTeacherFeedback_ReturnsNotesUnchanged() {
+		/* Arrange. */
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+
+		update_post_meta( $taken_question_id, '_answer_feedback', 'Feedback ES' );
+		update_post_meta( $display_question_id, '_answer_feedback', 'Feedback EN' );
+
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$notes = apply_filters( 'sensei_question_answer_notes', 'Muy buen razonamiento, Ana.', $taken_question_id, 0 );
+
+		/* Assert. */
+		$this->assertSame( 'Muy buen razonamiento, Ana.', $notes, 'Per-student feedback written by the teacher should be shown as written.' );
 	}
 
 	public function testTranslateTemplateData_TranslationForMultipleChoiceExists_ShowsViewerLanguageOptionLabels() {

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -39,6 +39,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals( 15, has_filter( 'sensei_get_question_template_data', array( $question_display, 'translate_template_data' ) ), 'The template data filter should be added after the type loaders.' );
 		$this->assertEquals( 10, has_filter( 'the_title', array( $question_display, 'translate_question_title' ) ), 'The title filter should be added.' );
+		$this->assertEquals( 10, has_filter( 'sensei_the_question_description_question_id', array( $question_display, 'translate_question_description_id' ) ), 'The description question filter should be added.' );
 		$this->assertEquals( 10, has_filter( 'sensei_question_answer_message_correct_answer', array( $question_display, 'translate_correct_answer_message' ) ), 'The right-answer reveal filter should be added.' );
 		$this->assertEquals( 10, has_filter( 'sensei_question_answer_notes', array( $question_display, 'translate_answer_notes' ) ), 'The answer notes filter should be added.' );
 	}
@@ -78,7 +79,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		$this->assertSame( '¿De qué color es el cielo?', $title );
 	}
 
-	public function testRenderQuestionDescription_ViewerLanguageDiffersFromTakenQuestion_ShowsViewerLanguageDescription() {
+	public function testTranslateQuestionDescriptionId_ViewerLanguageDiffersFromTakenQuestion_ShowsViewerLanguageDescription() {
 		/* Arrange. */
 		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
 
@@ -97,30 +98,14 @@ class Question_Display_Test extends \WP_UnitTestCase {
 
 		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
 
-		// Minimal question loop state for the core title callback on the same action.
-		global $sensei_question_loop;
-		$sensei_question_loop = array(
-			'current_page'     => 1,
-			'posts_per_page'   => 1,
-			'current'          => 0,
-			'current_question' => get_post( $taken_question_id ),
-			'quiz_id'          => $this->factory->quiz->create(),
-		);
-
 		$question_display = new Question_Display();
 		$question_display->init();
-		$question_display->replace_question_description_renderer();
 
 		/* Act. */
-		ob_start();
-		do_action( 'sensei_quiz_question_inside_before', $taken_question_id );
-		$html = ob_get_clean();
-
-		/* Clean up. */
-		$sensei_question_loop = null;
+		$description = \Sensei_Question::get_the_question_description( $taken_question_id );
 
 		/* Assert. */
-		$this->assertStringContainsString( 'EN description', $html );
+		$this->assertStringContainsString( 'EN description', $description );
 	}
 
 	public function testTranslateCorrectAnswerMessage_TranslationForMultipleChoiceExists_ShowsViewerLanguageRightAnswer() {

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -76,6 +76,70 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		$this->assertSame( '¿De qué color es el cielo?', $title );
 	}
 
+	public function testRenderQuestionDescription_ViewerLanguageDiffersFromTakenQuestion_ShowsViewerLanguageDescription() {
+		/* Arrange. */
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+
+		wp_update_post(
+			array(
+				'ID'           => $taken_question_id,
+				'post_content' => '<!-- wp:sensei-lms/question-description --><p>Descripción ES</p><!-- /wp:sensei-lms/question-description -->',
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'           => $display_question_id,
+				'post_content' => '<!-- wp:sensei-lms/question-description --><p>EN description</p><!-- /wp:sensei-lms/question-description -->',
+			)
+		);
+
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		// Minimal question loop state for the core title callback on the same action.
+		global $sensei_question_loop;
+		$sensei_question_loop = array(
+			'current_page'     => 1,
+			'posts_per_page'   => 1,
+			'current'          => 0,
+			'current_question' => get_post( $taken_question_id ),
+			'quiz_id'          => $this->factory->quiz->create(),
+		);
+
+		$question_display = new Question_Display();
+		$question_display->init();
+		$question_display->replace_question_description_renderer();
+
+		/* Act. */
+		ob_start();
+		do_action( 'sensei_quiz_question_inside_before', $taken_question_id );
+		$html = ob_get_clean();
+
+		/* Clean up. */
+		$sensei_question_loop = null;
+
+		/* Assert. */
+		$this->assertStringContainsString( 'EN description', $html );
+	}
+
+	public function testTranslateCorrectAnswerMessage_TranslationForMultipleChoiceExists_ShowsViewerLanguageRightAnswer() {
+		/* Arrange. */
+		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
+
+		wp_set_object_terms( $taken_question_id, 'multiple-choice', 'question-type' );
+		wp_set_object_terms( $display_question_id, 'multiple-choice', 'question-type' );
+
+		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
+
+		$question_display = new Question_Display();
+		$question_display->init();
+
+		/* Act. */
+		$message = apply_filters( 'sensei_question_answer_message_correct_answer', 'Azul', 0, $taken_question_id, 0, false );
+
+		/* Assert. */
+		$this->assertSame( 'Blue', $message );
+	}
+
 	public function testTranslateTemplateData_TranslationForMultipleChoiceExists_ShowsViewerLanguageOptionLabels() {
 		/* Arrange. */
 		list( $taken_question_id, $quiz_id ) = $this->arrange_real_taken_multiple_choice_with_translation();

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -142,6 +142,52 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		$this->assertSame( 'Blue', $message );
 	}
 
+	public function testTranslateTemplateData_QuizNotCompleted_ReturnsQuestionDataUnchanged() {
+		/* Arrange. */
+		list( $question_data, $taken_question_id ) = $this->arrange_loader_output_with_translation();
+
+		// The viewer's quiz is still open: the options are live form values.
+		$question_data['quiz_is_completed'] = false;
+
+		$question_display = new Question_Display();
+
+		/* Act. */
+		$actual = $question_display->translate_template_data( $question_data, $taken_question_id );
+
+		/* Assert. */
+		$this->assertSame( $question_data, $actual );
+	}
+
+	public function testTranslateTemplateData_AnswerListsSizesDiffer_ReturnsQuestionDataUnchanged() {
+		/* Arrange. */
+		list( $question_data, $taken_question_id ) = $this->arrange_loader_output_with_translation();
+
+		update_post_meta( $taken_question_id, '_question_wrong_answers', array( 'Verde', 'Rojo' ) );
+
+		$question_display = new Question_Display();
+
+		/* Act. */
+		$actual = $question_display->translate_template_data( $question_data, $taken_question_id );
+
+		/* Assert. */
+		$this->assertSame( $question_data, $actual, 'On an answer-list size mismatch the whole question should render as taken.' );
+	}
+
+	public function testTranslateTemplateData_NoTranslationExists_ReturnsQuestionDataUnchanged() {
+		/* Arrange. */
+		list( $question_data, $taken_question_id ) = $this->arrange_loader_output_with_translation();
+
+		remove_all_filters( 'wpml_object_id' );
+
+		$question_display = new Question_Display();
+
+		/* Act. */
+		$actual = $question_display->translate_template_data( $question_data, $taken_question_id );
+
+		/* Assert. */
+		$this->assertSame( $question_data, $actual );
+	}
+
 	public function testTranslateAnswerNotes_NotesMatchTakenQuestionGenericFeedback_ShowsViewerLanguageFeedback() {
 		/* Arrange. */
 		list( $taken_question_id, $display_question_id ) = $this->create_question_pair();
@@ -215,16 +261,15 @@ class Question_Display_Test extends \WP_UnitTestCase {
 
 	public function testTranslateTemplateData_ViewerLanguageDiffersFromTakenQuestion_ShowsViewerLanguageTitle() {
 		/* Arrange. */
-		list( $taken_question_id, $quiz_id ) = $this->arrange_taken_question_with_translation();
+		list( $question_data, $taken_question_id ) = $this->arrange_loader_output_with_translation();
 
 		$question_display = new Question_Display();
-		$question_display->init();
 
 		/* Act. */
-		$question_data = \Sensei_Question::get_template_data( $taken_question_id, $quiz_id );
+		$actual = $question_display->translate_template_data( $question_data, $taken_question_id );
 
 		/* Assert. */
-		$this->assertSame( 'Is the sky blue?', $question_data['title'] );
+		$this->assertSame( 'What color is the sky?', $actual['title'] );
 	}
 
 	/**
@@ -249,7 +294,35 @@ class Question_Display_Test extends \WP_UnitTestCase {
 
 		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
 
-		return array( $taken_question_id, $this->factory->quiz->create() );
+		$course_with_lessons = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 1,
+			)
+		);
+		$quiz_id             = $course_with_lessons['quiz_ids'][0];
+		$this->complete_quiz_for_current_user( $quiz_id, $course_with_lessons['lesson_ids'][0] );
+
+		return array( $taken_question_id, $quiz_id );
+	}
+
+	/**
+	 * Mark the quiz as submitted (awaiting grading) for a fresh logged-in
+	 * student, so the template data renders in review mode.
+	 *
+	 * @param int $quiz_id   Quiz ID.
+	 * @param int $lesson_id Lesson the quiz belongs to.
+	 */
+	private function complete_quiz_for_current_user( $quiz_id, $lesson_id ) {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		// The comments-based quiz progress piggybacks on the lesson progress.
+		\Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+
+		$progress = \Sensei()->quiz_progress_repository->create( $quiz_id, $user_id );
+		$progress->ungrade();
+		\Sensei()->quiz_progress_repository->save( $progress );
 	}
 
 	/**
@@ -270,6 +343,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 			'ID'                     => $taken_question_id,
 			'title'                  => '¿De qué color es el cielo?',
 			'content'                => '',
+			'quiz_is_completed'      => true,
 			'question_right_answer'  => 'Azul',
 			// The type loader merges the right answer into the wrong list.
 			'question_wrong_answers' => array( 'Verde', 'Azul' ),
@@ -348,42 +422,4 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		);
 	}
 
-	/**
-	 * Create an EN course whose quiz question has an ES twin, simulate WPML with
-	 * the viewer on EN, and return the as-taken (ES) question and the quiz.
-	 *
-	 * The scenario mirrors a student who took the quiz in ES and now views the
-	 * results with the site in EN: the page loop passes the stored ES question
-	 * to the template data builder.
-	 *
-	 * @return array{0: int, 1: int} As-taken question ID and quiz ID.
-	 */
-	private function arrange_taken_question_with_translation() {
-		$course_with_lessons = $this->factory->get_course_with_lessons(
-			array(
-				'lesson_count'   => 1,
-				'question_count' => 1,
-			)
-		);
-
-		$quiz_id             = $course_with_lessons['quiz_ids'][0];
-		$display_question_id = \Sensei()->quiz->get_questions( $quiz_id )[0]->ID;
-		wp_update_post(
-			array(
-				'ID'         => $display_question_id,
-				'post_title' => 'Is the sky blue?',
-			)
-		);
-
-		$taken_question_id = $this->factory->post->create(
-			array(
-				'post_type'  => 'question',
-				'post_title' => '¿El cielo es azul?',
-			)
-		);
-
-		$this->simulate_wpml_viewer_on_en( $taken_question_id, $display_question_id );
-
-		return array( $taken_question_id, $quiz_id );
-	}
 }

--- a/tests/unit-tests/wpml/test-class-question-display.php
+++ b/tests/unit-tests/wpml/test-class-question-display.php
@@ -39,7 +39,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals( 15, has_filter( 'sensei_get_question_template_data', array( $question_display, 'translate_template_data' ) ), 'The template data filter should be added after the type loaders.' );
 		$this->assertEquals( 10, has_filter( 'the_title', array( $question_display, 'translate_question_title' ) ), 'The title filter should be added.' );
-		$this->assertEquals( 10, has_filter( 'sensei_the_question_description_question_id', array( $question_display, 'translate_question_description_id' ) ), 'The description question filter should be added.' );
+		$this->assertEquals( 10, has_filter( 'sensei_question_description_post_id', array( $question_display, 'translate_question_description_id' ) ), 'The description question filter should be added.' );
 		$this->assertEquals( 10, has_filter( 'sensei_question_answer_message_correct_answer', array( $question_display, 'translate_correct_answer_message' ) ), 'The right-answer reveal filter should be added.' );
 		$this->assertEquals( 10, has_filter( 'sensei_question_answer_notes', array( $question_display, 'translate_answer_notes' ) ), 'The answer notes filter should be added.' );
 	}
@@ -119,7 +119,7 @@ class Question_Display_Test extends \WP_UnitTestCase {
 		$question_display->init();
 
 		/* Act. */
-		$question_id = apply_filters( 'sensei_the_question_description_question_id', $taken_question_id );
+		$question_id = apply_filters( 'sensei_question_description_post_id', $taken_question_id );
 
 		/* Clean up. */
 		unset( $GLOBALS['current_screen'] );


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SEN-102/wpml-taking-translated-quizzes-doesnt-work

## Proposed Changes

On multilingual sites, quiz submissions store the questions as they were taken, so the results page always showed them in the language the quiz was taken in: a student who took a quiz in a secondary language (or switched languages later) saw titles, options and feedback in the wrong language.

This adds a WPML compatibility class that translates what the results page displays, without touching stored data:

- Question titles, descriptions, and choice-option labels render in the current language. Option labels are swapped for the current-language question's, matching right answers with right answers and wrong with wrong by position, which is how WPML translates them (in place, never reordering). The student's selection, the grades, and the option order are untouched.
- The "Right Answer" reveal and the question-authored answer feedback also render in the current language. Per-student feedback written by the teacher while grading is shown as written.
- While a quiz is still open, the options render as taken: they are live form values, and translating them would make the form submit display-language labels against the as-taken questions. The title and description still translate.
- On any mismatch (no translation, different option counts), the question renders as taken, which is the previous behavior. Historical submissions benefit immediately since nothing depends on how the answers were stored.

It also fixes the question sync so the translated question post stores the question block's whole translated inner content (description and feedback blocks included), mirroring how the editor saves questions.

Known limits, deliberate: the gap-fill body stays in the taken language (the student's typed answer only makes sense against the gap in its own language), and the legacy question media is not translated.

## Testing Instructions

1. On a site with WPML active (English default, Spanish secondary) and this branch, create a course with one lesson and a quiz with a multiple-choice and a true/false question, with automatic grading. Give both questions a description and correct and incorrect answer feedback.
2. Translate the course and the lesson into Spanish with the Advanced Translation Editor, translating every segment (do not translate the questions individually; this branch syncs them from the lesson translation).
3. As an enrolled student, switch the frontend to Spanish, take the quiz answering the multiple-choice wrong and the true/false right, and submit.
4. Check the Spanish results page: titles, options, descriptions, the "Right Answer" reveal on the failed question, and the answer feedback all display in Spanish.
5. Staying logged in as the student, switch the frontend to English and open the quiz results: everything from step 4 should now display in English, with the student's selected answers still marked and the grade unchanged.
6. As a second student, take the quiz in English and check that their results display in Spanish when viewing the site in Spanish.
7. Deactivate WPML and check the results page renders exactly as before.

## New/Updated Hooks

- New filter `sensei_the_question_description_question_id`: filters the question ID whose description is rendered in `Sensei_Question::get_the_question_description()`. Takes and returns a question ID. Added so multilingual integrations can render the description from the question's translation.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message
Fixed the quiz results page showing questions in the language the quiz was taken in instead of the viewer's language on multilingual sites.

</details>
