### PR TITLE
Fix course-creation E2E for the iframed editor canvas

### DIFF
--- a/tests/e2e-playwright/pages/admin/courses/index.ts
+++ b/tests/e2e-playwright/pages/admin/courses/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Locator, Page } from '@playwright/test';
+import type { FrameLocator, Locator, Page } from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -57,8 +57,8 @@ class CourseOutline {
 	public readonly addModuleButton: Locator;
 	public readonly moduleBlock: ModuleBlock;
 
-	constructor( page: Page ) {
-		this.outline = page
+	constructor( page: Page, canvas: FrameLocator ) {
+		this.outline = canvas
 			.locator( '[aria-label="Block: Course Outline"]' )
 			.first();
 		this.addModuleOrLessonButton = this.outline.locator(
@@ -84,6 +84,7 @@ export default class CoursesPage extends PostType {
 	public readonly confirmPublishButton: Locator;
 	public readonly viewPreviewLink: Locator;
 	public readonly courseOutlineBlock: CourseOutline;
+	public readonly startWithBlankButton: Locator;
 
 	constructor( page: Page ) {
 		super( page, 'course' );
@@ -96,7 +97,13 @@ export default class CoursesPage extends PostType {
 			{ hasText: /^New Course$/ }
 		);
 
-		this.courseOutlineBlock = new CourseOutline( page );
+		const canvas = page.frameLocator( '[name="editor-canvas"]' );
+
+		this.startWithBlankButton = canvas.getByRole( 'button', {
+			name: 'Start with blank',
+		} );
+
+		this.courseOutlineBlock = new CourseOutline( page, canvas );
 
 		this.publishButton = page.locator(
 			'[aria-label="Editor top bar"] >> text=Publish'

--- a/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
+++ b/tests/e2e-playwright/specs/admin/teacher/course-creation.spec.ts
@@ -42,9 +42,7 @@ describe( 'Create Courses', () => {
 
 		await wizardModal.finishWithDefaultLayout();
 
-		await page
-			.getByRole( 'button', { name: 'Start with blank' } )
-			.dispatchEvent( 'click' );
+		await coursesPage.startWithBlankButton.dispatchEvent( 'click' );
 
 		await coursesPage.saveDraft();
 


### PR DESCRIPTION
## Proposed Changes

WordPress 7.1 always renders the post editor canvas inside an iframe ([Gutenberg #74042](https://github.com/WordPress/gutenberg/pull/74042)); before 7.1 this flow was not iframed. The `admin/teacher/course-creation.spec.ts` E2E located the Course Outline block and its "Start with blank" button on the top page, so once the canvas moved into the iframe the locators resolved to nothing and the test timed out on the latest WordPress.

This locates the block-canvas elements through the `editor-canvas` frame (matching the `canvas` helper Gutenberg uses in its own e2e utils). The block inserter menu opens on the page rather than in the iframe, so its item stays there. No product code changes.

## Testing Instructions

This is a test-only change (E2E infrastructure); there is no manual QA surface. It is exercised by the E2E job, which runs against the latest WordPress (currently 7.1):

- The `Create Courses › it should create a course` spec, which previously timed out at the "Start with blank" step, now passes.
- The sibling `it has a Courses menu item in the main menu` still passes.
