### PR TITLE
Update Node/npm versions to unbreak Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,8 @@
         "wp-hookdoc": "0.2.0"
       },
       "engines": {
-        "node": ">=20.10.0",
-        "npm": "^10.2.3"
+        "node": ">=22.10.0",
+        "npm": ">=10.9.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/Automattic/sensei/issues"
   },
   "engines": {
-    "npm": "^10.2.3",
-    "node": ">=20.10.0"
+    "npm": ">=10.9.0",
+    "node": ">=22.10.0"
   },
   "dependencies": {
     "@automattic/calypso-color-schemes": "3.1.1",


### PR DESCRIPTION
Resolve https://linear.app/a8c/issue/SEN-130/unblock-dependabot-in-sensei.

## Proposed Changes
The npm Dependabot job fails every run ([latest](https://github.com/Automattic/sensei/actions/runs/31520655875/job/93876593243), [previous](https://github.com/Automattic/sensei/actions/runs/31519223393/job/93871873307)). Dependabot's corepack step installs the **lower bound** of `engines.npm`, so `"^10.2.3"` had it running npm 10.2.3 (Nov 2023), under which Dependabot's proxy segfaults in `normaliseHost` and takes down all egress — every later request dies with `EHOSTUNREACH`.

Raising the floor moves it to npm 10.9.x. `>=` rather than a caret so Node 24 (bundles npm 11) isn't rejected by `engine-strict`. Node floor is 22.10.0 — the first 22.x to bundle npm 10.9.0; earlier 22.x ship 10.5–10.8.3 and would fail `engine-strict` against the npm floor. `.nvmrc` and `Makefile` already require 22.

**Contributors on Node 22.0–22.9 will need to upgrade** (`nvm install 22 && nvm use`) — `.nvmrc` resolves to the latest 22.x, but an older cached 22.x no longer satisfies the floor.

Mitigation, not a certain fix — the crash is in a GitHub-side binary. If it recurs, next step is narrowing the `wordpress-packages` group.

## Testing Instructions

- [x] On Node ≥22.10 (`nvm install 22 && nvm use`), run `npm install` — completes with no `EBADENGINE`.
- [x] Confirm `make up` still starts the wp-env stack.
- [x] After merge, re-run the npm Dependabot job and confirm no `EHOSTUNREACH`.

## Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Internal tooling change — applying the **No Changelog** label instead.

