### PR TITLE
Update blocks to Block API version 3 for iframe editor compatibility

### DIFF
--- a/assets/blocks/button/button-edit.js
+++ b/assets/blocks/button/button-edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -26,8 +26,10 @@ const ButtonEdit = ( props ) => {
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );
 
+	const blockProps = useBlockProps( getButtonWrapperProps( props ) );
+
 	return (
-		<div { ...getButtonWrapperProps( props ) }>
+		<div { ...blockProps }>
 			{ isReadonly ? (
 				<div { ...buttonProps }>{ props.text }</div>
 			) : (

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -78,6 +78,7 @@ export const createButtonBlockType = ( {
 
 	return merge(
 		{
+			apiVersion: 3,
 			name: 'sensei-lms/button',
 			title: 'Sensei Button',
 			category: 'sensei-lms',

--- a/assets/blocks/conditional-content-block/block.json
+++ b/assets/blocks/conditional-content-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/conditional-content",
   "title": "Conditional Content",
   "description": "Content inside this block will be shown to the selected subgroup of users.",

--- a/assets/blocks/conditional-content-block/conditional-content-edit.js
+++ b/assets/blocks/conditional-content-block/conditional-content-edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +24,6 @@ export const ConditionLabels = {
 };
 
 const ConditionalContentEdit = ( {
-	className,
 	hasInnerBlocks,
 	clientId,
 	attributes: { condition },
@@ -32,7 +31,7 @@ const ConditionalContentEdit = ( {
 } ) => {
 	return (
 		<>
-			<div className={ className }>
+			<div { ...useBlockProps() }>
 				<InnerBlocks
 					renderAppender={
 						! hasInnerBlocks && InnerBlocks.ButtonBlockAppender

--- a/assets/blocks/conditional-content-block/conditional-content-save.js
+++ b/assets/blocks/conditional-content-block/conditional-content-save.js
@@ -1,15 +1,10 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const ConditionalContentSave = ( { className } ) => (
-	<div className={ classnames( 'wp-block-group', className ) }>
+const ConditionalContentSave = () => (
+	<div { ...useBlockProps.save( { className: 'wp-block-group' } ) }>
 		<div className="wp-block-group__inner-container">
 			<InnerBlocks.Content />
 		</div>

--- a/assets/blocks/course-actions-block/course-actions/block.json
+++ b/assets/blocks/course-actions-block/course-actions/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 3,
 	"name": "sensei-lms/course-actions",
 	"title": "Course Actions",
 	"description": "Enable a student to perform specific actions for a course.",

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -6,6 +6,7 @@ import {
 	InnerBlocks,
 	BlockControls,
 	store as blockEditorStore,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -17,11 +18,6 @@ import InvalidUsageError from '../../../shared/components/invalid-usage';
 import CourseStatusToolbar from '../course-status-toolbar';
 import CourseStatusOptions from '../course-status-options';
 import CourseStatusContext from '../course-status-context';
-
-/**
- * External dependencies
- */
-import classnames from 'classnames';
 
 const innerBlocksTemplate = [
 	[
@@ -72,16 +68,11 @@ const useSelectChildBlock = ( clientId ) => {
  * Edit course actions block component.
  *
  * @param {Object} props
- * @param {Object} props.className        Block className.
  * @param {Object} props.context          Block context.
  * @param {Object} props.context.postType Post type.
  * @param {string} props.clientId         Block client ID.
  */
-const CourseActionsEdit = ( {
-	className,
-	context: { postType },
-	clientId,
-} ) => {
+const CourseActionsEdit = ( { context: { postType }, clientId } ) => {
 	const [ courseStatus, setCourseStatus ] = useState(
 		CourseStatusOptions[ 0 ].value
 	);
@@ -114,6 +105,10 @@ const CourseActionsEdit = ( {
 		};
 	}, [ courseStatus, setCourseStatusAndSelectChildBlock ] );
 
+	const blockProps = useBlockProps( {
+		className: `is-status-${ courseStatus }`,
+	} );
+
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
@@ -127,12 +122,7 @@ const CourseActionsEdit = ( {
 
 	return (
 		<CourseStatusContext.Provider value={ contextValue }>
-			<div
-				className={ classnames(
-					className,
-					`is-status-${ courseStatus }`
-				) }
-			>
+			<div { ...blockProps }>
 				<InnerBlocks
 					allowedBlocks={ [
 						'sensei-lms/button-take-course',

--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "sensei-lms/course-categories",
 	"title": "Course Categories",
 	"description": "Show the course categories",

--- a/assets/blocks/course-list-filter-block/block.json
+++ b/assets/blocks/course-list-filter-block/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "sensei-lms/course-list-filter",
 	"title": "Course List Filter",
 	"description": "Filter courses in Course List block",

--- a/assets/blocks/course-outline/lesson-block/block.json
+++ b/assets/blocks/course-outline/lesson-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-outline-lesson",
   "title": "Lesson",
   "description": "Where your course content lives.",

--- a/assets/blocks/course-outline/lesson-block/lesson-edit.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Icon, check, chevronRight } from '@wordpress/icons';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -23,7 +24,6 @@ import { useLessonPreviewStatus } from './use-lesson-preview-status';
  * Edit lesson block component.
  *
  * @param {Object}   props                     Component props.
- * @param {string}   props.className           Custom class name.
  * @param {Object}   props.attributes          Block attributes.
  * @param {string}   props.attributes.title    Lesson title.
  * @param {number}   props.attributes.id       Lesson Post ID
@@ -36,7 +36,6 @@ import { useLessonPreviewStatus } from './use-lesson-preview-status';
  */
 export const LessonEdit = ( props ) => {
 	const {
-		className,
 		attributes: { title, id, fontSize, draft, preview, placeholder },
 		backgroundColor,
 		textColor,
@@ -62,21 +61,16 @@ export const LessonEdit = ( props ) => {
 		postStatus = __( 'Draft', 'sensei-lms' );
 	}
 
-	const wrapperStyles = {
-		className: classnames(
-			className,
-			backgroundColor?.class,
-			textColor?.class,
-			{
-				completed: lessonStatus.previewStatus === Status.COMPLETED,
-				'is-auto-draft': ! id && ! title,
-			}
-		),
+	const blockProps = useBlockProps( {
+		className: classnames( backgroundColor?.class, textColor?.class, {
+			completed: lessonStatus.previewStatus === Status.COMPLETED,
+			'is-auto-draft': ! id && ! title,
+		} ),
 		style: {
 			backgroundColor: backgroundColor?.color,
 			color: textColor?.color,
 		},
-	};
+	} );
 
 	const inputContainerClasses = classnames(
 		'wp-block-sensei-lms-course-outline-lesson__input-container',
@@ -89,7 +83,7 @@ export const LessonEdit = ( props ) => {
 	return (
 		<>
 			<LessonSettings { ...props } { ...lessonStatus } />
-			<div { ...wrapperStyles } data-lesson-id={ id }>
+			<div { ...blockProps } data-lesson-id={ id }>
 				<Icon
 					icon={ check }
 					className="wp-block-sensei-lms-course-outline-lesson__status"

--- a/assets/blocks/course-outline/lesson-block/lesson-edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit.test.js
@@ -22,6 +22,17 @@ jest.mock( '@wordpress/data', () =>
 );
 
 jest.mock( '@wordpress/blocks' );
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: ( props = {} ) => ( {
+		...props,
+		className: [
+			'wp-block-sensei-lms-course-outline-lesson',
+			props.className,
+		]
+			.filter( Boolean )
+			.join( ' ' ),
+	} ),
+} ) );
 jest.mock( '../../../shared/blocks/settings', () => ( {
 	withColorSettings: () => ( Component ) => Component,
 } ) );
@@ -69,14 +80,15 @@ describe( '<LessonEdit />', () => {
 
 	it( 'Should render the edit lesson block correctly', () => {
 		const { container, getByPlaceholderText } = render(
-			<LessonEdit
-				className="custom-class"
-				attributes={ { title: 'Test' } }
-			/>
+			<LessonEdit attributes={ { title: 'Test' } } />
 		);
 
 		expect( getByPlaceholderText( 'Add Lesson' ) ).toBeTruthy();
-		expect( container.querySelector( '.custom-class' ) ).toBeTruthy();
+		expect(
+			container.querySelector(
+				'.wp-block-sensei-lms-course-outline-lesson'
+			)
+		).toBeTruthy();
 	} );
 
 	it( 'Should render the edit lesson block with preview correctly', () => {

--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-outline-module",
   "title": "Module",
   "description": "Group related lessons together.",

--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -7,7 +7,7 @@ import AnimateHeight from 'react-animate-height';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 import { Icon, chevronUp } from '@wordpress/icons';
 import { compose } from '@wordpress/compose';
 import { useContext, useState, useEffect } from '@wordpress/element';
@@ -35,7 +35,6 @@ const ALLOWED_BLOCKS = [ 'sensei-lms/course-outline-lesson' ];
  *
  * @param {Object}   props                             Component props.
  * @param {string}   props.clientId                    The module block id.
- * @param {string}   props.className                   Custom class name.
  * @param {Object}   props.attributes                  Block attributes.
  * @param {string}   props.attributes.title            Module title.
  * @param {string}   props.attributes.description      Module description.
@@ -52,7 +51,6 @@ const ALLOWED_BLOCKS = [ 'sensei-lms/course-outline-lesson' ];
 export const ModuleEdit = ( props ) => {
 	const {
 		clientId,
-		className,
 		attributes: {
 			title,
 			description,
@@ -115,10 +113,22 @@ export const ModuleEdit = ( props ) => {
 
 	const [ isExpanded, setExpanded ] = useState( true );
 
+	const bordered =
+		undefined !== borderedSelected ? borderedSelected : outlineBordered;
+
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			'wp-block-sensei-lms-course-outline-module-bordered': bordered,
+		} ),
+		style: {
+			borderColor: borderColorValue || defaultBorderColor?.color,
+		},
+	} );
+
 	const styleRegex = /is-style-(\w+)/;
 	const style =
-		className.match( styleRegex )?.[ 1 ] ||
-		outlineClassName.match( styleRegex )?.[ 1 ];
+		blockProps.className?.match( styleRegex )?.[ 1 ] ||
+		outlineClassName?.match( styleRegex )?.[ 1 ];
 
 	// Header styles.
 	const headerStyles = {
@@ -159,9 +169,6 @@ export const ModuleEdit = ( props ) => {
 		[]
 	);
 
-	const bordered =
-		undefined !== borderedSelected ? borderedSelected : outlineBordered;
-
 	return (
 		<>
 			<ModuleSettings
@@ -172,15 +179,7 @@ export const ModuleEdit = ( props ) => {
 				customSlug={ slug }
 				setCustomSlug={ updateSlug }
 			/>
-			<section
-				className={ classnames( className, {
-					'wp-block-sensei-lms-course-outline-module-bordered':
-						bordered,
-				} ) }
-				style={ {
-					borderColor: borderColorValue || defaultBorderColor?.color,
-				} }
-			>
+			<section { ...blockProps }>
 				<header
 					className="wp-block-sensei-lms-course-outline-module__header"
 					style={ headerStyles }

--- a/assets/blocks/course-outline/module-block/module-edit.test.js
+++ b/assets/blocks/course-outline/module-block/module-edit.test.js
@@ -30,6 +30,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 			} }
 		/>
 	),
+	useBlockProps: ( props ) => ( { ...props } ),
 	withColors: () => ( Component ) => Component,
 } ) );
 

--- a/assets/blocks/course-outline/outline-block/block.json
+++ b/assets/blocks/course-outline/outline-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-outline",
   "title": "Course Outline",
   "description": "Manage your Sensei LMS course outline.",

--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -134,7 +134,10 @@ const OutlineEdit = ( props ) => {
 						outlineClassName: blockProps.className,
 					} }
 				>
-					<OutlineSettings { ...props } />
+					<OutlineSettings
+						{ ...props }
+						outlineClassName={ blockProps.className }
+					/>
 
 					<section>
 						<InnerBlocks

--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -4,8 +4,8 @@
 import {
 	InnerBlocks,
 	store as blockEditorStore,
+	useBlockProps,
 } from '@wordpress/block-editor';
-import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	createContext,
@@ -18,7 +18,6 @@ import {
  * Internal dependencies
  */
 import OutlineSettings from './outline-settings';
-import { withDefaultBlockStyle } from '../../../shared/blocks/settings';
 import { useCourseLessonsStatusSync } from '../status-preview/use-course-lessons-status-sync';
 import { COURSE_STORE } from '../course-outline-store';
 import { useBlocksCreator } from '../use-block-creator';
@@ -44,12 +43,18 @@ export const OutlineAttributesContext = createContext();
  *
  * @param {Object}   props               Component props.
  * @param {string}   props.clientId      Block client ID.
- * @param {string}   props.className     Custom class name.
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Block setAttributes callback.
  */
 const OutlineEdit = ( props ) => {
-	const { clientId, className, attributes, setAttributes } = props;
+	const { clientId, attributes, setAttributes } = props;
+
+	const blockProps = useBlockProps( {
+		className:
+			attributes.className && attributes.className.includes( 'is-style-' )
+				? undefined
+				: 'is-style-default',
+	} );
 
 	const { loadStructure } = useDispatch( COURSE_STORE );
 
@@ -114,7 +119,7 @@ const OutlineEdit = ( props ) => {
 	}, [ removeCourseOutlineGeneratorUpsell ] );
 
 	return (
-		<div>
+		<div { ...blockProps }>
 			{ isEmpty ? (
 				<OutlinePlaceholder
 					addBlock={ ( type ) => setBlocks( [ { type } ], true ) }
@@ -126,12 +131,12 @@ const OutlineEdit = ( props ) => {
 					value={ {
 						outlineAttributes: attributes,
 						outlineSetAttributes: setAttributes,
-						outlineClassName: className,
+						outlineClassName: blockProps.className,
 					} }
 				>
 					<OutlineSettings { ...props } />
 
-					<section className={ className }>
+					<section>
 						<InnerBlocks
 							allowedBlocks={ ALLOWED_BLOCKS }
 							renderAppender={ AppenderComponent }
@@ -149,4 +154,4 @@ const OutlineEdit = ( props ) => {
 	);
 };
 
-export default compose( withDefaultBlockStyle() )( OutlineEdit );
+export default OutlineEdit;

--- a/assets/blocks/course-outline/outline-block/outline-settings.js
+++ b/assets/blocks/course-outline/outline-block/outline-settings.js
@@ -16,9 +16,12 @@ import { useSharedModuleStyles } from './use-shared-module-styles';
  * @param {Object} props Block props.
  */
 const OutlineSettings = ( props ) => {
-	const { attributes, setAttributes } = props;
+	const { attributes, setAttributes, outlineClassName } = props;
 
-	const { moduleBorder, setModuleBorder } = useSharedModuleStyles( props );
+	const { moduleBorder, setModuleBorder } = useSharedModuleStyles( {
+		...props,
+		className: outlineClassName,
+	} );
 
 	return (
 		<InspectorControls>

--- a/assets/blocks/course-overview-block/block.json
+++ b/assets/blocks/course-overview-block/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "sensei-lms/course-overview",
 	"title": "Course Overview",
 	"category": "sensei-lms",

--- a/assets/blocks/course-progress-block/block.json
+++ b/assets/blocks/course-progress-block/block.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "sensei-lms/course-progress",
   "title": "Course Progress",
   "description": "Display the user's progress in the course. This block is only displayed if the user is enrolled.",

--- a/assets/blocks/course-results-block/block.json
+++ b/assets/blocks/course-results-block/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 3,
 	"name": "sensei-lms/course-results",
 	"title": "Course Results",
 	"description": "Show course results to students on the course completion page.",

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -130,10 +131,12 @@ const CourseResultsEdit = ( props ) => {
 			borderColor?.color || defaultBorderColor?.color,
 	};
 
+	const blockProps = useBlockProps( { className, style: styleVars } );
+
 	return (
 		<>
 			<CourseResultsSettings { ...props } />
-			<section className={ className } style={ styleVars }>
+			<section { ...blockProps }>
 				<div className="wp-block-sensei-lms-course-results__grade">
 					<span className="wp-block-sensei-lms-course-results__grade-label">
 						{ __( 'Your Total Grade', 'sensei-lms' ) }

--- a/assets/blocks/featured-video/block.json
+++ b/assets/blocks/featured-video/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 3,
 	"name": "sensei-lms/featured-video",
 	"title": "Featured Video",
 	"description": "Add a featured video to your lesson to highlight the video and make use of our video templates.",

--- a/assets/blocks/featured-video/index.js
+++ b/assets/blocks/featured-video/index.js
@@ -3,7 +3,7 @@
  */
 import { useRef, useEffect } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -32,7 +32,7 @@ export default {
 			},
 		],
 	},
-	edit: function EditBlock( { className, clientId } ) {
+	edit: function EditBlock( { clientId } ) {
 		const { replaceInnerBlocks, moveBlockToPosition } =
 			useDispatch( 'core/block-editor' );
 		const innerBlockCount = useSelect(
@@ -78,7 +78,7 @@ export default {
 		] );
 
 		return (
-			<div className={ className }>
+			<div { ...useBlockProps() }>
 				{
 					<InnerBlocks
 						allowedBlocks={ ALLOWED_BLOCKS }

--- a/assets/blocks/learner-courses-block/block.json
+++ b/assets/blocks/learner-courses-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/learner-courses",
   "title": "Student Courses",
   "description": "Manage what students see on their dashboard. This block is only displayed to logged in students.",

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -12,7 +12,11 @@ import { createBlock } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { Icon, image } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { store as blockEditorStore, Warning } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	Warning,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -93,12 +97,14 @@ const FeaturedImagePlaceholder = () => (
  * @param {Array}  props.variables CSS variables.
  * @param {Object} props.children  Children elements.
  * @param {string} props.className Classes.
+ * @param {Object} props.style     Inline styles.
  */
 const StylesWrapper = ( {
 	tagName: TagName = 'div',
 	variables,
 	children,
 	className,
+	style,
 	...props
 } ) => {
 	const isEmpty = ( value ) => {
@@ -110,16 +116,20 @@ const StylesWrapper = ( {
 				'has-sensei-primary-color': !! variables.primaryColor,
 				'has-sensei-accent-color': !! variables.accentColor,
 			} ) }
-			style={ omitBy(
-				{
-					'--sensei-progress-bar-height': variables.progressBarHeight,
-					'--sensei-progress-bar-border-radius':
-						variables.progressBarBorderRadius,
-					'--sensei-primary-color': variables.primaryColor,
-					'--sensei-accent-color': variables.accentColor,
-				},
-				isEmpty
-			) }
+			style={ {
+				...style,
+				...omitBy(
+					{
+						'--sensei-progress-bar-height':
+							variables.progressBarHeight,
+						'--sensei-progress-bar-border-radius':
+							variables.progressBarBorderRadius,
+						'--sensei-primary-color': variables.primaryColor,
+						'--sensei-accent-color': variables.accentColor,
+					},
+					isEmpty
+				),
+			} }
 			{ ...props }
 		>
 			{ children }
@@ -132,18 +142,17 @@ const StylesWrapper = ( {
  *
  * @param {Object}   props
  * @param {Object}   props.clientId           Block client ID.
- * @param {Object}   props.className          Block className.
  * @param {Object}   props.attributes         Block attributes.
  * @param {Object}   props.attributes.options Block options attribute.
  * @param {Function} props.setAttributes      Block set attributes function.
  */
 const LearnerCoursesEdit = ( {
 	clientId,
-	className,
 	attributes: { options },
 	setAttributes,
 } ) => {
 	const [ filter, setFilter ] = useState( 'all' );
+	const blockProps = useBlockProps();
 
 	const filterHandler = ( filterValue ) => ( e ) => {
 		e.preventDefault();
@@ -249,7 +258,7 @@ const LearnerCoursesEdit = ( {
 		<>
 			<StylesWrapper
 				tagName="section"
-				className={ className }
+				{ ...blockProps }
 				variables={ {
 					primaryColor: options.primaryColor,
 					accentColor: options.accentColor,

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/lesson-actions",
   "title": "Lesson Actions",
   "description": "Enable a student to perform specific actions for a lesson.",

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -31,7 +31,6 @@ const courseThemeEnabled = window?.sensei?.courseThemeEnabled || false;
  * Edit lesson actions block component.
  *
  * @param {Object}   props
- * @param {string}   props.className                Custom class name.
  * @param {string}   props.clientId                 Block ID.
  * @param {Function} props.setAttributes            Block set attributes function.
  * @param {Object}   props.attributes               Block attributes.
@@ -39,7 +38,6 @@ const courseThemeEnabled = window?.sensei?.courseThemeEnabled || false;
  */
 const LessonActionsEdit = ( props ) => {
 	const {
-		className,
 		clientId,
 		setAttributes,
 		attributes: { toggledBlocks },
@@ -74,6 +72,15 @@ const LessonActionsEdit = ( props ) => {
 		: 'not-allowed';
 	const isInSiteEditorClass = isSiteEditor ? 'site-editor' : 'lesson-editor';
 
+	const blockProps = useBlockProps( {
+		className: classnames(
+			`wp-block-sensei-lms-lesson-actions__preview-${ previewState }`,
+			`wp-block-sensei-lms-lesson-actions__${ quizStateClass }`,
+			`wp-block-sensei-lms-lesson-actions__complete_lessons-${ completeLessonAllowedClass }`,
+			`wp-block-sensei-lms-lesson-actions__preview-${ isInSiteEditorClass }`
+		),
+	} );
+
 	if ( courseThemeEnabled ) {
 		return null;
 	}
@@ -90,15 +97,7 @@ const LessonActionsEdit = ( props ) => {
 				onPreviewChange={ onPreviewChange }
 				toggleBlocks={ toggleBlocks }
 			/>
-			<div
-				className={ classnames(
-					className,
-					`wp-block-sensei-lms-lesson-actions__preview-${ previewState }`,
-					`wp-block-sensei-lms-lesson-actions__${ quizStateClass }`,
-					`wp-block-sensei-lms-lesson-actions__complete_lessons-${ completeLessonAllowedClass }`,
-					`wp-block-sensei-lms-lesson-actions__preview-${ isInSiteEditorClass }`
-				) }
-			>
+			<div { ...blockProps }>
 				<div className="sensei-buttons-container">
 					<InnerBlocks
 						allowedBlocks={ ACTION_BLOCKS }

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-save.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-save.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const LessonActionsSave = ( { className } ) => (
-	<div className={ className }>
+const LessonActionsSave = () => (
+	<div { ...useBlockProps.save() }>
 		<div className="sensei-buttons-container">
 			<InnerBlocks.Content />
 		</div>

--- a/assets/blocks/lesson-properties/block.json
+++ b/assets/blocks/lesson-properties/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 3,
 	"name": "sensei-lms/lesson-properties",
 	"title": "Lesson Properties",
 	"description": "Add lesson properties such as length and difficulty.",

--- a/assets/blocks/lesson-properties/lesson-properties-edit.js
+++ b/assets/blocks/lesson-properties/lesson-properties-edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { useCallback } from '@wordpress/element';
 import { useEntityProp } from '@wordpress/core-data';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, Notice } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
 
@@ -20,8 +20,8 @@ import { DIFFICULTIES } from './constants';
 
 const courseThemeEnabled = window?.sensei?.courseThemeEnabled || false;
 
-const LessonPropertiesEdit = ( props ) => {
-	const { className } = props;
+const LessonPropertiesEdit = () => {
+	const blockProps = useBlockProps();
 
 	const [ meta, setMeta ] = useEntityProp( 'postType', 'lesson', 'meta' );
 	const { _lesson_complexity: difficulty = '', _lesson_length: length = 10 } =
@@ -91,7 +91,7 @@ const LessonPropertiesEdit = ( props ) => {
 					) }
 				</Notice>
 			) : (
-				<div className={ className }>
+				<div { ...blockProps }>
 					<span
 						className={ classnames(
 							'wp-block-sensei-lms-lesson-properties__length',

--- a/assets/blocks/quiz/answer-feedback-block/index.js
+++ b/assets/blocks/quiz/answer-feedback-block/index.js
@@ -11,6 +11,7 @@ import edit from './answer-feedback';
 import icon from '../../../icons/question.svg';
 
 const sharedMetadata = {
+	apiVersion: 3,
 	parent: [ 'sensei-lms/quiz-question' ],
 	category: 'sensei-lms',
 	supports: {

--- a/assets/blocks/quiz/category-question-block/block.json
+++ b/assets/blocks/quiz/category-question-block/block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/quiz-category-question",
   "title": "Category Question",
   "description": "Pull questions from a question category.",

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -3,6 +3,7 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -51,6 +52,12 @@ const CategoryQuestionEdit = ( props ) => {
 		getCategoryTermById( category )?.name ?? props.attributes.categoryName;
 	const categoryNameMatch = categoryName === props.attributes.categoryName;
 
+	const blockProps = useBlockProps( {
+		className: `sensei-lms-question-block sensei-lms-category-question-block ${
+			! category ? 'is-draft' : ''
+		}`,
+	} );
+
 	useEffect( () => {
 		if ( categoryName && ! categoryNameMatch ) {
 			setAttributes( {
@@ -62,11 +69,7 @@ const CategoryQuestionEdit = ( props ) => {
 	return (
 		<>
 			<CategoryQuestionSettings { ...props } />
-			<div
-				className={ `sensei-lms-question-block sensei-lms-category-question-block ${
-					! category ? 'is-draft' : ''
-				}` }
-			>
+			<div { ...blockProps }>
 				{ questionIndex }
 				<h2 className="sensei-lms-question-block__title">
 					{ categoryName ? (

--- a/assets/blocks/quiz/question-answers-block/block.json
+++ b/assets/blocks/quiz/question-answers-block/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "sensei-lms/question-answers",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"title": "Answers",
 	"description": "Question Answers.",
 	"parent": [ "sensei-lms/quiz-question" ],

--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "sensei-lms/quiz-question",
 	"title": "Question",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"description": "The building block of all quizzes.",
 	"parent": [
 		"sensei-lms/quiz"

--- a/assets/blocks/quiz/question-description-block/block.json
+++ b/assets/blocks/quiz/question-description-block/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "sensei-lms/question-description",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"title": "Description",
 	"description": "Question Description.",
 	"parent": [ "sensei-lms/quiz-question" ],

--- a/assets/blocks/quiz/quiz-block/block.json
+++ b/assets/blocks/quiz/quiz-block/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "sensei-lms/quiz",
 	"title": "Quiz",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"description": "Evaluate progress and strengthen understanding of course concepts.",
 	"category": "sensei-lms",
 	"textdomain": "sensei-lms",

--- a/assets/course-theme/blocks/course-navigation/course-navigation.block.json
+++ b/assets/course-theme/blocks/course-navigation/course-navigation.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/course-navigation",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "category": "theme",
   "supports": {
     "align": true,

--- a/assets/course-theme/blocks/lesson-blocks/course-content.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-content.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-content",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-bar.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-bar.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/course-theme-course-progress-bar",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "category": "theme",
   "supports": {
     "align": true,

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-counter.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-course-progress-counter.block.json
@@ -1,7 +1,7 @@
 {
   "name": "sensei-lms/course-theme-course-progress-counter",
   "category": "theme",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "supports": {
     "align": true,
     "color": {

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-actions.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-actions.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-theme-lesson-actions",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-video.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-lesson-video.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-theme-lesson-video",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-notices.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-notices.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-theme-notices",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-post-title.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-post-title.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-theme-post-title",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/course-theme-prev-next-lesson.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-theme-prev-next-lesson.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/course-theme-prev-next-lesson",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/course-title/block.json
+++ b/assets/course-theme/blocks/lesson-blocks/course-title/block.json
@@ -1,7 +1,7 @@
 {
     "name": "sensei-lms/course-title",
     "category": "theme",
-    "apiVersion": 2,
+    "apiVersion": 3,
     "supports": {
         "align": true,
         "color": true,

--- a/assets/course-theme/blocks/lesson-blocks/exit-course-button/block.json
+++ b/assets/course-theme/blocks/lesson-blocks/exit-course-button/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "sensei-lms/exit-course",
 	"category": "theme",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"supports": {
 		"align": true,
 		"color": {

--- a/assets/course-theme/blocks/lesson-blocks/focus-mode-toggle.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/focus-mode-toggle.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/focus-mode-toggle",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/index.js
+++ b/assets/course-theme/blocks/lesson-blocks/index.js
@@ -216,7 +216,6 @@ export default [
 			'Display pagination and related actions for the current page.',
 			'sensei-lms'
 		),
-		apiVersion: 2,
 		edit: function EditPageActions() {
 			const blockProps = useBlockProps( {
 				className: 'sensei-course-theme__post-pagination',
@@ -239,7 +238,6 @@ export default [
 			'Displays the featured video if there is one for the lesson.',
 			'sensei-lms'
 		),
-		apiVersion: 2,
 		edit: function EditLessonVideo() {
 			const blockProps = useBlockProps( {
 				className: 'sensei-course-theme-lesson-video',

--- a/assets/course-theme/blocks/lesson-blocks/learning-mode-lesson-properties.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/learning-mode-lesson-properties.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/learning-mode-lesson-properties",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/lesson-blocks/module-title/block.json
+++ b/assets/course-theme/blocks/lesson-blocks/module-title/block.json
@@ -1,7 +1,7 @@
 {
     "name": "sensei-lms/course-theme-lesson-module",
     "category": "theme",
-    "apiVersion": 2,
+    "apiVersion": 3,
     "attributes": {
         "className": {
             "type": "string"

--- a/assets/course-theme/blocks/lesson-blocks/page-actions.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/page-actions.block.json
@@ -1,7 +1,7 @@
 {
   "name": "sensei-lms/page-actions",
   "category": "theme",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "supports": {
     "align": true,
     "color": {

--- a/assets/course-theme/blocks/lesson-blocks/sidebar-toggle-button.block.json
+++ b/assets/course-theme/blocks/lesson-blocks/sidebar-toggle-button.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/sidebar-toggle-button",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/quiz-blocks/index.js
+++ b/assets/course-theme/blocks/quiz-blocks/index.js
@@ -93,7 +93,6 @@ export default [
 			'Display pagination and actions the learner can take for the current quiz page.',
 			'sensei-lms'
 		),
-		apiVersion: 2,
 		edit: function EditQuizActions() {
 			const blockProps = useBlockProps( {
 				className: 'sensei-quiz-pagination',

--- a/assets/course-theme/blocks/quiz-blocks/quiz-actions.block.json
+++ b/assets/course-theme/blocks/quiz-blocks/quiz-actions.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/quiz-actions",
   "category": "theme",
   "supports": {}

--- a/assets/course-theme/blocks/quiz-blocks/quiz-back-to-lesson.block.json
+++ b/assets/course-theme/blocks/quiz-blocks/quiz-back-to-lesson.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/quiz-back-to-lesson",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "category": "theme",
   "supports": {
     "align": true,

--- a/assets/course-theme/blocks/quiz-blocks/quiz-progress.block.json
+++ b/assets/course-theme/blocks/quiz-blocks/quiz-progress.block.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 3,
   "name": "sensei-lms/quiz-progress",
   "category": "theme",
   "supports": {

--- a/assets/course-theme/blocks/template-style/template-style.block.json
+++ b/assets/course-theme/blocks/template-style/template-style.block.json
@@ -2,7 +2,7 @@
 	"name": "sensei-lms/template-style",
 	"category": "theme",
 	"parent": [],
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"attributes": {
 		"content": {
             "source": "text",

--- a/assets/course-theme/blocks/ui/spacer.block.json
+++ b/assets/course-theme/blocks/ui/spacer.block.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms/spacer-flex",
   "category": "theme",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "supports": {}
 }

--- a/assets/course-theme/blocks/ui/ui.block.json
+++ b/assets/course-theme/blocks/ui/ui.block.json
@@ -1,7 +1,7 @@
 {
 	"name": "sensei-lms/ui",
 	"category": "theme",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"supports": {
 		"align": true,
 		"alignWide": true,

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -107,7 +107,7 @@ export const withDefaultBlockStyle =
 	( defaultStyleName = 'default' ) =>
 	( Component ) =>
 	( props ) => {
-		let { className } = props;
+		let className = props.attributes?.className;
 
 		const extraProps = {};
 
@@ -115,7 +115,11 @@ export const withDefaultBlockStyle =
 			className = extraProps.className = [
 				className,
 				`is-style-${ defaultStyleName }`,
-			].join( ' ' );
+			]
+				.filter( Boolean )
+				.join( ' ' );
+		} else {
+			extraProps.className = className;
 		}
 
 		const style = className.match( /is-style-(\w+)/ );

--- a/changelog/update-blocks-api-version-3
+++ b/changelog/update-blocks-api-version-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Sensei blocks to Block API version 3 so they render in the WordPress iframe block editor.


### PR DESCRIPTION
Resolves #8045

## Proposed Changes

WordPress 6.9 deprecates blocks registered with Block API version 2 or lower and renders them in a fallback editor instead of the iframe editor that WordPress is standardizing on. A future release removes that fallback, at which point the affected Sensei blocks would break.

This updates every Sensei block to Block API version 3 so they register for the iframe editor and stop emitting the deprecation warning.

These blocks were on the implicit Block API version 1. The wrapper migration happens at version 2 (WP 5.6): `edit` must call `useBlockProps()` and static `save` must call `useBlockProps.save()`, otherwise the generated wrapper class (`wp-block-{name}`, style, align) is no longer added automatically. Sensei's blocks never adopted that, so this PR does the wrapper migration and sets `apiVersion: 3` — version 3 (WP 6.3) renders the block in the editor iframe, which is what WordPress 6.9 requires.

Doing the wrapper migration fixes two problems in the iframe editor:

- The **Course Outline** rendered unstyled (the module header showed as a full-height black bar) and the **Module** block threw an error and could not be previewed.
- **Conditional Content**, **Featured Video** and **Lesson Properties** lost their wrapper class.

### Keeping existing content valid

The button/action blocks (Take Course, Contact Teacher, the lesson/course action buttons), the **Lesson Actions** container and **Conditional Content** have a static `save()`. At version 1 WordPress injected the wrapper classes into their saved markup automatically; from version 2 it does not. The saves reproduce the same markup by hand so existing content stays valid (the default Learning Mode templates and any page using these blocks) with no re-save:

- `withDefaultBlockStyle` reads the selected style from `attributes.className`, so the button/action blocks keep their style and their save regenerates the stored markup byte for byte.
- The Lesson Actions and Conditional Content saves use `useBlockProps.save()` to restore the default block class the API no longer merges automatically.

Existing content keeps validating with no re-save required, and no block deprecations are needed.

## Testing Instructions

- [x] On WordPress 6.9+, open the browser console and edit a Course. Confirm the "Block with API version 2 or lower is deprecated" warning no longer appears for Sensei blocks.
- [x] In the Course editor, insert a Course Outline, choose "Start with blank", and add a Module with a couple of lessons. Confirm the module renders with its styled header and lesson list and shows no block error.
- [x] Select the Course Outline and switch its style between Filled and Minimal. Confirm both render correctly.
- [x] In a Lesson, insert Featured Video, Lesson Properties and Conditional Content. Confirm each renders and can be selected.
- [x] In the Site Editor, open the Learning Mode "Lesson" template and confirm the Sensei blocks render with no "unexpected or invalid content" notice, and that the Lesson Actions buttons lay out in a horizontal row (not stacked vertically).
- [x] View a lesson on the front end with Learning Mode enabled and confirm the lesson actions and other Sensei blocks still render as before.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Changed - Changes existing functionality

#### Message

Update Sensei blocks to Block API version 3 so they render in the WordPress iframe block editor.

</details>


