### PR TITLE
Show Learning Mode and email templates in their own Site Editor group

### DIFF
--- a/changelog/learning-mode-templates-editor-group
+++ b/changelog/learning-mode-templates-editor-group
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Learning Mode and email templates now appear in their own group in the WordPress 7.1 Site Editor.
+Learning Mode and email templates now appear in their own group in the Site Editor.

--- a/changelog/learning-mode-templates-editor-group
+++ b/changelog/learning-mode-templates-editor-group
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Learning Mode and email templates now appear in their own group in the Site Editor.
+Learning Mode and email templates now appear in their own group in the WordPress 7.1 Site Editor.

--- a/changelog/learning-mode-templates-editor-group
+++ b/changelog/learning-mode-templates-editor-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Learning Mode and email templates now appear in their own group in the WordPress 7.1 Site Editor.

--- a/includes/course-theme/class-sensei-course-theme-template-selection.php
+++ b/includes/course-theme/class-sensei-course-theme-template-selection.php
@@ -219,12 +219,10 @@ class Sensei_Course_Theme_Template_Selection {
 	 * @param boolean $update Whether this was an update of the existing post or not.
 	 */
 	public function maybe_set_block_template_name( $post_id, $post, $update ) {
+		// Only the lesson and quiz wp_template posts get the template name suffix.
 		if (
-			// We set the template name meta only for wp_template post types.
 			'wp_template' !== $post->post_type ||
-
-			// We set the template name meta only for templates for lesson and quiz posts.
-			! in_array( $post->post_name, [ 'lesson', 'quiz' ], true )
+			! in_array( $post->post_name, array( Sensei_Course_Theme_Templates::LESSON_SLUG, Sensei_Course_Theme_Templates::QUIZ_SLUG ), true )
 		) {
 			return;
 		}
@@ -257,7 +255,7 @@ class Sensei_Course_Theme_Template_Selection {
 
 		// Check each lm template and append a template name postfix if they don't have it.
 		foreach ( $db_templates as $db_template ) {
-			if ( in_array( $db_template->post_name, [ 'lesson', 'quiz' ], true ) ) {
+			if ( in_array( $db_template->post_name, array( Sensei_Course_Theme_Templates::LESSON_SLUG, Sensei_Course_Theme_Templates::QUIZ_SLUG ), true ) ) {
 				$db_template->post_name = $db_template->post_name . self::TEMPLATE_NAME_SEPERATOR . self::DEFAULT_TEMPLATE_NAME;
 				wp_update_post( $db_template );
 			}

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -92,7 +92,7 @@ class Sensei_Course_Theme_Templates {
 	 * @since $$next-version$$
 	 */
 	public function register_block_templates() {
-		$namespace = dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) );
+		$namespace = basename( dirname( SENSEI_LMS_PLUGIN_FILE ) );
 
 		// The slug is the post type, which is how the customized template is keyed in the database.
 		foreach ( array( self::LESSON_SLUG, self::QUIZ_SLUG ) as $slug ) {
@@ -408,7 +408,7 @@ class Sensei_Course_Theme_Templates {
 
 			// Mark as plugin templates so the Site Editor groups them under "Sensei LMS".
 			$template_object->origin = 'plugin';
-			$template_object->plugin = dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) );
+			$template_object->plugin = basename( dirname( SENSEI_LMS_PLUGIN_FILE ) );
 
 			$templates[ $name ] = $template_object;
 		}

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -346,11 +346,14 @@ class Sensei_Course_Theme_Templates {
 	 * @return array
 	 */
 	private function remove_registered_placeholders( $templates ) {
-		return array_filter(
-			$templates,
-			function ( $template ) {
-				return ! ( 'plugin' === $template->source && in_array( $template->slug, array( self::LESSON_SLUG, self::QUIZ_SLUG ), true ) );
-			}
+		// array_values() reindexes so REST still encodes the result as an array, not an object.
+		return array_values(
+			array_filter(
+				$templates,
+				function ( $template ) {
+					return ! ( 'plugin' === $template->source && in_array( $template->slug, array( self::LESSON_SLUG, self::QUIZ_SLUG ), true ) );
+				}
+			)
 		);
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -93,16 +93,21 @@ class Sensei_Course_Theme_Templates {
 	 */
 	public function register_block_templates() {
 		$namespace = basename( dirname( SENSEI_LMS_PLUGIN_FILE ) );
+		$registry  = WP_Block_Templates_Registry::get_instance();
 
 		// The slug is the post type, which is how the customized template is keyed in the database.
 		foreach ( array( self::LESSON_SLUG, self::QUIZ_SLUG ) as $slug ) {
-			register_block_template(
-				$namespace . '//' . $slug,
-				array(
-					'post_types' => array( $slug ),
-					'content'    => '',
-				)
-			);
+			$name = $namespace . '//' . $slug;
+
+			if ( ! $registry->is_registered( $name ) ) {
+				register_block_template(
+					$name,
+					array(
+						'post_types' => array( $slug ),
+						'content'    => '',
+					)
+				);
+			}
 		}
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -25,6 +25,12 @@ class Sensei_Course_Theme_Templates {
 	const THEME_PREFIX = Sensei_Course_Theme::THEME_NAME;
 
 	/**
+	 * Learning Mode template slugs.
+	 */
+	const LESSON_SLUG = 'lesson';
+	const QUIZ_SLUG   = 'quiz';
+
+	/**
 	 * Instance of class.
 	 *
 	 * @var self
@@ -71,7 +77,33 @@ class Sensei_Course_Theme_Templates {
 		add_filter( 'theme_lesson_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
 		add_filter( 'theme_quiz_templates', [ $this, 'add_learning_mode_template' ], 10, 4 );
 		add_action( 'init', [ $this, 'load_course_theme_patterns' ] );
+		add_action( 'init', array( $this, 'register_block_templates' ) );
 
+	}
+
+	/**
+	 * Register the Learning Mode templates as plugin templates.
+	 *
+	 * This is what makes the Site Editor list them under their own "Sensei LMS" group.
+	 * The registrations are placeholders only.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 */
+	public function register_block_templates() {
+		$namespace = dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) );
+
+		// The slug is the post type, which is how the customized template is keyed in the database.
+		foreach ( array( self::LESSON_SLUG, self::QUIZ_SLUG ) as $slug ) {
+			register_block_template(
+				$namespace . '//' . $slug,
+				array(
+					'post_types' => array( $slug ),
+					'content'    => '',
+				)
+			);
+		}
 	}
 
 
@@ -96,7 +128,7 @@ class Sensei_Course_Theme_Templates {
 	 */
 	public function maybe_add_theme_supports() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Argument cast to int and used for comparison.
-		if ( isset( $_GET['post'] ) && in_array( get_post_type( (int) $_GET['post'] ), [ 'lesson', 'quiz' ], true ) ) {
+		if ( isset( $_GET['post'] ) && in_array( get_post_type( (int) $_GET['post'] ), array( self::LESSON_SLUG, self::QUIZ_SLUG ), true ) ) {
 			add_theme_support( 'block-templates' );
 		}
 	}
@@ -139,11 +171,11 @@ class Sensei_Course_Theme_Templates {
 		}
 
 		if ( $this->should_use_quiz_template() ) {
-			return array_merge( [ 'quiz', 'lesson' ], $templates );
+			return array_merge( array( self::QUIZ_SLUG, self::LESSON_SLUG ), $templates );
 		}
 
-		if ( ! in_array( 'lesson', $templates, true ) ) {
-			return array_merge( [ 'lesson' ], $templates );
+		if ( ! in_array( self::LESSON_SLUG, $templates, true ) ) {
+			return array_merge( array( self::LESSON_SLUG ), $templates );
 		}
 
 		return $templates;
@@ -165,7 +197,7 @@ class Sensei_Course_Theme_Templates {
 
 		$has_submitted_quiz = $progress && $progress->is_quiz_submitted();
 
-		if ( 'quiz' !== $post->post_type || $has_submitted_quiz ) {
+		if ( self::QUIZ_SLUG !== $post->post_type || $has_submitted_quiz ) {
 			return false;
 		}
 
@@ -195,27 +227,27 @@ class Sensei_Course_Theme_Templates {
 		];
 
 		$this->file_templates = [
-			'lesson' => array_merge(
+			self::LESSON_SLUG => array_merge(
 				$common_options,
 				[
 					// translators: %1$s is the block template name.
 					'title'       => sprintf( __( 'Lesson (Learning Mode - %1$s)', 'sensei-lms' ), $title ),
 					'description' => __( 'Displays course content.', 'sensei-lms' ),
-					'slug'        => 'lesson',
-					'id'          => self::THEME_PREFIX . '//lesson',
-					'content'     => $template->content['lesson'],
+					'slug'        => self::LESSON_SLUG,
+					'id'          => self::THEME_PREFIX . '//' . self::LESSON_SLUG,
+					'content'     => $template->content[ self::LESSON_SLUG ],
 					'styles'      => $template->styles,
 				]
 			),
-			'quiz'   => array_merge(
+			self::QUIZ_SLUG   => array_merge(
 				$common_options,
 				[
 					// translators: %1$s is the block template name.
 					'title'       => sprintf( __( 'Quiz (Learning Mode - %1$s)', 'sensei-lms' ), $title ),
 					'description' => __( 'Displays a lesson quiz.', 'sensei-lms' ),
-					'slug'        => 'quiz',
-					'id'          => self::THEME_PREFIX . '//quiz',
-					'content'     => $template->content['quiz'],
+					'slug'        => self::QUIZ_SLUG,
+					'id'          => self::THEME_PREFIX . '//' . self::QUIZ_SLUG,
+					'content'     => $template->content[ self::QUIZ_SLUG ],
 					'styles'      => $template->styles,
 				]
 			),
@@ -246,8 +278,9 @@ class Sensei_Course_Theme_Templates {
 			return $templates;
 		}
 
+		// Post editor with Learning Mode off: hide the lesson template, placeholder included.
 		if ( $this->should_hide_lesson_template( $query['post_type'] ?? null ) ) {
-			return $templates;
+			return $this->remove_registered_placeholders( $templates );
 		}
 
 		$slugs = $query['slug__in'] ?? $query['post_type'] ?? null;
@@ -255,7 +288,7 @@ class Sensei_Course_Theme_Templates {
 			$slugs = [ $slugs ];
 		}
 
-		$supported_template_types = [ 'lesson', 'quiz' ];
+		$supported_template_types = array( self::LESSON_SLUG, self::QUIZ_SLUG );
 
 		$is_site_editor_request   = Sensei_Course_Theme_Editor::is_site_editor_request();
 		$is_course_theme_override = ! empty( $query['theme'] ) && ( Sensei_Course_Theme::THEME_NAME === $query['theme'] );
@@ -272,8 +305,12 @@ class Sensei_Course_Theme_Templates {
 		);
 
 		if ( ! $is_site_editor && ! $is_supported_template ) {
+			// Keep the placeholders here: WordPress builds the group switcher from this list.
 			return $templates;
 		}
+
+		// Drop the placeholders; Sensei's real templates are injected below.
+		$templates = $this->remove_registered_placeholders( $templates );
 
 		// Remove the default lesson template for course theme.
 		$templates = $this->filter_single_lesson_template_in_learning_mode( $templates, wp_get_theme()->get( 'Name' ) );
@@ -295,10 +332,26 @@ class Sensei_Course_Theme_Templates {
 
 		// Return the lesson template as the default when there are no theme templates in the site editor.
 		if ( $is_site_editor && empty( $templates ) ) {
-			return [ $course_theme_templates['lesson'] ];
+			return array( $course_theme_templates[ self::LESSON_SLUG ] );
 		}
 
 		return $templates;
+	}
+
+	/**
+	 * Remove the placeholder copies of the Learning Mode templates.
+	 *
+	 * @param array $templates The block templates.
+	 *
+	 * @return array
+	 */
+	private function remove_registered_placeholders( $templates ) {
+		return array_filter(
+			$templates,
+			function ( $template ) {
+				return ! ( 'plugin' === $template->source && in_array( $template->slug, array( self::LESSON_SLUG, self::QUIZ_SLUG ), true ) );
+			}
+		);
 	}
 
 	/**
@@ -349,6 +402,10 @@ class Sensei_Course_Theme_Templates {
 					}
 				}
 			}
+
+			// Mark as plugin templates so the Site Editor groups them under "Sensei LMS".
+			$template_object->origin = 'plugin';
+			$template_object->plugin = dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) );
 
 			$templates[ $name ] = $template_object;
 		}
@@ -513,7 +570,7 @@ class Sensei_Course_Theme_Templates {
 	 * @return bool True if template should be hidden.
 	 */
 	private function should_hide_lesson_template( $post_type ) {
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && 'lesson' === $post_type ) {
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && self::LESSON_SLUG === $post_type ) {
 
 			$referer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
 

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -22,7 +22,7 @@ class Email_Page_Template {
 
 
 	public const THEME         = 'sensei-email';
-	public const SLUG          = 'single-sensei_email';
+	public const SLUG          = 'single-' . Email_Post_Type::POST_TYPE;
 	public const ID            = self::THEME . '//' . self::SLUG;
 	public const TEMPLATE_PATH = 'block-templates/email-template.php';
 
@@ -55,6 +55,27 @@ class Email_Page_Template {
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_from_file' ], 10, 3 );
 		add_filter( 'get_block_templates', [ $this, 'add_email_template' ], 10, 3 );
 		add_filter( 'get_block_template', [ $this, 'get_template' ], 10, 3 );
+		add_action( 'init', array( $this, 'register_email_block_template' ) );
+	}
+
+	/**
+	 * Register the email template as a plugin template.
+	 *
+	 * This is what makes the Site Editor list it under the "Sensei LMS" group.
+	 * The registration is a placeholder only.
+	 *
+	 * @internal
+	 *
+	 * @since $$next-version$$
+	 */
+	public function register_email_block_template(): void {
+		register_block_template(
+			dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) ) . '//' . self::SLUG,
+			array(
+				'post_types' => array( Email_Post_Type::POST_TYPE ),
+				'content'    => '',
+			)
+		);
 	}
 
 	/**
@@ -113,6 +134,14 @@ class Email_Page_Template {
 	 * @return WP_Block_Template The original or the email template.
 	 */
 	public function add_email_template( $query_result, $query, $template_type ) {
+		// Drop the placeholder; the real template is added below.
+		$query_result = array_filter(
+			$query_result,
+			function ( $template ) {
+				return ! ( 'plugin' === $template->source && self::SLUG === $template->slug );
+			}
+		);
+
 		if ( ! \Sensei_Course_Theme_Editor::is_site_editor_request() ) {
 			return $query_result;
 		}
@@ -137,11 +166,13 @@ class Email_Page_Template {
 
 		$from_db = $this->repository->get( self::ID );
 
-		if ( ! empty( $from_db ) ) {
-			$query_result[] = $from_db;
-		} else {  // Use the PHP email template.
-			$query_result[] = $this->repository->get_from_file( self::TEMPLATE_PATH, self::ID );
-		}
+		$template = ! empty( $from_db ) ? $from_db : $this->repository->get_from_file( self::TEMPLATE_PATH, self::ID );
+
+		// Mark as a plugin template so the Site Editor groups it under "Sensei LMS".
+		$template->origin = 'plugin';
+		$template->plugin = dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) );
+
+		$query_result[] = $template;
 
 		return $query_result;
 	}

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -141,7 +141,7 @@ class Email_Page_Template {
 
 		// Mark as a plugin template so the Site Editor groups it under "Sensei LMS".
 		$template->origin = 'plugin';
-		$template->plugin = dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) );
+		$template->plugin = basename( dirname( SENSEI_LMS_PLUGIN_FILE ) );
 
 		$query_result[] = $template;
 

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -55,27 +55,6 @@ class Email_Page_Template {
 		add_filter( 'pre_get_block_file_template', [ $this, 'get_from_file' ], 10, 3 );
 		add_filter( 'get_block_templates', [ $this, 'add_email_template' ], 10, 3 );
 		add_filter( 'get_block_template', [ $this, 'get_template' ], 10, 3 );
-		add_action( 'init', array( $this, 'register_email_block_template' ) );
-	}
-
-	/**
-	 * Register the email template as a plugin template.
-	 *
-	 * This is what makes the Site Editor list it under the "Sensei LMS" group.
-	 * The registration is a placeholder only.
-	 *
-	 * @internal
-	 *
-	 * @since $$next-version$$
-	 */
-	public function register_email_block_template(): void {
-		register_block_template(
-			dirname( plugin_basename( SENSEI_LMS_PLUGIN_FILE ) ) . '//' . self::SLUG,
-			array(
-				'post_types' => array( Email_Post_Type::POST_TYPE ),
-				'content'    => '',
-			)
-		);
 	}
 
 	/**
@@ -134,14 +113,6 @@ class Email_Page_Template {
 	 * @return WP_Block_Template The original or the email template.
 	 */
 	public function add_email_template( $query_result, $query, $template_type ) {
-		// Drop the placeholder; the real template is added below.
-		$query_result = array_filter(
-			$query_result,
-			function ( $template ) {
-				return ! ( 'plugin' === $template->source && self::SLUG === $template->slug );
-			}
-		);
-
 		if ( ! \Sensei_Course_Theme_Editor::is_site_editor_request() ) {
 			return $query_result;
 		}

--- a/includes/internal/emails/class-email-page-template.php
+++ b/includes/internal/emails/class-email-page-template.php
@@ -139,6 +139,10 @@ class Email_Page_Template {
 
 		$template = ! empty( $from_db ) ? $from_db : $this->repository->get_from_file( self::TEMPLATE_PATH, self::ID );
 
+		if ( empty( $template ) ) {
+			return $query_result;
+		}
+
 		// Mark as a plugin template so the Site Editor groups it under "Sensei LMS".
 		$template->origin = 'plugin';
 		$template->plugin = basename( dirname( SENSEI_LMS_PLUGIN_FILE ) );


### PR DESCRIPTION
Resolves [SEN-140](https://linear.app/a8c/issue/SEN-140/learning-mode-templates-no-longer-show-as-their-own-group-in-wordpress).

## Proposed Changes

WordPress 7.1 rebuilt the Site Editor's Templates screen and only shows a plugin's templates as their own group when they are registered as plugin templates. Sensei's Learning Mode (Lesson, Quiz) and email templates were added the older way, so on WP 7.1 they lost their grouping and folded into "All Templates", making them hard to find.

This registers those templates with `register_block_template()` so the editor lists them under a dedicated "Sensei LMS" group. Sensei still serves its own dynamic template content and keeps its existing customization storage, so saved Learning Mode and email customizations are unaffected.

## Screenshots

| Before | After |
| --- | --- |
| <img width="3006" height="1084" alt="Screenshot 2026-08-17 at 3 19 38 PM" src="https://github.com/user-attachments/assets/eb182a16-6230-4e79-8e80-67e3b54b4c14" /> | <img width="2518" height="1188" alt="Screenshot 2026-08-17 at 3 20 49 PM" src="https://github.com/user-attachments/assets/e6fe5ef4-e257-4278-84f0-a858d5051875" /> |

## Testing Instructions

- [x] On WordPress 7.1+, go to Appearance → Editor → Templates.
- [x] Confirm a "Sensei LMS" group appears.
- [x] Open it and confirm it lists Lesson (Learning Mode), Quiz (Learning Mode), and Sensei Email — with no duplicate rows.
- [x] On the frontend, view a lesson and its quiz in a Learning Mode course; confirm the Learning Mode layout still renders.
- [x] Customize a Learning Mode template, save, reload; confirm the edit persists and the template still appears under the Sensei LMS group.

## Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Learning Mode and email templates now appear in their own group in the WordPress 7.1 Site Editor.

</details>