### PR TITLE
Convert lesson prerequisites to the target language when WPML copies them

### DIFF
--- a/changelog/fix-wpml-lesson-prerequisite-translation
+++ b/changelog/fix-wpml-lesson-prerequisite-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix lesson prerequisites pointing to the original-language lesson on WPML-translated lessons.

--- a/includes/wpml/class-custom-fields.php
+++ b/includes/wpml/class-custom-fields.php
@@ -31,6 +31,7 @@ class Custom_Fields {
 		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_course_prerequisite_before_copied' ), 10, 4 );
 		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_quiz_id_before_copied' ), 10, 4 );
 		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_course_woocommerce_product_before_copied' ), 10, 4 );
+		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_lesson_prerequisite_before_copied' ), 10, 4 );
 	}
 
 	/**
@@ -165,5 +166,37 @@ class Custom_Fields {
 		}
 
 		return $this->get_object_id( $product_id, 'product', false, $target_language_code );
+	}
+
+	/**
+	 * Update lesson prerequisite before copied.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param mixed  $copied_value Copied value.
+	 * @param int    $post_id_from Post ID from.
+	 * @param int    $post_id_to   Post ID to.
+	 * @param string $meta_key     Meta key.
+	 * @return mixed
+	 */
+	public function update_lesson_prerequisite_before_copied( $copied_value, $post_id_from, $post_id_to, $meta_key ) {
+		if ( '_lesson_prerequisite' !== $meta_key ) {
+			return $copied_value;
+		}
+
+		if ( empty( $copied_value ) ) {
+			return $copied_value;
+		}
+
+		$lesson_id = (int) $copied_value;
+
+		$target_language_code = $this->get_element_language_code( $post_id_to, 'lesson' );
+		if ( ! $target_language_code ) {
+			$target_language_code = $this->get_current_language();
+		}
+
+		return $this->get_object_id( $lesson_id, 'lesson', false, $target_language_code );
 	}
 }

--- a/tests/unit-tests/wpml/test-class-custom-fields.php
+++ b/tests/unit-tests/wpml/test-class-custom-fields.php
@@ -36,17 +36,17 @@ class Custom_Fields_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
 
-		$object_id_fitler = function () {
+		$object_id_filter = function () {
 			return 4;
 		};
-		add_filter( 'wpml_object_id', $object_id_fitler, 10, 0 );
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 0 );
 
 		/* Act. */
 		$actual = $custom_fields->update_course_prerequisite_before_copied( 1, 2, 3, '_course_prerequisite' );
 
 		/* Clean up & Assert. */
 		remove_filter( 'wpml_element_language_code', $language_code_filter );
-		remove_filter( 'wpml_object_id', $object_id_fitler );
+		remove_filter( 'wpml_object_id', $object_id_filter );
 		$this->assertSame( 4, $actual );
 	}
 
@@ -59,17 +59,17 @@ class Custom_Fields_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
 
-		$object_id_fitler = function () {
+		$object_id_filter = function () {
 			return 4;
 		};
-		add_filter( 'wpml_object_id', $object_id_fitler, 10, 0 );
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 0 );
 
 		/* Act. */
 		$actual = $custom_fields->update_lesson_course_before_copied( 1, 2, 3, '_lesson_course' );
 
 		/* Clean up & Assert. */
 		remove_filter( 'wpml_element_language_code', $language_code_filter );
-		remove_filter( 'wpml_object_id', $object_id_fitler );
+		remove_filter( 'wpml_object_id', $object_id_filter );
 
 		$this->assertSame( 4, $actual );
 	}
@@ -86,17 +86,41 @@ class Custom_Fields_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
 
-		$object_id_fitler = function () {
+		$object_id_filter = function () {
 			return 4;
 		};
-		add_filter( 'wpml_object_id', $object_id_fitler, 10, 0 );
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 0 );
 
 		/* Act. */
 		$actual = $custom_fields->update_quiz_id_before_copied( 1, $old_quistion_id, $new_question_id, '_quiz_id' );
 
 		/* Clean up & Assert. */
 		remove_filter( 'wpml_element_language_code', $language_code_filter );
-		remove_filter( 'wpml_object_id', $object_id_fitler );
+		remove_filter( 'wpml_object_id', $object_id_filter );
+
+		$this->assertSame( 4, $actual );
+	}
+
+	public function testUpdateLessonPrerequisiteBeforeCopied_WhenCalled_ReturnsMatchingPrerequisiteForNewLesson() {
+		/* Arrange. */
+		$custom_fields = new Custom_Fields();
+
+		$language_code_filter = function () {
+			return 'a';
+		};
+		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
+
+		$object_id_filter = function () {
+			return 4;
+		};
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 0 );
+
+		/* Act. */
+		$actual = $custom_fields->update_lesson_prerequisite_before_copied( 1, 2, 3, '_lesson_prerequisite' );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $language_code_filter );
+		remove_filter( 'wpml_object_id', $object_id_filter );
 
 		$this->assertSame( 4, $actual );
 	}
@@ -110,17 +134,17 @@ class Custom_Fields_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
 
-		$object_id_fitler = function () {
+		$object_id_filter = function () {
 			return 4;
 		};
-		add_filter( 'wpml_object_id', $object_id_fitler, 10, 0 );
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 0 );
 
 		/* Act. */
 		$actual = $custom_fields->update_course_woocommerce_product_before_copied( 1, 2, 3, '_course_woocommerce_product' );
 
 		/* Clean up & Assert. */
 		remove_filter( 'wpml_element_language_code', $language_code_filter );
-		remove_filter( 'wpml_object_id', $object_id_fitler );
+		remove_filter( 'wpml_object_id', $object_id_filter );
 
 		$this->assertSame( 4, $actual );
 	}


### PR DESCRIPTION
Part of [SEN-101](https://linear.app/a8c/issue/SEN-101/wpml-move-functions-from-wcml-class-to-sensei)

## Proposed Changes

When WPML copies lesson meta to a translation, `_lesson_prerequisite` kept the source-language lesson ID, so a translated lesson pointed at the original-language lesson as its prerequisite. On a translated course this breaks the prerequisite gating and the editor shows no prerequisite selected.

This adds the missing conversion to `Custom_Fields`, mirroring what `_lesson_course` and `_course_prerequisite` already do: when the field is copied, the ID is mapped to the lesson in the target language. If the prerequisite lesson has no translation yet, the field is left empty, consistent with the other converted fields.

## Testing Instructions

1. On a WPML site (English default, Spanish secondary), create a course with two lessons, "Lesson 1" and "Lesson 2", and set Lesson 1 as the prerequisite of Lesson 2 in the lesson settings. Publish everything.
2. Translate the course and both lessons to Spanish with the Advanced Translation Editor.
3. Open the Spanish "Lesson 2" in the editor and check the Prerequisite panel: it should show the Spanish "Lesson 1" selected.
4. Verify the meta directly: `wp post meta get <spanish-lesson-2-id> _lesson_prerequisite` should print the ID of the Spanish Lesson 1, not the English one. Before this fix it kept the English ID.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message
Fix lesson prerequisites pointing to the original-language lesson on WPML-translated lessons.

</details>