### PR TITLE
Fix quiz surfaces breaking on secondary admin languages and translated lessons

### DIFF
--- a/changelog/fix-wpml-quiz-resolver-sweep
+++ b/changelog/fix-wpml-quiz-resolver-sweep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed quiz answers, grades, resets, and lesson quiz surfaces breaking when the admin uses a secondary language or the lesson is translated on multilingual sites.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3688,7 +3688,8 @@ class Sensei_Lesson {
 			return null;
 		}
 
-		$quiz_id = $this->lesson_quizzes( $lesson->ID );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = $this->get_quiz_id( $lesson->ID );
 
 		if ( ! $quiz_id || ! self::lesson_quiz_has_questions( $lesson->ID ) ) {
 			return null;
@@ -5237,8 +5238,8 @@ class Sensei_Lesson {
 	 * @return bool
 	 */
 	public function lesson_has_quiz_with_questions_and_pass_required( $lesson_id ) {
-		// Lesson quizzes
-		$quiz_id = $this->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = $this->get_quiz_id( $lesson_id );
 		if ( empty( $quiz_id ) ) {
 			return false;
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3710,7 +3710,8 @@ class Sensei_Lesson {
 	 * @return bool Whether quiz is submitted.
 	 */
 	public function is_quiz_submitted( int $lesson_id, int $user_id ): bool {
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 		if ( ! $quiz_id ) {
 			return false;
 		}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -849,8 +849,8 @@ class Sensei_Quiz {
 			return false;
 		}
 
-		// Get the lesson quiz.
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		// Check if the user has started the lesson or quiz.
 		$need_reset_data          = false;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2120,7 +2120,8 @@ class Sensei_Quiz {
 	 */
 	public static function is_pass_required( $lesson_id ) {
 
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		$reset_allowed = get_post_meta( $quiz_id, '_pass_required', true );
 		// backwards compatibility.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -2049,7 +2049,8 @@ class Sensei_Quiz {
 	 */
 	public static function get_user_quiz_grade( int $lesson_id, int $user_id ): float {
 
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 		if ( ! $quiz_id ) {
 			return 0;
 		}
@@ -2075,7 +2076,8 @@ class Sensei_Quiz {
 	 */
 	public static function is_reset_allowed( $lesson_id ) {
 
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		$reset_allowed = get_post_meta( $quiz_id, '_enable_quiz_reset', true );
 		// backwards compatibility.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -457,7 +457,8 @@ class Sensei_Quiz {
 		if ( ! empty( $transient_cached_answers ) ) {
 			$encoded_answers_map = $transient_cached_answers;
 		} else {
-			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+			// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+			$quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 			if ( ! $quiz_id ) {
 				return false;
 			}
@@ -1367,7 +1368,8 @@ class Sensei_Quiz {
 
 		// get the data if nothing was stored in the transient
 		if ( ! $encoded_feedback ) {
-			$quiz_id    = (int) Sensei()->lesson->lesson_quizzes( $lesson_id );
+			// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+			$quiz_id    = (int) Sensei()->lesson->get_quiz_id( $lesson_id );
 			$submission = Sensei()->quiz_submission_repository->get( $quiz_id, $user_id );
 			if ( ! $submission ) {
 				return false;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -653,8 +653,8 @@ class Sensei_Utils {
 			$user_id = get_current_user_id();
 		}
 
-		// Process quiz
-		$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$lesson_quiz_id = Sensei()->lesson->get_quiz_id( $lesson_id );
 
 		// Delete quiz answers, this auto deletes the corresponding meta data, such as the question/answer grade
 		self::sensei_delete_quiz_answers( $lesson_quiz_id, $user_id );

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -101,8 +101,8 @@ class Sensei_Course_Theme_Lesson {
 			return;
 		}
 
-		$notices       = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' );
 		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$notices       = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' );
 		$quiz_id       = Sensei()->lesson->get_quiz_id( $lesson_id );
 		$user_answers  = Sensei()->quiz->get_user_answers( $lesson_id, $user_id );
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -102,7 +102,8 @@ class Sensei_Course_Theme_Lesson {
 		}
 
 		$notices       = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' );
-		$quiz_id       = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id       = Sensei()->lesson->get_quiz_id( $lesson_id );
 		$user_answers  = Sensei()->quiz->get_user_answers( $lesson_id, $user_id );
 		$quiz_progress = Sensei()->quiz_progress_repository->get( $quiz_id, $user_id );
 

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -59,9 +59,9 @@ class Sensei_Course_Theme_Quiz {
 	 * @access private
 	 */
 	private function maybe_add_quiz_results_notice() {
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
 		$actions   = [];
 		$lesson_id = Sensei_Utils::get_current_lesson();
-		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
 		$quiz_id   = Sensei()->lesson->get_quiz_id( $lesson_id );
 		$user_id   = get_current_user_id();
 

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -61,7 +61,8 @@ class Sensei_Course_Theme_Quiz {
 	private function maybe_add_quiz_results_notice() {
 		$actions   = [];
 		$lesson_id = Sensei_Utils::get_current_lesson();
-		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		// Resolve the quiz from the lesson meta: post queries can be filtered by plugins and miss the quiz.
+		$quiz_id   = Sensei()->lesson->get_quiz_id( $lesson_id );
 		$user_id   = get_current_user_id();
 
 		if ( empty( $user_id ) ) {

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1860,4 +1860,39 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		remove_filter( 'posts_where', $language_filter );
 		$this->assertTrue( $pass_required, 'The stored pass-required setting should be honored when the quiz is hidden from post queries.' );
 	}
+
+	/**
+	 * Tests that a submitted quiz is reported as submitted when a plugin filter hides
+	 * the quiz from post queries, as multilingual plugins do when the quiz belongs to
+	 * another language.
+	 *
+	 * @covers Sensei_Lesson::is_quiz_submitted
+	 */
+	public function testIsQuizSubmitted_QuizHiddenFromPostQueries_ReturnsTrue() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+		$quiz_progress = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id );
+		$quiz_progress->pass();
+		Sensei()->quiz_progress_repository->save( $quiz_progress );
+
+		$language_filter = function ( $where, $query ) {
+			if ( 'quiz' === $query->get( 'post_type' ) ) {
+				$where .= ' AND 1=0';
+			}
+			return $where;
+		};
+		add_filter( 'posts_where', $language_filter, 10, 2 );
+
+		/* Act. */
+		$is_submitted = Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertTrue( $is_submitted, 'A submitted quiz should be reported as submitted when the quiz is hidden from post queries.' );
+	}
 }

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1809,18 +1809,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	 */
 	public function testGetQuizPermalink_QuizHiddenFromPostQueries_ReturnsThePermalink() {
 		/* Arrange. */
-		$lesson_id = $this->factory->get_random_lesson_id();
-		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
-
-		$language_filter = function ( $where, $query ) {
-			if ( 'quiz' === $query->get( 'post_type' ) ) {
-				$where .= ' AND 1=0';
-			}
-			return $where;
-		};
-		add_filter( 'posts_where', $language_filter, 10, 2 );
+		list( $lesson_id, $quiz_id, $language_filter ) = $this->arrange_lesson_with_hidden_quiz();
 
 		/* Act. */
 		$permalink = Sensei()->lesson->get_quiz_permalink( $lesson_id );
@@ -1839,19 +1828,9 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	 */
 	public function testLessonHasQuizWithQuestionsAndPassRequired_QuizHiddenFromPostQueries_ReturnsTrue() {
 		/* Arrange. */
-		$lesson_id = $this->factory->get_random_lesson_id();
-		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
-		update_post_meta( $quiz_id, '_pass_required', 'on' );
+		list( $lesson_id, $quiz_id, $language_filter ) = $this->arrange_lesson_with_hidden_quiz();
 
-		$language_filter = function ( $where, $query ) {
-			if ( 'quiz' === $query->get( 'post_type' ) ) {
-				$where .= ' AND 1=0';
-			}
-			return $where;
-		};
-		add_filter( 'posts_where', $language_filter, 10, 2 );
+		update_post_meta( $quiz_id, '_pass_required', 'on' );
 
 		/* Act. */
 		$pass_required = Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson_id );
@@ -1870,15 +1849,34 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	 */
 	public function testIsQuizSubmitted_QuizHiddenFromPostQueries_ReturnsTrue() {
 		/* Arrange. */
-		$user_id   = $this->factory->user->create();
-		$lesson_id = $this->factory->get_random_lesson_id();
-		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		list( $lesson_id, $quiz_id, $language_filter ) = $this->arrange_lesson_with_hidden_quiz();
 
+		$user_id = $this->factory->user->create();
 		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
 		$quiz_progress = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id );
 		$quiz_progress->pass();
 		Sensei()->quiz_progress_repository->save( $quiz_progress );
+
+		/* Act. */
+		$is_submitted = Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertTrue( $is_submitted, 'A submitted quiz should be reported as submitted when the quiz is hidden from post queries.' );
+	}
+
+	/**
+	 * Create a lesson whose quiz is wired through the lesson meta, and register a filter
+	 * that hides quiz posts from queries, the way multilingual plugins filter them to
+	 * another language.
+	 *
+	 * @return array{0: int, 1: int, 2: callable} Lesson, quiz, and the registered filter.
+	 */
+	private function arrange_lesson_with_hidden_quiz() {
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
 
 		$language_filter = function ( $where, $query ) {
 			if ( 'quiz' === $query->get( 'post_type' ) ) {
@@ -1888,11 +1886,6 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		};
 		add_filter( 'posts_where', $language_filter, 10, 2 );
 
-		/* Act. */
-		$is_submitted = Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id );
-
-		/* Clean up & Assert. */
-		remove_filter( 'posts_where', $language_filter );
-		$this->assertTrue( $is_submitted, 'A submitted quiz should be reported as submitted when the quiz is hidden from post queries.' );
+		return array( $lesson_id, $quiz_id, $language_filter );
 	}
 }

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1800,4 +1800,64 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		);
 		self::assertSame( $expected, $actual );
 	}
+
+	/**
+	 * Tests that the quiz permalink is returned when a plugin filter hides the quiz from post
+	 * queries, as multilingual plugins do when the quiz belongs to another language.
+	 *
+	 * @covers Sensei_Lesson::get_quiz_permalink
+	 */
+	public function testGetQuizPermalink_QuizHiddenFromPostQueries_ReturnsThePermalink() {
+		/* Arrange. */
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
+
+		$language_filter = function ( $where, $query ) {
+			if ( 'quiz' === $query->get( 'post_type' ) ) {
+				$where .= ' AND 1=0';
+			}
+			return $where;
+		};
+		add_filter( 'posts_where', $language_filter, 10, 2 );
+
+		/* Act. */
+		$permalink = Sensei()->lesson->get_quiz_permalink( $lesson_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertSame( get_permalink( $quiz_id ), $permalink, 'The quiz permalink should be returned when the quiz is hidden from post queries.' );
+	}
+
+	/**
+	 * Tests that the pass-required check honors the stored setting when a plugin filter
+	 * hides the quiz from post queries, as multilingual plugins do when the quiz belongs
+	 * to another language.
+	 *
+	 * @covers Sensei_Lesson::lesson_has_quiz_with_questions_and_pass_required
+	 */
+	public function testLessonHasQuizWithQuestionsAndPassRequired_QuizHiddenFromPostQueries_ReturnsTrue() {
+		/* Arrange. */
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
+		update_post_meta( $quiz_id, '_pass_required', 'on' );
+
+		$language_filter = function ( $where, $query ) {
+			if ( 'quiz' === $query->get( 'post_type' ) ) {
+				$where .= ' AND 1=0';
+			}
+			return $where;
+		};
+		add_filter( 'posts_where', $language_filter, 10, 2 );
+
+		/* Act. */
+		$pass_required = Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertTrue( $pass_required, 'The stored pass-required setting should be honored when the quiz is hidden from post queries.' );
+	}
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1237,8 +1237,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
 		$submission = Sensei()->quiz_submission_repository->create( $quiz_id, $user_id );
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Mirrors the stored format.
-		$answer     = Sensei()->quiz_answer_repository->create( $submission, $question_id, base64_encode( 'Answer' ) );
+		$answer     = Sensei()->quiz_answer_repository->create( $submission, $question_id, base64_encode( 'Answer' ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Mirrors the stored format.
 
 		$language_filter = function ( $where, $query ) {
 			if ( 'quiz' === $query->get( 'post_type' ) ) {

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1120,6 +1120,45 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the user answers are returned when a plugin filter hides the quiz from post
+	 * queries, as multilingual plugins do when the quiz belongs to another language.
+	 *
+	 * @covers Sensei_Quiz::get_user_answers
+	 */
+	public function testGetUserAnswers_QuizHiddenFromPostQueries_ReturnsTheAnswers() {
+		/* Arrange. */
+		list( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+
+		/* Act. */
+		$user_answers = Sensei()->quiz->get_user_answers( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertSame( array( $question_id => 'Answer' ), $user_answers, 'The user answers should be returned when the quiz is hidden from post queries.' );
+	}
+
+	/**
+	 * Tests that the answers feedback is returned when a plugin filter hides the quiz from post
+	 * queries, as multilingual plugins do when the quiz belongs to another language.
+	 *
+	 * @covers Sensei_Quiz::get_user_answers_feedback
+	 */
+	public function testGetUserAnswersFeedback_QuizHiddenFromPostQueries_ReturnsTheFeedback() {
+		/* Arrange. */
+		list( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Mirrors the stored format.
+		Sensei()->quiz_grade_repository->create( $submission, $answer, $question_id, 1, base64_encode( 'Great work' ) );
+
+		/* Act. */
+		$feedback = Sensei()->quiz->get_user_answers_feedback( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertSame( array( $question_id => 'Great work' ), $feedback, 'The answers feedback should be returned when the quiz is hidden from post queries.' );
+	}
+
+	/**
 	 * Create a lesson with a quiz, a user with a submission and one answer, and
 	 * register a filter that hides quiz posts from queries, the way multilingual
 	 * plugins filter them to another language.
@@ -1136,7 +1175,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
 		$submission = Sensei()->quiz_submission_repository->create( $quiz_id, $user_id );
-		$answer     = Sensei()->quiz_answer_repository->create( $submission, $question_id, 'Answer' );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Mirrors the stored format.
+		$answer     = Sensei()->quiz_answer_repository->create( $submission, $question_id, base64_encode( 'Answer' ) );
 
 		$language_filter = function ( $where, $query ) {
 			if ( 'quiz' === $query->get( 'post_type' ) ) {

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1179,6 +1179,26 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the pass-required setting is returned when a plugin filter hides the quiz
+	 * from post queries, as multilingual plugins do when the quiz belongs to another
+	 * language.
+	 *
+	 * @covers Sensei_Quiz::is_pass_required
+	 */
+	public function testIsPassRequired_QuizHiddenFromPostQueries_ReturnsTheStoredSetting() {
+		/* Arrange. */
+		list( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+		update_post_meta( $submission->get_quiz_id(), '_pass_required', 'on' );
+
+		/* Act. */
+		$pass_required = Sensei_Quiz::is_pass_required( $lesson_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertTrue( $pass_required, 'The stored pass-required setting should be returned when the quiz is hidden from post queries.' );
+	}
+
+	/**
 	 * Create a lesson with a quiz, a user with a submission and one answer, and
 	 * register a filter that hides quiz posts from queries, the way multilingual
 	 * plugins filter them to another language.

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1159,6 +1159,26 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that resetting a lesson deletes the quiz submission when a plugin filter hides
+	 * the quiz from post queries, as multilingual plugins do when the quiz belongs to
+	 * another language.
+	 *
+	 * @covers Sensei_Quiz::reset_user_lesson_data
+	 */
+	public function testResetUserLessonData_QuizHiddenFromPostQueries_DeletesTheQuizSubmission() {
+		/* Arrange. */
+		list( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+		$quiz_id = $submission->get_quiz_id();
+
+		/* Act. */
+		Sensei()->quiz->reset_user_lesson_data( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertNull( Sensei()->quiz_submission_repository->get( $quiz_id, $user_id ), 'The quiz submission should be deleted when the quiz is hidden from post queries.' );
+	}
+
+	/**
 	 * Create a lesson with a quiz, a user with a submission and one answer, and
 	 * register a filter that hides quiz posts from queries, the way multilingual
 	 * plugins filter them to another language.

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1199,6 +1199,28 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the user's quiz grade is returned when a plugin filter hides the quiz
+	 * from post queries, as multilingual plugins do when the quiz belongs to another
+	 * language.
+	 *
+	 * @covers Sensei_Quiz::get_user_quiz_grade
+	 */
+	public function testGetUserQuizGrade_QuizHiddenFromPostQueries_ReturnsTheGrade() {
+		/* Arrange. */
+		list( $user_id, $lesson_id, $question_id, $submission, $answer, $language_filter ) = $this->arrange_submission_with_filtered_quiz_queries();
+
+		$submission->set_final_grade( 80 );
+		Sensei()->quiz_submission_repository->save( $submission );
+
+		/* Act. */
+		$grade = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertSame( 80.0, $grade, 'The quiz grade should be returned when the quiz is hidden from post queries.' );
+	}
+
+	/**
 	 * Create a lesson with a quiz, a user with a submission and one answer, and
 	 * register a filter that hides quiz posts from queries, the way multilingual
 	 * plugins filter them to another language.

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -683,39 +683,4 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 'in-progress', $previous_status );
 	}
-
-	/**
-	 * Tests that removing a user from a lesson deletes the quiz submission when a plugin
-	 * filter hides the quiz from post queries, as multilingual plugins do when the quiz
-	 * belongs to another language.
-	 *
-	 * @covers Sensei_Utils::sensei_remove_user_from_lesson
-	 */
-	public function testSenseiRemoveUserFromLesson_QuizHiddenFromPostQueries_DeletesTheQuizSubmission() {
-		/* Arrange. */
-		$user_id     = $this->factory->user->create();
-		$lesson_id   = $this->factory->get_random_lesson_id();
-		$quiz_id     = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		$question_id = Sensei()->quiz->get_questions( $quiz_id )[0]->ID;
-		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
-
-		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
-		$submission = Sensei()->quiz_submission_repository->create( $quiz_id, $user_id );
-		Sensei()->quiz_answer_repository->create( $submission, $question_id, 'Answer' );
-
-		$language_filter = function ( $where, $query ) {
-			if ( 'quiz' === $query->get( 'post_type' ) ) {
-				$where .= ' AND 1=0';
-			}
-			return $where;
-		};
-		add_filter( 'posts_where', $language_filter, 10, 2 );
-
-		/* Act. */
-		Sensei_Utils::sensei_remove_user_from_lesson( $lesson_id, $user_id );
-
-		/* Clean up & Assert. */
-		remove_filter( 'posts_where', $language_filter );
-		$this->assertNull( Sensei()->quiz_submission_repository->get( $quiz_id, $user_id ), 'The quiz submission should be deleted when the quiz is hidden from post queries.' );
-	}
 }

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -683,4 +683,39 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 'in-progress', $previous_status );
 	}
+
+	/**
+	 * Tests that removing a user from a lesson deletes the quiz submission when a plugin
+	 * filter hides the quiz from post queries, as multilingual plugins do when the quiz
+	 * belongs to another language.
+	 *
+	 * @covers Sensei_Utils::sensei_remove_user_from_lesson
+	 */
+	public function testSenseiRemoveUserFromLesson_QuizHiddenFromPostQueries_DeletesTheQuizSubmission() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		$question_id = Sensei()->quiz->get_questions( $quiz_id )[0]->ID;
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+		$submission = Sensei()->quiz_submission_repository->create( $quiz_id, $user_id );
+		Sensei()->quiz_answer_repository->create( $submission, $question_id, 'Answer' );
+
+		$language_filter = function ( $where, $query ) {
+			if ( 'quiz' === $query->get( 'post_type' ) ) {
+				$where .= ' AND 1=0';
+			}
+			return $where;
+		};
+		add_filter( 'posts_where', $language_filter, 10, 2 );
+
+		/* Act. */
+		Sensei_Utils::sensei_remove_user_from_lesson( $lesson_id, $user_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'posts_where', $language_filter );
+		$this->assertNull( Sensei()->quiz_submission_repository->get( $quiz_id, $user_id ), 'The quiz submission should be deleted when the quiz is hidden from post queries.' );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -693,9 +693,9 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function testSenseiRemoveUserFromLesson_QuizHiddenFromPostQueries_DeletesTheQuizSubmission() {
 		/* Arrange. */
-		$user_id   = $this->factory->user->create();
-		$lesson_id = $this->factory->get_random_lesson_id();
-		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		$user_id     = $this->factory->user->create();
+		$lesson_id   = $this->factory->get_random_lesson_id();
+		$quiz_id     = Sensei()->lesson->lesson_quizzes( $lesson_id );
 		$question_id = Sensei()->quiz->get_questions( $quiz_id )[0]->ID;
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 


### PR DESCRIPTION
> **Parked in favor of #8130.** The same problem is solved there with a single change to `lesson_quizzes()` (query first, lesson meta as a fallback when the query returns nothing), which covers all 55 call sites instead of the ones swept here, including surfaces neither PR touched. Only one of the two should be merged, and the testing instructions for the fallback approach live in #8130.

Part of https://linear.app/a8c/issue/SEN-122/wpml-grading-a-quiz-with-the-admin-in-a-secondary-language-silently

## Proposed Changes

#8121 and #8126 fixed the grading write path, but many other quiz surfaces still resolve a lesson's quiz through a post query that plugins can filter. Under WPML that breaks in two situations, both verified live: with the wp-admin in a secondary language (the query misses original-language content), and on translated lessons whose quiz is untranslated (the query misses in every context, because the real quiz's post_parent is the original lesson).

What a user hits, before this branch:

- The grading screen in a secondary admin language shows no student answers and no saved feedback once the read caches expire.
- Resetting or removing a student from Sensei LMS → Students in a secondary admin language silently leaves the quiz submission, answers, and grades behind.
- A translated lesson page loses its quiz button, offers "Complete lesson" even when passing the quiz is required, reads the grade as 0%, and hides the passed/awaiting grade notices.

The fix resolves the quiz from the lesson meta with `Sensei_Lesson::get_quiz_id()` (the meta-first helper from #8121, with the previous query as fallback) at 12 call sites across `Sensei_Quiz`, `Sensei_Lesson`, `Sensei_Utils`, and the Course Theme notices, with the canonical comment used by the earlier fixes. Without a query-filtering plugin the resolution is unchanged.

## Testing Instructions

1. On a site with WPML active (English default, Spanish secondary) and this branch, create a course with one lesson and a quiz with one multiple choice question (right "blue", wrong "green"): automatic grading, "Allow retakes" ON, "Pass required" ON, passmark 50. Publish. Do not translate anything. Enroll a student.

2. As the student, take the quiz answering "blue" and submit: passed, 100%. As admin in English, open the submission in Sensei LMS → Grading, write custom feedback on the question, and Save.

3. Grading screen in Spanish: expire the read caches (`wp transient delete sensei_answers_{USER}_{LESSON}`, same for `quiz_grades_…` and `sensei_answers_feedback_…`), then open `/wp-admin/admin.php?page=sensei_grading&quiz_id={QUIZ}&user={USER}&lang=es` without loading any other page first. The student's answer and the saved feedback display. Before this branch, both were empty while the header still showed the total.

4. Students reset in Spanish: open `/wp-admin/admin.php?page=sensei_learners&course_id={COURSE}&lesson_id={LESSON}&view=learners&lang=es` and use Reset Progress on the student. The student's row switches to In Progress; in Sensei LMS → Grading (English admin) the student's graded submission is gone from the list; and as the student, the quiz page is blank again, with no previous answers and no grade. Before this branch, the reset only touched the lesson: the submission kept showing in Grading as graded 100%, and the student still saw their answers and grade.
 
5. As the student, retake and pass the quiz. As admin, duplicate the lesson to Spanish (WPML → Translation Management → Dashboard → select the lesson → Duplicate for Spanish), so the Spanish lesson points at the untranslated quiz.

6. As the student, open the English lesson page: it shows the "Quiz completed" notice with "Your Grade: 100%" and a "View quiz" link, and the lesson displays as completed. Now open the same lesson on the Spanish frontend (`/es/` URL or the language switcher): the exact same display. Before this branch, the Spanish page rendered as if the lesson had no quiz: no grade notice, no quiz link, and, before passing the quiz, a "Complete lesson" button that let the student complete the lesson without taking the required quiz.

7. Back in the Spanish Students screen, use Remove Progress on the student: the row disappears, and the student's submission no longer appears in Sensei LMS → Grading.

8. Deactivate WPML and run a normal take, grade, and reset cycle: everything behaves as before.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message
Fixed quiz answers, grades, resets, and lesson quiz surfaces breaking when the admin uses a secondary language or the lesson is translated on multilingual sites.

</details>