### PR TITLE
Restore JS hook conventions from the source spec

### DIFF
--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -69,10 +69,9 @@ Suffix with `_Abstract` and `_Interface` respectively: `Migration_Abstract`, `Co
 
 ### Hooks
 
-- Lowercase.
-- Dotted, camelCase segments:
+- Dotted segments, camelCase — PascalCase when a segment names a component, as core does in `editor.BlockEdit`:
   - Filter: `sensei.setupWizard.welcomeTitle`.
-  - Action: `sensei.courseOutline.clickHandler`.
+  - Action: `sensei.videoProgression.videoEnded`.
 - Do not abbreviate unnecessarily; do not build hook names programmatically.
 
 ### Block directory structure

--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -69,9 +69,11 @@ Suffix with `_Abstract` and `_Interface` respectively: `Migration_Abstract`, `Co
 
 ### Hooks
 
-- Dotted segments, camelCase — PascalCase when a segment names a component, as core does in `editor.BlockEdit`:
+- Dotted segments: the `sensei` root, then the context, then the thing.
+- Segments are camelCase, except one naming a component, which keeps the component's PascalCase name:
   - Filter: `sensei.setupWizard.welcomeTitle`.
   - Action: `sensei.videoProgression.videoEnded`.
+  - Component: `sensei.QuizAppender.controls`.
 - Do not abbreviate unnecessarily; do not build hook names programmatically.
 
 ### Block directory structure

--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -73,7 +73,6 @@ Suffix with `_Abstract` and `_Interface` respectively: `Migration_Abstract`, `Co
 - Segments are camelCase:
   - Filter: `sensei.setupWizard.welcomeTitle`.
   - Action: `sensei.videoProgression.videoEnded`.
-- A segment naming a component keeps the component's PascalCase name: `sensei.QuizAppender.controls`.
 - Do not abbreviate unnecessarily; do not build hook names programmatically.
 
 ### Block directory structure

--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -70,10 +70,10 @@ Suffix with `_Abstract` and `_Interface` respectively: `Migration_Abstract`, `Co
 ### Hooks
 
 - Dotted segments: the `sensei` root, then the context, then the thing.
-- Segments are camelCase, except one naming a component, which keeps the component's PascalCase name:
+- Segments are camelCase:
   - Filter: `sensei.setupWizard.welcomeTitle`.
   - Action: `sensei.videoProgression.videoEnded`.
-  - Component: `sensei.QuizAppender.controls`.
+- A segment naming a component keeps the component's PascalCase name: `sensei.QuizAppender.controls`.
 - Do not abbreviate unnecessarily; do not build hook names programmatically.
 
 ### Block directory structure

--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -69,11 +69,12 @@ Suffix with `_Abstract` and `_Interface` respectively: `Migration_Abstract`, `Co
 
 ### Hooks
 
-- Dotted segments: the `sensei` root, then the context, then the thing.
-- Segments are camelCase:
-  - Filter: `sensei.setupWizard.welcomeTitle`.
-  - Action: `sensei.videoProgression.videoEnded`.
-- Do not abbreviate unnecessarily; do not build hook names programmatically.
+- Use lowercase letters.
+- Hook names take the form:
+  - Filter — `<pluginName>.<screenOrFunctionalArea>.<optionalContext>.<dataToFilter>`. For example, `sensei.setupWizard.welcomeTitle`.
+  - Action — `<pluginName>.<screenOrFunctionalArea>.<optionalVerb>.<element>`. For example, `sensei.courseOutline.clickHandler`.
+- Do not abbreviate unnecessarily. Let hook names be unambiguous and self-documenting.
+- Do not programmatically create hook names. They should be hardcoded so they are easily searchable in the code base.
 
 ### Block directory structure
 


### PR DESCRIPTION
`docs/conventions/naming.md`'s JavaScript Hooks section had been condensed from the conventions P2 and lost the filter and action name templates along the way. This restores them verbatim:

- Filter — `<pluginName>.<screenOrFunctionalArea>.<optionalContext>.<dataToFilter>`
- Action — `<pluginName>.<screenOrFunctionalArea>.<optionalVerb>.<element>`

The lowercase, no-abbreviation, and no-programmatic-names rules are restored to the spec's wording too.

Sensei Pro is getting the same section with `senseiPro` as the plugin name (Automattic/sensei-pro#2723), so both plugins document the same convention.

Docs only, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)