### PR TITLE
Fix PHP notice from Learning Mode templates in WordPress 7.1

### DIFF
--- a/changelog/sen-139-learning-mode-templates-php-notice
+++ b/changelog/sen-139-learning-mode-templates-php-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a PHP notice logged by Learning Mode templates in WordPress 7.1.

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -191,7 +191,6 @@ class Sensei_Course_Theme_Templates {
 			'origin'         => 'theme',
 			'is_custom'      => false,
 			'has_theme_file' => true,
-			'modified'       => null,
 			'status'         => 'publish',
 		];
 
@@ -315,12 +314,13 @@ class Sensei_Course_Theme_Templates {
 
 		foreach ( $this->file_templates as $name => $template ) {
 
-			$db_template     = $db_templates[ $name ] ?? null;
-			$template_object = (object) $template;
+			$db_template = $db_templates[ $name ] ?? null;
 
 			if ( ! empty( $db_template ) ) {
 				$template_object = $this->build_template_from_post( $db_template );
 			} else {
+				$template_object = $this->build_default_template( $template );
+
 				// Prefill the template contents from their content files.
 				if ( ! empty( $template['content'] ) && file_exists( $template['content'] ) ) {
 
@@ -348,8 +348,6 @@ class Sensei_Course_Theme_Templates {
 						$template_object->content .= Template_Style::serialize_block( $css );
 					}
 				}
-				$template_object->wp_id  = null;
-				$template_object->author = null;
 			}
 
 			$templates[ $name ] = $template_object;
@@ -444,6 +442,29 @@ class Sensei_Course_Theme_Templates {
 		list( , $slug ) = explode( '//', $id );
 
 		return $templates[ $slug ] ?? $template;
+	}
+
+	/**
+	 * Build a default (uncustomized) template object from its field list.
+	 *
+	 * Uses a real WP_Block_Template so every field WordPress expects a template
+	 * to have is present, including fields WordPress adds in future releases.
+	 *
+	 * @param array $fields The template field list.
+	 *
+	 * @return WP_Block_Template
+	 */
+	private function build_default_template( $fields ) {
+		$template = new WP_Block_Template();
+
+		foreach ( $fields as $key => $value ) {
+			$template->$key = $value;
+		}
+
+		$template->wp_id  = null;
+		$template->author = null;
+
+		return $template;
 	}
 
 	/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-templates.php
@@ -106,6 +106,22 @@ class Sensei_Course_Theme_Templates_Test extends WP_UnitTestCase {
 		$this->assertCount( 2, $filtered_templates );
 	}
 
+	public function testGetBlockTemplates_LessonTemplateNotCustomized_ReturnsWpBlockTemplate() {
+		add_filter( 'pre_http_request', '__return_empty_array' );
+
+		$templates = Sensei_Course_Theme_Templates::instance()->get_block_templates();
+
+		$this->assertInstanceOf( WP_Block_Template::class, $templates['lesson'] );
+	}
+
+	public function testGetBlockTemplates_LessonTemplateNotCustomized_ReturnsTemplateWithLessonSlug() {
+		add_filter( 'pre_http_request', '__return_empty_array' );
+
+		$templates = Sensei_Course_Theme_Templates::instance()->get_block_templates();
+
+		$this->assertSame( 'lesson', $templates['lesson']->slug );
+	}
+
 	public function testShouldUseQuizTemplate_QuizPassed_ReturnsFalse(): void {
 		/* Arrange. */
 		global $post;


### PR DESCRIPTION
## Proposed Changes

With WordPress 7.1, loading the site's template list (e.g. Appearance → Editor → Templates) logs a PHP notice: `Undefined property: stdClass::$date`. Nothing visibly breaks, but it floods the error log.

Sensei's Learning Mode adds default lesson and quiz templates to WordPress's template list. Those defaults were built as plain generic objects from a hardcoded field list. WordPress reads a set of fields on every template in the list and adds new ones over time (`modified` in 6.3, `date` in 7.1); any field the hardcoded list is missing triggers the notice.

The default templates are now built as real `WP_Block_Template` objects — the same type the customized-template path already returns — so every field WordPress expects is present today and for future releases, without chasing them one at a time.

## Testing Instructions

- [x] Use a site running WordPress 7.1+ with `WP_DEBUG` and `WP_DEBUG_LOG` enabled.
- [x] Enable Learning Mode on a course (Course settings → Learning Mode).
- [x] Go to Appearance → Editor → Templates and open the templates list.
- [x] Confirm `wp-content/debug.log` shows no `Undefined property: stdClass::$date` notice.
- [x] Confirm the Learning Mode lesson and quiz templates still appear and render correctly on the front end.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fix a PHP notice logged by Learning Mode templates in WordPress 7.1.

</details>
