### PR TITLE
Fix module border showing in the editor when the border setting is off

### DIFF
--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -120,9 +120,11 @@ export const ModuleEdit = ( props ) => {
 		className: classnames( {
 			'wp-block-sensei-lms-course-outline-module-bordered': bordered,
 		} ),
-		style: {
-			borderColor: borderColorValue || defaultBorderColor?.color,
-		},
+		style: bordered
+			? {
+					borderColor: borderColorValue || defaultBorderColor?.color,
+			  }
+			: undefined,
 	} );
 
 	const styleRegex = /is-style-(\w+)/;

--- a/changelog/fix-module-border-when-unbordered
+++ b/changelog/fix-module-border-when-unbordered
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a thick border showing on Course Outline modules in the editor when the module border setting is off.


### PR DESCRIPTION
## Proposed Changes

In the block editor, a Course Outline module showed a thick (3px) border even when its **Border** setting was off, while a bordered module correctly showed a thin 1px border. The front end was unaffected.

The module always applied an inline `border-color` to its wrapper. WordPress core's `:where([style^="border-color"])` rule then forces `border-style: solid`, and with no explicit width the browser falls back to the `medium` (3px) width — so an unbordered module still rendered a 3px border in the editor. The inline `border-color` is now applied only when the module is bordered, so the border setting behaves consistently.

## Screenshots

| Before | After |
| --- | --- |
|  |  |

## Testing Instructions

- [x] Edit a Course, insert a Course Outline, and add a Module with a couple of lessons.
- [x] Select the Module and turn its **Border** setting off. Confirm the module no longer shows a thick border in the editor.
- [x] Turn the **Border** setting on. Confirm the module shows a single thin 1px border.
- [x] With the Course Outline block selected, toggle the **Border** control in the Modules panel and confirm all modules follow the same behavior.
- [x] View the course/lesson on the front end and confirm module borders render as before.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fix a thick border showing on Course Outline modules in the editor when the module border setting is off.

</details>
