### PR TITLE
Fix Show Template course layouts and remove the legacy template warning

### DIFF
--- a/assets/admin/editor-wizard/helpers.js
+++ b/assets/admin/editor-wizard/helpers.js
@@ -2,8 +2,14 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { applyFilters } from '@wordpress/hooks';
 
@@ -11,6 +17,65 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { EXTENSIONS_STORE } from '../../extensions/store';
+
+const SENSEI_POST_CONTENT_BLOCK_TYPE = 'sensei-lms/post-content';
+
+/**
+ * Filter and prepare the patterns used by the Sensei editor wizard.
+ *
+ * @param {Object[]} patterns Block patterns.
+ *
+ * @return {Object[]} Sensei block patterns with parsed blocks.
+ */
+export const getSenseiPatterns = ( patterns = [] ) =>
+	patterns
+		.filter( ( { blockTypes } ) =>
+			blockTypes?.includes( SENSEI_POST_CONTENT_BLOCK_TYPE )
+		)
+		// A pattern can appear in both editor settings and the REST response.
+		.filter(
+			( pattern, index, allPatterns ) =>
+				index ===
+				allPatterns.findIndex(
+					( candidate ) => candidate.name === pattern.name
+				)
+		)
+		.map( ( pattern ) => ( {
+			...pattern,
+			// REST patterns contain markup, while editor patterns may already have parsed blocks.
+			blocks:
+				pattern.blocks ||
+				parse( pattern.content || '', {
+					__unstableSkipMigrationLogs: true,
+				} ),
+		} ) );
+
+/**
+ * Get the Sensei patterns without filtering them through the active editor canvas.
+ *
+ * @return {Object[]} Sensei block patterns with parsed blocks.
+ */
+export const useSenseiPatterns = () => {
+	const { editorPatterns, registeredPatterns } = useSelect( ( select ) => {
+		const editorSettings = select( editorStore ).getEditorSettings() || {};
+
+		return {
+			// Include client-added patterns that may not be registered on the server.
+			editorPatterns:
+				editorSettings.__experimentalAdditionalBlockPatterns ||
+				editorSettings.__experimentalBlockPatterns ||
+				[],
+			// Unlike the block editor selector, core data does not apply the active canvas's insertion rules.
+			registeredPatterns: select( coreStore ).getBlockPatterns() || [],
+		};
+	}, [] );
+
+	return useMemo(
+		// Put editor patterns first so client-side versions win during deduplication.
+		() => getSenseiPatterns( [ ...editorPatterns, ...registeredPatterns ] ),
+		[ editorPatterns, registeredPatterns ]
+	);
+};
 
 /**
  * Update blocks content, replacing the placeholders with a content.
@@ -100,6 +165,19 @@ export const useWizardOpenState = () => {
 };
 
 /**
+ * Hook to replace the blocks belonging to the current post.
+ *
+ * @return {Function} Function to replace the current post blocks.
+ */
+export const useSetPostBlocks = () => {
+	const { resetEditorBlocks } = useDispatch( editorStore );
+
+	return ( blocks ) => {
+		resetEditorBlocks( blocks );
+	};
+};
+
+/**
  * Hook to set the default post pattern with replaced content.
  *
  * @param {Object} replaces Object containing content to be replaced. The keys are the block classNames to find. The values are the content to be replaced.
@@ -107,19 +185,15 @@ export const useWizardOpenState = () => {
  * @return {Function} Function to set the default pattern.
  */
 export const useSetDefaultPattern = ( replaces ) => {
-	const { patterns } = useSelect( ( select ) => ( {
-		patterns:
-			select( blockEditorStore )?.getPatternsByBlockTypes(
-				'sensei-lms/post-content'
-			) ||
-			select( blockEditorStore ).__experimentalGetPatternsByBlockTypes(
-				'sensei-lms/post-content'
-			),
-	} ) );
-	const { template } = useSelect( ( select ) => ( {
-		template: select( blockEditorStore ).getTemplate(),
-	} ) );
-	const { resetBlocks } = useDispatch( blockEditorStore );
+	const patterns = useSenseiPatterns();
+	const { template } = useSelect( ( select ) => {
+		const postType = select( editorStore ).getCurrentPostType();
+
+		return {
+			template: select( coreStore ).getPostType( postType )?.template,
+		};
+	} );
+	const setPostBlocks = useSetPostBlocks();
 
 	// Get the default pattern based on what's set in the template.
 	const pattern = patterns.find(
@@ -133,7 +207,7 @@ export const useSetDefaultPattern = ( replaces ) => {
 		}
 
 		const replacedBlocks = replacePlaceholders( pattern.blocks, replaces );
-		resetBlocks( replacedBlocks );
+		setPostBlocks( replacedBlocks );
 	};
 };
 

