### PR TITLE
Move naming and unit test conventions into docs/conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,17 @@
 See `make help` for the full list of available dev commands.
 
+## Read before writing code
+- Writing or changing a **test**? Read `docs/conventions/unit-tests.md` first.
+- Writing a **class, hook, meta key, block, or stylesheet**? Read `docs/conventions/naming.md` first.
+
+Apply them to code you add. Do not rewrite surrounding code to match.
+
 ## Repository layout
 - `includes/` — main plugin PHP source.
 - `assets/` — JS/CSS source, blocks, and built artifacts under `assets/dist/`.
 - `tests/unit-tests/` — PHPUnit suite.
 - `tests/e2e-playwright/` — Playwright end-to-end suite (see "End-to-end" below).
+- `docs/conventions/` — the naming and unit test conventions this repo is reviewed against.
 - `changelog/` — per-PR changelog entries (created from the PR description's changelog checkbox, or via `make changelog`; see Conventions).
 - `config/scoper.inc.php` — php-scoper config used during the build.
 - `scripts/linter-ci` — the diff-based PHPCS runner used by `make lint` and CI.
@@ -31,10 +38,6 @@ See `make help` for the full list of available dev commands.
 - **JS unit tests**: `npm run test-js`.
 - **End-to-end (Playwright)**: `npm run test:e2e` runs headless against the wp-env stack; `npm run test:e2e:debug` runs headed. Requires `make up` to be running first. The `pretest:e2e` hook runs ESLint + `tsc` before Playwright launches — failures there appear before any test output. See `tests/e2e-playwright/README.md` for details.
 - **Ad-hoc UI verification**: After `make up`, the dev site is at `http://localhost:8888` with admin credentials `admin` / `password` (wp-env defaults). For agent-driven verification, use the `/e2e-testing` skill (`.claude/skills/e2e-testing/SKILL.md`) — it scopes from `git diff`, lists Sensei's admin/frontend surfaces, and walks the Chrome DevTools MCP through the relevant flow.
-- **Unit test conventions**: New PHPUnit tests should follow these (source: [Unit Tests Conventions](https://senseip2.wordpress.com/2022/03/17/unit-tests-conventions/), internal P2):
-  - **Arrange-Act-Assert**: Separate each test into Arrange (set up preconditions and inputs), Act (call the method under test), and Assert (verify the result), divided by blank lines. Extra blank lines within Arrange are fine for readability; mock expectations may be set immediately before Act (there is no way to set them afterward).
-  - **Naming**: Name tests `testMethodName_Conditions_Expectation` — `MethodName` is the method under test in PascalCase, `Conditions` describes the input/state (past-tense verb), `Expectation` is the expected result (present-tense verb, third person). Example: `testGetQuestionType_QuestionIdGiven_ReturnsMatchingType`. `MethodName` must be an actual method on the class under test, not a feature or behavior name.
-  - **One assertion per test**: A test should fail for exactly one reason. Prefer splitting into multiple tests over multiple assertions. When multiple assertions in one test are unavoidable, pass a message as the third argument to each (e.g., `self::assertSame( $expected, $actual, 'Foo should be updated.' );`) so a failure points to the specific check that failed.
 
 ## Linting
 - **PHPCS**: Run `make lint` (the same diff-based check CI uses; requires a clean working tree). Whole-codebase scans: `./vendor/bin/phpcs`.
@@ -47,6 +50,5 @@ See `make help` for the full list of available dev commands.
 - **PR milestones**: Every PR MUST have a milestone or CI (`pr-validation.yml`) fails. The `pull-request` skill assigns the next shipping milestone when it opens a PR.
 - **Version placeholders in docblocks**: Never hardcode a release number in `@since` tags for new code. Use `@since $$next-version$$` — release tooling replaces the placeholder on version bump.
 - **Coding standards**: Follow the WordPress coding standards for the language you're touching — [PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/), [HTML](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/). See **Linting** above for the enforcing commands; HTML has no linter, so apply that standard by hand.
-- **Naming conventions**: Follow Sensei's naming conventions (internal P2: P6rkRX-4oA-p2). Use "student", not "learner", in new identifiers and user-facing strings.
 - **Documenting hooks and functions**: Document new or updated actions/filters and public functions with docblocks (params, return, `@since` per the version-placeholder rule above). When a change adds or updates a hook, describe it and apply the `Hooks` label; when it deprecates code, name the replacement and apply the `Deprecation` label.
 - **Minimum supported versions**: Test changes against the minimum supported PHP (7.4) and WordPress (6.8), not only the latest — use the `make up WP=… PHP=…` override (see Development environment) before pushing anything version-sensitive.

--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -1,0 +1,135 @@
+# Naming Conventions
+
+## General
+
+### Tracks events
+
+Follow the data team's [Tracks Event Design & Naming Conventions](https://fieldguide.automattic.com/data-at-a8c/data-tools/tracks/tracks-for-developers-product-teams/tracks-naming-conventions/).
+
+### Student, not learner
+
+Use "student" in new identifiers, comments, and user-facing strings. "Learner" only survives in existing public APIs and database keys that cannot be renamed.
+
+## PHP
+
+### Hooks
+
+- Lowercase letters, words separated by underscores — not spaces or dashes.
+- Prefix with `sensei_`, then the context, then the thing:
+  - Filter: `sensei_course_pricing_description`, `sensei_course_archive_page_url`.
+  - Action: `sensei_extensions_header`, `sensei_course_results_before_lessons`.
+- Do not abbreviate unnecessarily. Hook names should be unambiguous and self-documenting.
+- **Never build hook names programmatically.** Hardcode them so they stay greppable.
+
+  ```php
+  // Bad — not searchable.
+  do_action( "sensei_{$post_type}_saved", $post_id );
+
+  // Good.
+  if ( 'course' === $post_type ) {
+      do_action( 'sensei_course_saved', $post_id );
+  }
+  ```
+
+### File naming
+
+Per the [WordPress PHP coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions): class file names are the class name with `class-` prepended and underscores replaced by hyphens.
+
+`WP_Error` → `class-wp-error.php`.
+
+### Class naming
+
+Global namespace (no `namespace` declared) → prefix the class with `Sensei_`, since there is no namespace keeping it from colliding with other plugins, themes, or core:
+
+```php
+// includes/class-sensei-course-theme-course-content.php
+class Sensei_Course_Theme_Course_Content { ... }
+```
+
+Namespaced → no prefix:
+
+```php
+// includes/course-theme/class-course-content.php
+namespace Sensei\Course_Theme;
+
+class Course_Content { ... }
+```
+
+### Abstract classes and interfaces
+
+Suffix with `_Abstract` and `_Interface` respectively: `Migration_Abstract`, `Course_Progress_Repository_Interface`.
+
+### Meta keys
+
+- Underscores between words.
+- Prefix with `sensei_`.
+- Private meta (not user-editable) starts with an underscore: `_sensei_email_description`.
+
+## JavaScript
+
+### Hooks
+
+- Lowercase.
+- Dotted, camelCase segments:
+  - Filter: `sensei.setupWizard.welcomeTitle`.
+  - Action: `sensei.courseOutline.clickHandler`.
+- Do not abbreviate unnecessarily; do not build hook names programmatically.
+
+### Block directory structure
+
+```
+assets/blocks/
+  [BLOCK_NAME]-block/            # the -block suffix marks block folders
+  [SUBCONTEXT]/                  # group of related blocks, e.g. course-outline
+    [BLOCK_NAME]-block/
+```
+
+### Block file naming
+
+| File | Purpose |
+| --- | --- |
+| `block.json` | Block metadata used in frontend and backend. |
+| `index.js` | Exports the block component object. |
+| `[BLOCK_NAME]-edit.js` | Block `edit` function. |
+| `[BLOCK_NAME]-save.js` | Block `save` function. |
+| `[BLOCK_NAME]-settings.js` | Settings component, instanced in the block's edit render. |
+| `[BLOCK_NAME]-frontend.js` | Script loaded only on the frontend, if needed. |
+| `[BLOCK_NAME].scss` | Styles for editor and frontend. |
+| `[BLOCK_NAME]-editor.scss` | Editor-only styles. |
+| `[BLOCK_NAME]-frontend.scss` | Frontend-only styles, if needed. |
+
+### Named vs. default export
+
+When the export is the main purpose of the file, make it the default export, and match the exported function's name to the filename (or to the folder name for `index.js`).
+
+### Import ordering
+
+```js
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { getBlockDefaultClassName } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { getButtonProps, getButtonWrapperProps } from './button-props';
+```
+
+## CSS
+
+[BEM](https://getbem.com/naming/), with these caveats:
+
+- Prefix every class with `sensei` to avoid collisions with other plugins, themes, and core.
+- Block classes are prefixed `.wp-block-sensei-[block-name]` (e.g. `wp-block-sensei-course-outline`).
+- Sort properties alphabetically.
+
+## Tests
+
+See [unit-tests.md](unit-tests.md).

--- a/docs/conventions/unit-tests.md
+++ b/docs/conventions/unit-tests.md
@@ -1,0 +1,59 @@
+# Unit Test Conventions
+
+## 1. Arrange-Act-Assert
+
+Group each test into three sections separated by blank lines:
+
+- **Arrange** — set up all preconditions and inputs.
+- **Act** — call the method under test.
+- **Assert** — verify the expected result.
+
+Allowances:
+
+- Extra blank lines inside Arrange are fine when the setup is long.
+- Mock expectations (`->expects( ... )`) may be set immediately before Act, since there is no way to set them afterwards.
+
+```php
+public function testLessonHasQuizWithGradedQuestions_LessonWithNoQuiz_ReturnsFalse() {
+    $lesson_id = $this->factory->get_lesson_no_quiz();
+
+    $actual = Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson_id );
+
+    $this->assertFalse( $actual );
+}
+```
+
+## 2. Naming
+
+```
+testMethodName_Conditions_Expectation
+```
+
+- `test` — required prefix.
+- `MethodName` — the method or function under test, in PascalCase. It must be a **real method on the class under test**, not a feature or behaviour name.
+- `Conditions` — the specific input or state being exercised. Verb in past tense.
+- `Expectation` — what the method is expected to return or do. Verb in present tense, third person.
+
+Examples:
+
+- `testGetLoggedEvents_TheOnlyEventExistsAndEventNameGiven_ReturnsSingleEvent`
+- `testGetQuestionType_QuestionIdGiven_ReturnsMatchingType`
+- `testGetStatusAt_MicrotimeGiven_ReturnsMatchingStatus`
+- `testLessonHasQuizWithGradedQuestions_LessonWithoutGradedQuestionsGiven_ReturnsFalse`
+
+Names get long. That is the accepted trade-off: the reader gets the full context (what, under which circumstances, expecting what) without reading the body, and a reviewer can spot an expectation that does not match the assertion.
+
+## 3. One assertion per test
+
+A test should fail for exactly one reason. The run stops at the first failed assertion, which obscures what the test was actually for.
+
+- Prefer splitting into multiple tests over asserting multiple things.
+- When multiple assertions are genuinely unavoidable, pass a message as the third argument so a failure points at the specific check:
+
+  ```php
+  self::assertSame( $expected, $actual, 'Course progress should be updated.' );
+  ```
+
+When splitting, check what each assertion is actually verifying. An assertion that only confirms the fixture was built correctly — `assertEquals( '1', get_post_meta( $lesson_id, '_lesson_preview', true ) )` right after the factory created that lesson — tests the factory, not the class under test. Delete it; do not give it its own test.
+
+Trade-off: more tests and more copy-paste in setup. Accepted — the tests become clearer and fail for one reason.


### PR DESCRIPTION
## Proposed Changes

AGENTS.md pointed at an internal P2 for Sensei's naming conventions. That link can't be opened from the repo, so the rules were effectively invisible — which is part of why PRs keep missing them.

The rules now live in the repo:

* `docs/conventions/naming.md` — hooks, classes and files, meta keys, blocks, CSS, student-not-learner.
* `docs/conventions/unit-tests.md` — test naming, Arrange-Act-Assert, one assertion per test.

AGENTS.md gets a short "Read before writing code" section at the top pointing at both, and drops the partial copies of these rules it used to carry, so each rule is written down once.

The Field Guide link is internal, but I'm OK with that since 3PD shouldn't be adding Tracks events.

## Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

#### Type

#### Message

</details>
