### PR TITLE
Fix lesson order in translated courses and attach WPML duplicates

### DIFF
--- a/changelog/fix-wpml-translated-course-lesson-order
+++ b/changelog/fix-wpml-translated-course-lesson-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix lessons appearing out of order in translated courses when a new lesson is translated with WPML, and attach WPML lesson duplicates to the translated course.

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -62,7 +62,8 @@ class Course_Translation {
 			return;
 		}
 
-		$lesson_ids = Sensei()->course->course_lessons( $master_id, 'any', 'ids' );
+		$lesson_ids          = Sensei()->course->course_lessons( $master_id, 'any', 'ids' );
+		$duplicate_languages = array();
 		foreach ( $lesson_ids as $lesson_id ) {
 			if ( ! is_int( $lesson_id ) ) {
 				$lesson_id = (int) $lesson_id;
@@ -75,15 +76,24 @@ class Course_Translation {
 			}
 
 			$translations = $this->get_post_duplicates( $lesson_id );
-			foreach ( $translations as $translated_lesson_id ) {
+			foreach ( $translations as $language_code => $translated_lesson_id ) {
 				$this->update_lesson_course( (int) $translated_lesson_id, $new_course_id );
-				$this->update_translated_lesson_properties( (int) $translated_lesson_id, $lesson_id );
+				$this->set_module_taxonomies( (int) $translated_lesson_id, $lesson_id, array( 'language_code' => $language_code ) );
+				$duplicate_languages[ $language_code ] = true;
 			}
 
 			$this->update_quiz_translations( $lesson_id, $details['language_code'] );
 
 			// Sync lesson course field across translations.
 			$this->sync_custom_field( $lesson_id, '_lesson_course' );
+		}
+
+		// One order sync per language instead of one per lesson.
+		foreach ( array_keys( $duplicate_languages ) as $language_code ) {
+			$translated_course_id = $this->get_object_id( $master_id, 'course', false, $language_code );
+			if ( $translated_course_id && $translated_course_id !== $master_id ) {
+				$this->sync_course_lesson_order( $master_id, $translated_course_id, $language_code );
+			}
 		}
 	}
 }

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -77,6 +77,10 @@ class Course_Translation {
 
 			$translations = $this->get_post_duplicates( $lesson_id );
 			foreach ( $translations as $language_code => $translated_lesson_id ) {
+				if ( empty( $this->get_element_language_details( (int) $translated_lesson_id, 'lesson' ) ) ) {
+					continue;
+				}
+
 				$this->update_lesson_course( (int) $translated_lesson_id, $new_course_id );
 				$this->set_module_taxonomies( (int) $translated_lesson_id, $lesson_id, array( 'language_code' => $language_code ) );
 				$duplicate_languages[ $language_code ] = true;

--- a/includes/wpml/class-lesson-translation.php
+++ b/includes/wpml/class-lesson-translation.php
@@ -35,6 +35,8 @@ class Lesson_Translation {
 		// Run the deferred question sync when WPML writes the translated lesson content.
 		add_action( 'wp_after_insert_post', array( $this, 'update_question_translations_on_lesson_content_written' ), 10, 2 );
 		// Attach lesson duplicates to the translated course.
+		// "icl_make_duplicate" is WPML-internal but the WPML team confirmed it's safe to rely on.
+		// It also fires on duplicate refresh, so the handler must stay idempotent.
 		add_action( 'icl_make_duplicate', array( $this, 'update_lesson_properties_on_lesson_duplicated' ), 10, 4 );
 	}
 

--- a/includes/wpml/class-lesson-translation.php
+++ b/includes/wpml/class-lesson-translation.php
@@ -34,6 +34,8 @@ class Lesson_Translation {
 		add_action( 'wpml_pro_translation_completed', array( $this, 'update_lesson_translations_on_lesson_translation_created' ) );
 		// Run the deferred question sync when WPML writes the translated lesson content.
 		add_action( 'wp_after_insert_post', array( $this, 'update_question_translations_on_lesson_content_written' ), 10, 2 );
+		// Attach lesson duplicates to the translated course.
+		add_action( 'icl_make_duplicate', array( $this, 'update_lesson_properties_on_lesson_duplicated' ), 10, 4 );
 	}
 
 	/**
@@ -67,5 +69,43 @@ class Lesson_Translation {
 		$this->update_translated_lesson_properties( $new_lesson_id, $master_lesson_id );
 		$this->update_quiz_translations( $master_lesson_id, $details['language_code'] );
 		$this->defer_question_translations_update( $new_lesson_id );
+	}
+
+	/**
+	 * Attach a duplicated lesson to the translated course.
+	 *
+	 * WPML's duplicate flow copies custom fields verbatim, which leaves the
+	 * duplicate attached to the master course and carrying the master course's
+	 * order meta key, so it never shows up in the translated course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param int    $master_post_id Master lesson ID.
+	 * @param string $lang           Language code of the duplicate.
+	 * @param array  $post_array     Data of the duplicated post (unused).
+	 * @param int    $new_lesson_id  Duplicated lesson ID.
+	 */
+	public function update_lesson_properties_on_lesson_duplicated( $master_post_id, $lang, $post_array, $new_lesson_id ) {
+		if ( 'lesson' !== get_post_type( $new_lesson_id ) ) {
+			return;
+		}
+
+		$master_course_id = (int) get_post_meta( $master_post_id, '_lesson_course', true );
+		if ( ! $master_course_id ) {
+			return;
+		}
+
+		$new_course_id = $this->get_object_id( $master_course_id, 'course', false, $lang );
+		if ( ! $new_course_id || $new_course_id === $master_course_id ) {
+			return;
+		}
+
+		// The order meta copied from the master belongs to the master course.
+		delete_post_meta( $new_lesson_id, '_order_' . $master_course_id );
+
+		$this->update_lesson_course( $new_lesson_id, $new_course_id );
+		$this->update_translated_lesson_properties( $new_lesson_id, $master_post_id );
 	}
 }

--- a/includes/wpml/trait-lesson-translation-helper.php
+++ b/includes/wpml/trait-lesson-translation-helper.php
@@ -128,18 +128,16 @@ trait Lesson_Translation_Helper {
 	private function sync_course_lesson_order( $master_course_id, $new_course_id, $language_code ) {
 		// Translations of the master course's lessons, in the master's order.
 		$lesson_ids = array();
-		foreach ( Sensei()->course->course_lessons( $master_course_id, 'any', 'ids' ) as $master_lesson_id ) {
-			$translated_lesson_id = $this->get_object_id( (int) $master_lesson_id, 'lesson', false, $language_code );
-			if ( $translated_lesson_id && $translated_lesson_id !== (int) $master_lesson_id ) {
+		foreach ( array_map( 'intval', Sensei()->course->course_lessons( $master_course_id, 'any', 'ids' ) ) as $master_lesson_id ) {
+			$translated_lesson_id = $this->get_object_id( $master_lesson_id, 'lesson', false, $language_code );
+			if ( $translated_lesson_id && $translated_lesson_id !== $master_lesson_id ) {
 				$lesson_ids[] = (int) $translated_lesson_id;
 			}
 		}
 
 		// Lessons of the translated course with no counterpart in the master
 		// course keep their current relative order, after the mirrored ones.
-		foreach ( Sensei()->course->course_lessons( $new_course_id, 'any', 'ids' ) as $translated_lesson_id ) {
-			$lesson_ids[] = (int) $translated_lesson_id;
-		}
+		$lesson_ids = array_merge( $lesson_ids, array_map( 'intval', Sensei()->course->course_lessons( $new_course_id, 'any', 'ids' ) ) );
 
 		foreach ( array_values( array_unique( $lesson_ids ) ) as $index => $lesson_id ) {
 			update_post_meta( $lesson_id, '_order_' . $new_course_id, $index + 1 );

--- a/includes/wpml/trait-lesson-translation-helper.php
+++ b/includes/wpml/trait-lesson-translation-helper.php
@@ -58,7 +58,7 @@ trait Lesson_Translation_Helper {
 			$this->sync_custom_field( $master_lesson_id, '_lesson_course' );
 		}
 
-		$this->set_lesson_order( $new_lesson_id, $master_lesson_id, $details );
+		$this->set_lesson_order( $master_lesson_id, $details );
 		$this->set_module_taxonomies( $new_lesson_id, $master_lesson_id, $details );
 	}
 
@@ -91,25 +91,58 @@ trait Lesson_Translation_Helper {
 	}
 
 	/**
-	 * Set lesson order for the translated lesson.
+	 * Set the lesson order for the master lesson's course translation.
 	 *
-	 * @param int   $new_lesson_id New lesson ID.
 	 * @param int   $master_lesson_id Original lesson ID.
 	 * @param array $details Language details.
 	 */
-	private function set_lesson_order( $new_lesson_id, $master_lesson_id, $details ) {
-		$master_course_id = get_post_meta( $master_lesson_id, '_lesson_course', true );
+	private function set_lesson_order( $master_lesson_id, $details ) {
+		$master_course_id = (int) get_post_meta( $master_lesson_id, '_lesson_course', true );
 		if ( ! $master_course_id ) {
 			return;
 		}
-
-		$order = (int) get_post_meta( $master_lesson_id, '_order_' . $master_course_id, true );
 
 		$new_course_id = $this->get_object_id( $master_course_id, 'course', false, $details['language_code'] );
 		if ( ! $new_course_id ) {
 			return;
 		}
 
-		update_post_meta( $new_lesson_id, '_order_' . $new_course_id, $order );
+		$this->sync_course_lesson_order( $master_course_id, $new_course_id, $details['language_code'] );
+	}
+
+	/**
+	 * Mirror the master course's lesson order onto the translated course.
+	 *
+	 * Copying the order meta only to the lesson being translated is not enough:
+	 * lessons translated before this sync existed (or through flows that never
+	 * ran it, like the WordPress editor or WPML duplicates) have no
+	 * `_order_{course_id}` meta and fall back to the end of the course, so a
+	 * newly translated lesson would jump in front of all of them. Rewriting the
+	 * order of every lesson keeps the translated course consistent with the
+	 * master regardless of how each translation was created.
+	 *
+	 * @param int    $master_course_id Original course ID.
+	 * @param int    $new_course_id    Translated course ID.
+	 * @param string $language_code    Language of the translated course.
+	 */
+	private function sync_course_lesson_order( $master_course_id, $new_course_id, $language_code ) {
+		// Translations of the master course's lessons, in the master's order.
+		$lesson_ids = array();
+		foreach ( Sensei()->course->course_lessons( $master_course_id, 'any', 'ids' ) as $master_lesson_id ) {
+			$translated_lesson_id = $this->get_object_id( (int) $master_lesson_id, 'lesson', false, $language_code );
+			if ( $translated_lesson_id && $translated_lesson_id !== (int) $master_lesson_id ) {
+				$lesson_ids[] = (int) $translated_lesson_id;
+			}
+		}
+
+		// Lessons of the translated course with no counterpart in the master
+		// course keep their current relative order, after the mirrored ones.
+		foreach ( Sensei()->course->course_lessons( $new_course_id, 'any', 'ids' ) as $translated_lesson_id ) {
+			$lesson_ids[] = (int) $translated_lesson_id;
+		}
+
+		foreach ( array_values( array_unique( $lesson_ids ) ) as $index => $lesson_id ) {
+			update_post_meta( $lesson_id, '_order_' . $new_course_id, $index + 1 );
+		}
 	}
 }

--- a/includes/wpml/trait-lesson-translation-helper.php
+++ b/includes/wpml/trait-lesson-translation-helper.php
@@ -103,7 +103,7 @@ trait Lesson_Translation_Helper {
 		}
 
 		$new_course_id = $this->get_object_id( $master_course_id, 'course', false, $details['language_code'] );
-		if ( ! $new_course_id ) {
+		if ( ! $new_course_id || $new_course_id === $master_course_id ) {
 			return;
 		}
 

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -140,11 +140,12 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		);
 		add_filter(
 			'wpml_object_id',
-			function ( $object_id ) use ( $id_map ) {
-				return $id_map[ $object_id ] ?? 0;
+			function ( $object_id, $element_type ) use ( $id_map ) {
+				$counterpart_id = $id_map[ $object_id ] ?? 0;
+				return $counterpart_id && get_post_type( $counterpart_id ) === $element_type ? $counterpart_id : 0;
 			},
 			10,
-			1
+			2
 		);
 		// Every master lesson already has a translation...
 		add_filter( 'wpml_element_trid', fn() => 1 );

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -100,4 +100,100 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		);
 		$this->assertSame( $expected, $actual, 'Lesson course should be set to the new course in lesson translations' );
 	}
+
+	public function testUpdateLessonPropertiesOnCourseTranslationCreated_TranslatedLessonsWithoutOrderMetaGiven_MirrorsMasterLessonOrder() {
+		/* Arrange. */
+		$master_course_id     = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		// A master course whose lessons were never explicitly reordered: no
+		// order metas, so its display order comes from the post dates.
+		$master_lesson_ids = $this->create_course_lessons(
+			$master_course_id,
+			array( '2024-01-11 10:00:00', '2024-01-12 10:00:00', '2024-01-13 10:00:00' )
+		);
+		// The translations were created in the reverse order, so their date
+		// fallback disagrees with the master order.
+		$translated_lesson_ids = $this->create_course_lessons(
+			$translated_course_id,
+			array( '2024-02-13 10:00:00', '2024-02-12 10:00:00', '2024-02-11 10:00:00' )
+		);
+
+		$counterparts = array_combine( $master_lesson_ids, $translated_lesson_ids )
+			+ array( $master_course_id => $translated_course_id );
+		$id_map       = array();
+		foreach ( $counterparts as $original_id => $counterpart_id ) {
+			$id_map[ $original_id ]    = $counterpart_id;
+			$id_map[ $counterpart_id ] = $original_id;
+		}
+
+		add_filter(
+			'wpml_element_language_details',
+			function () {
+				return array(
+					'language_code'        => 'es',
+					'source_language_code' => 'en',
+				);
+			},
+			10,
+			0
+		);
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id ) use ( $id_map ) {
+				return $id_map[ $object_id ] ?? 0;
+			},
+			10,
+			1
+		);
+		// Every master lesson already has a translation...
+		add_filter( 'wpml_element_trid', fn() => 1 );
+		add_filter( 'wpml_get_element_translations', fn() => array( 'es' => true ), 10, 0 );
+		// ...delivered as a WPML duplicate.
+		add_filter(
+			'wpml_post_duplicates',
+			function ( $post_id ) use ( $counterparts ) {
+				return isset( $counterparts[ $post_id ] ) ? array( 'es' => $counterparts[ $post_id ] ) : array();
+			},
+			10,
+			1
+		);
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
+
+		/* Clean up & Assert. */
+		remove_all_filters( 'wpml_element_language_details' );
+		remove_all_filters( 'wpml_object_id' );
+		remove_all_filters( 'wpml_element_trid' );
+		remove_all_filters( 'wpml_get_element_translations' );
+		remove_all_filters( 'wpml_post_duplicates' );
+
+		$this->assertSame( $master_lesson_ids, array_map( fn( $id ) => $id_map[ $id ], Sensei()->course->course_lessons( $translated_course_id, 'any', 'ids' ) ) );
+	}
+
+	/**
+	 * Create lessons attached to a course, one per post date, in the given
+	 * order, without `_order_{course_id}` metas.
+	 *
+	 * @param int      $course_id  Course the lessons belong to.
+	 * @param string[] $post_dates One lesson is created per date.
+	 *
+	 * @return int[] Lesson IDs, in the order given.
+	 */
+	private function create_course_lessons( $course_id, $post_dates ) {
+		$lesson_ids = array();
+		foreach ( $post_dates as $post_date ) {
+			$lesson_ids[] = $this->factory->lesson->create(
+				array(
+					'post_date'  => $post_date,
+					'meta_input' => array( '_lesson_course' => $course_id ),
+				)
+			);
+		}
+
+		return $lesson_ids;
+	}
 }

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -485,11 +485,12 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 
 		add_filter(
 			'wpml_object_id',
-			function ( $object_id ) use ( $map ) {
-				return $map[ $object_id ] ?? 0;
+			function ( $object_id, $element_type ) use ( $map ) {
+				$counterpart_id = $map[ $object_id ] ?? 0;
+				return $counterpart_id && get_post_type( $counterpart_id ) === $element_type ? $counterpart_id : 0;
 			},
 			10,
-			1
+			2
 		);
 	}
 

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -250,6 +250,257 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( \Sensei()->lesson->get_answer_id( 'sí' ) . ',' . \Sensei()->lesson->get_answer_id( 'no' ), get_post_meta( $translated_question_id, '_answer_order', true ), 'The answer order should be recomputed from the translated labels in block order.' );
 	}
 
