### PR TITLE
Guard against null post in module teacher-meta update hook

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -127,12 +127,17 @@ class Sensei_Core_Modules {
 	 * @since 4.9.0
 	 * @access private
 	 *
-	 * @param int     $post_ID      Post ID.
-	 * @param WP_Post $post_after   Post object following the update.
-	 * @param WP_Post $post_before  Post object before the update.
+	 * @param int          $post_ID      Post ID.
+	 * @param WP_Post|null $post_after   Post object following the update.
+	 * @param WP_Post|null $post_before  Post object before the update.
 	 */
-	public function update_module_teacher_id_meta_on_post_teacher_update( int $post_ID, WP_Post $post_after, WP_Post $post_before ) {
-		if ( 'course' !== get_post( $post_ID )->post_type ) {
+	public function update_module_teacher_id_meta_on_post_teacher_update( $post_ID, $post_after = null, $post_before = null ) {
+		if ( ! $post_after instanceof WP_Post || ! $post_before instanceof WP_Post ) {
+			return;
+		}
+
+		$post = get_post( $post_ID );
+		if ( ! $post || 'course' !== $post->post_type ) {
 			return;
 		}
 


### PR DESCRIPTION
## Problem

`Sensei_Core_Modules::update_module_teacher_id_meta_on_post_teacher_update()` is hooked to `post_updated` with strict `WP_Post` type hints on `$post_after` / `$post_before`:

```php
public function update_module_teacher_id_meta_on_post_teacher_update( int $post_ID, WP_Post $post_after, WP_Post $post_before ) {
	if ( 'course' !== get_post( $post_ID )->post_type ) {
```

WordPress can fire `post_updated` with a `null` post object (e.g. when `get_post()` returns null for the post being updated). PHP then throws a fatal `TypeError` binding `null` to `WP_Post $post_after` **before the body runs**, so it can't be guarded from inside.

Observed when a WooCommerce **subscription** status is updated programmatically (`$subscription->update_status()`) while Sensei is active:

```
Uncaught TypeError: ...update_module_teacher_id_meta_on_post_teacher_update():
Argument #2 ($post_after) must be of type WP_Post, null given
```

## Fix

Relax the parameter types and return early when either post object isn't a `WP_Post`, and guard the `get_post()` lookup.

Backward-compatible: the change **widens** accepted inputs (a superset), so every previously-valid call still works, and the method is an internal `@access private` hook callback — not a public extension point.

## Testing

- Update a WooCommerce subscription's status programmatically with Sensei active → no fatal (previously fataled).
- Course teacher change still propagates module teacher meta as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)