### PR TITLE
Scope the student management user search

### DIFF
--- a/changelog/fix-student-search-user-scope
+++ b/changelog/fix-student-search-user-scope
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restrict the Students search to student accounts and stop returning email addresses.

--- a/changelog/fix-student-search-user-scope
+++ b/changelog/fix-student-search-user-scope
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Restrict the Students search to student accounts and stop returning email addresses.
+Scope the Students management user search to student accounts.

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -790,7 +790,7 @@ class Sensei_Learner_Management {
 			wp_send_json( $found_users );
 		}
 
-		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
+		$term = isset( $_GET['term'] ) && is_string( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
 
 		if ( empty( $term ) ) {
 			die();

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -774,20 +774,35 @@ class Sensei_Learner_Management {
 
 	/**
 	 * Searches for a Learner by name or username.
+	 *
+	 * The search is used to manually enrol students, so it requires the grades
+	 * capability and, for users who cannot manage all of Sensei, it is limited to
+	 * student-only accounts and never exposes email addresses.
 	 */
 	public function json_search_users() {
 
 		check_ajax_referer( 'search-users', 'security' );
 
-		$term = sanitize_text_field( stripslashes( $_GET['term'] ) );
+		$default     = isset( $_GET['default'] ) ? $_GET['default'] : __( 'None', 'sensei-lms' );
+		$found_users = array( '' => $default );
+
+		if ( ! current_user_can( 'manage_sensei_grades' ) ) {
+			wp_send_json( $found_users );
+		}
+
+		$term = isset( $_GET['term'] ) ? sanitize_text_field( stripslashes( $_GET['term'] ) ) : '';
 
 		if ( empty( $term ) ) {
 			die();
 		}
 
-		$default = isset( $_GET['default'] ) ? $_GET['default'] : __( 'None', 'sensei-lms' );
+		// Users who can manage all of Sensei may search everyone, including by email.
+		$can_manage_all = current_user_can( 'manage_sensei' );
+		$search_columns = array( 'ID', 'user_login', 'user_nicename', 'user_firstname', 'user_lastname' );
 
-		$found_users = array( '' => $default );
+		if ( $can_manage_all ) {
+			$search_columns[] = 'user_email';
+		}
 
 		$users_query = new WP_User_Query(
 			apply_filters(
@@ -796,7 +811,7 @@ class Sensei_Learner_Management {
 					'fields'         => 'all',
 					'orderby'        => 'display_name',
 					'search'         => '*' . $term . '*',
-					'search_columns' => array( 'ID', 'user_login', 'user_email', 'user_nicename', 'user_firstname', 'user_lastname' ),
+					'search_columns' => $search_columns,
 				),
 				$term
 			)
@@ -806,6 +821,12 @@ class Sensei_Learner_Management {
 
 		if ( $users ) {
 			foreach ( $users as $user ) {
+				// Restrict non-admins to student-only accounts so teachers cannot
+				// enumerate administrators, editors, or other teachers.
+				if ( ! $can_manage_all && ( user_can( $user->ID, 'edit_posts' ) || user_can( $user->ID, 'manage_sensei_grades' ) ) ) {
+					continue;
+				}
+
 				$full_name = Sensei_Learner::get_full_name( $user->ID );
 
 				if ( trim( $user->display_name ) === trim( $full_name ) ) {
@@ -818,7 +839,7 @@ class Sensei_Learner_Management {
 
 				}
 
-				$found_users[ $user->ID ] = $name . ' (#' . $user->ID . ' - ' . sanitize_email( $user->user_email ) . ')';
+				$found_users[ $user->ID ] = $name . ' (#' . $user->ID . ')';
 			}
 		}
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -783,7 +783,7 @@ class Sensei_Learner_Management {
 
 		check_ajax_referer( 'search-users', 'security' );
 
-		$default     = isset( $_GET['default'] ) ? $_GET['default'] : __( 'None', 'sensei-lms' );
+		$default     = isset( $_GET['default'] ) && is_string( $_GET['default'] ) ? sanitize_text_field( wp_unslash( $_GET['default'] ) ) : __( 'None', 'sensei-lms' );
 		$found_users = array( '' => $default );
 
 		if ( ! current_user_can( 'manage_sensei_grades' ) ) {

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -790,7 +790,7 @@ class Sensei_Learner_Management {
 			wp_send_json( $found_users );
 		}
 
-		$term = isset( $_GET['term'] ) ? sanitize_text_field( stripslashes( $_GET['term'] ) ) : '';
+		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
 
 		if ( empty( $term ) ) {
 			die();

--- a/tests/unit-tests/admin/test-class-sensei-learner-management-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learner-management-ajax.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * AJAX tests for Sensei_Learner_Management.
+ *
+ * @package sensei
+ *
+ * @group ajax-calls
+ */
+class Sensei_Learner_Management_AJAX_Test extends WP_Ajax_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		Sensei()->teacher->create_role();
+
+		new Sensei_Learner_Management( '' );
+
+		// _handleAjax() fires admin_init, which triggers WordPress's api.wordpress.org update checks.
+		add_filter( 'pre_http_request', '__return_empty_array' );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', '__return_empty_array' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Runs the search-users AJAX action and returns the decoded response.
+	 *
+	 * @param string $term Search term.
+	 *
+	 * @return array
+	 */
+	private function do_search( string $term ): array {
+		$nonce = wp_create_nonce( 'search-users' );
+
+		$_GET['term']         = $term;
+		$_GET['security']     = $nonce;
+		$_REQUEST['security'] = $nonce;
+
+		try {
+			$this->_handleAjax( 'sensei_json_search_users' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		return (array) json_decode( $this->_last_response, true );
+	}
+
+	/**
+	 * A teacher must not be able to see administrators through the user search.
+	 *
+	 * @covers Sensei_Learner_Management::json_search_users
+	 */
+	public function testJsonSearchUsers_TeacherSearchedForMatchingAdministrator_ExcludesAdminFromResults() {
+		/* Arrange. */
+		$teacher_id = self::factory()->user->create( array( 'role' => 'teacher' ) );
+		$admin_id   = self::factory()->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'searchme_admin',
+			)
+		);
+
+		wp_set_current_user( $teacher_id );
+
+		/* Act. */
+		$response = $this->do_search( 'searchme' );
+
+		/* Assert. */
+		$this->assertArrayNotHasKey( $admin_id, $response );
+	}
+
+	/**
+	 * The user search must not expose email addresses.
+	 *
+	 * @covers Sensei_Learner_Management::json_search_users
+	 */
+	public function testJsonSearchUsers_TeacherSearchedForMatchingStudent_OmitsEmailFromLabel() {
+		/* Arrange. */
+		$teacher_id = self::factory()->user->create( array( 'role' => 'teacher' ) );
+		$student_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'searchme_student',
+				'user_email' => 'searchme_student@example.com',
+			)
+		);
+
+		wp_set_current_user( $teacher_id );
+
+		/* Act. */
+		$response = $this->do_search( 'searchme' );
+
+		/* Assert. */
+		$this->assertStringNotContainsString( 'searchme_student@example.com', $response[ $student_id ] ?? '' );
+	}
+
+	/**
+	 * A user without the grades capability must not get any search results.
+	 *
+	 * @covers Sensei_Learner_Management::json_search_users
+	 */
+	public function testJsonSearchUsers_UserWithoutGradesCapGiven_ReturnsNoUsers() {
+		/* Arrange. */
+		$requester_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'searchme_target',
+			)
+		);
+
+		wp_set_current_user( $requester_id );
+
+		/* Act. */
+		$response = $this->do_search( 'searchme' );
+
+		/* Assert. */
+		$this->assertEmpty( array_filter( array_keys( $response ), 'is_numeric' ) );
+	}
+}

--- a/tests/unit-tests/admin/test-class-sensei-learner-management-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learner-management-ajax.php
@@ -143,4 +143,54 @@ class Sensei_Learner_Management_AJAX_Test extends WP_Ajax_UnitTestCase {
 		/* Assert. */
 		$this->assertEmpty( array_filter( array_keys( $response ), 'is_numeric' ) );
 	}
+
+	/**
+	 * An admin keeps the full search, including matching users by email.
+	 *
+	 * @covers Sensei_Learner_Management::json_search_users
+	 */
+	public function testJsonSearchUsers_AdminSearchedByEmail_ReturnsMatchingAdministrator() {
+		/* Arrange. */
+		$admin_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$target_id = self::factory()->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'other_admin',
+				'user_email' => 'searchme_byemail@example.com',
+			)
+		);
+
+		wp_set_current_user( $admin_id );
+
+		/* Act. */
+		$response = $this->do_search( 'searchme_byemail' );
+
+		/* Assert. */
+		$this->assertArrayHasKey( $target_id, $response );
+	}
+
+	/**
+	 * The user search must not expose email addresses, not even for admins.
+	 *
+	 * @covers Sensei_Learner_Management::json_search_users
+	 */
+	public function testJsonSearchUsers_AdminSearchedForMatchingStudent_OmitsEmailFromLabel() {
+		/* Arrange. */
+		$admin_id   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$student_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'searchme_labelstudent',
+				'user_email' => 'searchme_labelstudent@example.com',
+			)
+		);
+
+		wp_set_current_user( $admin_id );
+
+		/* Act. */
+		$response = $this->do_search( 'searchme_labelstudent' );
+
+		/* Assert. */
+		$this->assertStringNotContainsString( 'searchme_labelstudent@example.com', $response[ $student_id ] ?? '' );
+	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-learner-management-ajax.php
+++ b/tests/unit-tests/admin/test-class-sensei-learner-management-ajax.php
@@ -72,6 +72,30 @@ class Sensei_Learner_Management_AJAX_Test extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * A teacher must not be able to see other teachers through the user search.
+	 *
+	 * @covers Sensei_Learner_Management::json_search_users
+	 */
+	public function testJsonSearchUsers_TeacherSearchedForMatchingTeacher_ExcludesTeacherFromResults() {
+		/* Arrange. */
+		$teacher_id = self::factory()->user->create( array( 'role' => 'teacher' ) );
+		$target_id  = self::factory()->user->create(
+			array(
+				'role'       => 'teacher',
+				'user_login' => 'searchme_teacher',
+			)
+		);
+
+		wp_set_current_user( $teacher_id );
+
+		/* Act. */
+		$response = $this->do_search( 'searchme' );
+
+		/* Assert. */
+		$this->assertArrayNotHasKey( $target_id, $response );
+	}
+
+	/**
 	 * The user search must not expose email addresses.
 	 *
 	 * @covers Sensei_Learner_Management::json_search_users


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SEN-142

## Proposed Changes

Tightens the scope of the user search behind the Students management screen (`sensei_json_search_users`). The handler now requires the grades capability, limits results for non-administrators to student accounts, and drops email addresses from the result labels for everyone (administrators included). Administrators keep the full search, including matching users by email.

## Testing Instructions

1. As an administrator, create a teacher account and a student (subscriber) account.
2. Log in as the teacher, go to **Sensei LMS → Students**, open a course's student list, and scroll to the **Add Student to Course** search.
3. Search for a term matching administrators or editors (e.g. part of the admin login). Confirm those accounts do not appear in the dropdown.
4. Search for the student. Confirm they appear and that the result shows only `Name (#id)`, with no email address.
5. Log in as an administrator and repeat: confirm the search still returns all users.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Scope the Students management user search to student accounts.

</details>
