### PR TITLE
AGENTS.md tweak to stop writing low-value tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Apply them to code you add. Do not rewrite surrounding code to match.
 - `make build` runs `composer install --no-dev` inside the container, which strips all dev dependencies (`vendor/bin/phpunit`, `vendor/bin/psalm`, etc.). After a build, restore dev tooling before running tests or static analysis with `make install-php`.
 
 ## Testing
-- **Test-driven development**: Follow a TDD approach for new behavior and bug fixes — write a failing test that captures the desired behavior first, then implement until it passes. This applies to PHPUnit, JS unit, and (where practical) Playwright suites.
+- **Test-driven development**: Follow a TDD approach for non-trivial new behavior and bug fixes — write a failing test first, then implement until it passes. Skip tests for trivial changes: copy/string tweaks, config, mechanical renames, one-line passthroughs, styling. If unsure a change needs a test, ask rather than write one by default.
 - **PHPUnit**: `make test-php` (runs inside wp-env). Targeted runs: `make test-php-filter FILTER="TestClass"` or `FILTER="TestClass::method"`.
 - **PHPUnit with HPPS enabled**: `npm run test-php:wp-env:hpps`.
 - **JS unit tests**: `npm run test-js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Apply them to code you add. Do not rewrite surrounding code to match.
 ## Development environment
 - Run all dev commands inside the `make up` (wp-env) sandbox rather than against any host WordPress install — this keeps mistakes off shared/local state.
 - Use the Node version pinned in `.nvmrc`.
-- Ensure Docker Desktop (or Colima) is running before `make up`; verify with `docker info`. If it isn't running, start it without asking — this is a routine local action, not a user-facing change. Use `open -a Docker` on macOS, `colima start` on Colima, or `sudo systemctl start docker` on Linux, then wait until `docker info` succeeds.
+- Ensure Docker Desktop (or Colima) is running before `make up`; verify with `docker info`. If it isn't running, start it without asking — this is a routine local action, not a user-facing change. Use `open -a Docker` on macOS or `sudo systemctl start docker` on Linux, then wait until `docker info` succeeds.
 - `make up` boots the wp-env Docker stack; `make down` stops it; `make destroy` wipes containers and data for a clean slate.
 - `make shell` opens a shell inside the WordPress container; `make wp CMD="..."` runs wp-cli commands against it.
 - Override the WordPress or PHP version with `make up WP=6.8 PHP=8.3` (writes a transient `.wp-env.override.json`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Apply them to code you add. Do not rewrite surrounding code to match.
 - `make build` runs `composer install --no-dev` inside the container, which strips all dev dependencies (`vendor/bin/phpunit`, `vendor/bin/psalm`, etc.). After a build, restore dev tooling before running tests or static analysis with `make install-php`.
 
 ## Testing
-- **Test-driven development**: Follow a TDD approach for non-trivial new behavior and bug fixes — write a failing test first, then implement until it passes. Skip tests for trivial changes: copy/string tweaks, config, mechanical renames, one-line passthroughs, styling. If unsure a change needs a test, ask rather than write one by default.
+- **Test-driven development**: Follow a TDD approach for non-trivial new behavior and bug fixes — write a failing test first, then implement until it passes. Skip tests for trivial changes such as copy/string tweaks, config, mechanical renames, one-line passthroughs, styling etc.. If unsure a change needs a test, ask rather than write one by default.
 - **PHPUnit**: `make test-php` (runs inside wp-env). Targeted runs: `make test-php-filter FILTER="TestClass"` or `FILTER="TestClass::method"`.
 - **PHPUnit with HPPS enabled**: `npm run test-php:wp-env:hpps`.
 - **JS unit tests**: `npm run test-js`.


### PR DESCRIPTION
- Low-value tests are being added to the codebase. Update the language in `AGENTS.md` to discourage that.
- Remove Colima reference.