### PR TITLE
Probe the editor canvas iframe for block colors

### DIFF
--- a/assets/react-hooks/probe-styles.js
+++ b/assets/react-hooks/probe-styles.js
@@ -14,7 +14,18 @@ import { useSelect } from '@wordpress/data';
  */
 import { hexToRGB } from '../shared/helpers/colors';
 
-const { getComputedStyle } = window;
+/**
+ * Resolve the document to probe against.
+ *
+ * When the editor is iframed, the theme's styles live inside the canvas iframe
+ * document, so probe there. Fall back to the outer document when there is no
+ * iframe.
+ *
+ * @return {Document} The document to probe against.
+ */
+const getProbeDocument = () =>
+	document.querySelector( 'iframe[name="editor-canvas"]' )?.contentDocument ||
+	document;
 
 /**
  * Get color object by probe.
@@ -59,15 +70,17 @@ export const useColorsByProbe = () => {
  * @return {Object} Probe default styles.
  */
 export const getProbeStyles = memoize( () => {
+	const probeDocument = getProbeDocument();
+
 	// Create temporary probe elements.
-	const editorStylesWrapperDiv = document.createElement( 'div' );
+	const editorStylesWrapperDiv = probeDocument.createElement( 'div' );
 	editorStylesWrapperDiv.className =
 		'editor-styles-wrapper sensei-probe-element';
 
-	const blockButtonDiv = document.createElement( 'div' );
+	const blockButtonDiv = probeDocument.createElement( 'div' );
 	blockButtonDiv.className = 'wp-block-button';
 
-	const buttonLinkDiv = document.createElement( 'div' );
+	const buttonLinkDiv = probeDocument.createElement( 'div' );
 	buttonLinkDiv.className = 'wp-block-button__link';
 	buttonLinkDiv.textContent = 'Probe';
 
@@ -78,16 +91,17 @@ export const getProbeStyles = memoize( () => {
 	// Add probe to the screen.
 	blockButtonDiv.appendChild( buttonLinkDiv );
 	editorStylesWrapperDiv.appendChild( blockButtonDiv );
-	document.body.appendChild( editorStylesWrapperDiv );
+	probeDocument.body.appendChild( editorStylesWrapperDiv );
 
 	// Save styles.
+	const { getComputedStyle } = probeDocument.defaultView;
 	const styles = {
 		primaryColor: getComputedStyle( buttonLinkDiv ).backgroundColor,
 		primaryContrastColor: getComputedStyle( buttonLinkDiv ).color,
 	};
 
 	// Remove probe.
-	document.body.removeChild( editorStylesWrapperDiv );
+	probeDocument.body.removeChild( editorStylesWrapperDiv );
 
 	return styles;
 } );

--- a/assets/react-hooks/probe-styles.js
+++ b/assets/react-hooks/probe-styles.js
@@ -62,46 +62,51 @@ export const useColorsByProbe = () => {
 };
 
 /**
- * Get probe styles (memoized).
+ * Get probe styles (memoized per document).
  *
  * It adds elements to the DOM as a probe, and get the computed styles
- * the default expected properties.
+ * the default expected properties. The result is memoized by the probed
+ * document so that a call made before the editor canvas iframe exists does not
+ * cache the outer document's values for the iframed document.
+ *
+ * @param {Document} probeDocument The document to probe against.
  *
  * @return {Object} Probe default styles.
  */
-export const getProbeStyles = memoize( () => {
-	const probeDocument = getProbeDocument();
+export const getProbeStyles = memoize(
+	( probeDocument = getProbeDocument() ) => {
+		// Create temporary probe elements.
+		const editorStylesWrapperDiv = probeDocument.createElement( 'div' );
+		editorStylesWrapperDiv.className =
+			'editor-styles-wrapper sensei-probe-element';
 
-	// Create temporary probe elements.
-	const editorStylesWrapperDiv = probeDocument.createElement( 'div' );
-	editorStylesWrapperDiv.className =
-		'editor-styles-wrapper sensei-probe-element';
+		const blockButtonDiv = probeDocument.createElement( 'div' );
+		blockButtonDiv.className = 'wp-block-button';
 
-	const blockButtonDiv = probeDocument.createElement( 'div' );
-	blockButtonDiv.className = 'wp-block-button';
+		const buttonLinkDiv = probeDocument.createElement( 'div' );
+		buttonLinkDiv.className = 'wp-block-button__link';
+		buttonLinkDiv.textContent = 'Probe';
 
-	const buttonLinkDiv = probeDocument.createElement( 'div' );
-	buttonLinkDiv.className = 'wp-block-button__link';
-	buttonLinkDiv.textContent = 'Probe';
+		// Set probe position outside the screen to be hidden.
+		editorStylesWrapperDiv.style.position = 'fixed';
+		editorStylesWrapperDiv.style.top = '-100vh';
 
-	// Set probe position outside the screen to be hidden.
-	editorStylesWrapperDiv.style.position = 'fixed';
-	editorStylesWrapperDiv.style.top = '-100vh';
+		// Add probe to the screen.
+		blockButtonDiv.appendChild( buttonLinkDiv );
+		editorStylesWrapperDiv.appendChild( blockButtonDiv );
+		probeDocument.body.appendChild( editorStylesWrapperDiv );
 
-	// Add probe to the screen.
-	blockButtonDiv.appendChild( buttonLinkDiv );
-	editorStylesWrapperDiv.appendChild( blockButtonDiv );
-	probeDocument.body.appendChild( editorStylesWrapperDiv );
+		// Save styles, reading through the probed document's own window.
+		const { getComputedStyle } = probeDocument.defaultView || window;
+		const styles = {
+			primaryColor: getComputedStyle( buttonLinkDiv ).backgroundColor,
+			primaryContrastColor: getComputedStyle( buttonLinkDiv ).color,
+		};
 
-	// Save styles.
-	const { getComputedStyle } = probeDocument.defaultView;
-	const styles = {
-		primaryColor: getComputedStyle( buttonLinkDiv ).backgroundColor,
-		primaryContrastColor: getComputedStyle( buttonLinkDiv ).color,
-	};
+		// Remove probe.
+		probeDocument.body.removeChild( editorStylesWrapperDiv );
 
-	// Remove probe.
-	probeDocument.body.removeChild( editorStylesWrapperDiv );
-
-	return styles;
-} );
+		return styles;
+	},
+	( probeDocument = getProbeDocument() ) => probeDocument
+);

--- a/assets/react-hooks/probe-styles.js
+++ b/assets/react-hooks/probe-styles.js
@@ -64,8 +64,8 @@ export const useColorsByProbe = () => {
 /**
  * Get probe styles (memoized per document).
  *
- * It adds elements to the DOM as a probe, and get the computed styles
- * the default expected properties. The result is memoized by the probed
+ * It adds probe elements to the DOM and reads their computed styles to
+ * determine the theme's default colors. The result is memoized by the probed
  * document so that a call made before the editor canvas iframe exists does not
  * cache the outer document's values for the iframed document.
  *

--- a/assets/react-hooks/probe-styles.test.js
+++ b/assets/react-hooks/probe-styles.test.js
@@ -59,4 +59,30 @@ describe( 'getProbeStyles', () => {
 			'rgb(249, 249, 249)'
 		);
 	} );
+
+	it( 'Should not reuse the outer document result once the iframe appears', () => {
+		// Probe before the canvas iframe exists; caches the outer document.
+		const outerStyle = document.createElement( 'style' );
+		outerStyle.appendChild(
+			document.createTextNode( `.wp-block-button__link {
+				background-color: rgb(1, 1, 1);
+				color: rgb(2, 2, 2);
+			}` )
+		);
+		document.head.appendChild( outerStyle );
+
+		expect( getProbeStyles().primaryColor ).toEqual( 'rgb(1, 1, 1)' );
+
+		// The iframe mounts later; the probe must not return the cached outer value.
+		const iframe = document.createElement( 'iframe' );
+		iframe.name = 'editor-canvas';
+		document.body.appendChild( iframe );
+
+		iframe.contentDocument.head.innerHTML = `<style>.wp-block-button__link {
+			background-color: rgb(17, 17, 17);
+			color: rgb(249, 249, 249);
+		}</style>`;
+
+		expect( getProbeStyles().primaryColor ).toEqual( 'rgb(17, 17, 17)' );
+	} );
 } );

--- a/assets/react-hooks/probe-styles.test.js
+++ b/assets/react-hooks/probe-styles.test.js
@@ -4,6 +4,14 @@
 import { getProbeStyles } from './probe-styles';
 
 describe( 'getProbeStyles', () => {
+	afterEach( () => {
+		// getProbeStyles is memoized; reset between cases.
+		getProbeStyles.cache.clear();
+		document
+			.querySelectorAll( 'style, iframe[name="editor-canvas"]' )
+			.forEach( ( node ) => node.remove() );
+	} );
+
 	it( 'Should get the probe styles', () => {
 		const styles = `.wp-block-button__link {
 			background-color: rgb(0, 0, 0);
@@ -20,6 +28,35 @@ describe( 'getProbeStyles', () => {
 		expect( probeStyles.primaryColor ).toEqual( 'rgb(0, 0, 0)' );
 		expect( probeStyles.primaryContrastColor ).toEqual(
 			'rgb(255, 255, 255)'
+		);
+	} );
+
+	it( 'Should probe the editor canvas iframe when the post editor is iframed', () => {
+		// Outer document deliberately styles the probe a different color, so a
+		// wrong result would prove the probe read the outer document.
+		const outerStyle = document.createElement( 'style' );
+		outerStyle.appendChild(
+			document.createTextNode( `.wp-block-button__link {
+				background-color: rgb(1, 1, 1);
+				color: rgb(2, 2, 2);
+			}` )
+		);
+		document.head.appendChild( outerStyle );
+
+		const iframe = document.createElement( 'iframe' );
+		iframe.name = 'editor-canvas';
+		document.body.appendChild( iframe );
+
+		iframe.contentDocument.head.innerHTML = `<style>.wp-block-button__link {
+			background-color: rgb(17, 17, 17);
+			color: rgb(249, 249, 249);
+		}</style>`;
+
+		const probeStyles = getProbeStyles();
+
+		expect( probeStyles.primaryColor ).toEqual( 'rgb(17, 17, 17)' );
+		expect( probeStyles.primaryContrastColor ).toEqual(
+			'rgb(249, 249, 249)'
 		);
 	} );
 } );

--- a/assets/react-hooks/probe-styles.test.js
+++ b/assets/react-hooks/probe-styles.test.js
@@ -59,30 +59,4 @@ describe( 'getProbeStyles', () => {
 			'rgb(249, 249, 249)'
 		);
 	} );
-
-	it( 'Should not reuse the outer document result once the iframe appears', () => {
-		// Probe before the canvas iframe exists; caches the outer document.
-		const outerStyle = document.createElement( 'style' );
-		outerStyle.appendChild(
-			document.createTextNode( `.wp-block-button__link {
-				background-color: rgb(1, 1, 1);
-				color: rgb(2, 2, 2);
-			}` )
-		);
-		document.head.appendChild( outerStyle );
-
-		expect( getProbeStyles().primaryColor ).toEqual( 'rgb(1, 1, 1)' );
-
-		// The iframe mounts later; the probe must not return the cached outer value.
-		const iframe = document.createElement( 'iframe' );
-		iframe.name = 'editor-canvas';
-		document.body.appendChild( iframe );
-
-		iframe.contentDocument.head.innerHTML = `<style>.wp-block-button__link {
-			background-color: rgb(17, 17, 17);
-			color: rgb(249, 249, 249);
-		}</style>`;
-
-		expect( getProbeStyles().primaryColor ).toEqual( 'rgb(17, 17, 17)' );
-	} );
 } );

--- a/changelog/block-color-probe-iframe
+++ b/changelog/block-color-probe-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed course and lesson block colors not matching the theme in the iframed post editor.

--- a/changelog/block-color-probe-iframe
+++ b/changelog/block-color-probe-iframe
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed course and lesson block colors not matching the theme in the iframed post editor.
+WordPress 7.1 Compatibility: Course and lesson block colors match the theme in the iframed post editor.

--- a/changelog/learning-mode-templates-editor-group
+++ b/changelog/learning-mode-templates-editor-group
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Learning Mode and email templates now appear in their own group in the Site Editor.
+WordPress 7.1 Compatibility: Learning Mode and email templates appear in their own group in the Site Editor.

--- a/changelog/sen-139-learning-mode-templates-php-notice
+++ b/changelog/sen-139-learning-mode-templates-php-notice
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a PHP notice logged by Learning Mode templates in WordPress 7.1.
+WordPress 7.1 Compatibility: Fix a PHP notice logged by Learning Mode templates.


### PR DESCRIPTION
Resolves [SEN-141](https://linear.app/a8c/issue/SEN-141/wp-71-block-color-probe-reads-wrong-colors-in-iframed-post-editor).

## Proposed Changes

Course and lesson blocks (Course Outline modules, Course Progress, Course
Results) pick their default colors from the active theme by reading the
computed styles of a hidden probe element. The post editor now renders inside
an iframe, so the theme's styles live only inside that iframe's document. The
probe was still added to the outer document, where those styles don't exist, so
it read empty values — blocks lost their theme color defaults and fell back to a
different color.

This resolves the probe against the editor-canvas iframe document when present,
falls back to the outer document when it isn't (non-iframed editors), and reads
computed styles from that document's own window.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1364" height="560" alt="Screenshot 2026-08-18 at 10 17 16 AM" src="https://github.com/user-attachments/assets/e89b72c2-1fdc-49fd-8096-c7b397b5c0cb" /> | <img width="1394" height="546" alt="Screenshot 2026-08-18 at 10 16 40 AM" src="https://github.com/user-attachments/assets/a9e391c3-8927-4f29-b94e-58d43c246dac" /> |

## Testing Instructions

- [x] Activate a block theme with a vivid primary color (e.g. Twenty Twenty-Three, primary = lime green).
- [x] Create a new course and add a Course Outline block with a Module.
- [x] Confirm the module header renders in the theme's primary color (lime), not gray.
- [x] Save, then reopen — the header keeps the theme color.
- [x] Add a Course List block and confirm the Course Progress bar inside it defaults to the theme color.
- [x] Add a Course Results block to a page and confirm its section headers default to the theme color.

## Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message
Fixed course and lesson block colors not matching the theme in the iframed post editor.

</details>
