### PR TITLE
Fix quiz question editor spacing on WordPress 7.1

### DIFF
--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -6,7 +6,7 @@ $toogle-size: 26px;
 	align-items: center;
 	position: relative;
 
-	.edit-post-visual-editor & {
+	.editor-styles-wrapper & {
 		font-family: inherit;
 		font-size: inherit;
 		padding: 0;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -105,7 +105,7 @@ $block: '.sensei-lms-question-block';
 				margin-left: 12px;
 			}
 
-			.edit-post-visual-editor & {
+			.editor-styles-wrapper & {
 				margin: 0;
 				padding: 4px;
 				font-size: 12px;

--- a/assets/blocks/quiz/single-question.editor.scss
+++ b/assets/blocks/quiz/single-question.editor.scss
@@ -7,7 +7,8 @@ body.post-type-question {
 		display: none;
 	}
 
-	.editor-styles-wrapper {
+	.editor-styles-wrapper,
+	&.editor-styles-wrapper {
 		padding: 64px 0;
 	}
 }

--- a/changelog/fix-iframed-editor-quiz-styles
+++ b/changelog/fix-iframed-editor-quiz-styles
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed spacing and styling of quiz question options in the editor on WordPress 7.1.
+Fixed spacing and styling of quiz question options when using the iframed block editor.

--- a/changelog/fix-iframed-editor-quiz-styles
+++ b/changelog/fix-iframed-editor-quiz-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed spacing and styling of quiz question options in the editor on WordPress 7.1.


### PR DESCRIPTION
Resolves [SEN-138](https://linear.app/a8c/issue/SEN-138/wp-71-fix-quiz-question-editor-styles-broken-by-iframed-editor)

## Proposed Changes
WordPress 7.1 moves the post editor into an iframe. Sensei's quiz question styles were scoped to an editor class that now sits outside that iframe, so a few things looked wrong when editing questions:

- Multiple Choice option toggles sat too tight against their answer text.
- The "right answer" toggle button (Multiple Choice / True-False) lost its spacing and styling.
- The question editing canvas lost its top/bottom padding.

This re-scopes those rules to a class that's present inside the iframe, so the spacing is correct on 7.1 while still working on older WordPress versions.

## Screenshots

| Before | After |
| --- | --- |
| <img width="2412" height="1028" alt="Before" src="https://github.com/user-attachments/assets/91968da3-7129-48da-90d6-9df0065305d6" /> | <img width="2232" height="1010" alt="After" src="https://github.com/user-attachments/assets/6e916500-4127-4b6c-b812-3e7bb4a5cd60" /> |

## Testing Instructions

- [x] On WordPress 7.1+, add or edit a Question (Sensei LMS → Questions → Add Question).
- [x] Multiple Choice: confirm the answer toggles have a small gap before the text, and the right-answer toggle button looks styled (bordered, uppercase).
- [x] True/False: confirm the right-answer toggle button is styled the same way.
- [x] Confirm the question canvas has padding at the top and bottom (content isn't flush to the edge).
- [x] Repeat on an older WordPress (e.g. 6.8) and confirm everything still looks correct (`make up WP=6.8`).

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fixed

#### Message
Fixed spacing and styling of quiz question options when using the iframed block editor.

</details>

