### PR TITLE
Declare date-fns to stop Dependabot PRs failing npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "comment-parser": "1.1.5",
         "copy-webpack-plugin": "10.2.0",
         "cross-env": "7.0.2",
+        "date-fns": "4.4.0",
         "eslint-import-resolver-typescript": "4.2.2",
         "gettext-parser": "4.0.4",
         "husky": "6.0.0",
@@ -10755,16 +10756,6 @@
         }
       }
     },
-    "node_modules/@wordpress/admin-ui/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
     "node_modules/@wordpress/admin-ui/node_modules/gettext-parser": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
@@ -11181,6 +11172,16 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/components/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/@wordpress/components/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -11354,16 +11355,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@wordpress/date": {
@@ -11566,6 +11557,16 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@wordpress/editor/node_modules/uuid": {
@@ -14233,18 +14234,6 @@
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@wordpress/ui/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@wordpress/ui/node_modules/gettext-parser": {
@@ -18248,9 +18237,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -32092,16 +32081,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-day-picker/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "comment-parser": "1.1.5",
     "copy-webpack-plugin": "10.2.0",
     "cross-env": "7.0.2",
+    "date-fns": "4.4.0",
     "eslint-import-resolver-typescript": "4.2.2",
     "gettext-parser": "4.0.4",
     "husky": "6.0.0",


### PR DESCRIPTION
## Proposed Changes

Every Dependabot npm PR fails all seven JS and build jobs. Their regenerated `package-lock.json` omits `date-fns@4.4.0` nested under `@wordpress/ui`, so `npm ci` aborts with `Missing: date-fns@4.4.0 from lock file`. #8153, #8154 and #8155 all hit it, as would every future npm PR.

`@base-ui/react` declares `date-fns ^4.0.0` as an **optional peer** dependency — the only one in our tree, and unavoidable, since it arrives via `@wordpress/edit-post` → `@wordpress/admin-ui` → `@wordpress/ui`. Dependabot regenerates lockfiles without optional peer entries; npm's resolver still treats this one as required. Declaring `date-fns` makes it a required node, so the lockfile no longer depends on how a resolver handles optional peers.

No package changes version — the only lockfile entries that move are `date-fns` itself, which appears in none of the built files. Build output is unchanged.

## Testing Instructions

The next Dependabot npm PR should have passing JS and build jobs with no manual lockfile repair.

## Changelog entry

- [ ] Automatically create a changelog entry from the details below.