+	public function testUpdateLessonTranslationsOnLessonTranslationCreated_TranslatedLessonsWithoutOrderMetaGiven_PlacesNewTranslationLast() {
+		/* Arrange. */
+		$master_course_id     = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		$master_lesson_ids = $this->create_course_lessons(
+			$master_course_id,
+			array( '2024-01-11 10:00:00', '2024-01-12 10:00:00', '2024-01-13 10:00:00', '2024-01-14 10:00:00' ),
+			true
+		);
+		// Lessons translated before the order sync existed carry no order meta.
+		$translated_lesson_ids = $this->create_course_lessons(
+			$translated_course_id,
+			array( '2024-02-11 10:00:00', '2024-02-12 10:00:00', '2024-02-13 10:00:00', '2024-02-14 10:00:00' ),
+			false
+		);
+		$new_lesson_id         = $translated_lesson_ids[3];
+
+		$this->simulate_wpml_language_pair(
+			array_combine( $master_lesson_ids, $translated_lesson_ids ) + array( $master_course_id => $translated_course_id )
+		);
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_lesson_translations_on_lesson_translation_created( $new_lesson_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_language_pair_filters();
+		$this->assertSame( $translated_lesson_ids, Sensei()->course->course_lessons( $translated_course_id, 'any', 'ids' ) );
+	}
+
+	public function testUpdateLessonTranslationsOnLessonTranslationCreated_LessonsWithoutMasterCounterpartGiven_KeepsThemLastInRelativeOrder() {
+		/* Arrange. */
+		$master_course_id     = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		$master_lesson_ids = $this->create_course_lessons(
+			$master_course_id,
+			array( '2024-01-11 10:00:00', '2024-01-12 10:00:00' ),
+			true
+		);
+		// Lessons that only exist in the translated course, created before the translated counterparts.
+		$orphan_lesson_ids     = $this->create_course_lessons(
+			$translated_course_id,
+			array( '2024-02-11 10:00:00', '2024-02-12 10:00:00' ),
+			false
+		);
+		$translated_lesson_ids = $this->create_course_lessons(
+			$translated_course_id,
+			array( '2024-02-13 10:00:00', '2024-02-14 10:00:00' ),
+			false
+		);
+		$new_lesson_id         = $translated_lesson_ids[1];
+
+		$this->simulate_wpml_language_pair(
+			array_combine( $master_lesson_ids, $translated_lesson_ids ) + array( $master_course_id => $translated_course_id )
+		);
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_lesson_translations_on_lesson_translation_created( $new_lesson_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_language_pair_filters();
+		$this->assertSame(
+			array_merge( $translated_lesson_ids, $orphan_lesson_ids ),
+			Sensei()->course->course_lessons( $translated_course_id, 'any', 'ids' )
+		);
+	}
+
+	public function testUpdateLessonPropertiesOnLessonDuplicated_DuplicatedLessonGiven_AttachesItToTranslatedCourse() {
+		/* Arrange. */
+		$master_course_id     = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		$master_lesson_ids    = $this->create_course_lessons( $master_course_id, array( '2024-01-11 10:00:00' ), true );
+		$duplicated_lesson_id = $this->create_lesson_duplicate( $master_lesson_ids[0], $master_course_id );
+
+		$this->simulate_wpml_language_pair(
+			array(
+				$master_lesson_ids[0] => $duplicated_lesson_id,
+				$master_course_id     => $translated_course_id,
+			)
+		);
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_lesson_properties_on_lesson_duplicated( $master_lesson_ids[0], 'es', array(), $duplicated_lesson_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_language_pair_filters();
+		$this->assertSame( $translated_course_id, (int) get_post_meta( $duplicated_lesson_id, '_lesson_course', true ) );
+	}
+
+	public function testUpdateLessonPropertiesOnLessonDuplicated_TranslatedLessonsWithoutOrderMetaGiven_PlacesDuplicateLast() {
+		/* Arrange. */
+		$master_course_id     = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		$master_lesson_ids = $this->create_course_lessons(
+			$master_course_id,
+			array( '2024-01-11 10:00:00', '2024-01-12 10:00:00', '2024-01-13 10:00:00', '2024-01-14 10:00:00' ),
+			true
+		);
+		// Lessons translated before the order sync existed carry no order meta.
+		$translated_lesson_ids = $this->create_course_lessons(
+			$translated_course_id,
+			array( '2024-02-11 10:00:00', '2024-02-12 10:00:00', '2024-02-13 10:00:00' ),
+			false
+		);
+		$duplicated_lesson_id  = $this->create_lesson_duplicate( $master_lesson_ids[3], $master_course_id );
+
+		$this->simulate_wpml_language_pair(
+			array_combine( $master_lesson_ids, array_merge( $translated_lesson_ids, array( $duplicated_lesson_id ) ) )
+			+ array( $master_course_id => $translated_course_id )
+		);
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_lesson_properties_on_lesson_duplicated( $master_lesson_ids[3], 'es', array(), $duplicated_lesson_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_language_pair_filters();
+		$this->assertSame(
+			array_merge( $translated_lesson_ids, array( $duplicated_lesson_id ) ),
+			Sensei()->course->course_lessons( $translated_course_id, 'any', 'ids' )
+		);
+	}
+
+	public function testUpdateLessonPropertiesOnLessonDuplicated_CourseWithoutTranslationGiven_KeepsMasterCourse() {
+		/* Arrange. */
+		$master_course_id     = $this->factory->course->create();
+		$master_lesson_ids    = $this->create_course_lessons( $master_course_id, array( '2024-01-11 10:00:00' ), true );
+		$duplicated_lesson_id = $this->create_lesson_duplicate( $master_lesson_ids[0], $master_course_id );
+
+		$this->simulate_wpml_language_pair(
+			array( $master_lesson_ids[0] => $duplicated_lesson_id )
+		);
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_lesson_properties_on_lesson_duplicated( $master_lesson_ids[0], 'es', array(), $duplicated_lesson_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_language_pair_filters();
+		$this->assertSame( $master_course_id, (int) get_post_meta( $duplicated_lesson_id, '_lesson_course', true ) );
+	}
+
+	/**
+	 * Create lessons attached to a course, one per post date, in the given order.
+	 *
+	 * @param int      $course_id  Course the lessons belong to.
+	 * @param string[] $post_dates One lesson is created per date.
+	 * @param bool     $set_order  Whether to write the 1-based `_order_{course_id}` meta.
+	 *
+	 * @return int[] Lesson IDs, in the order given.
+	 */
+	private function create_course_lessons( $course_id, $post_dates, $set_order ) {
+		$lesson_ids = array();
+		foreach ( $post_dates as $index => $post_date ) {
+			$lesson_id = $this->factory->lesson->create(
+				array(
+					'post_date'  => $post_date,
+					'meta_input' => array( '_lesson_course' => $course_id ),
+				)
+			);
+
+			if ( $set_order ) {
+				update_post_meta( $lesson_id, '_order_' . $course_id, $index + 1 );
+			}
+
+			$lesson_ids[] = $lesson_id;
+		}
+
+		return $lesson_ids;
+	}
+
+	/**
+	 * Create a lesson the way WPML's duplicate flow leaves it: custom fields
+	 * copied verbatim from the master, so it points at the master course and
+	 * carries the master course's order meta key.
+	 *
+	 * @param int $master_lesson_id Master lesson ID.
+	 * @param int $master_course_id Master course ID.
+	 *
+	 * @return int Duplicated lesson ID.
+	 */
+	private function create_lesson_duplicate( $master_lesson_id, $master_course_id ) {
+		$duplicated_lesson_id = $this->factory->lesson->create(
+			array(
+				'post_date'  => '2024-02-14 10:00:00',
+				'meta_input' => array( '_lesson_course' => $master_course_id ),
+			)
+		);
+		update_post_meta(
+			$duplicated_lesson_id,
+			'_order_' . $master_course_id,
+			(int) get_post_meta( $master_lesson_id, '_order_' . $master_course_id, true )
+		);
+
+		return $duplicated_lesson_id;
+	}
+
+	/**
+	 * Stand in for WPML: fixed es/en language details, and a wpml_object_id
+	 * map resolving each post to its counterpart in the other language.
+	 *
+	 * @param array $counterparts Map of post ID to counterpart post ID (registered in both directions).
+	 */
+	private function simulate_wpml_language_pair( $counterparts ) {
+		add_filter(
+			'wpml_element_language_details',
+			function () {
+				return array(
+					'language_code'        => 'es',
+					'source_language_code' => 'en',
+				);
+			},
+			10,
+			0
+		);
+
+		$map = array();
+		foreach ( $counterparts as $original_id => $counterpart_id ) {
+			$map[ $original_id ]    = $counterpart_id;
+			$map[ $counterpart_id ] = $original_id;
+		}
+
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id ) use ( $map ) {
+				return $map[ $object_id ] ?? 0;
+			},
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Remove the filters registered by simulate_wpml_language_pair().
+	 */
+	private function remove_wpml_language_pair_filters() {
+		remove_all_filters( 'wpml_element_language_details' );
+		remove_all_filters( 'wpml_object_id' );
+	}
+
 	/**
 	 * Register the WPML hooks that stand in for a real lesson translation: the
 	 * language details, the source/translation id map, and quiz duplication.

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -292,7 +292,9 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 			array( '2024-01-11 10:00:00', '2024-01-12 10:00:00' ),
 			true
 		);
-		// Lessons that only exist in the translated course, created before the translated counterparts.
+		// Lessons that only exist in the translated course. Their dates are
+		// earlier than the translated counterparts', so without the sync the
+		// date fallback would list them first.
 		$orphan_lesson_ids     = $this->create_course_lessons(
 			$translated_course_id,
 			array( '2024-02-11 10:00:00', '2024-02-12 10:00:00' ),


### PR DESCRIPTION
Closes [SEN-129](https://linear.app/a8c/issue/SEN-129/lessons-appear-out-of-order-in-wpml-translated-courses-when-a-new)

## Proposed Changes

When a lesson is translated with WPML into a course whose other lessons were translated before Sensei 4.22 (or with the WordPress editor instead of the Translation Editor), those lessons carry no order meta, so the new translation jumps to the first position of the translated course. Separately, WPML lesson duplicates copy custom fields verbatim, so a duplicated lesson stays attached to the master course and never shows up in the translated one.

Instead of copying the order meta only to the lesson being translated, every lesson translation now mirrors the master course's effective lesson order onto the whole translated course. Lessons that only exist in the translated course keep their relative order after the mirrored ones. A new handler on WPML's `icl_make_duplicate` attaches duplicated lessons to the translated course, removing the master course order meta they inherit.

## Testing Instructions

Requires a WPML site (Advanced Translation Editor enabled) with English as default language and Spanish as secondary. While testing the legacy scenario, don't re-save the Spanish lessons or course between steps: any lesson save recomputes the whole course order and would mask the broken state.

### New lesson translated into a course with legacy translations (the reported bug)

1. Create a course in English with `Lesson 1` to `Lesson 3` via the Course Outline block, and publish the course and its lessons.
2. Translate the course to Spanish using the "+" icon and complete the translation, which creates the lesson translations automatically.
3. Simulate translations made before the order sync existed by deleting the Spanish order metas: `wp post meta delete <ES_lesson_id> _order_<ES_course_id>` for each of the three Spanish lessons (both IDs are the Spanish ones).
4. Check the Spanish course on the frontend: lessons show 1, 2, 3.
5. Add `Lesson 4` at the end of the English course outline, update the course, and publish the new lesson.
6. Translate `Lesson 4` to Spanish with the "+" icon.
7. Check the Spanish course again: it shows 1, 2, 3, 4. Without this fix, `Lesson 4` appears first.

### Duplicated lesson joins the translated course

1. On the same course, add `Lesson 5` to the English outline, update the course, and publish the new lesson.
2. Open `Lesson 5` and duplicate it to Spanish from WPML's Language panel.
3. Check the Spanish course again: the duplicate appears in the last position. Without this fix, it never appears in the Spanish course.

### Course translation keeps mirroring the master order (regression check)

This flow already worked, but the mechanism underneath changed (the whole order is now mirrored by position instead of copying each lesson's meta), so confirm the visible result is unchanged.

1. Create a new English course with three lessons, then drag them in the outline so the order differs from creation order (e.g. `C, A, B`), and update.
2. Translate the course to Spanish via the Translation Editor.
3. The Spanish course lists the lessons in the master's order (`C, A, B`), not in creation order.

### Duplicating into a language without a course translation (guard)

1. Add a third language (e.g. Catalan) in WPML without translating any course.
2. Duplicate any lesson of a course into that language.
3. No errors, and the duplicate stays attached to the master course since there is no translated course to attach it to.

### No regressions without WPML

1. On a site without WPML, reorder lessons and add a new lesson through the outline block.
2. Ordering behaves exactly as before on the frontend and in the ordering screen.
