### PR TITLE
Stop passing a null answer into the multi-line question editor

### DIFF
--- a/changelog/fix-null-content-deprecation-multi-line-question
+++ b/changelog/fix-null-content-deprecation-multi-line-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.1 deprecation notices rendered into the quiz page for unanswered Multi Line questions.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -321,8 +321,7 @@ class Sensei_Utils {
 	 */
 	public static function sensei_text_editor( $content = '', $editor_id = 'senseitexteditor', $input_name = '' ) {
 
-		// Callers pass a stored answer straight through, and that is null while the question is unanswered.
-		// Only null is normalised, so any other unexpected type still fails loudly.
+		// Normalise the null of an unsaved answer, which raises a PHP 8.1+ deprecation in wp_editor().
 		$content = $content ?? '';
 
 		if ( ! $input_name ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -314,12 +314,15 @@ class Sensei_Utils {
 	/**
 	 * Load the WordPress rich text editor
 	 *
-	 * @param  string $content    Initial content for editor
-	 * @param  string $editor_id  ID of editor (only lower case characters - no spaces, underscores, hyphens, etc.)
-	 * @param  string $input_name Name for text area form element
+	 * @param  string|null $content    Initial content for editor. Null is treated as empty.
+	 * @param  string      $editor_id  ID of editor (only lower case characters - no spaces, underscores, hyphens, etc.)
+	 * @param  string      $input_name Name for text area form element
 	 * @return void
 	 */
 	public static function sensei_text_editor( $content = '', $editor_id = 'senseitexteditor', $input_name = '' ) {
+
+		// Callers pass a stored answer straight through, and that is null while the question is unanswered.
+		$content = (string) $content;
 
 		if ( ! $input_name ) {
 			$input_name = $editor_id;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -322,7 +322,8 @@ class Sensei_Utils {
 	public static function sensei_text_editor( $content = '', $editor_id = 'senseitexteditor', $input_name = '' ) {
 
 		// Callers pass a stored answer straight through, and that is null while the question is unanswered.
-		$content = (string) $content;
+		// Only null is normalised, so any other unexpected type still fails loudly.
+		$content = $content ?? '';
 
 		if ( ! $input_name ) {
 			$input_name = $editor_id;

--- a/templates/single-quiz/question-type-multi-line.php
+++ b/templates/single-quiz/question-type-multi-line.php
@@ -25,7 +25,7 @@ $sensei_is_quiz_view_only_mode = $question_data['quiz_is_completed'] || ! Sensei
 if ( $sensei_is_quiz_view_only_mode ) {
 	?>
 	<div class="wp-block-sensei-lms-question-answers__answer">
-		<?php echo wp_kses_post( $question_data['user_answer_entry'] ); ?>
+		<?php echo wp_kses_post( (string) $question_data['user_answer_entry'] ); ?>
 	</div>
 	<?php
 } else {

--- a/templates/single-quiz/question-type-multi-line.php
+++ b/templates/single-quiz/question-type-multi-line.php
@@ -25,7 +25,7 @@ $sensei_is_quiz_view_only_mode = $question_data['quiz_is_completed'] || ! Sensei
 if ( $sensei_is_quiz_view_only_mode ) {
 	?>
 	<div class="wp-block-sensei-lms-question-answers__answer">
-		<?php echo wp_kses_post( (string) $question_data['user_answer_entry'] ); ?>
+		<?php echo wp_kses_post( $question_data['user_answer_entry'] ?? '' ); ?>
 	</div>
 	<?php
 } else {

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -683,4 +683,29 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 'in-progress', $previous_status );
 	}
+
+	public function testSenseiTextEditor_NullContentGiven_DoesNotTriggerADeprecation(): void {
+		/* Arrange. */
+		$deprecations = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- The deprecation is only observable through an error handler.
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$deprecations ) {
+				$deprecations[] = $errstr;
+				return true;
+			},
+			E_DEPRECATED
+		);
+
+		/* Act. */
+		try {
+			ob_start();
+			Sensei_Utils::sensei_text_editor( null, 'testeditor', 'testeditor' );
+		} finally {
+			ob_end_clean();
+			restore_error_handler();
+		}
+
+		/* Assert. */
+		$this->assertSame( array(), $deprecations );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-utils.php
+++ b/tests/unit-tests/test-class-sensei-utils.php
@@ -683,29 +683,4 @@ class Sensei_Utils_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertSame( 'in-progress', $previous_status );
 	}
-
-	public function testSenseiTextEditor_NullContentGiven_DoesNotTriggerADeprecation(): void {
-		/* Arrange. */
-		$deprecations = array();
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- The deprecation is only observable through an error handler.
-		set_error_handler(
-			function ( $errno, $errstr ) use ( &$deprecations ) {
-				$deprecations[] = $errstr;
-				return true;
-			},
-			E_DEPRECATED
-		);
-
-		/* Act. */
-		try {
-			ob_start();
-			Sensei_Utils::sensei_text_editor( null, 'testeditor', 'testeditor' );
-		} finally {
-			ob_end_clean();
-			restore_error_handler();
-		}
-
-		/* Assert. */
-		$this->assertSame( array(), $deprecations );
-	}
 }


### PR DESCRIPTION
## Proposed Changes

* Stop passing a `null` answer into the rich text editor when a Multi Line question has not been answered yet.

`Sensei_Question::get_template_data()` fills `user_answer_entry` from `Sensei_Quiz::get_user_question_answer()`, which returns `null` whenever the student has no stored answer for that question — the normal state the first time a quiz is opened, and also when the viewer is not logged in. `templates/single-quiz/question-type-multi-line.php` passes that value straight into two string consumers, so on PHP 8.1+ each one raises a deprecation:

| Branch | Consumer | Notice |
| --- | --- | --- |
| Quiz open | `wp_editor()` → `stripos()` | `Passing null to parameter #1 ($haystack)` in `class-wp-editor.php:305` |
| View only | `wp_kses_post()` → `preg_replace()` | `Passing null to parameter #3 ($subject)` in `kses.php:1939` |

Nothing breaks today — PHP coerces the `null` to `''`, which is the correct rendering — but the notices are printed inline into the quiz markup when `WP_DEBUG` is on, and in PHP 9 the same calls will throw a `TypeError` and stop the question from rendering.

The two branches are independent: the view-only one never calls `Sensei_Utils::sensei_text_editor()`, so both sites need the fix.

* `Sensei_Utils::sensei_text_editor()` now casts `$content` on entry, and its docblock documents `string|null`. The cast lives in the helper rather than in the template because it is a public static method — Sensei Pro, themes, and templates overridden in `yourtheme/sensei/` can all call it with a stored answer, and every one of those paths carries the same `null`.
* The view-only branch of `question-type-multi-line.php` casts before `wp_kses_post()`.

## Testing Instructions

Requires **PHP 8.1 or newer** and `define( 'WP_DEBUG', true );`. On PHP 7.4 and 8.0 these deprecations do not exist, so you will correctly see nothing before or after the fix.

Set up a published course with a lesson and a quiz, add one **Multi Line** question to that quiz, and enrol a student in the course. No other question type touches this code.

**Path 1 — open quiz (rich text editor)**

1. Log in as the enrolled student and open the quiz **without having answered it before**.
2. Confirm the question renders as a TinyMCE editor (toolbar plus an empty text area).
3. On `trunk`, a `stripos(): Passing null to parameter #1 ($haystack)` notice from `class-wp-editor.php` line 305 appears just above the editor.
4. On this branch the notice is gone and the editor renders identically, empty.

**Path 2 — view-only quiz**

1. Log in as an **admin who is not enrolled** in the course, and open the same quiz.
2. Confirm the question renders as plain text inside a `div`, with no editor.
3. On `trunk`, a `preg_replace(): Passing null to parameter #3 ($subject)` notice from `kses.php` line 1939 appears in its place.
4. On this branch the notice is gone and the empty block renders identically.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fix PHP 8.1 deprecation notices rendered into the quiz page for unanswered Multi Line questions.

</details>