--- a/assets/admin/editor-wizard/helpers.test.js
+++ b/assets/admin/editor-wizard/helpers.test.js
@@ -1,12 +1,31 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, renderHook, fireEvent, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { parse } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import { replacePlaceholders, useWizardOpenState } from './helpers';
+import {
+	getSenseiPatterns,
+	replacePlaceholders,
+	useSetDefaultPattern,
+	useWizardOpenState,
+} from './helpers';
+
+jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/blocks', () => ( {
+	...jest.requireActual( '@wordpress/blocks' ),
+	parse: jest.fn(),
+} ) );
 
 describe( 'replacePlaceholders', () => {
 	const replaces = {
@@ -73,6 +92,108 @@ describe( 'replacePlaceholders', () => {
 		const newBlocks = replacePlaceholders( blocks, replaces );
 
 		expect( newBlocks ).toEqual( expectedBlocks );
+	} );
+} );
+
+describe( 'getSenseiPatterns', () => {
+	beforeEach( () => {
+		parse.mockReset();
+	} );
+
+	it( 'Should filter Sensei patterns and parse serialized content', () => {
+		const parsedBlocks = [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Course content' },
+			},
+		];
+		parse.mockReturnValue( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Course content' },
+			},
+		] );
+		const patterns = getSenseiPatterns( [
+			{
+				name: 'sensei-lms/course-default',
+				blockTypes: [ 'sensei-lms/post-content' ],
+				content: '<!-- wp:paragraph {"content":"Course content"} /-->',
+			},
+			{
+				name: 'core/query-standard-posts',
+				blockTypes: [ 'core/query' ],
+				content: '<!-- wp:query /-->',
+			},
+		] );
+
+		expect( patterns ).toHaveLength( 1 );
+		expect( patterns[ 0 ].name ).toBe( 'sensei-lms/course-default' );
+		expect( patterns[ 0 ].blocks ).toEqual( parsedBlocks );
+		expect( parse ).toHaveBeenCalledWith(
+			'<!-- wp:paragraph {"content":"Course content"} /-->',
+			{ __unstableSkipMigrationLogs: true }
+		);
+	} );
+
+	it( 'Should prefer the first version of a duplicate pattern', () => {
+		const editorBlocks = [ { name: 'core/paragraph' } ];
+		const patterns = getSenseiPatterns( [
+			{
+				name: 'sensei-lms/course-default',
+				blockTypes: [ 'sensei-lms/post-content' ],
+				blocks: editorBlocks,
+			},
+			{
+				name: 'sensei-lms/course-default',
+				blockTypes: [ 'sensei-lms/post-content' ],
+				content: '<!-- wp:paragraph /-->',
+			},
+		] );
+
+		expect( patterns ).toHaveLength( 1 );
+		expect( patterns[ 0 ].blocks ).toBe( editorBlocks );
+		expect( parse ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useSetDefaultPattern', () => {
+	it( 'Should use the post type template when setting the default pattern', () => {
+		const blocks = [ { name: 'core/paragraph', attributes: {} } ];
+		parse.mockReturnValue( blocks );
+		const resetEditorBlocks = jest.fn();
+		const getBlockPatterns = jest.fn( () => [
+			{
+				name: 'sensei-lms/course-default',
+				blockTypes: [ 'sensei-lms/post-content' ],
+				content: '<!-- wp:paragraph /-->',
+			},
+		] );
+		const getCurrentPostType = jest.fn( () => 'course' );
+		const getEditorSettings = jest.fn( () => ( {} ) );
+		const getPostType = jest.fn( () => ( {
+			template: [
+				[ 'core/pattern', { slug: 'sensei-lms/course-default' } ],
+			],
+		} ) );
+		useSelect.mockImplementation( ( callback ) =>
+			callback( ( store ) => {
+				if ( coreStore === store ) {
+					return { getBlockPatterns, getPostType };
+				}
+
+				if ( editorStore === store ) {
+					return { getCurrentPostType, getEditorSettings };
+				}
+			} )
+		);
+		useDispatch.mockReturnValue( { resetEditorBlocks } );
+		const { result } = renderHook( () => useSetDefaultPattern( {} ) );
+
+		result.current();
+
+		expect( resetEditorBlocks ).toHaveBeenCalledWith( [
+			expect.objectContaining( { name: 'core/paragraph' } ),
+		] );
 	} );
 } );
 

--- a/assets/admin/editor-wizard/patterns-list.js
+++ b/assets/admin/editor-wizard/patterns-list.js
@@ -1,16 +1,17 @@
 /**
  * WordPress dependencies
  */
-import {
-	store as blockEditorStore,
-	BlockPreview,
-} from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { BlockPreview } from '@wordpress/block-editor';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { getBlockType, getBlockFromExample } from '@wordpress/blocks';
 import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSenseiPatterns } from './helpers';
 
 /**
  * It returns events to fire the click event on click, pressing enter, and pressing space.
@@ -92,15 +93,7 @@ const NoPatternsWarning = () => {
  * @param {Function} props.onChoose          Callback on choosing a pattern.
  */
 const PatternsList = ( { patternsToExclude = [], onChoose } ) => {
-	const { patterns } = useSelect( ( select ) => ( {
-		patterns:
-			select( blockEditorStore )?.getPatternsByBlockTypes(
-				'sensei-lms/post-content'
-			) ||
-			select( blockEditorStore ).__experimentalGetPatternsByBlockTypes(
-				'sensei-lms/post-content'
-			),
-	} ) );
+	const patterns = useSenseiPatterns();
 
 	const patternFilter = useCallback(
 		( { name, categories } ) => {

--- a/assets/admin/editor-wizard/patterns-list.test.js
+++ b/assets/admin/editor-wizard/patterns-list.test.js
@@ -2,12 +2,15 @@
  * External dependencies
  */
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
+import { parse } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -15,12 +18,36 @@ import { useSelect } from '@wordpress/data';
 import PatternsList from './patterns-list';
 
 jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	BlockPreview: () => null,
+} ) );
+jest.mock( '@wordpress/blocks', () => ( {
+	...jest.requireActual( '@wordpress/blocks' ),
+	parse: jest.fn(),
+} ) );
 
 describe( '<PatternsList />', () => {
+	const mockPatternSelectors = ( registeredPatterns = [] ) => {
+		const getBlockPatterns = jest.fn( () => registeredPatterns );
+
+		useSelect.mockImplementation( ( callback ) =>
+			callback( ( store ) => {
+				if ( coreStore === store ) {
+					return { getBlockPatterns };
+				}
+
+				if ( editorStore === store ) {
+					return { getEditorSettings: () => ( {} ) };
+				}
+			} )
+		);
+
+		return getBlockPatterns;
+	};
+
 	it( 'Should show warning when no layouts available.', () => {
-		useSelect.mockReturnValue( {
-			patterns: [],
-		} );
+		mockPatternSelectors();
 
 		const { queryByText } = render(
 			<PatternsList onChoose={ () => {} } />
@@ -29,5 +56,33 @@ describe( '<PatternsList />', () => {
 		expect(
 			queryByText( 'No layouts available for this theme.' )
 		).toBeVisible();
+	} );
+
+	it( 'Should load and select layouts from registered pattern data', () => {
+		const blocks = [ { name: 'core/paragraph', attributes: {} } ];
+		parse.mockReturnValue( blocks );
+		const getBlockPatterns = mockPatternSelectors( [
+			{
+				name: 'sensei-lms/course-default',
+				title: 'Default Course',
+				categories: [ 'sensei-lms' ],
+				blockTypes: [ 'sensei-lms/post-content' ],
+				content: '<!-- wp:paragraph /-->',
+			},
+		] );
+		const onChoose = jest.fn();
+
+		const { queryByText } = render(
+			<PatternsList onChoose={ onChoose } />
+		);
+
+		fireEvent.click( queryByText( 'Default Course' ) );
+
+		expect( getBlockPatterns ).toHaveBeenCalled();
+		expect( onChoose ).toHaveBeenCalledWith(
+			blocks,
+			'sensei-lms/course-default',
+			undefined
+		);
 	} );
 } );

--- a/assets/admin/editor-wizard/patterns-list.test.js
+++ b/assets/admin/editor-wizard/patterns-list.test.js
@@ -72,11 +72,9 @@ describe( '<PatternsList />', () => {
 		] );
 		const onChoose = jest.fn();
 
-		const { queryByText } = render(
-			<PatternsList onChoose={ onChoose } />
-		);
+		const { getByText } = render( <PatternsList onChoose={ onChoose } /> );
 
-		fireEvent.click( queryByText( 'Default Course' ) );
+		fireEvent.click( getByText( 'Default Course' ) );
 
 		expect( getBlockPatterns ).toHaveBeenCalled();
 		expect( onChoose ).toHaveBeenCalledWith(

--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 
@@ -71,9 +70,7 @@ export const hasSomeBlocks = ( blocksToFind, blocks = [] ) =>
 
 /**
  * Start blocks toggling control.
- * It controls the metaboxes and a notice if the page will
- * render differently (legacy template or blocks) after
- * saving the post.
+ * It controls the metaboxes based on the blocks in the editor.
  *
  * @param {string} postType Current post type.
  */
@@ -81,8 +78,6 @@ export const startBlocksTogglingControl = ( postType ) => {
 	if ( ! editorSelector ) {
 		return;
 	}
-
-	const { createWarningNotice, removeNotice } = dispatch( 'core/notices' );
 
 	let lastBlocks;
 
@@ -94,19 +89,9 @@ export const startBlocksTogglingControl = ( postType ) => {
 			if ( newBlocks !== lastBlocks ) {
 				lastBlocks = newBlocks;
 				toggleLegacyMetaboxes();
-				toggleLegacyOrBlocksNotice();
 			}
 		},
 	} );
-
-	/**
-	 * Check whether it has Sensei blocks.
-	 */
-	const hasSenseiBlocks = () =>
-		hasSomeBlocks(
-			Object.values( SENSEI_BLOCKS[ postType ] ),
-			editorSelector.getEditorBlocks()
-		);
 
 	/**
 	 * Toggle metaboxes if a replacement block is present or not.
@@ -143,36 +128,5 @@ export const startBlocksTogglingControl = ( postType ) => {
 			} );
 	};
 
-	/**
-	 * Show a warning notice when changing to a state where it
-	 * will start using the legacy template or the blocks.
-	 */
-	const toggleLegacyOrBlocksNotice = () => {
-		const withSenseiBlocks = hasSenseiBlocks();
-		const courseThemeEnabled = window?.sensei?.courseThemeEnabled;
-
-		if ( withSenseiBlocks || courseThemeEnabled ) {
-			removeNotice( 'sensei-using-template' );
-		} else {
-			createWarningNotice(
-				__(
-					"It looks like this course page doesn't have any Sensei blocks. This means that content will be handled by custom templates.",
-					'sensei-lms'
-				),
-				{
-					id: 'sensei-using-template',
-					isDismissible: true,
-					actions: [
-						{
-							label: __( 'Learn more', 'sensei-lms' ),
-							url: 'https://senseilms.com/documentation/course-page-blocks/',
-						},
-					],
-				}
-			);
-		}
-	};
-
 	toggleLegacyMetaboxes();
-	toggleLegacyOrBlocksNotice();
 };

--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -97,12 +97,11 @@ export const startBlocksTogglingControl = ( postType ) => {
 	 * Toggle metaboxes if a replacement block is present or not.
 	 */
 	const toggleLegacyMetaboxes = () => {
+		const blocks = editorSelector.getEditorBlocks();
+
 		Object.entries( metaboxReplacements[ postType ] ).forEach(
 			( [ metaboxName, blockDeps ] ) => {
-				const enable = ! hasSomeBlocks(
-					blockDeps,
-					editorSelector.getEditorBlocks()
-				);
+				const enable = ! hasSomeBlocks( blockDeps, blocks );
 				if ( enable !== isEditorPanelEnabled( metaboxName ) ) {
 					toggleEditorPanelEnabled( metaboxName );
 				}

--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -3,7 +3,6 @@
  */
 import { select, dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 
@@ -42,7 +41,6 @@ const metaboxReplacements = {
 };
 
 // WordPress data.
-const blockEditorSelector = select( blockEditorStore );
 const editorSelector = select( editorStore );
 const editorDispatcher = dispatch( editorStore );
 const editPostSelector = select( editPostStore );
@@ -57,6 +55,21 @@ const toggleEditorPanelEnabled = editorDispatcher.toggleEditorPanelEnabled
 	: editPostDispatcher.toggleEditorPanelEnabled;
 
 /**
+ * Check whether a block tree contains at least one of the given block types.
+ *
+ * @param {string[]} blocksToFind Block types to find.
+ * @param {Object[]} blocks       Blocks to search.
+ *
+ * @return {boolean} Whether the block tree contains a matching block.
+ */
+export const hasSomeBlocks = ( blocksToFind, blocks = [] ) =>
+	blocks.some(
+		( block ) =>
+			blocksToFind.includes( block.name ) ||
+			hasSomeBlocks( blocksToFind, block.innerBlocks ?? [] )
+	);
+
+/**
  * Start blocks toggling control.
  * It controls the metaboxes and a notice if the page will
  * render differently (legacy template or blocks) after
@@ -65,7 +78,7 @@ const toggleEditorPanelEnabled = editorDispatcher.toggleEditorPanelEnabled
  * @param {string} postType Current post type.
  */
 export const startBlocksTogglingControl = ( postType ) => {
-	if ( ! blockEditorSelector ) {
+	if ( ! editorSelector ) {
 		return;
 	}
 
@@ -75,7 +88,7 @@ export const startBlocksTogglingControl = ( postType ) => {
 
 	editorLifecycle( {
 		subscribeListener: () => {
-			const newBlocks = blockEditorSelector.getBlocks();
+			const newBlocks = editorSelector.getEditorBlocks();
 
 			// Check if blocks were changed.
 			if ( newBlocks !== lastBlocks ) {
@@ -90,7 +103,10 @@ export const startBlocksTogglingControl = ( postType ) => {
 	 * Check whether it has Sensei blocks.
 	 */
 	const hasSenseiBlocks = () =>
-		hasSomeBlocks( Object.values( SENSEI_BLOCKS[ postType ] ) );
+		hasSomeBlocks(
+			Object.values( SENSEI_BLOCKS[ postType ] ),
+			editorSelector.getEditorBlocks()
+		);
 
 	/**
 	 * Toggle metaboxes if a replacement block is present or not.
@@ -98,7 +114,10 @@ export const startBlocksTogglingControl = ( postType ) => {
 	const toggleLegacyMetaboxes = () => {
 		Object.entries( metaboxReplacements[ postType ] ).forEach(
 			( [ metaboxName, blockDeps ] ) => {
-				const enable = ! hasSomeBlocks( blockDeps );
+				const enable = ! hasSomeBlocks(
+					blockDeps,
+					editorSelector.getEditorBlocks()
+				);
 				if ( enable !== isEditorPanelEnabled( metaboxName ) ) {
 					toggleEditorPanelEnabled( metaboxName );
 				}
@@ -146,8 +165,7 @@ export const startBlocksTogglingControl = ( postType ) => {
 					actions: [
 						{
 							label: __( 'Learn more', 'sensei-lms' ),
-							url:
-								'https://senseilms.com/documentation/course-page-blocks/',
+							url: 'https://senseilms.com/documentation/course-page-blocks/',
 						},
 					],
 				}
@@ -155,16 +173,6 @@ export const startBlocksTogglingControl = ( postType ) => {
 		}
 	};
 
-	/**
-	 * Check whether it has at least one block.
-	 *
-	 * @param {string[]} blocks Blocks to check.
-	 *
-	 * @return {boolean} Whether it has at least one block.
-	 */
-	const hasSomeBlocks = ( blocks ) =>
-		blocks.some(
-			( blockName ) =>
-				blockEditorSelector.getGlobalBlockCount( blockName ) > 0
-		);
+	toggleLegacyMetaboxes();
+	toggleLegacyOrBlocksNotice();
 };

--- a/assets/js/admin/blocks-toggling-control.test.js
+++ b/assets/js/admin/blocks-toggling-control.test.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import { hasSomeBlocks } from './blocks-toggling-control';
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( () => ( {} ) ),
+	select: jest.fn( () => ( {} ) ),
+} ) );
+
+describe( 'hasSomeBlocks', () => {
+	it( 'Should find a matching nested block', () => {
+		const blocks = [
+			{
+				name: 'core/group',
+				innerBlocks: [ { name: 'sensei-lms/course-progress' } ],
+			},
+		];
+
+		const result = hasSomeBlocks(
+			[ 'sensei-lms/course-progress' ],
+			blocks
+		);
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'Should return false when no matching block exists', () => {
+		const blocks = [ { name: 'core/paragraph' } ];
+
+		const result = hasSomeBlocks(
+			[ 'sensei-lms/course-progress' ],
+			blocks
+		);
+
+		expect( result ).toBe( false );
+	} );
+} );

--- a/changelog/fix-show-template-editor-wizard
+++ b/changelog/fix-show-template-editor-wizard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix course layouts and Sensei blocks not loading when Show template is enabled.


### PR DESCRIPTION
Resolves [SEN-109](https://linear.app/a8c/issue/SEN-109/show-template-enabled-breaks-sensei-block-loading-no-sensei-blocks).
Fixes https://github.com/Automattic/sensei/issues/8103.

## Proposed Changes

- Load Sensei patterns independently of the active block-editor canvas.
- Share the same pattern-loading logic between the layout picker and default-layout insertion.
- Use the post type’s registered template to determine the default pattern.
- Reset the complete post content through the editor store.
- Detect nested Sensei blocks from the complete editor block tree when toggling legacy metaboxes.
- Remove the “It looks like this course page doesn’t have any Sensei blocks” notice.
- Add regression tests for pattern loading, parsing, deduplication, layout selection, default-layout insertion, and nested block detection.

### Root cause

With **Show template** enabled, WordPress scopes `core/block-editor` selectors to the active template canvas. Sensei used those selectors to find patterns, insert the default layout, and detect Sensei blocks.

As a result, the wizard could receive no layouts, default blocks could fail to load, and nested Sensei blocks could be missed.

The fix uses canvas-independent pattern data from `core-data` and complete post content from the editor store.

## Testing Instructions

- [x] Open an existing course. In the Course settings sidebar, find **Template**, open **Template options**, and select **Show template**.
- [x] Navigate to **Courses → New Course**.
- [x] Enter a course title and description, then click **Continue**.
- [x] Confirm that Course Default, Video Hero, Long Sales Page, and Life Coach appear.
- [x] Select a layout and confirm its blocks are added to the course.
- [x] Repeat the flow, but close the wizard after entering a title and description.
- [x] Confirm that the default layout is added and contains the entered description.
- [x] Start with a blank canvas or remove all Sensei blocks, then confirm the “It looks like this course page…” notice is not displayed.