### PR TITLE
Fix manual grading losing per-question grades and feedback on WPML admin languages

### DIFF
--- a/changelog/fix-wpml-manual-grading-quiz-id
+++ b/changelog/fix-wpml-manual-grading-quiz-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed manual grading losing the per-question grades and feedback when the admin uses a secondary language on multilingual sites.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1131,7 +1131,8 @@ class Sensei_Quiz {
 			$user_id = get_current_user_id();
 		}
 
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		// make sure the parameters are valid before continuing
 		if (
@@ -1283,7 +1284,8 @@ class Sensei_Quiz {
 	 */
 	public function save_user_answers_feedback( $answers_feedback, $lesson_id, $user_id = 0 ) {
 
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		// make sure the parameters are valid before continuing
 		if (

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1074,6 +1074,82 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that grading persists the per-question grades when quiz post
+	 * queries are filtered to another language by a multilingual plugin.
+	 *
+	 * @covers Sensei_Quiz::set_user_grades
+	 */
+	public function testSetUserGrades_QuizQueryFilteredToAnotherLanguage_PersistsTheGrades() {
+		/* Arrange. */
+		list( $user_id, $lesson_id, $question_id, $submission, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+
+		/* Act. */
+		Sensei()->quiz->set_user_grades( array( $question_id => 1 ), $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$points_map = array();
+		foreach ( Sensei()->quiz_grade_repository->get_all( $submission->get_id() ) as $grade ) {
+			$points_map[ $grade->get_question_id() ] = $grade->get_points();
+		}
+		$this->assertSame( array( $question_id => 1 ), $points_map, 'The per-question grades should persist when quiz queries are language filtered.' );
+	}
+
+	/**
+	 * Tests that grading persists the answers feedback when quiz post
+	 * queries are filtered to another language by a multilingual plugin.
+	 *
+	 * @covers Sensei_Quiz::save_user_answers_feedback
+	 */
+	public function testSaveUserAnswersFeedback_QuizQueryFilteredToAnotherLanguage_PersistsTheFeedback() {
+		/* Arrange. */
+		list( $user_id, $lesson_id, $question_id, $submission, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+
+		Sensei()->quiz->set_user_grades( array( $question_id => 1 ), $lesson_id, $user_id );
+
+		/* Act. */
+		Sensei()->quiz->save_user_answers_feedback( array( $question_id => 'Great work' ), $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$feedback_map = array();
+		foreach ( Sensei()->quiz_grade_repository->get_all( $submission->get_id() ) as $grade ) {
+			$feedback_map[ $grade->get_question_id() ] = $grade->get_feedback();
+		}
+		$this->assertSame( array( $question_id => base64_encode( 'Great work' ) ), $feedback_map, 'The answers feedback should persist when quiz queries are language filtered.' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Mirrors the stored format.
+	}
+
+	/**
+	 * Create a lesson with a quiz, a user with a submission and one answer, and
+	 * register a filter that hides quiz posts from queries, the way multilingual
+	 * plugins filter them to another language.
+	 *
+	 * @return array{0: int, 1: int, 2: int, 3: object, 4: callable} User, lesson,
+	 *         question, submission, and the registered filter.
+	 */
+	private function arrange_submission_with_filtered_quiz_queries() {
+		$user_id     = $this->factory->user->create();
+		$lesson_id   = $this->factory->get_random_lesson_id();
+		$quiz_id     = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		$question_id = Sensei()->quiz->get_questions( $quiz_id )[0]->ID;
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+		$submission = Sensei()->quiz_submission_repository->create( $quiz_id, $user_id );
+		Sensei()->quiz_answer_repository->create( $submission, $question_id, 'Answer' );
+
+		$language_filter = function ( $where, $query ) {
+			if ( 'quiz' === $query->get( 'post_type' ) ) {
+				$where .= ' AND 1=0';
+			}
+			return $where;
+		};
+		add_filter( 'posts_where', $language_filter, 10, 2 );
+
+		return array( $user_id, $lesson_id, $question_id, $submission, $language_filter );
+	}
+
+	/**
 	 * Tests that stored grades survive quiz post queries being filtered
 	 * to another language by a multilingual plugin.
 	 *

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1081,7 +1081,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	 */
 	public function testSetUserGrades_QuizQueryFilteredToAnotherLanguage_PersistsTheGrades() {
 		/* Arrange. */
-		list( $user_id, $lesson_id, $question_id, $submission, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+		list( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
 
 		/* Act. */
 		Sensei()->quiz->set_user_grades( array( $question_id => 1 ), $lesson_id, $user_id );
@@ -1103,9 +1103,9 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	 */
 	public function testSaveUserAnswersFeedback_QuizQueryFilteredToAnotherLanguage_PersistsTheFeedback() {
 		/* Arrange. */
-		list( $user_id, $lesson_id, $question_id, $submission, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+		list( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
 
-		Sensei()->quiz->set_user_grades( array( $question_id => 1 ), $lesson_id, $user_id );
+		Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, 1 );
 
 		/* Act. */
 		Sensei()->quiz->save_user_answers_feedback( array( $question_id => 'Great work' ), $lesson_id, $user_id );
@@ -1124,8 +1124,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	 * register a filter that hides quiz posts from queries, the way multilingual
 	 * plugins filter them to another language.
 	 *
-	 * @return array{0: int, 1: int, 2: int, 3: object, 4: callable} User, lesson,
-	 *         question, submission, and the registered filter.
+	 * @return array{0: int, 1: int, 2: int, 3: object, 4: object, 5: callable} User, lesson,
+	 *         question, submission, answer, and the registered filter.
 	 */
 	private function arrange_submission_with_filtered_quiz_queries() {
 		$user_id     = $this->factory->user->create();
@@ -1136,7 +1136,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
 		$submission = Sensei()->quiz_submission_repository->create( $quiz_id, $user_id );
-		Sensei()->quiz_answer_repository->create( $submission, $question_id, 'Answer' );
+		$answer     = Sensei()->quiz_answer_repository->create( $submission, $question_id, 'Answer' );
 
 		$language_filter = function ( $where, $query ) {
 			if ( 'quiz' === $query->get( 'post_type' ) ) {
@@ -1146,7 +1146,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		};
 		add_filter( 'posts_where', $language_filter, 10, 2 );
 
-		return array( $user_id, $lesson_id, $question_id, $submission, $language_filter );
+		return array( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter );
 	}
 
 	/**


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SEN-122/wpml-grading-a-quiz-with-the-admin-in-a-secondary-language-silently

## Proposed Changes

When a teacher graded a quiz with the wp-admin language set to a secondary language on a multilingual site, the grading was a silent half-save: the total grade and the graded status persisted, but every per-question grade and feedback text was lost, with the screen still confirming success. The two saving functions (`set_user_grades()` and `save_user_answers_feedback()`) re-resolved the quiz through a post query that multilingual plugins filter by language, missed it, and returned false unnoticed.

Both now resolve the quiz from the lesson meta through `Sensei_Lesson::get_quiz_id()`, the same helper and pattern already used by the grading screen link and the grades read path (#8121). Without a multilingual plugin the resolution is unchanged: the meta and the query point to the same quiz, and the previous query remains as the fallback.

## Testing Instructions

1. On a site with WPML active (English as default, Spanish as secondary), create a course with one lesson and, in the lesson, a quiz with two questions: a multiple choice and a true/false.
2. In the quiz settings, disable "Grade quiz automatically" and enable "Allow retakes". Publish the course. Do not translate anything.
3. Enroll a student and, on the frontend, take the quiz and submit it. The submission appears as Ungraded in Sensei LMS → Grading.
4. Switch the wp-admin language to Spanish (the WPML language switcher in the admin bar, or Users → Profile → Language).
5. Go to Sensei LMS → Grading and open the submission. Mark one question as right and the other as wrong, write "Great work" in a question's "Add custom feedback" box, and save.
6. Reopen the submission: the per-question marks and the feedback should still be there, matching the total. Before this fix, everything but the total was silently lost.
7. As the student, retake and resubmit the quiz; grade it again with the wp-admin language set back to English and check grading still works as usual.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message
Fixed manual grading losing the per-question grades and feedback when the admin uses a secondary language on multilingual sites.

</details>
