### PR TITLE
Fix Add Student metabox layout

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -226,13 +226,13 @@ div.question_boolean_fields {
 
 /* Students */
 .sensei-lms_page_sensei_learners {
-	#add_learner_search {
-		min-width: 300px;
+	#add_learner_search + .select2-container {
+		max-width: 300px;
 	}
 
 	@media only screen and (min-width: 768px) {
-		#add_learner_search {
-			min-width: 500px;
+		#add_learner_search + .select2-container {
+			max-width: 500px;
 		}
 	}
 

--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -146,16 +146,6 @@ div.question_boolean_fields {
 	margin: 3px;
 }
 
-#add_learner_search {
-	min-width: 300px;
-}
-
-@media only screen and (min-width: 768px) {
-	#add_learner_search {
-		min-width: 500px;
-	}
-}
-
 .post-type-lesson .inline-edit-col-right .inline-edit-col {
 	border: none !important;
 	padding-left: 2em !important;
@@ -234,20 +224,45 @@ div.question_boolean_fields {
 	}
 }
 
-.sensei-students__subheading {
-	a {
-		color: $text_primary;
-		text-decoration: none;
+/* Students */
+.sensei-lms_page_sensei_learners {
+	#add_learner_search {
+		min-width: 300px;
 	}
-}
 
-.sensei-students__call-to-action {
-	display: flex;
-	flex-flow: column;
-	margin: 20px auto;
+	@media only screen and (min-width: 768px) {
+		#add_learner_search {
+			min-width: 500px;
+		}
+	}
 
-	div {
-		margin: 8px auto;
+	.postbox {
+		padding: 1em 0 0 1em;
+
+		.inside {
+			padding: 0;
+		}
+	}
+
+	.sensei-students__subheading {
+		a {
+			color: $text_primary;
+			text-decoration: none;
+		}
+	}
+
+	.sensei-students__call-to-action {
+		display: flex;
+		flex-flow: column;
+		margin: 20px auto;
+
+		div {
+			margin: 8px auto;
+		}
+	}
+
+	.sensei-students__enrolled-course {
+		display: block;
 	}
 }
 
@@ -368,10 +383,6 @@ a.sensei-custom-navigation__info {
 	white-space: nowrap;
 	border-radius: 10px;
 	background-color: #91e7c5;
-}
-
-.sensei-students__enrolled-course {
-	display: block;
 }
 
 .sensei-plugin-document-setting-panel .components-panel__body-toggle.components-button .components-panel__arrow {

--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -236,12 +236,32 @@ div.question_boolean_fields {
 		}
 	}
 
+	.add-student-form-container {
+		label {
+			display: block;
+		}
+
+		input.select2-search__field {
+			padding: 0;
+		}
+	}
+
+	.select2-selection__rendered li {
+		margin-bottom: 0;
+	}
+
 	.postbox {
 		padding: 1em 0 0 1em;
 
 		.inside {
 			padding: 0;
 		}
+	}
+
+	#add_learner_submit[disabled] {
+		background-color: #037ABA !important;
+		color: #66AFD6 !important;
+		border-color: #037ABA !important;
 	}
 
 	.sensei-students__subheading {

--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -251,11 +251,17 @@ div.question_boolean_fields {
 	}
 
 	.postbox {
-		padding: 1em 0 0 1em;
+		padding: 1em 1em 0;
 
 		.inside {
 			padding: 0;
 		}
+	}
+
+	#add_learner_submit {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	#add_learner_submit[disabled] {

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -387,56 +387,6 @@ table.wp_list_table_sensei_learner_admins {
 	.select2-container--default .select2-selection--single {
 		min-height: 30px;
 	}
-
-	.sensei-learners-extra {
-		.add-student-form-container {
-			&.student-search-empty .select2-selection:before {
-				position: absolute;
-				font-family: dashicons;
-				content: "\f179";
-				font-size: 200%;
-				z-index: 1;
-				top: 0;
-				color: #9b9b9b;
-				padding: 1px 0 0 5px;
-				height: 100%;
-				display: flex;
-				flex-direction: row;
-				align-items: center;
-				justify-content: center;
-			}
-
-			label {
-				display: block;
-			}
-
-			.select2-search__field {
-				padding-left: 2.2em;
-			}
-		}
-
-		.select2-selection__rendered li {
-			margin-bottom: 0;
-		}
-
-		.postbox {
-			padding: 1em 0 0 1em;
-
-			h2#add-student-to-course-header {
-				padding: 0;
-			}
-
-			.inside {
-				padding: 0;
-			}
-		}
-
-		#add_learner_submit[disabled] {
-			background-color: #037ABA !important;
-			color: #66AFD6 !important;
-			border-color: #037ABA !important;
-		}
-	}
 }
 
 .enrolment-helper {

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -245,7 +245,7 @@ jQuery( document ).ready( function ( $ ) {
 	$learnerSearchSelect.select2( {
 		minimumInputLength: 3,
 		placeholder: window.woo_learners_general_data.selectplaceholder,
-		width: '300px',
+		width: '100%',
 		ajax: {
 			// in wp-admin ajaxurl is supplied by WordPress and is available globaly
 			url: window.ajaxurl,

--- a/changelog/fix-students-metaboxes
+++ b/changelog/fix-students-metaboxes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Add Student form layout on the Students page.


### PR DESCRIPTION
Resolves #7339.

The Students styles remained in `settings.scss`, but `settings.css` stopped loading on the Students page after [#5440](https://github.com/Automattic/sensei/pull/5440) changed lesson metabox registration from `admin_menu` to `add_meta_boxes`.

That change correctly improved Classic Editor support, but unintentionally left the Students styles in a stylesheet no longer loaded on that screen.

## Proposed Changes

- Move Students-specific styles to the stylesheet loaded on the Students page.
- Fix metabox spacing and place the completion checkbox below the student selector.
- Remove the search icon and its extra input padding.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1766" height="888" alt="Before" src="https://github.com/user-attachments/assets/6e29ad15-91b5-4056-bb67-da448bfeb3e0" /> | <img width="1590" height="842" alt="Screenshot 2026-08-10 at 5 54 33 PM" src="https://github.com/user-attachments/assets/ca90e155-79e9-4842-956e-388b35c5d870" /> |

## Testing Instructions

- [x] Open **Sensei LMS → Students** and select a course.
- [x] Confirm the Add Student metabox content is aligned and the checkbox appears below the student selector.
- [x] With Sensei Pro active, confirm the Manual Content Drip metabox spacing is correct.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fix the Add Student form layout on the Students page.

</details>