### PR TITLE
Fix unresolvable-owner module test on multisite

### DIFF
--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -905,8 +905,8 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$previous_blog_admin_email = get_option( 'admin_email' );
 		$previous_site_admins      = get_site_option( 'site_admins' );
 		update_term_meta( $module_id, 'module_author', 999999 );
-		update_site_option( 'admin_email', 'non-existant-user-mail@abc.com' );
-		update_option( 'admin_email', 'non-existant-user-mail@abc.com' );
+		update_site_option( 'admin_email', 'non-existent-user-mail@example.com' );
+		update_option( 'admin_email', 'non-existent-user-mail@example.com' );
 		update_site_option( 'site_admins', array( 'a-login-with-no-user' ) );
 
 		try {

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -901,10 +901,12 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		);
 		// Make the owner unresolvable: the meta points at a missing user and no admin
 		// account can be found by email or super admin login.
-		$previous_admin_email = get_site_option( 'admin_email' );
-		$previous_site_admins = get_site_option( 'site_admins' );
+		$previous_admin_email      = get_site_option( 'admin_email' );
+		$previous_blog_admin_email = get_option( 'admin_email' );
+		$previous_site_admins      = get_site_option( 'site_admins' );
 		update_term_meta( $module_id, 'module_author', 999999 );
 		update_site_option( 'admin_email', 'non-existant-user-mail@abc.com' );
+		update_option( 'admin_email', 'non-existant-user-mail@abc.com' );
 		update_site_option( 'site_admins', array( 'a-login-with-no-user' ) );
 
 		try {
@@ -927,6 +929,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 			$this->assertNotWPError( $save_result );
 		} finally {
 			update_site_option( 'admin_email', $previous_admin_email );
+			update_option( 'admin_email', $previous_blog_admin_email );
 			update_site_option( 'site_admins', $previous_site_admins );
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

The `testSave_TeacherSavesModuleWithUnresolvableOwner_DoesNotReturnError` test failed only on multisite. It simulated an unresolvable module owner by overriding just the network `admin_email` (`update_site_option`), but `get_term_author()` reads the per-site `admin_email` via `get_bloginfo()`. On multisite those are different options, so a real admin still resolved as the module owner and `save()` returned a false "owned by another teacher" `WP_Error`, failing the assertion.

The test now also overrides and restores the per-site `admin_email` so the owner is truly unresolvable on both single-site and multisite. No production code changed.

## Testing Instructions

Test-only change; no manual surface. Verified `testSave_TeacherSavesModuleWithUnresolvableOwner_DoesNotReturnError` passes both single-site and with `WP_MULTISITE=1`.