### PR TITLE
Make request-input handling consistent across the admin and frontend

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,6 +51,9 @@ jobs:
             - name: Check for nonces
               run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.NonceVerification .
 
+            - name: Check for input sanitization
+              run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.ValidatedSanitizedInput .
+
             - name: Check WPCOM rules
               run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
     test:

--- a/changelog/phpcs-security-fix-violations
+++ b/changelog/phpcs-security-fix-violations
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Hardened handling of request input across the admin and frontend by consistently unslashing and sanitizing user-supplied values.
+Hardened handling of request input across the admin and frontend.

--- a/changelog/phpcs-security-fix-violations
+++ b/changelog/phpcs-security-fix-violations
@@ -1,4 +1,4 @@
 Significance: patch
-Type: security
+Type: changed
 
-Hardened handling of request input across the admin and frontend.
+Made request-input handling consistent across the admin and frontend.

--- a/changelog/phpcs-security-fix-violations
+++ b/changelog/phpcs-security-fix-violations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hardened handling of request input across the admin and frontend by consistently unslashing and sanitizing user-supplied values.

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -255,7 +255,7 @@ class Sensei_Admin_Notices {
 			<?php
 			echo '<div class="sensei-notice__content">';
 			if ( ! empty( $notice['icon'] ) ) {
-				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the function.
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_icon() escapes its own dynamic parts.
 				echo Sensei()->assets->get_icon( $notice['icon'], 'sensei-notice__icon' );
 			}
 			echo '<div>';
@@ -280,6 +280,7 @@ class Sensei_Admin_Notices {
 						wp_enqueue_script( 'sensei-dismiss-notices' );
 						$extra_attrs = ' data-sensei-notice-tasks="' . esc_attr( wp_json_encode( $action['tasks'] ) ) . '"';
 					}
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $extra_attrs is assembled from esc_attr()'d values above; other parts escaped inline.
 					echo '<a href="' . esc_url( $action['url'] ) . '" target="' . esc_attr( $action['target'] ?? '_self' ) . '" rel="noopener noreferrer" class="button ' . esc_attr( $button_class ) . '"' . $extra_attrs . '>';
 					echo esc_html( $action['label'] );
 					echo '</a>';

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -731,7 +731,7 @@ class Sensei_Admin_Notices {
 		check_ajax_referer( self::DISMISS_NOTICE_NONCE_ACTION, 'nonce' );
 
 		$notices   = $this->get_notices();
-		$notice_id = isset( $_POST['notice'] ) ? sanitize_text_field( wp_unslash( $_POST['notice'] ) ) : false;
+		$notice_id = isset( $_POST['notice'] ) ? sensei_request_text( $_POST['notice'] ) : false;
 		if ( ! $notice_id || ! isset( $notices[ $notice_id ] ) ) {
 			return;
 		}

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -56,9 +56,9 @@ class Sensei_Exit_Survey {
 		check_ajax_referer( 'sensei_exit_survey' );
 
 		$feedback = [
-			'reason'  => isset( $_POST['reason'] ) ? sanitize_text_field( wp_unslash( $_POST['reason'] ) ) : null,
-			'details' => isset( $_POST['details'] ) ? sanitize_text_field( wp_unslash( $_POST['details'] ) ) : null,
-			'theme'   => isset( $_POST['theme'] ) ? sanitize_text_field( wp_unslash( $_POST['theme'] ) ) : null,
+			'reason'  => isset( $_POST['reason'] ) ? sensei_request_text( $_POST['reason'] ) : null,
+			'details' => isset( $_POST['details'] ) ? sensei_request_text( $_POST['details'] ) : null,
+			'theme'   => isset( $_POST['theme'] ) ? sensei_request_text( $_POST['theme'] ) : null,
 		];
 
 		update_option( 'sensei_exit_survey_data', $feedback );

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -861,7 +861,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['add_learner_nonce'] ) ? '' : $_POST['add_learner_nonce'] ) ), 'add_learner_to_sensei' ) ) {
+		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['add_learner_nonce'] ) ), 'add_learner_to_sensei' ) ) {
 			return $result;
 		}
 
@@ -869,7 +869,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		$post_type = sanitize_text_field( wp_unslash( is_array( $_POST['add_post_type'] ) ? '' : $_POST['add_post_type'] ) );
+		$post_type = sanitize_text_field( wp_unslash( $_POST['add_post_type'] ) );
 		$user_ids  = array_map( 'intval', $_POST['add_user_id'] );
 		$course_id = intval( $_POST['add_course_id'] );
 		$lesson_id = intval( $_POST['add_lesson_id'] );

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -376,8 +376,8 @@ class Sensei_Learner_Management {
 	 * @since  1.6.0
 	 */
 	public function learners_default_nav() {
-		$course_id = (int) sanitize_text_field( wp_unslash( $_GET['course_id'] ?? 0 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$lesson_id = (int) sanitize_text_field( wp_unslash( $_GET['lesson_id'] ?? 0 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$course_id = (int) sensei_request_text( $_GET['course_id'] ?? 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$lesson_id = (int) sensei_request_text( $_GET['lesson_id'] ?? 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( 0 < $course_id && 0 < $lesson_id ) {
 			$back_url = add_query_arg(
@@ -503,7 +503,7 @@ class Sensei_Learner_Management {
 		}
 
 		if ( ! empty( $_POST['data']['new_dates']['start-date'] ) ) {
-			$date_string = sanitize_text_field( wp_unslash( $_POST['data']['new_dates']['start-date'] ) );
+			$date_string = sensei_request_text( $_POST['data']['new_dates']['start-date'] );
 		} else {
 			exit;
 		}
@@ -673,7 +673,7 @@ class Sensei_Learner_Management {
 		$redirect_url = remove_query_arg( [ 'learner_action', '_wpnonce', 'user_id' ] );
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce checked below.
-		$learner_action = sanitize_text_field( wp_unslash( $_GET['learner_action'] ) );
+		$learner_action = sensei_request_text( $_GET['learner_action'] );
 		if ( ! in_array( $learner_action, [ 'enrol', 'restore_enrollment', 'withdraw' ], true ) ) {
 			wp_safe_redirect( esc_url_raw( $redirect_url ) );
 			exit;
@@ -785,14 +785,14 @@ class Sensei_Learner_Management {
 
 		check_ajax_referer( 'search-users', 'security' );
 
-		$default     = isset( $_GET['default'] ) && is_string( $_GET['default'] ) ? sanitize_text_field( wp_unslash( $_GET['default'] ) ) : __( 'None', 'sensei-lms' );
+		$default     = isset( $_GET['default'] ) && is_string( $_GET['default'] ) ? sensei_request_text( $_GET['default'] ) : __( 'None', 'sensei-lms' );
 		$found_users = array( '' => $default );
 
 		if ( ! current_user_can( 'manage_sensei_grades' ) ) {
 			wp_send_json( $found_users );
 		}
 
-		$term = isset( $_GET['term'] ) && is_string( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
+		$term = isset( $_GET['term'] ) && is_string( $_GET['term'] ) ? sensei_request_text( $_GET['term'] ) : '';
 
 		if ( empty( $term ) ) {
 			die();
@@ -861,7 +861,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['add_learner_nonce'] ) ), 'add_learner_to_sensei' ) ) {
+		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( sensei_request_text( $_POST['add_learner_nonce'] ), 'add_learner_to_sensei' ) ) {
 			return $result;
 		}
 
@@ -869,7 +869,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		$post_type = sanitize_text_field( wp_unslash( $_POST['add_post_type'] ) );
+		$post_type = sensei_request_text( $_POST['add_post_type'] );
 		$user_ids  = array_map( 'intval', $_POST['add_user_id'] );
 		$course_id = intval( $_POST['add_course_id'] );
 		$lesson_id = intval( $_POST['add_lesson_id'] );
@@ -962,7 +962,7 @@ class Sensei_Learner_Management {
 	 */
 	public function add_learner_notices() {
 		if ( isset( $_GET['page'] ) && $this->page_slug === $_GET['page'] && isset( $_GET['message'] ) && '' !== $_GET['message'] ) {
-			$message = sanitize_text_field( wp_unslash( $_GET['message'] ) );
+			$message = sensei_request_text( $_GET['message'] );
 			$notice  = false;
 
 			switch ( $message ) {

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -440,7 +440,7 @@ class Sensei_Learner_Management {
 		check_ajax_referer( 'course_category_nonce', 'security' );
 
 		// Parse POST data.
-		$data        = $_POST['data'];
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$course_data = array();
 		parse_str( $data, $course_data );
 
@@ -593,7 +593,7 @@ class Sensei_Learner_Management {
 		check_ajax_referer( 'modify_user_post_nonce', 'security' );
 
 		// Parse POST data.
-		$data        = sanitize_text_field( $_POST['data'] );
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$action_data = array();
 		parse_str( $data, $action_data );
 
@@ -859,7 +859,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( $_POST['add_learner_nonce'], 'add_learner_to_sensei' ) ) {
+		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['add_learner_nonce'] ) ), 'add_learner_to_sensei' ) ) {
 			return $result;
 		}
 
@@ -867,7 +867,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		$post_type = $_POST['add_post_type'];
+		$post_type = sanitize_text_field( wp_unslash( $_POST['add_post_type'] ) );
 		$user_ids  = array_map( 'intval', $_POST['add_user_id'] );
 		$course_id = intval( $_POST['add_course_id'] );
 		$lesson_id = intval( $_POST['add_lesson_id'] );
@@ -959,7 +959,7 @@ class Sensei_Learner_Management {
 	 * Displays a notice to indicate whether or not the Learner(s) was added successfully.
 	 */
 	public function add_learner_notices() {
-		if ( isset( $_GET['page'] ) && $this->page_slug === $_GET['page'] && isset( $_GET['message'] ) && $_GET['message'] ) {
+		if ( isset( $_GET['page'] ) && $this->page_slug === $_GET['page'] && isset( $_GET['message'] ) && '' !== $_GET['message'] ) {
 			$message = sanitize_text_field( wp_unslash( $_GET['message'] ) );
 			$notice  = false;
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -440,7 +440,7 @@ class Sensei_Learner_Management {
 		check_ajax_referer( 'course_category_nonce', 'security' );
 
 		// Parse POST data.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$course_data = array();
 		parse_str( $data, $course_data );
 
@@ -593,7 +593,7 @@ class Sensei_Learner_Management {
 		check_ajax_referer( 'modify_user_post_nonce', 'security' );
 
 		// Parse POST data.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$action_data = array();
 		parse_str( $data, $action_data );
 
@@ -859,7 +859,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['add_learner_nonce'] ) ), 'add_learner_to_sensei' ) ) {
+		if ( ! isset( $_POST['add_learner_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['add_learner_nonce'] ) ? '' : $_POST['add_learner_nonce'] ) ), 'add_learner_to_sensei' ) ) {
 			return $result;
 		}
 
@@ -867,7 +867,7 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		$post_type = sanitize_text_field( wp_unslash( $_POST['add_post_type'] ) );
+		$post_type = sanitize_text_field( wp_unslash( is_array( $_POST['add_post_type'] ) ? '' : $_POST['add_post_type'] ) );
 		$user_ids  = array_map( 'intval', $_POST['add_user_id'] );
 		$course_id = intval( $_POST['add_course_id'] );
 		$lesson_id = intval( $_POST['add_lesson_id'] );

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -440,7 +440,8 @@ class Sensei_Learner_Management {
 		check_ajax_referer( 'course_category_nonce', 'security' );
 
 		// Parse POST data.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data        = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$course_data = array();
 		parse_str( $data, $course_data );
 
@@ -593,7 +594,8 @@ class Sensei_Learner_Management {
 		check_ajax_referer( 'modify_user_post_nonce', 'security' );
 
 		// Parse POST data.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data        = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$action_data = array();
 		parse_str( $data, $action_data );
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -208,9 +208,9 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		$this->check_nonce();
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce checked in check_nonce
-		$sensei_bulk_action = sanitize_text_field( wp_unslash( $_POST['sensei_bulk_action'] ) );
-		$course_ids         = explode( ',', sanitize_text_field( wp_unslash( $_POST['bulk_action_course_ids'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
-		$user_ids           = array_map( 'absint', explode( ',', sanitize_text_field( wp_unslash( $_POST['bulk_action_user_ids'] ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		$sensei_bulk_action = sensei_request_text( $_POST['sensei_bulk_action'] );
+		$course_ids         = explode( ',', sensei_request_text( $_POST['bulk_action_course_ids'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		$user_ids           = array_map( 'absint', explode( ',', sensei_request_text( $_POST['bulk_action_user_ids'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		if ( ! array_key_exists( $sensei_bulk_action, $this->get_known_bulk_actions() ) ) {
 			$this->redirect_to_learner_admin_index( 'error-invalid-action' );
@@ -415,7 +415,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of message.
-		$msg       = sanitize_text_field( wp_unslash( $_GET['message'] ) );
+		$msg       = sensei_request_text( $_GET['message'] );
 		$msg_class = 'notice notice-error';
 
 		switch ( $msg ) {

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -416,7 +416,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		$selected_course = 0;
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
-		if ( isset( $_GET['filter_by_course_id'] ) && '' !== esc_html( sanitize_text_field( wp_unslash( $_GET['filter_by_course_id'] ) ) ) ) {
+		if ( isset( $_GET['filter_by_course_id'] ) && '' !== esc_html( sensei_request_text( $_GET['filter_by_course_id'] ) ) ) {
 			$selected_course = (int) $_GET['filter_by_course_id']; // phpcs:ignore WordPress.Security.NonceVerification
 		}
 		?>
@@ -537,7 +537,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to order columns.
 		if ( ! empty( $_GET['orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby_input = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			$orderby_input = sensei_request_text( $_GET['orderby'] );
 			if ( array_key_exists( $orderby_input, $this->get_sortable_columns() ) ) {
 				$orderby = $orderby_input;
 			}
@@ -548,7 +548,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to order columns.
 		if ( ! empty( $_GET['order'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$order = 'ASC' === strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
+			$order = 'ASC' === strtoupper( sensei_request_text( $_GET['order'] ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search.
@@ -602,7 +602,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for filtering.
 		if ( ! empty( $_GET['filter_type'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$filter_type_input = sanitize_text_field( wp_unslash( $_GET['filter_type'] ) );
+			$filter_type_input = sensei_request_text( $_GET['filter_type'] );
 			$filter_type       = in_array( $filter_type_input, array( 'inc', 'exc' ), true ) ? $filter_type_input : 'inc';
 		}
 		$page = $this->page_slug;

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -97,14 +97,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		}
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'lessons', 'learners' ), true ) ) {
-			$this->view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
+			$this->view = sensei_request_text( $_GET['view'] );
 		} else {
 			$this->view = '';
 		}
 
 		$this->enrolment_status = 'all';
 		if ( isset( $_GET['enrolment_status'] ) ) {
-			$this->enrolment_status = sanitize_text_field( wp_unslash( $_GET['enrolment_status'] ) );
+			$this->enrolment_status = sensei_request_text( $_GET['enrolment_status'] );
 
 			$valid_enrolment_statuses = [ 'all', 'enrolled', 'unenrolled' ];
 
@@ -270,7 +270,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		// Handle orderby.
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			$orderby_arg = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			$orderby_arg = sensei_request_text( $_GET['orderby'] );
 			if ( array_key_exists( $orderby_arg, $this->get_sortable_columns() ) ) {
 				$orderby = $orderby_arg;
 			}
@@ -279,7 +279,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		// Handle order.
 		$order = 'DESC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = 'ASC' === strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
+			$order = 'ASC' === strtoupper( sensei_request_text( $_GET['order'] ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle category selection.
@@ -291,7 +291,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		// Handle search.
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification
 

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -123,7 +123,7 @@ class Sensei_Tools {
 		$tools = $this->get_tools();
 
 		if ( ! empty( $_GET['tool'] ) ) {
-			$tool_id = sanitize_text_field( wp_unslash( $_GET['tool'] ) );
+			$tool_id = sensei_request_text( $_GET['tool'] );
 			if ( ! isset( $tools[ $tool_id ] ) ) {
 				$this->trigger_invalid_request();
 
@@ -169,7 +169,7 @@ class Sensei_Tools {
 		$tools = $this->get_tools();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$tool_id = ! empty( $_GET['tool'] ) ? sanitize_text_field( wp_unslash( $_GET['tool'] ) ) : false;
+		$tool_id = ! empty( $_GET['tool'] ) ? sensei_request_text( $_GET['tool'] ) : false;
 
 		if (
 			$tool_id

--- a/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-featured-filter.php
@@ -54,7 +54,7 @@ class Sensei_Course_List_Featured_Filter extends Sensei_Course_List_Filter_Abstr
 		$is_inherited     = $block->context['query']['inherit'] ?? false;
 		$filter_param_key = $is_inherited ? 'course_filter' : self::PARAM_KEY . $query_id;
 		$default_option   = $attributes['defaultOptions']['featured'] ?? 'all';
-		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
+		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sensei_request_text( $_GET[ $filter_param_key ] ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 
 		return '<select data-param-key="' . esc_attr( $filter_param_key ) . '">' .
 			implode(
@@ -81,7 +81,7 @@ class Sensei_Course_List_Featured_Filter extends Sensei_Course_List_Filter_Abstr
 			return [];
 		}
 		// phpcs:ignore WordPress.Security.NonceVerification
-		$selected_option = sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) );
+		$selected_option = sensei_request_text( $_GET[ $filter_param_key ] );
 
 		if ( 'all' === $selected_option || ! in_array( $selected_option, array_keys( $this->featured_options ), true ) ) {
 			return [];

--- a/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
+++ b/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php
@@ -58,7 +58,7 @@ class Sensei_Course_List_Student_Course_Filter extends Sensei_Course_List_Filter
 		$is_inherited     = $block->context['query']['inherit'] ?? false;
 		$filter_param_key = $is_inherited ? 'student_course_filter' : self::PARAM_KEY . $query_id;
 		$default_option   = $attributes['defaultOptions']['student_course'] ?? 'all';
-		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
+		$selected_option  = isset( $_GET[ $filter_param_key ] ) ? sensei_request_text( $_GET[ $filter_param_key ] ) : $default_option; // phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to filter courses.
 
 		return '<select data-param-key="' . esc_attr( $filter_param_key ) . '">' .
 			implode(
@@ -90,7 +90,7 @@ class Sensei_Course_List_Student_Course_Filter extends Sensei_Course_List_Filter
 			return [];
 		}
 		// phpcs:ignore WordPress.Security.NonceVerification
-		$selected_option = sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) );
+		$selected_option = sensei_request_text( $_GET[ $filter_param_key ] );
 
 		if ( 'all' === $selected_option || ! in_array( $selected_option, array_keys( $this->filter_options ), true ) ) {
 			return [];

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1767,13 +1767,13 @@ class Sensei_Admin {
 		$event_name = sanitize_text_field( wp_unslash( $_REQUEST['event_name'] ) );
 		// $_REQUEST['properties'] is a JSON string or array; sanitized via map_deep() after decoding below.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$properties = isset( $_REQUEST['properties'] ) ? wp_unslash( $_REQUEST['properties'] ) : [];
+		$properties = isset( $_REQUEST['properties'] ) ? wp_unslash( $_REQUEST['properties'] ) : array();
 
 		if ( is_string( $properties ) ) {
 			$properties = json_decode( $properties, true );
 		}
 
-		$properties = is_array( $properties ) ? map_deep( $properties, 'sanitize_text_field' ) : [];
+		$properties = is_array( $properties ) ? map_deep( $properties, 'sanitize_text_field' ) : array();
 
 		// Set the source to js-event.
 		add_filter(

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1103,8 +1103,8 @@ class Sensei_Admin {
 		check_admin_referer( 'order_courses' );
 
 		$ordered = null;
-		if ( isset( $_POST['course-order'] ) && 0 < strlen( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) ) ) {
-			$ordered = $this->save_course_order( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) );
+		if ( isset( $_POST['course-order'] ) && 0 < strlen( sensei_request_text( $_POST['course-order'] ) ) ) {
+			$ordered = $this->save_course_order( sensei_request_text( $_POST['course-order'] ) );
 		}
 
 		wp_redirect(
@@ -1518,7 +1518,7 @@ class Sensei_Admin {
 					&& ! empty( $course_structure[ $key ]['lessons'] )
 				) {
 					// phpcs:ignore WordPress.Security.NonceVerification
-					$order = sanitize_text_field( wp_unslash( $_POST[ 'lesson-order-module-' . $module['id'] ] ) );
+					$order = sensei_request_text( $_POST[ 'lesson-order-module-' . $module['id'] ] );
 					$order = array_map( 'absint', explode( ',', $order ) );
 
 					$course_structure[ $key ]['lessons'] = Sensei_Course_Structure::sort_structure( $course_structure[ $key ]['lessons'], $order, 'lesson' );
@@ -1690,7 +1690,7 @@ class Sensei_Admin {
 	public function theme_compatibility_notices() {
 
 		if ( isset( $_GET['sensei_hide_notice'] ) ) {
-			switch ( sanitize_text_field( wp_unslash( $_GET['sensei_hide_notice'] ) ) ) {
+			switch ( sensei_request_text( $_GET['sensei_hide_notice'] ) ) {
 				case 'menu_settings':
 					add_user_meta( get_current_user_id(), 'sensei_hide_menu_settings_notice', true );
 					break;
@@ -1764,7 +1764,7 @@ class Sensei_Admin {
 			wp_die();
 		}
 
-		$event_name = sanitize_text_field( wp_unslash( $_REQUEST['event_name'] ) );
+		$event_name = sensei_request_text( $_REQUEST['event_name'] );
 		// $_REQUEST['properties'] is a JSON string or array; sanitized via map_deep() after decoding below.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$properties = isset( $_REQUEST['properties'] ) ? wp_unslash( $_REQUEST['properties'] ) : array();

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1765,7 +1765,7 @@ class Sensei_Admin {
 		}
 
 		$event_name = sensei_request_text( $_REQUEST['event_name'] );
-		// $_REQUEST['properties'] is a JSON string or array; sanitized via map_deep() after decoding below.
+		// $_REQUEST['properties'] is a JSON string or array; string values are sanitized via sanitize_event_properties() after decoding below.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$properties = isset( $_REQUEST['properties'] ) ? wp_unslash( $_REQUEST['properties'] ) : array();
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1793,8 +1793,7 @@ class Sensei_Admin {
 	 * Recursively sanitize the string values of an event property array.
 	 *
 	 * Non-string scalar values (int, float, bool, null) are returned untouched so the
-	 * logged event keeps the types produced by json_decode(), rather than coercing them
-	 * to strings the way map_deep( ..., 'sanitize_text_field' ) would.
+	 * logged event keeps the types produced by json_decode().
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1103,8 +1103,8 @@ class Sensei_Admin {
 		check_admin_referer( 'order_courses' );
 
 		$ordered = null;
-		if ( isset( $_POST['course-order'] ) && 0 < strlen( sanitize_text_field( wp_unslash( is_array( $_POST['course-order'] ) ? '' : $_POST['course-order'] ) ) ) ) {
-			$ordered = $this->save_course_order( sanitize_text_field( wp_unslash( is_array( $_POST['course-order'] ) ? '' : $_POST['course-order'] ) ) );
+		if ( isset( $_POST['course-order'] ) && 0 < strlen( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) ) ) {
+			$ordered = $this->save_course_order( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) );
 		}
 
 		wp_redirect(
@@ -1690,7 +1690,7 @@ class Sensei_Admin {
 	public function theme_compatibility_notices() {
 
 		if ( isset( $_GET['sensei_hide_notice'] ) ) {
-			switch ( sanitize_text_field( wp_unslash( is_array( $_GET['sensei_hide_notice'] ) ? '' : $_GET['sensei_hide_notice'] ) ) ) {
+			switch ( sanitize_text_field( wp_unslash( $_GET['sensei_hide_notice'] ) ) ) {
 				case 'menu_settings':
 					add_user_meta( get_current_user_id(), 'sensei_hide_menu_settings_notice', true );
 					break;
@@ -1764,7 +1764,7 @@ class Sensei_Admin {
 			wp_die();
 		}
 
-		$event_name = sanitize_text_field( wp_unslash( is_array( $_REQUEST['event_name'] ) ? '' : $_REQUEST['event_name'] ) );
+		$event_name = sanitize_text_field( wp_unslash( $_REQUEST['event_name'] ) );
 		// $_REQUEST['properties'] is a JSON string or array; sanitized via map_deep() after decoding below.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$properties = isset( $_REQUEST['properties'] ) ? wp_unslash( $_REQUEST['properties'] ) : array();

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1773,7 +1773,9 @@ class Sensei_Admin {
 			$properties = json_decode( $properties, true );
 		}
 
-		$properties = is_array( $properties ) ? map_deep( $properties, 'sanitize_text_field' ) : array();
+		// Sanitize string values only, preserving the JSON-decoded scalar types (int/float/bool/null)
+		// so logged event properties keep the same types and values they had before sanitization.
+		$properties = is_array( $properties ) ? $this->sanitize_event_properties( $properties ) : array();
 
 		// Set the source to js-event.
 		add_filter(
@@ -1785,6 +1787,30 @@ class Sensei_Admin {
 
 		sensei_log_event( $event_name, $properties );
 		// phpcs:enable WordPress.Security.NonceVerification
+	}
+
+	/**
+	 * Recursively sanitize the string values of an event property array.
+	 *
+	 * Non-string scalar values (int, float, bool, null) are returned untouched so the
+	 * logged event keeps the types produced by json_decode(), rather than coercing them
+	 * to strings the way map_deep( ..., 'sanitize_text_field' ) would.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $properties Decoded event properties.
+	 * @return array The properties with their string values sanitized.
+	 */
+	private function sanitize_event_properties( array $properties ): array {
+		foreach ( $properties as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$properties[ $key ] = $this->sanitize_event_properties( $value );
+			} elseif ( is_string( $value ) ) {
+				$properties[ $key ] = sanitize_text_field( $value );
+			}
+		}
+
+		return $properties;
 	}
 
 	/**

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1103,8 +1103,8 @@ class Sensei_Admin {
 		check_admin_referer( 'order_courses' );
 
 		$ordered = null;
-		if ( isset( $_POST['course-order'] ) && 0 < strlen( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) ) ) {
-			$ordered = $this->save_course_order( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) );
+		if ( isset( $_POST['course-order'] ) && 0 < strlen( sanitize_text_field( wp_unslash( is_array( $_POST['course-order'] ) ? '' : $_POST['course-order'] ) ) ) ) {
+			$ordered = $this->save_course_order( sanitize_text_field( wp_unslash( is_array( $_POST['course-order'] ) ? '' : $_POST['course-order'] ) ) );
 		}
 
 		wp_redirect(
@@ -1690,7 +1690,7 @@ class Sensei_Admin {
 	public function theme_compatibility_notices() {
 
 		if ( isset( $_GET['sensei_hide_notice'] ) ) {
-			switch ( sanitize_text_field( wp_unslash( $_GET['sensei_hide_notice'] ) ) ) {
+			switch ( sanitize_text_field( wp_unslash( is_array( $_GET['sensei_hide_notice'] ) ? '' : $_GET['sensei_hide_notice'] ) ) ) {
 				case 'menu_settings':
 					add_user_meta( get_current_user_id(), 'sensei_hide_menu_settings_notice', true );
 					break;
@@ -1764,7 +1764,7 @@ class Sensei_Admin {
 			wp_die();
 		}
 
-		$event_name = sanitize_text_field( wp_unslash( $_REQUEST['event_name'] ) );
+		$event_name = sanitize_text_field( wp_unslash( is_array( $_REQUEST['event_name'] ) ? '' : $_REQUEST['event_name'] ) );
 		// $_REQUEST['properties'] is a JSON string or array; sanitized via map_deep() after decoding below.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$properties = isset( $_REQUEST['properties'] ) ? wp_unslash( $_REQUEST['properties'] ) : array();

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -643,7 +643,7 @@ class Sensei_Admin {
 			wp_die( esc_html( sprintf( __( 'Please supply a %1$s ID.', 'sensei-lms' ) ), $post_type ) );
 		}
 
-		$post_id = $_GET['post'];
+		$post_id = absint( $_GET['post'] );
 		$post    = get_post( $post_id );
 		if ( ! in_array( get_post_type( $post_id ), array( 'lesson', 'course' ), true ) ) {
 			wp_die( esc_html__( 'Invalid post type. Can duplicate only lessons and courses', 'sensei-lms' ) );
@@ -721,7 +721,7 @@ class Sensei_Admin {
 			);
 			$courses = get_posts( $args );
 
-			$selected       = isset( $_GET['lesson_course'] ) ? $_GET['lesson_course'] : '';
+			$selected       = isset( $_GET['lesson_course'] ) ? absint( $_GET['lesson_course'] ) : '';
 			$course_options = '';
 			foreach ( $courses as $course ) {
 				$course_options .= '<option value="' . esc_attr( $course->ID ) . '" ' . selected( $selected, $course->ID, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>';
@@ -757,7 +757,7 @@ class Sensei_Admin {
 		global $typenow;
 
 		if ( is_admin() && 'lesson' == $typenow ) {
-			$lesson_course = isset( $_GET['lesson_course'] ) ? $_GET['lesson_course'] : '';
+			$lesson_course = isset( $_GET['lesson_course'] ) ? absint( $_GET['lesson_course'] ) : '';
 
 			if ( $lesson_course ) {
 				$request['meta_key']     = '_lesson_course';
@@ -1103,8 +1103,8 @@ class Sensei_Admin {
 		check_admin_referer( 'order_courses' );
 
 		$ordered = null;
-		if ( isset( $_POST['course-order'] ) && 0 < strlen( $_POST['course-order'] ) ) {
-			$ordered = $this->save_course_order( esc_attr( $_POST['course-order'] ) );
+		if ( isset( $_POST['course-order'] ) && 0 < strlen( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) ) ) {
+			$ordered = $this->save_course_order( sanitize_text_field( wp_unslash( $_POST['course-order'] ) ) );
 		}
 
 		wp_redirect(
@@ -1137,7 +1137,7 @@ class Sensei_Admin {
 
 								$html = '';
 
-								if ( isset( $_GET['ordered'] ) && $_GET['ordered'] ) {
+								if ( isset( $_GET['ordered'] ) && '' !== $_GET['ordered'] ) {
 									$html .= '<div class="updated fade">' . "\n";
 									$html .= '<p>' . esc_html__( 'The course order has been saved.', 'sensei-lms' ) . '</p>' . "\n";
 									$html .= '</div>' . "\n";
@@ -1690,7 +1690,7 @@ class Sensei_Admin {
 	public function theme_compatibility_notices() {
 
 		if ( isset( $_GET['sensei_hide_notice'] ) ) {
-			switch ( esc_attr( $_GET['sensei_hide_notice'] ) ) {
+			switch ( sanitize_text_field( wp_unslash( $_GET['sensei_hide_notice'] ) ) ) {
 				case 'menu_settings':
 					add_user_meta( get_current_user_id(), 'sensei_hide_menu_settings_notice', true );
 					break;
@@ -1764,12 +1764,16 @@ class Sensei_Admin {
 			wp_die();
 		}
 
-		$event_name = $_REQUEST['event_name'];
-		$properties = isset( $_REQUEST['properties'] ) ? $_REQUEST['properties'] : [];
+		$event_name = sanitize_text_field( wp_unslash( $_REQUEST['event_name'] ) );
+		// $_REQUEST['properties'] is a JSON string or array; sanitized via map_deep() after decoding below.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$properties = isset( $_REQUEST['properties'] ) ? wp_unslash( $_REQUEST['properties'] ) : [];
 
 		if ( is_string( $properties ) ) {
-			$properties = json_decode( stripslashes( $properties ), true );
+			$properties = json_decode( $properties, true );
 		}
+
+		$properties = is_array( $properties ) ? map_deep( $properties, 'sanitize_text_field' ) : [];
 
 		// Set the source to js-event.
 		add_filter(

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -84,7 +84,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory() )->create_reports_listing_service();
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
-			$this->view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
+			$this->view = sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) );
 		}
 
 		// Viewing a single Learner always sets the view to Lessons
@@ -239,15 +239,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
@@ -323,21 +323,21 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -1031,7 +1031,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	 */
 	private function get_search_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
-		return isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+		return isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) ) : '';
 	}
 }
 

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -84,7 +84,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory() )->create_reports_listing_service();
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
-			$this->view = $_GET['view'];
+			$this->view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
 		}
 
 		// Viewing a single Learner always sets the view to Lessons
@@ -239,21 +239,21 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = esc_html( $_GET['s'] );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -323,21 +323,21 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = esc_html( $_GET['s'] );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -84,7 +84,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory() )->create_reports_listing_service();
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
-			$this->view = sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) );
+			$this->view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
 		}
 
 		// Viewing a single Learner always sets the view to Lessons
@@ -239,15 +239,15 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
@@ -323,21 +323,21 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -1031,7 +1031,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	 */
 	private function get_search_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
-		return isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) ) : '';
+		return isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 	}
 }
 

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -84,7 +84,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory() )->create_reports_listing_service();
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
-			$this->view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
+			$this->view = sensei_request_text( $_GET['view'] );
 		}
 
 		// Viewing a single Learner always sets the view to Lessons
@@ -239,21 +239,21 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sensei_request_text( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
+				$orderby = sensei_request_text( $_GET['orderby'] );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		$this->search = $search;
 
@@ -323,21 +323,21 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sensei_request_text( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
+				$orderby = sensei_request_text( $_GET['orderby'] );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		$this->search = $search;
 
@@ -1031,7 +1031,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	 */
 	private function get_search_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
-		return isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+		return isset( $_GET['s'] ) ? sensei_request_text( $_GET['s'] ) : '';
 	}
 }
 

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -114,21 +114,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = esc_html( $_GET['s'] );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -188,21 +188,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = esc_html( $_GET['s'] );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -114,21 +114,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -188,21 +188,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -114,21 +114,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sensei_request_text( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
+				$orderby = sensei_request_text( $_GET['orderby'] );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		$this->search = $search;
 
@@ -188,21 +188,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sensei_request_text( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
+				$orderby = sensei_request_text( $_GET['orderby'] );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -114,21 +114,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -188,21 +188,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -281,7 +281,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			$orderby = sensei_request_text( $_GET['orderby'] );
 		}
 
 		// Handle order.
@@ -289,7 +289,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['order'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
@@ -322,7 +322,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$args['search'] = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$args['search'] = sensei_request_text( $_GET['s'] );
 		}
 
 		switch ( $this->type ) {
@@ -368,7 +368,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			$orderby = sensei_request_text( $_GET['orderby'] );
 		}
 
 		// Handle order.
@@ -376,7 +376,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['order'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison,WordPress.Security.NonceVerification.Recommended
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$args = array(
@@ -390,7 +390,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$args['search'] = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$args['search'] = sensei_request_text( $_GET['s'] );
 		}
 
 		switch ( $this->type ) {
@@ -1474,7 +1474,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : $default;
+		$start_date = isset( $_GET['start_date'] ) ? sensei_request_text( $_GET['start_date'] ) : $default;
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -1503,7 +1503,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	private function get_end_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
+		$end_date = isset( $_GET['end_date'] ) ? sensei_request_text( $_GET['end_date'] ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -281,7 +281,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 		}
 
 		// Handle order.
@@ -289,7 +289,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['order'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
@@ -368,7 +368,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 		}
 
 		// Handle order.
@@ -376,7 +376,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['order'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison,WordPress.Security.NonceVerification.Recommended
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$args = array(
@@ -390,7 +390,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$args['search'] = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
+			$args['search'] = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 
 		switch ( $this->type ) {
@@ -1474,7 +1474,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['start_date'] ) ? '' : $_GET['start_date'] ) ) : $default;
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : $default;
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -1503,7 +1503,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	private function get_end_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['end_date'] ) ? '' : $_GET['end_date'] ) ) : '';
+		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -281,7 +281,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 		}
 
 		// Handle order.
@@ -289,7 +289,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['order'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
@@ -368,7 +368,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 		}
 
 		// Handle order.
@@ -376,7 +376,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['order'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison,WordPress.Security.NonceVerification.Recommended
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$args = array(
@@ -390,7 +390,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$args['search'] = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$args['search'] = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
 		}
 
 		switch ( $this->type ) {
@@ -1474,7 +1474,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : $default;
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['start_date'] ) ? '' : $_GET['start_date'] ) ) : $default;
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -1503,7 +1503,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	private function get_end_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
+		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['end_date'] ) ? '' : $_GET['end_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -280,16 +280,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$orderby = '';
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			$orderby = esc_html( $_GET['orderby'] );
+			// phpcs:ignore WordPress.Security.NonceVerification
+			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 		}
 
 		// Handle order.
 		$order = 'ASC';
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['order'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
@@ -321,8 +321,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// Handle search.
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$args['search'] = esc_html( wp_unslash( $_GET['s'] ) );
+			// phpcs:ignore WordPress.Security.NonceVerification
+			$args['search'] = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 
 		switch ( $this->type ) {
@@ -367,16 +367,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$orderby = '';
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$orderby = esc_html( $_GET['orderby'] );
+			// phpcs:ignore WordPress.Security.NonceVerification
+			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 		}
 
 		// Handle order.
 		$order = 'ASC';
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['order'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison,WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			// phpcs:ignore WordPress.Security.NonceVerification,Universal.Operators.StrictComparisons.LooseComparison,WordPress.Security.NonceVerification.Recommended
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		$args = array(
@@ -389,8 +389,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// Handle search.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$args['search'] = esc_html( $_GET['s'] );
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$args['search'] = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 
 		switch ( $this->type ) {
@@ -1473,8 +1473,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	private function get_start_date_filter_value(): string {
 		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
 
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$start_date = $_GET['start_date'] ?? $default;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : $default;
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -1502,8 +1502,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @return string The end date or empty string if none.
 	 */
 	private function get_end_date_filter_value(): string {
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$end_date = $_GET['end_date'] ?? '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
+		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -112,21 +112,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -186,21 +186,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -112,21 +112,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sensei_request_text( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
+				$orderby = sensei_request_text( $_GET['orderby'] );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		$this->search = $search;
 
@@ -186,21 +186,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sensei_request_text( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
+				$orderby = sensei_request_text( $_GET['orderby'] );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -112,21 +112,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = esc_html( $_GET['s'] );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -186,21 +186,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = esc_html( $_GET['s'] );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -112,21 +112,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search, need 4.1 version of WP to be able to restrict statuses to known post_ids
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 
@@ -186,21 +186,21 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'ASC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -852,7 +852,7 @@ class Sensei_Analysis {
 	public function report_download_page() {
 		// Check if is a report
 		if ( ! empty( $_GET['sensei_report_download'] ) ) {
-			$report = sanitize_text_field( wp_unslash( $_GET['sensei_report_download'] ) );
+			$report = sanitize_text_field( wp_unslash( is_array( $_GET['sensei_report_download'] ) ? '' : $_GET['sensei_report_download'] ) );
 
 			// Simple verification to ensure intent, Note that a Nonce is per user, so the URL can't be shared
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Do not change the nonce.
@@ -885,7 +885,7 @@ class Sensei_Analysis {
 			if ( isset( $_GET['user_id'] ) ) {
 				$user_id = intval( $_GET['user_id'] );
 			}
-			$type = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : false;
+			$type = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) ) : false;
 
 			$this->check_course_lesson( $course_id, $lesson_id, $user_id );
 
@@ -919,7 +919,7 @@ class Sensei_Analysis {
 			} else {
 				// Overview of all Learners, all Courses, or all Lessons
 				$sensei_analysis_report_object = $this->load_report_object( 'Overview', $type );
-				$event_properties['view']      = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : '';
+				$event_properties['view']      = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) ) : '';
 			}
 
 			// Handle the headers

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -852,7 +852,7 @@ class Sensei_Analysis {
 	public function report_download_page() {
 		// Check if is a report
 		if ( ! empty( $_GET['sensei_report_download'] ) ) {
-			$report = sanitize_text_field( wp_unslash( is_array( $_GET['sensei_report_download'] ) ? '' : $_GET['sensei_report_download'] ) );
+			$report = sanitize_text_field( wp_unslash( $_GET['sensei_report_download'] ) );
 
 			// Simple verification to ensure intent, Note that a Nonce is per user, so the URL can't be shared
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Do not change the nonce.
@@ -885,7 +885,7 @@ class Sensei_Analysis {
 			if ( isset( $_GET['user_id'] ) ) {
 				$user_id = intval( $_GET['user_id'] );
 			}
-			$type = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) ) : false;
+			$type = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : false;
 
 			$this->check_course_lesson( $course_id, $lesson_id, $user_id );
 
@@ -919,7 +919,7 @@ class Sensei_Analysis {
 			} else {
 				// Overview of all Learners, all Courses, or all Lessons
 				$sensei_analysis_report_object = $this->load_report_object( 'Overview', $type );
-				$event_properties['view']      = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) ) : '';
+				$event_properties['view']      = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : '';
 			}
 
 			// Handle the headers

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -852,7 +852,7 @@ class Sensei_Analysis {
 	public function report_download_page() {
 		// Check if is a report
 		if ( ! empty( $_GET['sensei_report_download'] ) ) {
-			$report = sanitize_text_field( wp_unslash( $_GET['sensei_report_download'] ) );
+			$report = sensei_request_text( $_GET['sensei_report_download'] );
 
 			// Simple verification to ensure intent, Note that a Nonce is per user, so the URL can't be shared
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Do not change the nonce.
@@ -885,7 +885,7 @@ class Sensei_Analysis {
 			if ( isset( $_GET['user_id'] ) ) {
 				$user_id = intval( $_GET['user_id'] );
 			}
-			$type = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : false;
+			$type = isset( $_GET['view'] ) ? sensei_request_text( $_GET['view'] ) : false;
 
 			$this->check_course_lesson( $course_id, $lesson_id, $user_id );
 
@@ -919,7 +919,7 @@ class Sensei_Analysis {
 			} else {
 				// Overview of all Learners, all Courses, or all Lessons
 				$sensei_analysis_report_object = $this->load_report_object( 'Overview', $type );
-				$event_properties['view']      = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : '';
+				$event_properties['view']      = isset( $_GET['view'] ) ? sensei_request_text( $_GET['view'] ) : '';
 			}
 
 			// Handle the headers

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -852,7 +852,7 @@ class Sensei_Analysis {
 	public function report_download_page() {
 		// Check if is a report
 		if ( ! empty( $_GET['sensei_report_download'] ) ) {
-			$report = sanitize_text_field( $_GET['sensei_report_download'] );
+			$report = sanitize_text_field( wp_unslash( $_GET['sensei_report_download'] ) );
 
 			// Simple verification to ensure intent, Note that a Nonce is per user, so the URL can't be shared
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Do not change the nonce.
@@ -885,7 +885,7 @@ class Sensei_Analysis {
 			if ( isset( $_GET['user_id'] ) ) {
 				$user_id = intval( $_GET['user_id'] );
 			}
-			$type = isset( $_GET['view'] ) ? esc_html( $_GET['view'] ) : false;
+			$type = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : false;
 
 			$this->check_course_lesson( $course_id, $lesson_id, $user_id );
 
@@ -919,7 +919,7 @@ class Sensei_Analysis {
 			} else {
 				// Overview of all Learners, all Courses, or all Lessons
 				$sensei_analysis_report_object = $this->load_report_object( 'Overview', $type );
-				$event_properties['view']      = isset( $_GET['view'] ) ? $_GET['view'] : '';
+				$event_properties['view']      = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : '';
 			}
 
 			// Handle the headers

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1000,7 +1000,7 @@ class Sensei_Course {
 		global $post;
 
 		/* Verify the nonce before proceeding. */
-		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_noonce' ] ) ), plugin_basename( __FILE__ ) ) ) {
+		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( sensei_request_text( $_POST[ 'woo_' . $this->token . '_noonce' ] ), plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
 
@@ -1058,7 +1058,7 @@ class Sensei_Course {
 				return;
 			}
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$new_meta_value = sanitize_html_class( wp_unslash( $_POST[ $post_key ] ) );
+			$new_meta_value = sanitize_html_class( wp_unslash( is_array( $_POST[ $post_key ] ) ? '' : $_POST[ $post_key ] ) );
 		}
 
 		/**
@@ -2723,7 +2723,7 @@ class Sensei_Course {
 	public function save_course_notification_meta_box( $course_id ) {
 
 		if ( ! isset( $_POST['_sensei_course_notification'] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_sensei_course_notification'] ) ), 'update-course-notification-setting' ) ) {
+			|| ! wp_verify_nonce( sensei_request_text( $_POST['_sensei_course_notification'] ), 'update-course-notification-setting' ) ) {
 			return;
 		}
 
@@ -3173,7 +3173,7 @@ class Sensei_Course {
 		$selected = 'default';
 		if ( isset( $_REQUEST['course-orderby'] ) && in_array( $selected, array_keys( $course_order_by_options ), true ) ) {
 
-			$selected = sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) );
+			$selected = sensei_request_text( $_REQUEST['course-orderby'] );
 
 		}
 
@@ -3248,7 +3248,7 @@ class Sensei_Course {
 			<?php
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
-			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['course_filter'] ) ) : 'all';
+			$active_course_filter = isset( $_GET['course_filter'] ) ? sensei_request_text( $_GET['course_filter'] ) : 'all';
 
 			foreach ( $filters as $filter ) {
 
@@ -3334,7 +3334,7 @@ class Sensei_Course {
 		if ( isset( $_GET['student_course_filter'] ) && $query->is_main_query() && is_user_logged_in() ) {
 			$learner_manager = Sensei_Learner::instance();
 			$user_id         = get_current_user_id();
-			$selected_option = sanitize_text_field( wp_unslash( $_GET['student_course_filter'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			$selected_option = sensei_request_text( $_GET['student_course_filter'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			$args            = [
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
@@ -3372,7 +3372,7 @@ class Sensei_Course {
 		_deprecated_function( __METHOD__, '3.15.0' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive sort.
-		if ( isset( $_REQUEST['course-orderby'] ) && 'title' === sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) )
+		if ( isset( $_REQUEST['course-orderby'] ) && 'title' === sensei_request_text( $_REQUEST['course-orderby'] )
 			&& 'course' === $query->get( 'post_type' ) && $query->is_main_query() ) {
 			// Setup the order by title for this query.
 			$query->set( 'orderby', 'title' );
@@ -3408,7 +3408,7 @@ class Sensei_Course {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_REQUEST['course-orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$request_orderby = sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) );
+			$request_orderby = sensei_request_text( $_REQUEST['course-orderby'] );
 			switch ( $request_orderby ) {
 				case 'title':
 					$orderby = 'title';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1000,7 +1000,7 @@ class Sensei_Course {
 		global $post;
 
 		/* Verify the nonce before proceeding. */
-		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_noonce' ], plugin_basename( __FILE__ ) ) ) {
+		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_noonce' ] ) ), plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
 
@@ -1012,7 +1012,7 @@ class Sensei_Course {
 			return $post_id;
 		}
 
-		if ( 'page' == $_POST['post_type'] ) {
+		if ( isset( $_POST['post_type'] ) && 'page' == $_POST['post_type'] ) {
 			if ( ! current_user_can( 'edit_page', $post_id ) ) {
 				return $post_id;
 			}
@@ -1048,8 +1048,8 @@ class Sensei_Course {
 		$meta_key = '_' . $post_key;
 		// Get the posted data and sanitize it for use as an HTML class.
 		if ( 'course_video_embed' == $post_key ) {
-			// phpcs:ignore WordPress.Security.NonceVerification
-			$new_meta_value = ( isset( $_POST[ $post_key ] ) ) ? $_POST[ $post_key ] : '';
+			// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by Sensei_Wp_Kses::maybe_sanitize() below.
+			$new_meta_value = ( isset( $_POST[ $post_key ] ) ) ? wp_unslash( $_POST[ $post_key ] ) : '';
 			$new_meta_value = Sensei_Wp_Kses::maybe_sanitize( $new_meta_value, self::$allowed_html );
 		} else {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -1057,7 +1057,7 @@ class Sensei_Course {
 				return;
 			}
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$new_meta_value = sanitize_html_class( $_POST[ $post_key ] );
+			$new_meta_value = sanitize_html_class( wp_unslash( $_POST[ $post_key ] ) );
 		}
 
 		/**
@@ -2081,7 +2081,7 @@ class Sensei_Course {
 
 				$current_page = 1;
 				if ( isset( $_GET['active_page'] ) && 0 < intval( $_GET['active_page'] ) ) {
-					$current_page = $_GET['active_page'];
+					$current_page = absint( $_GET['active_page'] );
 				}
 
 				$active_html .= '<nav class="pagination woo-pagination">';
@@ -2193,7 +2193,7 @@ class Sensei_Course {
 
 				$current_page = 1;
 				if ( isset( $_GET['completed_page'] ) && 0 < intval( $_GET['completed_page'] ) ) {
-					$current_page = $_GET['completed_page'];
+					$current_page = absint( $_GET['completed_page'] );
 				}
 
 				$complete_html .= '<nav class="pagination woo-pagination">';
@@ -2722,7 +2722,7 @@ class Sensei_Course {
 	public function save_course_notification_meta_box( $course_id ) {
 
 		if ( ! isset( $_POST['_sensei_course_notification'] )
-			|| ! wp_verify_nonce( $_POST['_sensei_course_notification'], 'update-course-notification-setting' ) ) {
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_sensei_course_notification'] ) ), 'update-course-notification-setting' ) ) {
 			return;
 		}
 
@@ -3172,7 +3172,7 @@ class Sensei_Course {
 		$selected = 'default';
 		if ( isset( $_REQUEST['course-orderby'] ) && in_array( $selected, array_keys( $course_order_by_options ), true ) ) {
 
-			$selected = sanitize_text_field( $_REQUEST['course-orderby'] );
+			$selected = sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) );
 
 		}
 
@@ -3245,7 +3245,7 @@ class Sensei_Course {
 		<ul class="sensei-course-filters clearfix" >
 			<?php
 
-			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( $_GET['course_filter'] ) : 'all';
+			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['course_filter'] ) ) : 'all';
 
 			foreach ( $filters as $filter ) {
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1000,7 +1000,7 @@ class Sensei_Course {
 		global $post;
 
 		/* Verify the nonce before proceeding. */
-		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $nonce_value = $_POST[ 'woo_' . $this->token . '_noonce' ] ) ? '' : $nonce_value ) ), plugin_basename( __FILE__ ) ) ) {
+		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_noonce' ] ) ), plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
 
@@ -1058,7 +1058,7 @@ class Sensei_Course {
 				return;
 			}
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$new_meta_value = sanitize_html_class( wp_unslash( is_array( $_POST[ $post_key ] ) ? '' : $_POST[ $post_key ] ) );
+			$new_meta_value = sanitize_html_class( wp_unslash( $_POST[ $post_key ] ) );
 		}
 
 		/**
@@ -2723,7 +2723,7 @@ class Sensei_Course {
 	public function save_course_notification_meta_box( $course_id ) {
 
 		if ( ! isset( $_POST['_sensei_course_notification'] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['_sensei_course_notification'] ) ? '' : $_POST['_sensei_course_notification'] ) ), 'update-course-notification-setting' ) ) {
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_sensei_course_notification'] ) ), 'update-course-notification-setting' ) ) {
 			return;
 		}
 
@@ -3248,7 +3248,7 @@ class Sensei_Course {
 			<?php
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
-			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['course_filter'] ) ? '' : $_GET['course_filter'] ) ) : 'all';
+			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['course_filter'] ) ) : 'all';
 
 			foreach ( $filters as $filter ) {
 
@@ -3408,7 +3408,7 @@ class Sensei_Course {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_REQUEST['course-orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$request_orderby = sanitize_text_field( wp_unslash( is_array( $_REQUEST['course-orderby'] ) ? '' : $_REQUEST['course-orderby'] ) );
+			$request_orderby = sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) );
 			switch ( $request_orderby ) {
 				case 'title':
 					$orderby = 'title';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3181,13 +3181,14 @@ class Sensei_Course {
 
 		<form class="sensei-ordering" name="sensei-course-order" method="get">
 			<?php
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only ordering form; preserves existing query args.
 			foreach ( $_GET as $param => $value ) {
 				// We should ignore the field that will be set just below.
 				if ( 'course-orderby' !== $param ) {
 					echo '<input type="hidden" name="' . esc_attr( $param ) . '" value="' . esc_attr( $value ) . '" />';
 				}
 			}
+			// phpcs:enable WordPress.Security.NonceVerification.Recommended
 			?>
 			<select name="course-orderby" class="orderby">
 				<?php
@@ -3246,6 +3247,7 @@ class Sensei_Course {
 		<ul class="sensei-course-filters clearfix" >
 			<?php
 
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
 			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['course_filter'] ) ) : 'all';
 
 			foreach ( $filters as $filter ) {
@@ -3273,6 +3275,7 @@ class Sensei_Course {
 	 * @return WP_Query $query
 	 */
 	public static function course_archive_featured_filter( $query ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
 		if ( isset( $_GET['course_filter'] ) && 'featured' == $_GET['course_filter'] && $query->is_main_query() ) {
 			// setup meta query for featured courses
 			$query->set( 'meta_value', 'featured' );
@@ -3296,6 +3299,7 @@ class Sensei_Course {
 	 * @return WP_Query $query
 	 */
 	public static function course_archive_category_filter( $query ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
 		if ( isset( $_GET['course_category_filter'] ) && intval( $_GET['course_category_filter'] ) > 0 && $query->is_main_query() ) {
 			$query->set(
 				'tax_query',
@@ -3303,6 +3307,7 @@ class Sensei_Course {
 					[
 						'taxonomy' => 'course-category',
 						'field'    => 'id',
+						// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
 						'terms'    => intval( $_GET['course_category_filter'] ),
 					],
 				]
@@ -3325,6 +3330,7 @@ class Sensei_Course {
 	 * @return WP_Query $query
 	 */
 	public static function course_archive_student_course_state_filter( $query ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
 		if ( isset( $_GET['student_course_filter'] ) && $query->is_main_query() && is_user_logged_in() ) {
 			$learner_manager = Sensei_Learner::instance();
 			$user_id         = get_current_user_id();
@@ -3365,6 +3371,7 @@ class Sensei_Course {
 	public static function course_archive_order_by_title( $query ) {
 		_deprecated_function( __METHOD__, '3.15.0' );
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive sort.
 		if ( isset( $_REQUEST['course-orderby'] ) && 'title' === sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) )
 			&& 'course' === $query->get( 'post_type' ) && $query->is_main_query() ) {
 			// Setup the order by title for this query.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1000,7 +1000,7 @@ class Sensei_Course {
 		global $post;
 
 		/* Verify the nonce before proceeding. */
-		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_noonce' ] ) ), plugin_basename( __FILE__ ) ) ) {
+		if ( ( get_post_type() != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_noonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $nonce_value = $_POST[ 'woo_' . $this->token . '_noonce' ] ) ? '' : $nonce_value ) ), plugin_basename( __FILE__ ) ) ) {
 			return;
 		}
 
@@ -1058,7 +1058,7 @@ class Sensei_Course {
 				return;
 			}
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$new_meta_value = sanitize_html_class( wp_unslash( $_POST[ $post_key ] ) );
+			$new_meta_value = sanitize_html_class( wp_unslash( is_array( $_POST[ $post_key ] ) ? '' : $_POST[ $post_key ] ) );
 		}
 
 		/**
@@ -2723,7 +2723,7 @@ class Sensei_Course {
 	public function save_course_notification_meta_box( $course_id ) {
 
 		if ( ! isset( $_POST['_sensei_course_notification'] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_sensei_course_notification'] ) ), 'update-course-notification-setting' ) ) {
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['_sensei_course_notification'] ) ? '' : $_POST['_sensei_course_notification'] ) ), 'update-course-notification-setting' ) ) {
 			return;
 		}
 
@@ -3248,7 +3248,7 @@ class Sensei_Course {
 			<?php
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only archive filter.
-			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['course_filter'] ) ) : 'all';
+			$active_course_filter = isset( $_GET['course_filter'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['course_filter'] ) ? '' : $_GET['course_filter'] ) ) : 'all';
 
 			foreach ( $filters as $filter ) {
 
@@ -3408,7 +3408,7 @@ class Sensei_Course {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_REQUEST['course-orderby'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$request_orderby = sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) );
+			$request_orderby = sanitize_text_field( wp_unslash( is_array( $_REQUEST['course-orderby'] ) ? '' : $_REQUEST['course-orderby'] ) );
 			switch ( $request_orderby ) {
 				case 'title':
 					$orderby = 'title';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1048,8 +1048,9 @@ class Sensei_Course {
 		$meta_key = '_' . $post_key;
 		// Get the posted data and sanitize it for use as an HTML class.
 		if ( 'course_video_embed' == $post_key ) {
-			// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by Sensei_Wp_Kses::maybe_sanitize() below.
-			$new_meta_value = ( isset( $_POST[ $post_key ] ) ) ? wp_unslash( $_POST[ $post_key ] ) : '';
+			// Passed slashed to update_post_meta() below, which unslashes internally; sanitized by Sensei_Wp_Kses::maybe_sanitize().
+			// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+			$new_meta_value = ( isset( $_POST[ $post_key ] ) ) ? $_POST[ $post_key ] : '';
 			$new_meta_value = Sensei_Wp_Kses::maybe_sanitize( $new_meta_value, self::$allowed_html );
 		} else {
 			// phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1167,7 +1167,7 @@ class Sensei_Frontend {
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_password"><?php esc_html_e( 'Password', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php echo ( ! empty( $_POST['sensei_reg_password'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_reg_password'] ) ? '' : $_POST['sensei_reg_password'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" />
 						</p>
 
 						<!-- Spam Trap -->

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -699,7 +699,7 @@ class Sensei_Frontend {
 			return;
 		}
 
-		if ( ! isset( $_POST['woothemes_sensei_complete_lesson_noonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_lesson_noonce'] ) ), 'woothemes_sensei_complete_lesson_noonce' ) ) {
+		if ( ! isset( $_POST['woothemes_sensei_complete_lesson_noonce'] ) || ! wp_verify_nonce( sensei_request_text( $_POST['woothemes_sensei_complete_lesson_noonce'] ), 'woothemes_sensei_complete_lesson_noonce' ) ) {
 			return;
 		}
 
@@ -710,7 +710,7 @@ class Sensei_Frontend {
 		}
 
 		// Handle Quiz Completion.
-		$sanitized_submit = sanitize_text_field( wp_unslash( $_POST['quiz_action'] ) );
+		$sanitized_submit = sensei_request_text( $_POST['quiz_action'] );
 
 		switch ( $sanitized_submit ) {
 			case 'lesson-complete':
@@ -812,9 +812,9 @@ class Sensei_Frontend {
 	public function sensei_complete_course() {
 		global $current_user;
 
-		if ( isset( $_POST['course_complete'], $_POST['woothemes_sensei_complete_course_noonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_course_noonce'] ) ), 'woothemes_sensei_complete_course_noonce' ) ) {
+		if ( isset( $_POST['course_complete'], $_POST['woothemes_sensei_complete_course_noonce'] ) && wp_verify_nonce( sensei_request_text( $_POST['woothemes_sensei_complete_course_noonce'] ), 'woothemes_sensei_complete_course_noonce' ) ) {
 
-			$sanitized_submit    = sanitize_text_field( wp_unslash( $_POST['course_complete'] ) );
+			$sanitized_submit    = sensei_request_text( $_POST['course_complete'] );
 			$sanitized_course_id = isset( $_POST['course_complete_id'] ) ? absint( wp_unslash( $_POST['course_complete_id'] ) ) : 0;
 			// Handle submit data.
 			switch ( $sanitized_submit ) {
@@ -1157,12 +1157,12 @@ class Sensei_Frontend {
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_username"><?php esc_html_e( 'Username', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_username'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( sensei_request_text( $_POST['sensei_reg_username'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_email"><?php esc_html_e( 'Email address', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_email'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( sensei_request_text( $_POST['sensei_reg_email'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
@@ -1478,12 +1478,12 @@ class Sensei_Frontend {
 		if ( isset( $_REQUEST['form'] ) && 'sensei-login' == $_REQUEST['form'] ) {
 
 			// Validate the login request nonce.
-			if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'sensei-login' ) ) {
+			if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sensei_request_text( $_REQUEST['_wpnonce'] ), 'sensei-login' ) ) {
 				return;
 			}
 
 			// get the page where the sensei log form is located.
-			$referrer = isset( $_REQUEST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( $_REQUEST['_wp_http_referer'] ) ) : '';
+			$referrer = isset( $_REQUEST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( is_array( $_REQUEST['_wp_http_referer'] ) ? '' : $_REQUEST['_wp_http_referer'] ) ) : '';
 
 			if ( ( isset( $_REQUEST['log'] ) && ! empty( $_REQUEST['log'] ) )
 				 && ( isset( $_REQUEST['pwd'] ) && ! empty( $_REQUEST['pwd'] ) ) ) {
@@ -1492,8 +1492,8 @@ class Sensei_Frontend {
 				$creds = array();
 
 				// check if the requests login is an email address.
-				if ( is_email( trim( sanitize_text_field( wp_unslash( $_REQUEST['log'] ) ) ) ) ) {
-					$login = sanitize_email( wp_unslash( $_REQUEST['log'] ) );
+				if ( is_email( trim( sensei_request_text( $_REQUEST['log'] ) ) ) ) {
+					$login = sanitize_email( wp_unslash( is_array( $_REQUEST['log'] ) ? '' : $_REQUEST['log'] ) );
 
 					// Occasionally a user's username IS an email,
 					// but they have changed their actual email, so check for this case.
@@ -1519,7 +1519,7 @@ class Sensei_Frontend {
 				} else {
 
 					// process this as a default username login.
-					$creds['user_login'] = sanitize_text_field( wp_unslash( $_REQUEST['log'] ) );
+					$creds['user_login'] = sensei_request_text( $_REQUEST['log'] );
 
 				}
 
@@ -1601,7 +1601,7 @@ class Sensei_Frontend {
 		}
 
 		// Validate the registration request nonce.
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'sensei-register' ) ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sensei_request_text( $_POST['_wpnonce'] ), 'sensei-register' ) ) {
 			return;
 		}
 
@@ -1613,8 +1613,8 @@ class Sensei_Frontend {
 		}
 
 		// retreive form variables.
-		$new_user_name  = sanitize_user( wp_unslash( $_POST['sensei_reg_username'] ) );
-		$new_user_email = sanitize_email( wp_unslash( $_POST['sensei_reg_email'] ) );
+		$new_user_name  = sanitize_user( wp_unslash( is_array( $_POST['sensei_reg_username'] ) ? '' : $_POST['sensei_reg_username'] ) );
+		$new_user_email = sanitize_email( wp_unslash( is_array( $_POST['sensei_reg_email'] ) ? '' : $_POST['sensei_reg_email'] ) );
 		// Pass the password to WordPress slashed and unsanitized to match wp-login.php; altering it breaks the hash check.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$new_user_password = $_POST['sensei_reg_password'];

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1524,8 +1524,9 @@ class Sensei_Frontend {
 				}
 
 				// get setup the rest of the creds array.
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Password must not be altered by sanitization.
-				$creds['user_password'] = wp_unslash( $_REQUEST['pwd'] );
+				// Pass the password to WordPress slashed and unsanitized to match wp-login.php; altering it breaks the hash check.
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+				$creds['user_password'] = $_REQUEST['pwd'];
 				$creds['remember']      = isset( $_REQUEST['rememberme'] ) ? true : false;
 
 				// attempt logging in with the given details.
@@ -1614,8 +1615,9 @@ class Sensei_Frontend {
 		// retreive form variables.
 		$new_user_name  = sanitize_user( wp_unslash( $_POST['sensei_reg_username'] ) );
 		$new_user_email = sanitize_email( wp_unslash( $_POST['sensei_reg_email'] ) );
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Password must not be altered by sanitization.
-		$new_user_password = wp_unslash( $_POST['sensei_reg_password'] );
+		// Pass the password to WordPress slashed and unsanitized to match wp-login.php; altering it breaks the hash check.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$new_user_password = $_POST['sensei_reg_password'];
 
 		// Check the username.
 		$username_error_notice = '';

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -699,7 +699,7 @@ class Sensei_Frontend {
 			return;
 		}
 
-		if ( ! isset( $_POST['woothemes_sensei_complete_lesson_noonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['woothemes_sensei_complete_lesson_noonce'] ) ? '' : $_POST['woothemes_sensei_complete_lesson_noonce'] ) ), 'woothemes_sensei_complete_lesson_noonce' ) ) {
+		if ( ! isset( $_POST['woothemes_sensei_complete_lesson_noonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_lesson_noonce'] ) ), 'woothemes_sensei_complete_lesson_noonce' ) ) {
 			return;
 		}
 
@@ -710,7 +710,7 @@ class Sensei_Frontend {
 		}
 
 		// Handle Quiz Completion.
-		$sanitized_submit = sanitize_text_field( wp_unslash( is_array( $_POST['quiz_action'] ) ? '' : $_POST['quiz_action'] ) );
+		$sanitized_submit = sanitize_text_field( wp_unslash( $_POST['quiz_action'] ) );
 
 		switch ( $sanitized_submit ) {
 			case 'lesson-complete':
@@ -812,9 +812,9 @@ class Sensei_Frontend {
 	public function sensei_complete_course() {
 		global $current_user;
 
-		if ( isset( $_POST['course_complete'], $_POST['woothemes_sensei_complete_course_noonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['woothemes_sensei_complete_course_noonce'] ) ? '' : $_POST['woothemes_sensei_complete_course_noonce'] ) ), 'woothemes_sensei_complete_course_noonce' ) ) {
+		if ( isset( $_POST['course_complete'], $_POST['woothemes_sensei_complete_course_noonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_course_noonce'] ) ), 'woothemes_sensei_complete_course_noonce' ) ) {
 
-			$sanitized_submit    = sanitize_text_field( wp_unslash( is_array( $_POST['course_complete'] ) ? '' : $_POST['course_complete'] ) );
+			$sanitized_submit    = sanitize_text_field( wp_unslash( $_POST['course_complete'] ) );
 			$sanitized_course_id = isset( $_POST['course_complete_id'] ) ? absint( wp_unslash( $_POST['course_complete_id'] ) ) : 0;
 			// Handle submit data.
 			switch ( $sanitized_submit ) {
@@ -1157,12 +1157,12 @@ class Sensei_Frontend {
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_username"><?php esc_html_e( 'Username', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_reg_username'] ) ? '' : $_POST['sensei_reg_username'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_username'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_email"><?php esc_html_e( 'Email address', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_reg_email'] ) ? '' : $_POST['sensei_reg_email'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_email'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
@@ -1478,12 +1478,12 @@ class Sensei_Frontend {
 		if ( isset( $_REQUEST['form'] ) && 'sensei-login' == $_REQUEST['form'] ) {
 
 			// Validate the login request nonce.
-			if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_REQUEST['_wpnonce'] ) ? '' : $_REQUEST['_wpnonce'] ) ), 'sensei-login' ) ) {
+			if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'sensei-login' ) ) {
 				return;
 			}
 
 			// get the page where the sensei log form is located.
-			$referrer = isset( $_REQUEST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( is_array( $_REQUEST['_wp_http_referer'] ) ? '' : $_REQUEST['_wp_http_referer'] ) ) : '';
+			$referrer = isset( $_REQUEST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( $_REQUEST['_wp_http_referer'] ) ) : '';
 
 			if ( ( isset( $_REQUEST['log'] ) && ! empty( $_REQUEST['log'] ) )
 				 && ( isset( $_REQUEST['pwd'] ) && ! empty( $_REQUEST['pwd'] ) ) ) {
@@ -1492,8 +1492,8 @@ class Sensei_Frontend {
 				$creds = array();
 
 				// check if the requests login is an email address.
-				if ( is_email( trim( sanitize_text_field( wp_unslash( is_array( $_REQUEST['log'] ) ? '' : $_REQUEST['log'] ) ) ) ) ) {
-					$login = sanitize_email( wp_unslash( is_array( $_REQUEST['log'] ) ? '' : $_REQUEST['log'] ) );
+				if ( is_email( trim( sanitize_text_field( wp_unslash( $_REQUEST['log'] ) ) ) ) ) {
+					$login = sanitize_email( wp_unslash( $_REQUEST['log'] ) );
 
 					// Occasionally a user's username IS an email,
 					// but they have changed their actual email, so check for this case.
@@ -1519,7 +1519,7 @@ class Sensei_Frontend {
 				} else {
 
 					// process this as a default username login.
-					$creds['user_login'] = sanitize_text_field( wp_unslash( is_array( $_REQUEST['log'] ) ? '' : $_REQUEST['log'] ) );
+					$creds['user_login'] = sanitize_text_field( wp_unslash( $_REQUEST['log'] ) );
 
 				}
 
@@ -1601,7 +1601,7 @@ class Sensei_Frontend {
 		}
 
 		// Validate the registration request nonce.
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['_wpnonce'] ) ? '' : $_POST['_wpnonce'] ) ), 'sensei-register' ) ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'sensei-register' ) ) {
 			return;
 		}
 
@@ -1613,8 +1613,8 @@ class Sensei_Frontend {
 		}
 
 		// retreive form variables.
-		$new_user_name  = sanitize_user( wp_unslash( is_array( $_POST['sensei_reg_username'] ) ? '' : $_POST['sensei_reg_username'] ) );
-		$new_user_email = sanitize_email( wp_unslash( is_array( $_POST['sensei_reg_email'] ) ? '' : $_POST['sensei_reg_email'] ) );
+		$new_user_name  = sanitize_user( wp_unslash( $_POST['sensei_reg_username'] ) );
+		$new_user_email = sanitize_email( wp_unslash( $_POST['sensei_reg_email'] ) );
 		// Pass the password to WordPress slashed and unsanitized to match wp-login.php; altering it breaks the hash check.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$new_user_password = $_POST['sensei_reg_password'];

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -699,7 +699,7 @@ class Sensei_Frontend {
 			return;
 		}
 
-		if ( ! isset( $_POST['woothemes_sensei_complete_lesson_noonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_lesson_noonce'] ) ), 'woothemes_sensei_complete_lesson_noonce' ) ) {
+		if ( ! isset( $_POST['woothemes_sensei_complete_lesson_noonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['woothemes_sensei_complete_lesson_noonce'] ) ? '' : $_POST['woothemes_sensei_complete_lesson_noonce'] ) ), 'woothemes_sensei_complete_lesson_noonce' ) ) {
 			return;
 		}
 
@@ -710,7 +710,7 @@ class Sensei_Frontend {
 		}
 
 		// Handle Quiz Completion.
-		$sanitized_submit = sanitize_text_field( wp_unslash( $_POST['quiz_action'] ) );
+		$sanitized_submit = sanitize_text_field( wp_unslash( is_array( $_POST['quiz_action'] ) ? '' : $_POST['quiz_action'] ) );
 
 		switch ( $sanitized_submit ) {
 			case 'lesson-complete':
@@ -812,9 +812,9 @@ class Sensei_Frontend {
 	public function sensei_complete_course() {
 		global $current_user;
 
-		if ( isset( $_POST['course_complete'], $_POST['woothemes_sensei_complete_course_noonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_course_noonce'] ) ), 'woothemes_sensei_complete_course_noonce' ) ) {
+		if ( isset( $_POST['course_complete'], $_POST['woothemes_sensei_complete_course_noonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['woothemes_sensei_complete_course_noonce'] ) ? '' : $_POST['woothemes_sensei_complete_course_noonce'] ) ), 'woothemes_sensei_complete_course_noonce' ) ) {
 
-			$sanitized_submit    = sanitize_text_field( wp_unslash( $_POST['course_complete'] ) );
+			$sanitized_submit    = sanitize_text_field( wp_unslash( is_array( $_POST['course_complete'] ) ? '' : $_POST['course_complete'] ) );
 			$sanitized_course_id = isset( $_POST['course_complete_id'] ) ? absint( wp_unslash( $_POST['course_complete_id'] ) ) : 0;
 			// Handle submit data.
 			switch ( $sanitized_submit ) {
@@ -1157,17 +1157,17 @@ class Sensei_Frontend {
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_username"><?php esc_html_e( 'Username', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_username'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_reg_username'] ) ? '' : $_POST['sensei_reg_username'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_email"><?php esc_html_e( 'Email address', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_email'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_reg_email'] ) ? '' : $_POST['sensei_reg_email'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_password"><?php esc_html_e( 'Password', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php echo ( ! empty( $_POST['sensei_reg_password'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_password'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php echo ( ! empty( $_POST['sensei_reg_password'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_reg_password'] ) ? '' : $_POST['sensei_reg_password'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<!-- Spam Trap -->
@@ -1478,12 +1478,12 @@ class Sensei_Frontend {
 		if ( isset( $_REQUEST['form'] ) && 'sensei-login' == $_REQUEST['form'] ) {
 
 			// Validate the login request nonce.
-			if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'sensei-login' ) ) {
+			if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_REQUEST['_wpnonce'] ) ? '' : $_REQUEST['_wpnonce'] ) ), 'sensei-login' ) ) {
 				return;
 			}
 
 			// get the page where the sensei log form is located.
-			$referrer = isset( $_REQUEST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( $_REQUEST['_wp_http_referer'] ) ) : '';
+			$referrer = isset( $_REQUEST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( is_array( $_REQUEST['_wp_http_referer'] ) ? '' : $_REQUEST['_wp_http_referer'] ) ) : '';
 
 			if ( ( isset( $_REQUEST['log'] ) && ! empty( $_REQUEST['log'] ) )
 				 && ( isset( $_REQUEST['pwd'] ) && ! empty( $_REQUEST['pwd'] ) ) ) {
@@ -1492,8 +1492,8 @@ class Sensei_Frontend {
 				$creds = array();
 
 				// check if the requests login is an email address.
-				if ( is_email( trim( sanitize_text_field( wp_unslash( $_REQUEST['log'] ) ) ) ) ) {
-					$login = sanitize_email( wp_unslash( $_REQUEST['log'] ) );
+				if ( is_email( trim( sanitize_text_field( wp_unslash( is_array( $_REQUEST['log'] ) ? '' : $_REQUEST['log'] ) ) ) ) ) {
+					$login = sanitize_email( wp_unslash( is_array( $_REQUEST['log'] ) ? '' : $_REQUEST['log'] ) );
 
 					// Occasionally a user's username IS an email,
 					// but they have changed their actual email, so check for this case.
@@ -1519,7 +1519,7 @@ class Sensei_Frontend {
 				} else {
 
 					// process this as a default username login.
-					$creds['user_login'] = sanitize_text_field( wp_unslash( $_REQUEST['log'] ) );
+					$creds['user_login'] = sanitize_text_field( wp_unslash( is_array( $_REQUEST['log'] ) ? '' : $_REQUEST['log'] ) );
 
 				}
 
@@ -1601,7 +1601,7 @@ class Sensei_Frontend {
 		}
 
 		// Validate the registration request nonce.
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'sensei-register' ) ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['_wpnonce'] ) ? '' : $_POST['_wpnonce'] ) ), 'sensei-register' ) ) {
 			return;
 		}
 
@@ -1613,8 +1613,8 @@ class Sensei_Frontend {
 		}
 
 		// retreive form variables.
-		$new_user_name  = sanitize_user( wp_unslash( $_POST['sensei_reg_username'] ) );
-		$new_user_email = sanitize_email( wp_unslash( $_POST['sensei_reg_email'] ) );
+		$new_user_name  = sanitize_user( wp_unslash( is_array( $_POST['sensei_reg_username'] ) ? '' : $_POST['sensei_reg_username'] ) );
+		$new_user_email = sanitize_email( wp_unslash( is_array( $_POST['sensei_reg_email'] ) ? '' : $_POST['sensei_reg_email'] ) );
 		// Pass the password to WordPress slashed and unsanitized to match wp-login.php; altering it breaks the hash check.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$new_user_password = $_POST['sensei_reg_password'];
@@ -1706,10 +1706,12 @@ class Sensei_Frontend {
 		$message = '';
 
 		// only output message if the url contains login=failed and login=emptyfields.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only display of the wp-login redirect status.
 		if ( isset( $_GET['login'] ) && 'failed' == $_GET['login'] ) {
 
 			$message = __( 'Incorrect login details', 'sensei-lms' );
 
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only display of the wp-login redirect status.
 		} elseif ( isset( $_GET['login'] ) && 'emptyfields' == $_GET['login'] ) {
 
 			$message = __( 'Please enter your username and password', 'sensei-lms' );

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -411,8 +411,10 @@ class Sensei_Frontend {
 					break;
 			}
 
-			$_root_relative_current = untrailingslashit( $_SERVER['REQUEST_URI'] );
-			$current_url            = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_root_relative_current );
+			$request_uri            = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+			$http_host              = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+			$_root_relative_current = untrailingslashit( $request_uri );
+			$current_url            = set_url_scheme( 'http://' . $http_host . $_root_relative_current );
 			$item_url               = untrailingslashit( $item->url );
 			$_indexless_current     = untrailingslashit( preg_replace( '/' . preg_quote( $wp_rewrite->index, '/' ) . '$/', '', $current_url ) );
 			// Highlight current menu item.
@@ -697,7 +699,7 @@ class Sensei_Frontend {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( $_POST['woothemes_sensei_complete_lesson_noonce'], 'woothemes_sensei_complete_lesson_noonce' ) ) {
+		if ( ! isset( $_POST['woothemes_sensei_complete_lesson_noonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_lesson_noonce'] ) ), 'woothemes_sensei_complete_lesson_noonce' ) ) {
 			return;
 		}
 
@@ -708,7 +710,7 @@ class Sensei_Frontend {
 		}
 
 		// Handle Quiz Completion.
-		$sanitized_submit = esc_html( $_POST['quiz_action'] );
+		$sanitized_submit = sanitize_text_field( wp_unslash( $_POST['quiz_action'] ) );
 
 		switch ( $sanitized_submit ) {
 			case 'lesson-complete':
@@ -810,10 +812,10 @@ class Sensei_Frontend {
 	public function sensei_complete_course() {
 		global $current_user;
 
-		if ( isset( $_POST['course_complete'] ) && wp_verify_nonce( $_POST['woothemes_sensei_complete_course_noonce'], 'woothemes_sensei_complete_course_noonce' ) ) {
+		if ( isset( $_POST['course_complete'], $_POST['woothemes_sensei_complete_course_noonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['woothemes_sensei_complete_course_noonce'] ) ), 'woothemes_sensei_complete_course_noonce' ) ) {
 
-			$sanitized_submit    = esc_html( $_POST['course_complete'] );
-			$sanitized_course_id = absint( esc_html( $_POST['course_complete_id'] ) );
+			$sanitized_submit    = sanitize_text_field( wp_unslash( $_POST['course_complete'] ) );
+			$sanitized_course_id = isset( $_POST['course_complete_id'] ) ? absint( wp_unslash( $_POST['course_complete_id'] ) ) : 0;
 			// Handle submit data.
 			switch ( $sanitized_submit ) {
 				case __( 'Mark as Complete', 'sensei-lms' ):
@@ -1155,17 +1157,17 @@ class Sensei_Frontend {
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_username"><?php esc_html_e( 'Username', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( $_POST['sensei_reg_username'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php echo ( ! empty( $_POST['sensei_reg_username'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_username'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_email"><?php esc_html_e( 'Email address', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( $_POST['sensei_reg_email'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php echo ( ! empty( $_POST['sensei_reg_email'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_email'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_password"><?php esc_html_e( 'Password', 'sensei-lms' ); ?> <span class="required">*</span></label>
-							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php echo ( ! empty( $_POST['sensei_reg_password'] ) ) ? esc_attr( $_POST['sensei_reg_password'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
+							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php echo ( ! empty( $_POST['sensei_reg_password'] ) ) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['sensei_reg_password'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification ?>" />
 						</p>
 
 						<!-- Spam Trap -->
@@ -1454,7 +1456,8 @@ class Sensei_Frontend {
 		}
 
 		// Get the reffering page, where did the post submission come from?
-		$referrer = add_query_arg( 'login', false, $_SERVER['HTTP_REFERER'] );
+		$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+		$referrer = add_query_arg( 'login', false, $referrer );
 
 		 // if there's a valid referrer, and it's not the default log-in screen.
 		if ( ! empty( $referrer ) && ! strstr( $referrer, 'wp-login' ) && ! strstr( $referrer, 'wp-admin' ) ) {
@@ -1475,12 +1478,12 @@ class Sensei_Frontend {
 		if ( isset( $_REQUEST['form'] ) && 'sensei-login' == $_REQUEST['form'] ) {
 
 			// Validate the login request nonce.
-			if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'sensei-login' ) ) {
+			if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'sensei-login' ) ) {
 				return;
 			}
 
 			// get the page where the sensei log form is located.
-			$referrer = $_REQUEST['_wp_http_referer'];
+			$referrer = isset( $_REQUEST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( $_REQUEST['_wp_http_referer'] ) ) : '';
 
 			if ( ( isset( $_REQUEST['log'] ) && ! empty( $_REQUEST['log'] ) )
 				 && ( isset( $_REQUEST['pwd'] ) && ! empty( $_REQUEST['pwd'] ) ) ) {
@@ -1489,8 +1492,8 @@ class Sensei_Frontend {
 				$creds = array();
 
 				// check if the requests login is an email address.
-				if ( is_email( trim( $_REQUEST['log'] ) ) ) {
-					$login = sanitize_email( $_REQUEST['log'] );
+				if ( is_email( trim( sanitize_text_field( wp_unslash( $_REQUEST['log'] ) ) ) ) ) {
+					$login = sanitize_email( wp_unslash( $_REQUEST['log'] ) );
 
 					// Occasionally a user's username IS an email,
 					// but they have changed their actual email, so check for this case.
@@ -1516,12 +1519,13 @@ class Sensei_Frontend {
 				} else {
 
 					// process this as a default username login.
-					$creds['user_login'] = sanitize_text_field( $_REQUEST['log'] );
+					$creds['user_login'] = sanitize_text_field( wp_unslash( $_REQUEST['log'] ) );
 
 				}
 
 				// get setup the rest of the creds array.
-				$creds['user_password'] = $_REQUEST['pwd'];
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Password must not be altered by sanitization.
+				$creds['user_password'] = wp_unslash( $_REQUEST['pwd'] );
 				$creds['remember']      = isset( $_REQUEST['rememberme'] ) ? true : false;
 
 				// attempt logging in with the given details.
@@ -1596,7 +1600,7 @@ class Sensei_Frontend {
 		}
 
 		// Validate the registration request nonce.
-		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'sensei-register' ) ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'sensei-register' ) ) {
 			return;
 		}
 
@@ -1608,9 +1612,10 @@ class Sensei_Frontend {
 		}
 
 		// retreive form variables.
-		$new_user_name     = sanitize_user( $_POST['sensei_reg_username'] );
-		$new_user_email    = $_POST['sensei_reg_email'];
-		$new_user_password = $_POST['sensei_reg_password'];
+		$new_user_name  = sanitize_user( wp_unslash( $_POST['sensei_reg_username'] ) );
+		$new_user_email = sanitize_email( wp_unslash( $_POST['sensei_reg_email'] ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Password must not be altered by sanitization.
+		$new_user_password = wp_unslash( $_POST['sensei_reg_password'] );
 
 		// Check the username.
 		$username_error_notice = '';
@@ -1699,11 +1704,11 @@ class Sensei_Frontend {
 		$message = '';
 
 		// only output message if the url contains login=failed and login=emptyfields.
-		if ( $_GET['login'] == 'failed' ) {
+		if ( isset( $_GET['login'] ) && 'failed' == $_GET['login'] ) {
 
 			$message = __( 'Incorrect login details', 'sensei-lms' );
 
-		} elseif ( $_GET['login'] == 'emptyfields' ) {
+		} elseif ( isset( $_GET['login'] ) && 'emptyfields' == $_GET['login'] ) {
 
 			$message = __( 'Please enter your username and password', 'sensei-lms' );
 		}

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -141,21 +141,21 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sensei_request_text( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
+				$orderby = sensei_request_text( $_GET['orderby'] );
 			}
 		}
 
 		// Handle order
 		$order = 'DESC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sensei_request_text( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sensei_request_text( $_GET['s'] );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -141,21 +141,21 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'DESC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = esc_html( $_GET['s'] );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -141,21 +141,21 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'DESC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -141,21 +141,21 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( sanitize_text_field( wp_unslash( $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
-				$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
+			if ( array_key_exists( sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ), $this->get_sortable_columns() ) ) {
+				$orderby = sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) );
 			}
 		}
 
 		// Handle order
 		$order = 'DESC';
 		if ( ! empty( $_GET['order'] ) ) {
-			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+			$order = ( 'ASC' == strtoupper( sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 		}
 
 		// Handle search
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
-			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+			$search = sanitize_text_field( wp_unslash( is_array( $_GET['s'] ) ? '' : $_GET['s'] ) );
 		}
 		$this->search = $search;
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -719,8 +719,8 @@ class Sensei_Grading {
 	 */
 	private function deprecated_get_lessons_dropdown() {
 		// Parse POST data
-		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No modifications are made here. URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data        = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$course_data = array();
 		parse_str( $data, $course_data );
 
@@ -997,8 +997,8 @@ class Sensei_Grading {
 	 */
 	private function deprecated_get_redirect_url() {
 		// Parse POST data
-		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No modifications are made here. URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data        = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$lesson_data = array();
 		parse_str( $data, $lesson_data );
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -849,7 +849,7 @@ class Sensei_Grading {
 			$question_feedback = '';
 			if ( isset( $_POST['questions_feedback'][ $question_id ] ) ) {
 
-				$question_feedback = sanitize_textarea_field( wp_unslash( $_POST['questions_feedback'][ $question_id ] ) );
+				$question_feedback = wp_kses_post( wp_unslash( $_POST['questions_feedback'][ $question_id ] ) );
 
 			}
 			$all_answers_feedback[ $question_id ] = $question_feedback;

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -257,7 +257,7 @@ class Sensei_Grading {
 			$user_id = intval( $_GET['user_id'] );
 		}
 		if ( ! empty( $_GET['view'] ) ) {
-			$view = esc_html( $_GET['view'] );
+			$view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
 		}
 
 		$sensei_grading_overview = new Sensei_Grading_Main( compact( 'course_id', 'lesson_id', 'user_id', 'view' ) );
@@ -457,7 +457,7 @@ class Sensei_Grading {
 		}
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
 
-			$user_name = Sensei_Learner::get_full_name( $_GET['user_id'] );
+			$user_name = Sensei_Learner::get_full_name( absint( $_GET['user_id'] ) );
 			$title    .= '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;' . esc_html( $user_name ) . '</span>';
 
 		}
@@ -511,7 +511,7 @@ class Sensei_Grading {
 		}
 		if ( isset( $_GET['user'] ) && 0 < intval( $_GET['user'] ) ) {
 
-			$user_name = Sensei_Learner::get_full_name( $_GET['user'] );
+			$user_name = Sensei_Learner::get_full_name( absint( $_GET['user'] ) );
 			$title    .= '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;' . esc_html( $user_name ) . '</span>';
 
 		}
@@ -720,7 +720,7 @@ class Sensei_Grading {
 	private function deprecated_get_lessons_dropdown() {
 		// Parse POST data
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = $_POST['data'];
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$course_data = array();
 		parse_str( $data, $course_data );
 
@@ -795,7 +795,8 @@ class Sensei_Grading {
 	public function admin_process_grading_submission() {
 
 		if ( ! isset( $_POST['sensei_manual_grade'] )
-			|| ! wp_verify_nonce( $_POST['_wp_sensei_manual_grading_nonce'], 'sensei_manual_grading' )
+			|| ! isset( $_POST['_wp_sensei_manual_grading_nonce'] )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wp_sensei_manual_grading_nonce'] ) ), 'sensei_manual_grading' )
 			|| ! isset( $_GET['quiz_id'] )
 			|| $_GET['quiz_id'] != $_POST['sensei_manual_grade'] ) {
 
@@ -804,7 +805,7 @@ class Sensei_Grading {
 		}
 
 		$quiz_id = absint( $_GET['quiz_id'] );
-		$user_id = absint( $_GET['user'] );
+		$user_id = isset( $_GET['user'] ) ? absint( $_GET['user'] ) : 0;
 
 		$quiz_lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
 
@@ -824,7 +825,7 @@ class Sensei_Grading {
 
 		$questions            = Sensei_Utils::sensei_get_quiz_questions( $quiz_id );
 		$quiz_grade           = 0;
-		$quiz_grade_total     = $_POST['quiz_grade_total'];
+		$quiz_grade_total     = isset( $_POST['quiz_grade_total'] ) ? absint( wp_unslash( $_POST['quiz_grade_total'] ) ) : 0;
 		$all_question_grades  = array();
 		$all_answers_feedback = array();
 
@@ -848,7 +849,7 @@ class Sensei_Grading {
 			$question_feedback = '';
 			if ( isset( $_POST['questions_feedback'][ $question_id ] ) ) {
 
-				$question_feedback = wp_unslash( $_POST['questions_feedback'][ $question_id ] );
+				$question_feedback = sanitize_textarea_field( wp_unslash( $_POST['questions_feedback'][ $question_id ] ) );
 
 			}
 			$all_answers_feedback[ $question_id ] = $question_feedback;
@@ -876,7 +877,7 @@ class Sensei_Grading {
 
 		// $_POST['all_questions_graded'] is set when all questions have been graded
 		// in the class sensei grading user quiz -> display()
-		if ( $_POST['all_questions_graded'] == 'yes' ) {
+		if ( isset( $_POST['all_questions_graded'] ) && 'yes' == $_POST['all_questions_graded'] ) {
 
 			// Set the users total quiz grade.
 			$grade = Sensei_Utils::quotient_as_absolute_rounded_percentage( $quiz_grade, $quiz_grade_total, 2 );
@@ -931,13 +932,13 @@ class Sensei_Grading {
 
 		}
 
-		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( $_POST['sensei_grade_next_learner'] ) > 0 ) {
+		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( sanitize_text_field( wp_unslash( $_POST['sensei_grade_next_learner'] ) ) ) > 0 ) {
 
 			$load_url = add_query_arg( array( 'message' => 'graded' ) );
 
 		} elseif ( isset( $_POST['_wp_http_referer'] ) ) {
 
-			$load_url = add_query_arg( array( 'message' => 'graded' ), $_POST['_wp_http_referer'] );
+			$load_url = add_query_arg( array( 'message' => 'graded' ), esc_url_raw( wp_unslash( $_POST['_wp_http_referer'] ) ) );
 
 		} else {
 
@@ -967,7 +968,7 @@ class Sensei_Grading {
 		// Get data.
 		$course_id    = intval( $_GET['course_id'] );
 		$lesson_id    = intval( $_GET['lesson_id'] );
-		$grading_view = ( isset( $_GET['view'] ) && $_GET['view'] ) ? $_GET['view'] : 'ungraded';
+		$grading_view = ( isset( $_GET['view'] ) && '' !== $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'ungraded';
 
 		if ( 0 < $lesson_id && 0 < $course_id ) {
 			echo esc_url_raw(
@@ -997,7 +998,7 @@ class Sensei_Grading {
 	private function deprecated_get_redirect_url() {
 		// Parse POST data
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = $_POST['data'];
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$lesson_data = array();
 		parse_str( $data, $lesson_data );
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -257,7 +257,7 @@ class Sensei_Grading {
 			$user_id = intval( $_GET['user_id'] );
 		}
 		if ( ! empty( $_GET['view'] ) ) {
-			$view = sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) );
+			$view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
 		}
 
 		$sensei_grading_overview = new Sensei_Grading_Main( compact( 'course_id', 'lesson_id', 'user_id', 'view' ) );
@@ -796,7 +796,7 @@ class Sensei_Grading {
 
 		if ( ! isset( $_POST['sensei_manual_grade'] )
 			|| ! isset( $_POST['_wp_sensei_manual_grading_nonce'] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['_wp_sensei_manual_grading_nonce'] ) ? '' : $_POST['_wp_sensei_manual_grading_nonce'] ) ), 'sensei_manual_grading' )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wp_sensei_manual_grading_nonce'] ) ), 'sensei_manual_grading' )
 			|| ! isset( $_GET['quiz_id'] )
 			|| $_GET['quiz_id'] != $_POST['sensei_manual_grade'] ) {
 
@@ -849,7 +849,7 @@ class Sensei_Grading {
 			$question_feedback = '';
 			if ( isset( $_POST['questions_feedback'][ $question_id ] ) ) {
 
-				$question_feedback = wp_kses_post( wp_unslash( is_array( $_POST['questions_feedback'][ $question_id ] ) ? '' : $_POST['questions_feedback'][ $question_id ] ) );
+				$question_feedback = wp_kses_post( wp_unslash( $_POST['questions_feedback'][ $question_id ] ) );
 
 			}
 			$all_answers_feedback[ $question_id ] = $question_feedback;
@@ -932,13 +932,13 @@ class Sensei_Grading {
 
 		}
 
-		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_grade_next_learner'] ) ? '' : $_POST['sensei_grade_next_learner'] ) ) ) > 0 ) {
+		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( sanitize_text_field( wp_unslash( $_POST['sensei_grade_next_learner'] ) ) ) > 0 ) {
 
 			$load_url = add_query_arg( array( 'message' => 'graded' ) );
 
 		} elseif ( isset( $_POST['_wp_http_referer'] ) ) {
 
-			$load_url = add_query_arg( array( 'message' => 'graded' ), esc_url_raw( wp_unslash( is_array( $_POST['_wp_http_referer'] ) ? '' : $_POST['_wp_http_referer'] ) ) );
+			$load_url = add_query_arg( array( 'message' => 'graded' ), esc_url_raw( wp_unslash( $_POST['_wp_http_referer'] ) ) );
 
 		} else {
 
@@ -968,7 +968,7 @@ class Sensei_Grading {
 		// Get data.
 		$course_id    = intval( $_GET['course_id'] );
 		$lesson_id    = intval( $_GET['lesson_id'] );
-		$grading_view = ( isset( $_GET['view'] ) && '' !== $_GET['view'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) ) : 'ungraded';
+		$grading_view = ( isset( $_GET['view'] ) && '' !== $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'ungraded';
 
 		if ( 0 < $lesson_id && 0 < $course_id ) {
 			echo esc_url_raw(

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -257,7 +257,7 @@ class Sensei_Grading {
 			$user_id = intval( $_GET['user_id'] );
 		}
 		if ( ! empty( $_GET['view'] ) ) {
-			$view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
+			$view = sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) );
 		}
 
 		$sensei_grading_overview = new Sensei_Grading_Main( compact( 'course_id', 'lesson_id', 'user_id', 'view' ) );
@@ -720,7 +720,7 @@ class Sensei_Grading {
 	private function deprecated_get_lessons_dropdown() {
 		// Parse POST data
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$course_data = array();
 		parse_str( $data, $course_data );
 
@@ -796,7 +796,7 @@ class Sensei_Grading {
 
 		if ( ! isset( $_POST['sensei_manual_grade'] )
 			|| ! isset( $_POST['_wp_sensei_manual_grading_nonce'] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wp_sensei_manual_grading_nonce'] ) ), 'sensei_manual_grading' )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['_wp_sensei_manual_grading_nonce'] ) ? '' : $_POST['_wp_sensei_manual_grading_nonce'] ) ), 'sensei_manual_grading' )
 			|| ! isset( $_GET['quiz_id'] )
 			|| $_GET['quiz_id'] != $_POST['sensei_manual_grade'] ) {
 
@@ -849,7 +849,7 @@ class Sensei_Grading {
 			$question_feedback = '';
 			if ( isset( $_POST['questions_feedback'][ $question_id ] ) ) {
 
-				$question_feedback = wp_kses_post( wp_unslash( $_POST['questions_feedback'][ $question_id ] ) );
+				$question_feedback = wp_kses_post( wp_unslash( is_array( $_POST['questions_feedback'][ $question_id ] ) ? '' : $_POST['questions_feedback'][ $question_id ] ) );
 
 			}
 			$all_answers_feedback[ $question_id ] = $question_feedback;
@@ -932,13 +932,13 @@ class Sensei_Grading {
 
 		}
 
-		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( sanitize_text_field( wp_unslash( $_POST['sensei_grade_next_learner'] ) ) ) > 0 ) {
+		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( sanitize_text_field( wp_unslash( is_array( $_POST['sensei_grade_next_learner'] ) ? '' : $_POST['sensei_grade_next_learner'] ) ) ) > 0 ) {
 
 			$load_url = add_query_arg( array( 'message' => 'graded' ) );
 
 		} elseif ( isset( $_POST['_wp_http_referer'] ) ) {
 
-			$load_url = add_query_arg( array( 'message' => 'graded' ), esc_url_raw( wp_unslash( $_POST['_wp_http_referer'] ) ) );
+			$load_url = add_query_arg( array( 'message' => 'graded' ), esc_url_raw( wp_unslash( is_array( $_POST['_wp_http_referer'] ) ? '' : $_POST['_wp_http_referer'] ) ) );
 
 		} else {
 
@@ -968,7 +968,7 @@ class Sensei_Grading {
 		// Get data.
 		$course_id    = intval( $_GET['course_id'] );
 		$lesson_id    = intval( $_GET['lesson_id'] );
-		$grading_view = ( isset( $_GET['view'] ) && '' !== $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'ungraded';
+		$grading_view = ( isset( $_GET['view'] ) && '' !== $_GET['view'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['view'] ) ? '' : $_GET['view'] ) ) : 'ungraded';
 
 		if ( 0 < $lesson_id && 0 < $course_id ) {
 			echo esc_url_raw(
@@ -998,7 +998,7 @@ class Sensei_Grading {
 	private function deprecated_get_redirect_url() {
 		// Parse POST data
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$lesson_data = array();
 		parse_str( $data, $lesson_data );
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -257,7 +257,7 @@ class Sensei_Grading {
 			$user_id = intval( $_GET['user_id'] );
 		}
 		if ( ! empty( $_GET['view'] ) ) {
-			$view = sanitize_text_field( wp_unslash( $_GET['view'] ) );
+			$view = sensei_request_text( $_GET['view'] );
 		}
 
 		$sensei_grading_overview = new Sensei_Grading_Main( compact( 'course_id', 'lesson_id', 'user_id', 'view' ) );
@@ -796,7 +796,7 @@ class Sensei_Grading {
 
 		if ( ! isset( $_POST['sensei_manual_grade'] )
 			|| ! isset( $_POST['_wp_sensei_manual_grading_nonce'] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wp_sensei_manual_grading_nonce'] ) ), 'sensei_manual_grading' )
+			|| ! wp_verify_nonce( sensei_request_text( $_POST['_wp_sensei_manual_grading_nonce'] ), 'sensei_manual_grading' )
 			|| ! isset( $_GET['quiz_id'] )
 			|| $_GET['quiz_id'] != $_POST['sensei_manual_grade'] ) {
 
@@ -849,7 +849,7 @@ class Sensei_Grading {
 			$question_feedback = '';
 			if ( isset( $_POST['questions_feedback'][ $question_id ] ) ) {
 
-				$question_feedback = wp_kses_post( wp_unslash( $_POST['questions_feedback'][ $question_id ] ) );
+				$question_feedback = wp_kses_post( wp_unslash( is_array( $_POST['questions_feedback'][ $question_id ] ) ? '' : $_POST['questions_feedback'][ $question_id ] ) );
 
 			}
 			$all_answers_feedback[ $question_id ] = $question_feedback;
@@ -932,13 +932,13 @@ class Sensei_Grading {
 
 		}
 
-		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( sanitize_text_field( wp_unslash( $_POST['sensei_grade_next_learner'] ) ) ) > 0 ) {
+		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( sensei_request_text( $_POST['sensei_grade_next_learner'] ) ) > 0 ) {
 
 			$load_url = add_query_arg( array( 'message' => 'graded' ) );
 
 		} elseif ( isset( $_POST['_wp_http_referer'] ) ) {
 
-			$load_url = add_query_arg( array( 'message' => 'graded' ), esc_url_raw( wp_unslash( $_POST['_wp_http_referer'] ) ) );
+			$load_url = add_query_arg( array( 'message' => 'graded' ), esc_url_raw( wp_unslash( is_array( $_POST['_wp_http_referer'] ) ? '' : $_POST['_wp_http_referer'] ) ) );
 
 		} else {
 
@@ -968,7 +968,7 @@ class Sensei_Grading {
 		// Get data.
 		$course_id    = intval( $_GET['course_id'] );
 		$lesson_id    = intval( $_GET['lesson_id'] );
-		$grading_view = ( isset( $_GET['view'] ) && '' !== $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'ungraded';
+		$grading_view = ( isset( $_GET['view'] ) && '' !== $_GET['view'] ) ? sensei_request_text( $_GET['view'] ) : 'ungraded';
 
 		if ( 0 < $lesson_id && 0 < $course_id ) {
 			echo esc_url_raw(
@@ -1029,8 +1029,8 @@ class Sensei_Grading {
 	}
 
 	public function add_grading_notices() {
-		$page    = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : false;
-		$message = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : false;
+		$page    = isset( $_GET['page'] ) ? sensei_request_text( $_GET['page'] ) : false;
+		$message = isset( $_GET['message'] ) ? sensei_request_text( $_GET['message'] ) : false;
 
 		if (
 			$page

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2066,7 +2066,8 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data          = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -2411,7 +2412,8 @@ class Sensei_Lesson {
 			}
 			wp_die();
 		}
-		$answer    = sanitize_text_field( wp_unslash( is_array( $_GET['answer_value'] ) ? '' : $_GET['answer_value'] ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is only md5-hashed for lookup, never stored or output; it must match the raw answer text hashed by every other get_answer_id() caller.
+		$answer    = wp_unslash( is_array( $_GET['answer_value'] ) ? '' : $_GET['answer_value'] );
 		$answer_id = $this->get_answer_id( $answer );
 		echo esc_html( $answer_id );
 		wp_die();
@@ -2421,8 +2423,8 @@ class Sensei_Lesson {
 	 * Deprecated version of question_get_answer_id() to use as a fallback.
 	 */
 	private function deprecated_question_get_answer_id() {
-		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No modifications are made here. URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data        = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$answer_data = array();
 		parse_str( $data, $answer_data );
 		$answer    = $answer_data['answer_value'];
@@ -2926,7 +2928,8 @@ class Sensei_Lesson {
 		// WP slashes all incoming data regardless of Magic Quotes setting (see wp_magic_quotes()), which means that
 		// even the $_POST['data'] encoded with encodeURIComponent has it's apostrophes slashed.
 		// So first restore the original unslashed apostrophes by removing those slashes.
-		$data = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		// Then parse the string to an array (note that parse_str automatically urldecodes all the variables).
 		$question_data = array();
 		parse_str( $data, $question_data );
@@ -2985,7 +2988,8 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data          = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -3049,7 +3053,8 @@ class Sensei_Lesson {
 
 		// Parse POST data
 		$question_data = array();
-		parse_str( sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ), $question_data );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		parse_str( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ), $question_data );
 
 		$question_id_to_remove      = $question_data['question_id'];
 		$quiz_id_to_be_removed_from = $question_data['quiz_id'];
@@ -3119,8 +3124,8 @@ class Sensei_Lesson {
 		$return = 1;
 
 		// Parse POST data
-		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data     = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No modifications are made here. URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data     = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$cat_data = array();
 		parse_str( $data, $cat_data );
 
@@ -3151,7 +3156,8 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data          = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -3219,7 +3225,8 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data      = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 
@@ -3245,7 +3252,8 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data      = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 
@@ -3279,7 +3287,8 @@ class Sensei_Lesson {
 
 		}
 		// Parse POST data
-		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL-encoded payload; parse_str urldecodes it and the parsed fields are sanitized before use.
+		$data      = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -925,7 +925,7 @@ class Sensei_Lesson {
 		}
 
 		// Verify the nonce before proceeding.
-		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $nonce_value = $_POST[ 'woo_' . $this->token . '_nonce' ] ) ? '' : $nonce_value ) ), 'sensei-save-post-meta' ) ) {
+		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_nonce' ] ) ), 'sensei-save-post-meta' ) ) {
 			if ( isset( $post->ID ) ) {
 				return $post->ID;
 			} else {
@@ -2058,7 +2058,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['filter_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['filter_existing_questions_nonce'] ) ? '' : $_POST['filter_existing_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['filter_existing_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'filter_existing_questions_nonce' ) ) {
@@ -2413,7 +2413,7 @@ class Sensei_Lesson {
 			wp_die();
 		}
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is only md5-hashed for lookup, never stored or output; it must match the raw answer text hashed by every other get_answer_id() caller.
-		$answer    = wp_unslash( is_array( $_GET['answer_value'] ) ? '' : $_GET['answer_value'] );
+		$answer    = wp_unslash( $_GET['answer_value'] );
 		$answer_id = $this->get_answer_id( $answer );
 		echo esc_html( $answer_id );
 		wp_die();
@@ -2915,7 +2915,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request.
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_question_nonce'] ) ? '' : $_POST['lesson_update_question_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_nonce'] ) );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_nonce' )
 			|| ! current_user_can( 'edit_questions' ) ) {
@@ -2979,7 +2979,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_add_multiple_questions_nonce'] ) ? '' : $_POST['lesson_add_multiple_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_multiple_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_multiple_questions_nonce' )
@@ -3043,7 +3043,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_remove_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_remove_multiple_questions_nonce'] ) ? '' : $_POST['lesson_remove_multiple_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_remove_multiple_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_remove_multiple_questions_nonce' )
@@ -3147,7 +3147,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_add_existing_questions_nonce'] ) ? '' : $_POST['lesson_add_existing_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_existing_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_existing_questions_nonce' )
@@ -3213,7 +3213,7 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_update_grade_type_nonce'] ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_grade_type_nonce'] ) ? '' : $_POST['lesson_update_grade_type_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_grade_type_nonce'] ) );
 
 		}
 
@@ -3243,7 +3243,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_question_order_nonce'] ) ? '' : $_POST['lesson_update_question_order_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_nonce' )
@@ -3278,7 +3278,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_random_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_question_order_random_nonce'] ) ? '' : $_POST['lesson_update_question_order_random_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_random_nonce'] ) );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_random_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -692,12 +692,12 @@ class Sensei_Lesson {
 			}
 		}
 
-		$new_pass_required     = isset( $_POST['pass_required'] ) ? sanitize_text_field( wp_unslash( $_POST['pass_required'] ) ) : null;
-		$new_pass_percentage   = isset( $_POST['quiz_passmark'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_passmark'] ) ) : null;
-		$new_enable_quiz_reset = isset( $_POST['enable_quiz_reset'] ) ? sanitize_text_field( wp_unslash( $_POST['enable_quiz_reset'] ) ) : null;
-		$show_questions        = isset( $_POST['show_questions'] ) ? sanitize_text_field( wp_unslash( $_POST['show_questions'] ) ) : null;
-		$random_question_order = isset( $_POST['random_question_order'] ) ? sanitize_text_field( wp_unslash( $_POST['random_question_order'] ) ) : null;
-		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_grade_type'] ) ) : null;
+		$new_pass_required     = isset( $_POST['pass_required'] ) ? sensei_request_text( $_POST['pass_required'] ) : null;
+		$new_pass_percentage   = isset( $_POST['quiz_passmark'] ) ? sensei_request_text( $_POST['quiz_passmark'] ) : null;
+		$new_enable_quiz_reset = isset( $_POST['enable_quiz_reset'] ) ? sensei_request_text( $_POST['enable_quiz_reset'] ) : null;
+		$show_questions        = isset( $_POST['show_questions'] ) ? sensei_request_text( $_POST['show_questions'] ) : null;
+		$random_question_order = isset( $_POST['random_question_order'] ) ? sensei_request_text( $_POST['random_question_order'] ) : null;
+		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sensei_request_text( $_POST['quiz_grade_type'] ) : null;
 
 		$new_settings = array(
 			'pass_required'         => $new_pass_required,
@@ -925,7 +925,7 @@ class Sensei_Lesson {
 		}
 
 		// Verify the nonce before proceeding.
-		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_nonce' ] ) ), 'sensei-save-post-meta' ) ) {
+		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( sensei_request_text( $_POST[ 'woo_' . $this->token . '_nonce' ] ), 'sensei-save-post-meta' ) ) {
 			if ( isset( $post->ID ) ) {
 				return $post->ID;
 			} else {
@@ -1083,7 +1083,7 @@ class Sensei_Lesson {
 		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified in caller
 		if ( isset( $_POST[ $field['id'] ] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified in caller
-			$value = sanitize_text_field( wp_unslash( $_POST[ $field['id'] ] ) );
+			$value = sensei_request_text( $_POST[ $field['id'] ] );
 		}
 
 		return $value;
@@ -2058,7 +2058,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['filter_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['filter_existing_questions_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['filter_existing_questions_nonce'] );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'filter_existing_questions_nonce' ) ) {
@@ -2915,7 +2915,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request.
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['lesson_update_question_nonce'] );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_nonce' )
 			|| ! current_user_can( 'edit_questions' ) ) {
@@ -2979,7 +2979,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_multiple_questions_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['lesson_add_multiple_questions_nonce'] );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_multiple_questions_nonce' )
@@ -3043,7 +3043,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_remove_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_remove_multiple_questions_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['lesson_remove_multiple_questions_nonce'] );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_remove_multiple_questions_nonce' )
@@ -3147,7 +3147,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_existing_questions_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['lesson_add_existing_questions_nonce'] );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_existing_questions_nonce' )
@@ -3213,7 +3213,7 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_update_grade_type_nonce'] ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_grade_type_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['lesson_update_grade_type_nonce'] );
 
 		}
 
@@ -3243,7 +3243,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['lesson_update_question_order_nonce'] );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_nonce' )
@@ -3278,7 +3278,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_random_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_random_nonce'] ) );
+			$nonce = sensei_request_text( $_POST['lesson_update_question_order_random_nonce'] );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_random_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -925,7 +925,7 @@ class Sensei_Lesson {
 		}
 
 		// Verify the nonce before proceeding.
-		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_nonce' ] ) ), 'sensei-save-post-meta' ) ) {
+		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $nonce_value = $_POST[ 'woo_' . $this->token . '_nonce' ] ) ? '' : $nonce_value ) ), 'sensei-save-post-meta' ) ) {
 			if ( isset( $post->ID ) ) {
 				return $post->ID;
 			} else {
@@ -2058,7 +2058,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['filter_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['filter_existing_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['filter_existing_questions_nonce'] ) ? '' : $_POST['filter_existing_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'filter_existing_questions_nonce' ) ) {
@@ -2066,7 +2066,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -2411,7 +2411,7 @@ class Sensei_Lesson {
 			}
 			wp_die();
 		}
-		$answer    = sanitize_text_field( wp_unslash( $_GET['answer_value'] ) );
+		$answer    = sanitize_text_field( wp_unslash( is_array( $_GET['answer_value'] ) ? '' : $_GET['answer_value'] ) );
 		$answer_id = $this->get_answer_id( $answer );
 		echo esc_html( $answer_id );
 		wp_die();
@@ -2422,7 +2422,7 @@ class Sensei_Lesson {
 	 */
 	private function deprecated_question_get_answer_id() {
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$answer_data = array();
 		parse_str( $data, $answer_data );
 		$answer    = $answer_data['answer_value'];
@@ -2913,7 +2913,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request.
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_question_nonce'] ) ? '' : $_POST['lesson_update_question_nonce'] ) );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_nonce' )
 			|| ! current_user_can( 'edit_questions' ) ) {
@@ -2926,7 +2926,7 @@ class Sensei_Lesson {
 		// WP slashes all incoming data regardless of Magic Quotes setting (see wp_magic_quotes()), which means that
 		// even the $_POST['data'] encoded with encodeURIComponent has it's apostrophes slashed.
 		// So first restore the original unslashed apostrophes by removing those slashes.
-		$data = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		// Then parse the string to an array (note that parse_str automatically urldecodes all the variables).
 		$question_data = array();
 		parse_str( $data, $question_data );
@@ -2976,7 +2976,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_multiple_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_add_multiple_questions_nonce'] ) ? '' : $_POST['lesson_add_multiple_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_multiple_questions_nonce' )
@@ -2985,7 +2985,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -3039,7 +3039,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_remove_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_remove_multiple_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_remove_multiple_questions_nonce'] ) ? '' : $_POST['lesson_remove_multiple_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_remove_multiple_questions_nonce' )
@@ -3049,7 +3049,7 @@ class Sensei_Lesson {
 
 		// Parse POST data
 		$question_data = array();
-		parse_str( sanitize_text_field( wp_unslash( $_POST['data'] ) ), $question_data );
+		parse_str( sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ), $question_data );
 
 		$question_id_to_remove      = $question_data['question_id'];
 		$quiz_id_to_be_removed_from = $question_data['quiz_id'];
@@ -3120,7 +3120,7 @@ class Sensei_Lesson {
 
 		// Parse POST data
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data     = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data     = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$cat_data = array();
 		parse_str( $data, $cat_data );
 
@@ -3142,7 +3142,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_existing_questions_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_add_existing_questions_nonce'] ) ? '' : $_POST['lesson_add_existing_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_existing_questions_nonce' )
@@ -3151,7 +3151,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -3207,7 +3207,7 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_update_grade_type_nonce'] ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_grade_type_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_grade_type_nonce'] ) ? '' : $_POST['lesson_update_grade_type_nonce'] ) );
 
 		}
 
@@ -3219,7 +3219,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 
@@ -3236,7 +3236,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_question_order_nonce'] ) ? '' : $_POST['lesson_update_question_order_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_nonce' )
@@ -3245,7 +3245,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 
@@ -3270,7 +3270,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_random_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_random_nonce'] ) );
+			$nonce = sanitize_text_field( wp_unslash( is_array( $_POST['lesson_update_question_order_random_nonce'] ) ? '' : $_POST['lesson_update_question_order_random_nonce'] ) );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_random_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {
@@ -3279,7 +3279,7 @@ class Sensei_Lesson {
 
 		}
 		// Parse POST data
-		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
+		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -925,7 +925,7 @@ class Sensei_Lesson {
 		}
 
 		// Verify the nonce before proceeding.
-		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_nonce' ], 'sensei-save-post-meta' ) ) {
+		if ( ( 'lesson' != get_post_type( $post_id ) ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_' . $this->token . '_nonce' ] ) ), 'sensei-save-post-meta' ) ) {
 			if ( isset( $post->ID ) ) {
 				return $post->ID;
 			} else {
@@ -2058,7 +2058,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['filter_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['filter_existing_questions_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['filter_existing_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'filter_existing_questions_nonce' ) ) {
@@ -2066,7 +2066,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = $_POST['data'];
+		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -2411,7 +2411,7 @@ class Sensei_Lesson {
 			}
 			wp_die();
 		}
-		$answer    = $_GET['answer_value'];
+		$answer    = sanitize_text_field( wp_unslash( $_GET['answer_value'] ) );
 		$answer_id = $this->get_answer_id( $answer );
 		echo esc_html( $answer_id );
 		wp_die();
@@ -2422,7 +2422,7 @@ class Sensei_Lesson {
 	 */
 	private function deprecated_question_get_answer_id() {
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data        = $_POST['data'];
+		$data        = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$answer_data = array();
 		parse_str( $data, $answer_data );
 		$answer    = $answer_data['answer_value'];
@@ -2913,7 +2913,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request.
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['lesson_update_question_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_nonce'] ) );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_nonce' )
 			|| ! current_user_can( 'edit_questions' ) ) {
@@ -2926,7 +2926,7 @@ class Sensei_Lesson {
 		// WP slashes all incoming data regardless of Magic Quotes setting (see wp_magic_quotes()), which means that
 		// even the $_POST['data'] encoded with encodeURIComponent has it's apostrophes slashed.
 		// So first restore the original unslashed apostrophes by removing those slashes.
-		$data = wp_unslash( $_POST['data'] );
+		$data = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		// Then parse the string to an array (note that parse_str automatically urldecodes all the variables).
 		$question_data = array();
 		parse_str( $data, $question_data );
@@ -2976,7 +2976,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['lesson_add_multiple_questions_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_multiple_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_multiple_questions_nonce' )
@@ -2985,7 +2985,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = $_POST['data'];
+		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -3039,7 +3039,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_remove_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['lesson_remove_multiple_questions_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_remove_multiple_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_remove_multiple_questions_nonce' )
@@ -3049,7 +3049,7 @@ class Sensei_Lesson {
 
 		// Parse POST data
 		$question_data = array();
-		parse_str( $_POST['data'], $question_data );
+		parse_str( sanitize_text_field( wp_unslash( $_POST['data'] ) ), $question_data );
 
 		$question_id_to_remove      = $question_data['question_id'];
 		$quiz_id_to_be_removed_from = $question_data['quiz_id'];
@@ -3086,7 +3086,7 @@ class Sensei_Lesson {
 		$return = 1;
 
 		if ( isset( $_GET['cat'] ) && '' != $_GET['cat'] ) {
-			$cat = get_term( $_GET['cat'], 'question-category' );
+			$cat = get_term( absint( $_GET['cat'] ), 'question-category' );
 			if ( isset( $cat->count ) ) {
 				$return = $cat->count;
 			}
@@ -3120,7 +3120,7 @@ class Sensei_Lesson {
 
 		// Parse POST data
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
-		$data     = $_POST['data'];
+		$data     = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$cat_data = array();
 		parse_str( $data, $cat_data );
 
@@ -3142,7 +3142,7 @@ class Sensei_Lesson {
 		$nonce = '';
 		if ( isset( $_POST['lesson_add_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['lesson_add_existing_questions_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_add_existing_questions_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_existing_questions_nonce' )
@@ -3151,7 +3151,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data          = $_POST['data'];
+		$data          = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$question_data = array();
 		parse_str( $data, $question_data );
 
@@ -3207,7 +3207,7 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_update_grade_type_nonce'] ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['lesson_update_grade_type_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_grade_type_nonce'] ) );
 
 		}
 
@@ -3219,7 +3219,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data      = $_POST['data'];
+		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 
@@ -3236,7 +3236,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['lesson_update_question_order_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_nonce'] ) );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_nonce' )
@@ -3245,7 +3245,7 @@ class Sensei_Lesson {
 		}
 
 		// Parse POST data
-		$data      = $_POST['data'];
+		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 
@@ -3270,7 +3270,7 @@ class Sensei_Lesson {
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_order_random_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$nonce = esc_html( $_POST['lesson_update_question_order_random_nonce'] );
+			$nonce = sanitize_text_field( wp_unslash( $_POST['lesson_update_question_order_random_nonce'] ) );
 		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_random_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {
@@ -3279,7 +3279,7 @@ class Sensei_Lesson {
 
 		}
 		// Parse POST data
-		$data      = $_POST['data'];
+		$data      = isset( $_POST['data'] ) ? sanitize_text_field( wp_unslash( $_POST['data'] ) ) : '';
 		$quiz_data = array();
 		parse_str( $data, $quiz_data );
 
@@ -3743,7 +3743,7 @@ class Sensei_Lesson {
 
 		// Setup the user id.
 		if ( is_admin() ) {
-			$user_id = isset( $_GET['user'] ) ? $_GET['user'] : '';
+			$user_id = isset( $_GET['user'] ) ? absint( $_GET['user'] ) : '';
 		} else {
 			$user_id = get_current_user_id();
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2427,7 +2427,7 @@ class Sensei_Lesson {
 		$data        = isset( $_POST['data'] ) ? wp_unslash( is_array( $_POST['data'] ) ? '' : $_POST['data'] ) : '';
 		$answer_data = array();
 		parse_str( $data, $answer_data );
-		$answer    = $answer_data['answer_value'];
+		$answer    = $answer_data['answer_value'] ?? '';
 		$answer_id = $this->get_answer_id( $answer );
 		echo esc_html( $answer_id );
 		die();

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -375,7 +375,7 @@ class Sensei_Messages {
 
 		$message = empty( $_POST['contact_message'] )
 			? ''
-			: sanitize_text_field( wp_unslash( $_POST['contact_message'] ) );
+			: sensei_request_text( $_POST['contact_message'] );
 
 		$this->save_new_message_post( $current_user->ID, $post->post_author, $message, $post->ID );
 	}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2533,8 +2533,8 @@ class Sensei_Core_Modules {
 
 		$course_id = isset( $_POST['course_id'] ) ? sanitize_text_field( wp_unslash( $_POST['course_id'] ) ) : '';
 
-		// save the term
-		$slug = wp_insert_term( $term_name, 'module', array( 'slug' => $term_slug ) );
+		// save the term. wp_insert_term() unslashes internally, so re-slash to preserve any backslashes in the name.
+		$slug = wp_insert_term( wp_slash( $term_name ), 'module', array( 'slug' => $term_slug ) );
 
 		// send error for all errors except term exits
 		if ( is_wp_error( $slug ) ) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -477,7 +477,7 @@ class Sensei_Core_Modules {
 
 		// Verify post type and nonce
 		if ( ( get_post_type( $post ) != 'lesson' ) || ! isset( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $nonce_value = $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] ) ? '' : $nonce_value ) ), plugin_basename( $this->file ) ) ) {
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] ) ), plugin_basename( $this->file ) ) ) {
 			return $post_id;
 		}
 
@@ -495,8 +495,8 @@ class Sensei_Core_Modules {
 		// Get module and course IDs
 		$lesson_module_id_key = 'lesson_module';
 		$lesson_course_id_key = 'lesson_course';
-		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? sanitize_text_field( wp_unslash( is_array( $_POST[ $lesson_module_id_key ] ) ? '' : $_POST[ $lesson_module_id_key ] ) ) : '';
-		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? sanitize_text_field( wp_unslash( is_array( $_POST[ $lesson_course_id_key ] ) ? '' : $_POST[ $lesson_course_id_key ] ) ) : '';
+		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_module_id_key ] ) ) : '';
+		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_course_id_key ] ) ) : '';
 
 		// Set the module on the lesson
 		$lesson_modules = new Sensei_Core_Lesson_Modules( $post_id );
@@ -686,7 +686,7 @@ class Sensei_Core_Modules {
 		$module           = get_term( $module_id );
 		$event_properties = [
 			// phpcs:ignore WordPress.Security.NonceVerification
-			'page'      => isset( $_REQUEST['from_page'] ) ? sanitize_text_field( wp_unslash( is_array( $_REQUEST['from_page'] ) ? '' : $_REQUEST['from_page'] ) ) : '',
+			'page'      => isset( $_REQUEST['from_page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['from_page'] ) ) : '',
 			'parent_id' => -1,
 		];
 
@@ -711,7 +711,7 @@ class Sensei_Core_Modules {
 		header( 'Content-Type: application/json; charset=utf-8' );
 
 		// Get user input
-		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['term'] ) ? '' : $_GET['term'] ) ) : '';
+		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
 		$term = urldecode( $term );
 
 		// Return nothing if term is empty
@@ -720,7 +720,7 @@ class Sensei_Core_Modules {
 		}
 
 		// Set a default if none is given
-		$default = isset( $_GET['default'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['default'] ) ? '' : $_GET['default'] ) ) : __( 'No course', 'sensei-lms' );
+		$default = isset( $_GET['default'] ) ? sanitize_text_field( wp_unslash( $_GET['default'] ) ) : __( 'No course', 'sensei-lms' );
 
 		// Set up array of results
 		$found_courses = array( '' => $default );
@@ -2514,12 +2514,12 @@ class Sensei_Core_Modules {
 	 */
 	public static function add_new_module_term() {
 
-		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['security'] ) ? '' : $_POST['security'] ) ), '_ajax_nonce-add-module' ) ) {
+		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['security'] ) ), '_ajax_nonce-add-module' ) ) {
 			wp_send_json_error( array( 'error' => 'wrong security nonce' ) );
 		}
 
 		// get the term an create the new term storing infomration
-		$term_name = isset( $_POST['newTerm'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['newTerm'] ) ? '' : $_POST['newTerm'] ) ) : '';
+		$term_name = isset( $_POST['newTerm'] ) ? sanitize_text_field( wp_unslash( $_POST['newTerm'] ) ) : '';
 
 		if ( current_user_can( 'manage_options' ) ) {
 
@@ -2531,7 +2531,7 @@ class Sensei_Core_Modules {
 
 		}
 
-		$course_id = isset( $_POST['course_id'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['course_id'] ) ? '' : $_POST['course_id'] ) ) : '';
+		$course_id = isset( $_POST['course_id'] ) ? sanitize_text_field( wp_unslash( $_POST['course_id'] ) ) : '';
 
 		// save the term. wp_insert_term() unslashes internally, so re-slash to preserve any backslashes in the name.
 		$slug = wp_insert_term( wp_slash( $term_name ), 'module', array( 'slug' => $term_slug ) );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -477,7 +477,7 @@ class Sensei_Core_Modules {
 
 		// Verify post type and nonce
 		if ( ( get_post_type( $post ) != 'lesson' ) || ! isset( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] ) ), plugin_basename( $this->file ) ) ) {
+			|| ! wp_verify_nonce( sensei_request_text( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] ), plugin_basename( $this->file ) ) ) {
 			return $post_id;
 		}
 
@@ -495,8 +495,8 @@ class Sensei_Core_Modules {
 		// Get module and course IDs
 		$lesson_module_id_key = 'lesson_module';
 		$lesson_course_id_key = 'lesson_course';
-		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_module_id_key ] ) ) : '';
-		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_course_id_key ] ) ) : '';
+		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? sensei_request_text( $_POST[ $lesson_module_id_key ] ) : '';
+		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? sensei_request_text( $_POST[ $lesson_course_id_key ] ) : '';
 
 		// Set the module on the lesson
 		$lesson_modules = new Sensei_Core_Lesson_Modules( $post_id );
@@ -658,7 +658,7 @@ class Sensei_Core_Modules {
 		if ( isset( $_POST['module_courses'] ) && ! empty( $_POST['module_courses'] ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$course_ids = is_array( $_POST['module_courses'] ) ? array_map( 'absint', wp_unslash( $_POST['module_courses'] ) ) : explode( ',', sanitize_text_field( wp_unslash( $_POST['module_courses'] ) ) );
+			$course_ids = is_array( $_POST['module_courses'] ) ? array_map( 'absint', wp_unslash( $_POST['module_courses'] ) ) : explode( ',', sensei_request_text( $_POST['module_courses'] ) );
 
 			foreach ( $course_ids as $course_id ) {
 
@@ -686,7 +686,7 @@ class Sensei_Core_Modules {
 		$module           = get_term( $module_id );
 		$event_properties = [
 			// phpcs:ignore WordPress.Security.NonceVerification
-			'page'      => isset( $_REQUEST['from_page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['from_page'] ) ) : '',
+			'page'      => isset( $_REQUEST['from_page'] ) ? sensei_request_text( $_REQUEST['from_page'] ) : '',
 			'parent_id' => -1,
 		];
 
@@ -711,7 +711,7 @@ class Sensei_Core_Modules {
 		header( 'Content-Type: application/json; charset=utf-8' );
 
 		// Get user input
-		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
+		$term = isset( $_GET['term'] ) ? sensei_request_text( $_GET['term'] ) : '';
 		$term = urldecode( $term );
 
 		// Return nothing if term is empty
@@ -720,7 +720,7 @@ class Sensei_Core_Modules {
 		}
 
 		// Set a default if none is given
-		$default = isset( $_GET['default'] ) ? sanitize_text_field( wp_unslash( $_GET['default'] ) ) : __( 'No course', 'sensei-lms' );
+		$default = isset( $_GET['default'] ) ? sensei_request_text( $_GET['default'] ) : __( 'No course', 'sensei-lms' );
 
 		// Set up array of results
 		$found_courses = array( '' => $default );
@@ -1303,7 +1303,7 @@ class Sensei_Core_Modules {
 		check_admin_referer( 'order_modules' );
 
 		$course_id    = isset( $_POST['course_id'] ) ? intval( $_POST['course_id'] ) : 0;
-		$module_order = isset( $_POST['module-order'] ) ? sanitize_text_field( wp_unslash( $_POST['module-order'] ) ) : '';
+		$module_order = isset( $_POST['module-order'] ) ? sensei_request_text( $_POST['module-order'] ) : '';
 
 		if (
 			! Sensei_Course::can_current_user_edit_course( $course_id )
@@ -2514,12 +2514,12 @@ class Sensei_Core_Modules {
 	 */
 	public static function add_new_module_term() {
 
-		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['security'] ) ), '_ajax_nonce-add-module' ) ) {
+		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( sensei_request_text( $_POST['security'] ), '_ajax_nonce-add-module' ) ) {
 			wp_send_json_error( array( 'error' => 'wrong security nonce' ) );
 		}
 
 		// get the term an create the new term storing infomration
-		$term_name = isset( $_POST['newTerm'] ) ? sanitize_text_field( wp_unslash( $_POST['newTerm'] ) ) : '';
+		$term_name = isset( $_POST['newTerm'] ) ? sensei_request_text( $_POST['newTerm'] ) : '';
 
 		if ( current_user_can( 'manage_options' ) ) {
 
@@ -2531,7 +2531,7 @@ class Sensei_Core_Modules {
 
 		}
 
-		$course_id = isset( $_POST['course_id'] ) ? sanitize_text_field( wp_unslash( $_POST['course_id'] ) ) : '';
+		$course_id = isset( $_POST['course_id'] ) ? sensei_request_text( $_POST['course_id'] ) : '';
 
 		// save the term. wp_insert_term() unslashes internally, so re-slash to preserve any backslashes in the name.
 		$slug = wp_insert_term( wp_slash( $term_name ), 'module', array( 'slug' => $term_slug ) );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -477,7 +477,7 @@ class Sensei_Core_Modules {
 
 		// Verify post type and nonce
 		if ( ( get_post_type( $post ) != 'lesson' ) || ! isset( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] )
-			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] ) ), plugin_basename( $this->file ) ) ) {
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $nonce_value = $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] ) ? '' : $nonce_value ) ), plugin_basename( $this->file ) ) ) {
 			return $post_id;
 		}
 
@@ -495,8 +495,8 @@ class Sensei_Core_Modules {
 		// Get module and course IDs
 		$lesson_module_id_key = 'lesson_module';
 		$lesson_course_id_key = 'lesson_course';
-		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_module_id_key ] ) ) : null;
-		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_course_id_key ] ) ) : null;
+		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? sanitize_text_field( wp_unslash( is_array( $_POST[ $lesson_module_id_key ] ) ? '' : $_POST[ $lesson_module_id_key ] ) ) : '';
+		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? sanitize_text_field( wp_unslash( is_array( $_POST[ $lesson_course_id_key ] ) ? '' : $_POST[ $lesson_course_id_key ] ) ) : '';
 
 		// Set the module on the lesson
 		$lesson_modules = new Sensei_Core_Lesson_Modules( $post_id );
@@ -686,7 +686,7 @@ class Sensei_Core_Modules {
 		$module           = get_term( $module_id );
 		$event_properties = [
 			// phpcs:ignore WordPress.Security.NonceVerification
-			'page'      => isset( $_REQUEST['from_page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['from_page'] ) ) : '',
+			'page'      => isset( $_REQUEST['from_page'] ) ? sanitize_text_field( wp_unslash( is_array( $_REQUEST['from_page'] ) ? '' : $_REQUEST['from_page'] ) ) : '',
 			'parent_id' => -1,
 		];
 
@@ -711,7 +711,7 @@ class Sensei_Core_Modules {
 		header( 'Content-Type: application/json; charset=utf-8' );
 
 		// Get user input
-		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
+		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['term'] ) ? '' : $_GET['term'] ) ) : '';
 		$term = urldecode( $term );
 
 		// Return nothing if term is empty
@@ -720,7 +720,7 @@ class Sensei_Core_Modules {
 		}
 
 		// Set a default if none is given
-		$default = isset( $_GET['default'] ) ? sanitize_text_field( wp_unslash( $_GET['default'] ) ) : __( 'No course', 'sensei-lms' );
+		$default = isset( $_GET['default'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['default'] ) ? '' : $_GET['default'] ) ) : __( 'No course', 'sensei-lms' );
 
 		// Set up array of results
 		$found_courses = array( '' => $default );
@@ -2514,12 +2514,12 @@ class Sensei_Core_Modules {
 	 */
 	public static function add_new_module_term() {
 
-		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['security'] ) ), '_ajax_nonce-add-module' ) ) {
+		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( is_array( $_POST['security'] ) ? '' : $_POST['security'] ) ), '_ajax_nonce-add-module' ) ) {
 			wp_send_json_error( array( 'error' => 'wrong security nonce' ) );
 		}
 
 		// get the term an create the new term storing infomration
-		$term_name = isset( $_POST['newTerm'] ) ? sanitize_text_field( wp_unslash( $_POST['newTerm'] ) ) : '';
+		$term_name = isset( $_POST['newTerm'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['newTerm'] ) ? '' : $_POST['newTerm'] ) ) : '';
 
 		if ( current_user_can( 'manage_options' ) ) {
 
@@ -2531,7 +2531,7 @@ class Sensei_Core_Modules {
 
 		}
 
-		$course_id = isset( $_POST['course_id'] ) ? sanitize_text_field( wp_unslash( $_POST['course_id'] ) ) : '';
+		$course_id = isset( $_POST['course_id'] ) ? sanitize_text_field( wp_unslash( is_array( $_POST['course_id'] ) ? '' : $_POST['course_id'] ) ) : '';
 
 		// save the term. wp_insert_term() unslashes internally, so re-slash to preserve any backslashes in the name.
 		$slug = wp_insert_term( wp_slash( $term_name ), 'module', array( 'slug' => $term_slug ) );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -711,8 +711,8 @@ class Sensei_Core_Modules {
 		header( 'Content-Type: application/json; charset=utf-8' );
 
 		// Get user input
-		$term = isset( $_GET['term'] ) ? sensei_request_text( $_GET['term'] ) : '';
-		$term = urldecode( $term );
+		// Decode before sanitizing: sanitize_text_field() strips percent-encoded octets, so it must run after urldecode().
+		$term = isset( $_GET['term'] ) ? sanitize_text_field( urldecode( wp_unslash( is_array( $_GET['term'] ) ? '' : $_GET['term'] ) ) ) : '';
 
 		// Return nothing if term is empty
 		if ( empty( $term ) ) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -477,7 +477,7 @@ class Sensei_Core_Modules {
 
 		// Verify post type and nonce
 		if ( ( get_post_type( $post ) != 'lesson' ) || ! isset( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] )
-			|| ! wp_verify_nonce( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ], plugin_basename( $this->file ) ) ) {
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] ) ), plugin_basename( $this->file ) ) ) {
 			return $post_id;
 		}
 
@@ -495,8 +495,8 @@ class Sensei_Core_Modules {
 		// Get module and course IDs
 		$lesson_module_id_key = 'lesson_module';
 		$lesson_course_id_key = 'lesson_course';
-		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? $_POST[ $lesson_module_id_key ] : null;
-		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? $_POST[ $lesson_course_id_key ] : null;
+		$module_id            = isset( $_POST[ $lesson_module_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_module_id_key ] ) ) : null;
+		$course_id            = isset( $_POST[ $lesson_course_id_key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $lesson_course_id_key ] ) ) : null;
 
 		// Set the module on the lesson
 		$lesson_modules = new Sensei_Core_Lesson_Modules( $post_id );
@@ -658,7 +658,7 @@ class Sensei_Core_Modules {
 		if ( isset( $_POST['module_courses'] ) && ! empty( $_POST['module_courses'] ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$course_ids = is_array( $_POST['module_courses'] ) ? $_POST['module_courses'] : explode( ',', $_POST['module_courses'] );
+			$course_ids = is_array( $_POST['module_courses'] ) ? array_map( 'absint', wp_unslash( $_POST['module_courses'] ) ) : explode( ',', sanitize_text_field( wp_unslash( $_POST['module_courses'] ) ) );
 
 			foreach ( $course_ids as $course_id ) {
 
@@ -686,7 +686,7 @@ class Sensei_Core_Modules {
 		$module           = get_term( $module_id );
 		$event_properties = [
 			// phpcs:ignore WordPress.Security.NonceVerification
-			'page'      => isset( $_REQUEST['from_page'] ) ? $_REQUEST['from_page'] : '',
+			'page'      => isset( $_REQUEST['from_page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['from_page'] ) ) : '',
 			'parent_id' => -1,
 		];
 
@@ -711,7 +711,8 @@ class Sensei_Core_Modules {
 		header( 'Content-Type: application/json; charset=utf-8' );
 
 		// Get user input
-		$term = urldecode( stripslashes( $_GET['term'] ) );
+		$term = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
+		$term = urldecode( $term );
 
 		// Return nothing if term is empty
 		if ( empty( $term ) ) {
@@ -719,7 +720,7 @@ class Sensei_Core_Modules {
 		}
 
 		// Set a default if none is given
-		$default = isset( $_GET['default'] ) ? $_GET['default'] : __( 'No course', 'sensei-lms' );
+		$default = isset( $_GET['default'] ) ? sanitize_text_field( wp_unslash( $_GET['default'] ) ) : __( 'No course', 'sensei-lms' );
 
 		// Set up array of results
 		$found_courses = array( '' => $default );
@@ -2513,12 +2514,12 @@ class Sensei_Core_Modules {
 	 */
 	public static function add_new_module_term() {
 
-		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( $_POST['security'], '_ajax_nonce-add-module' ) ) {
+		if ( ! isset( $_POST['security'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['security'] ) ), '_ajax_nonce-add-module' ) ) {
 			wp_send_json_error( array( 'error' => 'wrong security nonce' ) );
 		}
 
 		// get the term an create the new term storing infomration
-		$term_name = sanitize_text_field( $_POST['newTerm'] );
+		$term_name = isset( $_POST['newTerm'] ) ? sanitize_text_field( wp_unslash( $_POST['newTerm'] ) ) : '';
 
 		if ( current_user_can( 'manage_options' ) ) {
 
@@ -2530,7 +2531,7 @@ class Sensei_Core_Modules {
 
 		}
 
-		$course_id = sanitize_text_field( $_POST['course_id'] );
+		$course_id = isset( $_POST['course_id'] ) ? sanitize_text_field( wp_unslash( $_POST['course_id'] ) ) : '';
 
 		// save the term
 		$slug = wp_insert_term( $term_name, 'module', array( 'slug' => $term_slug ) );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -712,6 +712,7 @@ class Sensei_Core_Modules {
 
 		// Get user input
 		// Decode before sanitizing: sanitize_text_field() strips percent-encoded octets, so it must run after urldecode().
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized with sanitize_text_field() after urldecode(); the sniff cannot trace sanitization through urldecode().
 		$term = isset( $_GET['term'] ) ? sanitize_text_field( urldecode( wp_unslash( is_array( $_GET['term'] ) ? '' : $_GET['term'] ) ) ) : '';
 
 		// Return nothing if term is empty

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -344,6 +344,7 @@ class Sensei_PostTypes {
 			wp_safe_redirect( esc_url_raw( $course_url ) );
 			exit;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -1069,7 +1070,7 @@ class Sensei_PostTypes {
 			// translators: Placeholder is the singular label for the post type.
 			4  => sprintf( __( '%1$s updated.', 'sensei-lms' ), $labels['singular'] ),
 			// translators: Placeholders are the singular label for the post type and the post's revision, respectively.
-			5  => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s.', 'sensei-lms' ), $labels['singular'], wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			5  => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s.', 'sensei-lms' ), $labels['singular'], wp_post_revision_title( (int) $_GET['revision'], false ) ) : false, // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only post-updated message.
 			// translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
 			6  => sprintf( __( '%1$s published. %2$sView %1$s%3$s.', 'sensei-lms' ), $labels['singular'], '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
 			// translators: Placeholder is the singular label for the post type.

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -462,7 +462,7 @@ class Sensei_Question {
 			$output = '';
 
 			// Question type
-			$selected       = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
+			$selected       = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_type'] ) ? '' : $_GET['question_type'] ) ) : '';
 			$type_options   = '<option value="">' . esc_html__( 'All types', 'sensei-lms' ) . '</option>';
 			$question_types = $this->question_types();
 
@@ -483,7 +483,7 @@ class Sensei_Question {
 			);
 
 			if ( ! empty( $cats ) && ! is_wp_error( $cats ) ) {
-				$selected    = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
+				$selected    = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_cat'] ) ? '' : $_GET['question_cat'] ) ) : '';
 				$cat_options = '<option value="">' . esc_html__( 'All categories', 'sensei-lms' ) . '</option>';
 				foreach ( $cats as $cat ) {
 					$cat_options .= '<option value="' . esc_attr( $cat->slug ) . '" ' . selected( $selected, $cat->slug, false ) . '>' . esc_html( $cat->name ) . '</option>';
@@ -521,7 +521,7 @@ class Sensei_Question {
 		if ( is_admin() && 'question' == $typenow ) {
 
 			// Question type
-			$question_type = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
+			$question_type = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_type'] ) ? '' : $_GET['question_type'] ) ) : '';
 			if ( $question_type ) {
 				$type_query             = array(
 					'taxonomy' => 'question-type',
@@ -532,7 +532,7 @@ class Sensei_Question {
 			}
 
 			// Question category
-			$question_cat = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
+			$question_cat = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_cat'] ) ? '' : $_GET['question_cat'] ) ) : '';
 			if ( $question_cat ) {
 				$cat_query              = array(
 					'taxonomy' => 'question-category',

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -462,7 +462,7 @@ class Sensei_Question {
 			$output = '';
 
 			// Question type
-			$selected       = isset( $_GET['question_type'] ) ? $_GET['question_type'] : '';
+			$selected       = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
 			$type_options   = '<option value="">' . esc_html__( 'All types', 'sensei-lms' ) . '</option>';
 			$question_types = $this->question_types();
 
@@ -483,7 +483,7 @@ class Sensei_Question {
 			);
 
 			if ( ! empty( $cats ) && ! is_wp_error( $cats ) ) {
-				$selected    = isset( $_GET['question_cat'] ) ? $_GET['question_cat'] : '';
+				$selected    = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
 				$cat_options = '<option value="">' . esc_html__( 'All categories', 'sensei-lms' ) . '</option>';
 				foreach ( $cats as $cat ) {
 					$cat_options .= '<option value="' . esc_attr( $cat->slug ) . '" ' . selected( $selected, $cat->slug, false ) . '>' . esc_html( $cat->name ) . '</option>';
@@ -521,7 +521,7 @@ class Sensei_Question {
 		if ( is_admin() && 'question' == $typenow ) {
 
 			// Question type
-			$question_type = isset( $_GET['question_type'] ) ? $_GET['question_type'] : '';
+			$question_type = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
 			if ( $question_type ) {
 				$type_query             = array(
 					'taxonomy' => 'question-type',
@@ -532,7 +532,7 @@ class Sensei_Question {
 			}
 
 			// Question category
-			$question_cat = isset( $_GET['question_cat'] ) ? $_GET['question_cat'] : '';
+			$question_cat = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
 			if ( $question_cat ) {
 				$cat_query              = array(
 					'taxonomy' => 'question-category',

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -462,7 +462,7 @@ class Sensei_Question {
 			$output = '';
 
 			// Question type
-			$selected       = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
+			$selected       = isset( $_GET['question_type'] ) ? sensei_request_text( $_GET['question_type'] ) : '';
 			$type_options   = '<option value="">' . esc_html__( 'All types', 'sensei-lms' ) . '</option>';
 			$question_types = $this->question_types();
 
@@ -483,7 +483,7 @@ class Sensei_Question {
 			);
 
 			if ( ! empty( $cats ) && ! is_wp_error( $cats ) ) {
-				$selected    = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
+				$selected    = isset( $_GET['question_cat'] ) ? sensei_request_text( $_GET['question_cat'] ) : '';
 				$cat_options = '<option value="">' . esc_html__( 'All categories', 'sensei-lms' ) . '</option>';
 				foreach ( $cats as $cat ) {
 					$cat_options .= '<option value="' . esc_attr( $cat->slug ) . '" ' . selected( $selected, $cat->slug, false ) . '>' . esc_html( $cat->name ) . '</option>';
@@ -521,7 +521,7 @@ class Sensei_Question {
 		if ( is_admin() && 'question' == $typenow ) {
 
 			// Question type
-			$question_type = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
+			$question_type = isset( $_GET['question_type'] ) ? sensei_request_text( $_GET['question_type'] ) : '';
 			if ( $question_type ) {
 				$type_query             = array(
 					'taxonomy' => 'question-type',
@@ -532,7 +532,7 @@ class Sensei_Question {
 			}
 
 			// Question category
-			$question_cat = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
+			$question_cat = isset( $_GET['question_cat'] ) ? sensei_request_text( $_GET['question_cat'] ) : '';
 			if ( $question_cat ) {
 				$cat_query              = array(
 					'taxonomy' => 'question-category',

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -462,7 +462,7 @@ class Sensei_Question {
 			$output = '';
 
 			// Question type
-			$selected       = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_type'] ) ? '' : $_GET['question_type'] ) ) : '';
+			$selected       = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
 			$type_options   = '<option value="">' . esc_html__( 'All types', 'sensei-lms' ) . '</option>';
 			$question_types = $this->question_types();
 
@@ -483,7 +483,7 @@ class Sensei_Question {
 			);
 
 			if ( ! empty( $cats ) && ! is_wp_error( $cats ) ) {
-				$selected    = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_cat'] ) ? '' : $_GET['question_cat'] ) ) : '';
+				$selected    = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
 				$cat_options = '<option value="">' . esc_html__( 'All categories', 'sensei-lms' ) . '</option>';
 				foreach ( $cats as $cat ) {
 					$cat_options .= '<option value="' . esc_attr( $cat->slug ) . '" ' . selected( $selected, $cat->slug, false ) . '>' . esc_html( $cat->name ) . '</option>';
@@ -521,7 +521,7 @@ class Sensei_Question {
 		if ( is_admin() && 'question' == $typenow ) {
 
 			// Question type
-			$question_type = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_type'] ) ? '' : $_GET['question_type'] ) ) : '';
+			$question_type = isset( $_GET['question_type'] ) ? sanitize_text_field( wp_unslash( $_GET['question_type'] ) ) : '';
 			if ( $question_type ) {
 				$type_query             = array(
 					'taxonomy' => 'question-type',
@@ -532,7 +532,7 @@ class Sensei_Question {
 			}
 
 			// Question category
-			$question_cat = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['question_cat'] ) ? '' : $_GET['question_cat'] ) ) : '';
+			$question_cat = isset( $_GET['question_cat'] ) ? sanitize_text_field( wp_unslash( $_GET['question_cat'] ) ) : '';
 			if ( $question_cat ) {
 				$cat_query              = array(
 					'taxonomy' => 'question-category',

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -639,7 +639,7 @@ class Sensei_Quiz {
 
 		// Redirect to the target page.
 		wp_safe_redirect(
-			add_query_arg( [ 'bypass_server_cache' => uniqid() ], sanitize_text_field( wp_unslash( $_POST['quiz_target_page'] ) ) )
+			add_query_arg( [ 'bypass_server_cache' => uniqid() ], sensei_request_text( $_POST['quiz_target_page'] ) )
 		);
 		exit;
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1560,7 +1560,7 @@ class Sensei_Quiz {
 
 		$lesson = get_post( $lesson_id );
 
-		if ( is_singular( 'quiz' ) && ! $has_questions && $_SERVER['REQUEST_URI'] !== "/lesson/$lesson->post_name" ) {
+		if ( is_singular( 'quiz' ) && ! $has_questions && isset( $_SERVER['REQUEST_URI'] ) && sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) !== "/lesson/$lesson->post_name" ) {
 
 			wp_redirect( get_permalink( $lesson->ID ), 301 );
 			exit;

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1073,7 +1073,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 */
 	public function log_settings_update( $old_value, $value ) {
 		// Only process user-initiated settings updates.
-		if ( ! ( 'POST' === $_SERVER['REQUEST_METHOD'] && ! defined( 'REST_REQUEST' ) && 'options' === get_current_screen()->id ) ) {
+		if ( ! ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] && ! defined( 'REST_REQUEST' ) && 'options' === get_current_screen()->id ) ) {
 			return;
 		}
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -1046,7 +1046,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 */
 	public function flush_rewrite_rules_on_update() {
 		$nonce_action = $this->token . '-options';
-		$nonce_value  = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ?? '' ) );
+		$nonce_value  = sensei_request_text( $_POST['_wpnonce'] ?? '' );
 		if ( ! wp_verify_nonce( $nonce_value, $nonce_action ) ) {
 			return;
 		}
@@ -1583,7 +1583,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * Marks the given section as visited.
 	 */
 	public function mark_section_as_visited() {
-		if ( isset( $_POST['nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'sensei-mark-settings-section-visited' ) ) {
+		if ( isset( $_POST['nonce'] ) && wp_verify_nonce( sensei_request_text( $_POST['nonce'] ), 'sensei-mark-settings-section-visited' ) ) {
 			if ( isset( $_POST['section_id'] ) ) {
 				$section_id = sanitize_key( $_POST['section_id'] );
 				$visited    = get_option( self::VISITED_SECTIONS_OPTION_KEY, [] );

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -384,7 +384,7 @@ class Sensei_Teacher {
 
 		// If a custom slug is of a module that belongs to another teacher from another course, don't process farther.
 		if ( isset( $_POST['course_module_custom_slugs'] ) ) {
-			$module_custom_slugs = json_decode( sanitize_text_field( wp_unslash( $_POST['course_module_custom_slugs'] ) ) );
+			$module_custom_slugs = json_decode( sensei_request_text( $_POST['course_module_custom_slugs'] ) );
 			foreach ( $module_custom_slugs as $module_custom_slug ) {
 				$course_name = self::is_module_in_use_by_different_course_and_teacher( $module_custom_slug, $course_id, absint( $_POST['sensei-course-teacher-author'] ) );
 				if ( $course_name ) {

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1528,7 +1528,7 @@ AND comments.comment_type = 'sensei_course_status'";
 		$users_who_can_edit_courses = get_users( $user_query_args );
 
 		// Create the select element with the given users who can edit course
-		$selected       = isset( $_GET['course_teacher'] ) ? $_GET['course_teacher'] : '';
+		$selected       = isset( $_GET['course_teacher'] ) ? absint( $_GET['course_teacher'] ) : '';
 		$course_options = '';
 		foreach ( $users_who_can_edit_courses as $user ) {
 			$course_options .= '<option value="' . esc_attr( $user->ID ) . '" ' . selected( $selected, $user->ID, false ) . '>' . esc_html( $user->display_name ) . '</option>';
@@ -1568,7 +1568,7 @@ AND comments.comment_type = 'sensei_course_status'";
 		if ( ! is_admin() && 'course' != $typenow || ! current_user_can( 'manage_sensei' ) ) {
 			return $query;
 		}
-		$course_teacher = isset( $_GET['course_teacher'] ) ? $_GET['course_teacher'] : '';
+		$course_teacher = isset( $_GET['course_teacher'] ) ? absint( $_GET['course_teacher'] ) : '';
 
 		if ( empty( $course_teacher ) ) {
 			return $query;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -912,11 +912,11 @@ class Sensei_Utils {
 	 * @return array $return_array ordered data
 	 */
 	public static function array_sort_reorder( $return_array ) {
-		if ( isset( $_GET['orderby'] ) && '' != esc_html( $_GET['orderby'] ) ) {
+		if ( isset( $_GET['orderby'] ) && '' != sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) ) {
 			$sort_key = '';
 			if ( '' != $sort_key ) {
 					self::sort_array_by_key( $return_array, $sort_key );
-				if ( isset( $_GET['order'] ) && 'desc' == esc_html( $_GET['order'] ) ) {
+				if ( isset( $_GET['order'] ) && 'desc' == sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) {
 					$return_array = array_reverse( $return_array, true );
 				}
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -912,11 +912,11 @@ class Sensei_Utils {
 	 * @return array $return_array ordered data
 	 */
 	public static function array_sort_reorder( $return_array ) {
-		if ( isset( $_GET['orderby'] ) && '' != sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) ) {
+		if ( isset( $_GET['orderby'] ) && '' != sensei_request_text( $_GET['orderby'] ) ) {
 			$sort_key = '';
 			if ( '' != $sort_key ) {
 					self::sort_array_by_key( $return_array, $sort_key );
-				if ( isset( $_GET['order'] ) && 'desc' == sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) {
+				if ( isset( $_GET['order'] ) && 'desc' == sensei_request_text( $_GET['order'] ) ) {
 					$return_array = array_reverse( $return_array, true );
 				}
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -912,11 +912,11 @@ class Sensei_Utils {
 	 * @return array $return_array ordered data
 	 */
 	public static function array_sort_reorder( $return_array ) {
-		if ( isset( $_GET['orderby'] ) && '' != sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ) ) {
+		if ( isset( $_GET['orderby'] ) && '' != sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) ) {
 			$sort_key = '';
 			if ( '' != $sort_key ) {
 					self::sort_array_by_key( $return_array, $sort_key );
-				if ( isset( $_GET['order'] ) && 'desc' == sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) {
+				if ( isset( $_GET['order'] ) && 'desc' == sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) {
 					$return_array = array_reverse( $return_array, true );
 				}
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -912,11 +912,11 @@ class Sensei_Utils {
 	 * @return array $return_array ordered data
 	 */
 	public static function array_sort_reorder( $return_array ) {
-		if ( isset( $_GET['orderby'] ) && '' != sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) ) {
+		if ( isset( $_GET['orderby'] ) && '' != sanitize_text_field( wp_unslash( is_array( $_GET['orderby'] ) ? '' : $_GET['orderby'] ) ) ) {
 			$sort_key = '';
 			if ( '' != $sort_key ) {
 					self::sort_array_by_key( $return_array, $sort_key );
-				if ( isset( $_GET['order'] ) && 'desc' == sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) {
+				if ( isset( $_GET['order'] ) && 'desc' == sanitize_text_field( wp_unslash( is_array( $_GET['order'] ) ? '' : $_GET['order'] ) ) ) {
 					$return_array = array_reverse( $return_array, true );
 				}
 			}

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -115,11 +115,11 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'sensei-home' ) ) {
+		if ( ! wp_verify_nonce( sensei_request_text( $_GET['nonce'] ), 'sensei-home' ) ) {
 			wp_die( esc_html__( 'Invalid request', 'sensei-lms' ) );
 		}
 
-		$job_id      = sanitize_text_field( wp_unslash( $_GET['job_id'] ) );
+		$job_id      = sensei_request_text( $_GET['job_id'] );
 		$job         = $this->get_job( $job_id );
 		$imported_id = $job->get_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, self::SAMPLE_COURSE_ID );
 

--- a/includes/internal/emails/class-email-preview.php
+++ b/includes/internal/emails/class-email-preview.php
@@ -82,6 +82,7 @@ class Email_Preview {
 		} else {
 			$this->render_page();
 		}
+		// phpcs:enable WordPress.Security.NonceVerification
 	}
 
 	/**

--- a/includes/internal/emails/views/html-settings.php
+++ b/includes/internal/emails/views/html-settings.php
@@ -49,7 +49,7 @@ $options           = isset( $options ) ? $options : [];
 			<th scope="row">
 				<?php
 				esc_html_e( 'MailPoet', 'sensei-lms' );
-				echo Sensei()->assets->get_icon( 'mailpoet-logo', 'sensei-mailpoet-icon' ); // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the method.
+				echo Sensei()->assets->get_icon( 'mailpoet-logo', 'sensei-mailpoet-icon' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_icon() escapes its own dynamic parts.
 				?>
 			</th>
 			<td>
@@ -76,7 +76,7 @@ $options           = isset( $options ) ? $options : [];
 			<th scope="row">
 				<?php
 				esc_html_e( 'AutomateWoo', 'sensei-lms' );
-				echo Sensei()->assets->get_icon( 'woo-logo', 'sensei-woo-icon' ); // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the method.
+				echo Sensei()->assets->get_icon( 'woo-logo', 'sensei-woo-icon' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_icon() escapes its own dynamic parts.
 				?>
 			</th>
 			<td>

--- a/includes/internal/tools/class-progress-tables-eraser.php
+++ b/includes/internal/tools/class-progress-tables-eraser.php
@@ -100,7 +100,7 @@ class Progress_Tables_Eraser implements Sensei_Tool_Interface, Sensei_Tool_Inter
 			return;
 		}
 
-		$wpnonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ) : '';
+		$wpnonce = isset( $_POST['_wpnonce'] ) ? sensei_request_text( $_POST['_wpnonce'] ) : '';
 		if ( empty( $wpnonce ) || ! wp_verify_nonce( wp_unslash( $wpnonce ), self::NONCE_ACTION ) ) {
 			Sensei_Tools::instance()->trigger_invalid_request( $this );
 			return;

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -20,7 +20,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_start_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['start_date'] ) ? '' : $_GET['start_date'] ) ) : '';
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -54,7 +54,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_end_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['end_date'] ) ? '' : $_GET['end_date'] ) ) : '';
+		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}
@@ -88,7 +88,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_timezone(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$user_timezone = isset( $_GET['timezone'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['timezone'] ) ? '' : $_GET['timezone'] ) ) : '';
+		$user_timezone = isset( $_GET['timezone'] ) ? sanitize_text_field( wp_unslash( $_GET['timezone'] ) ) : '';
 
 		if ( $user_timezone ) {
 			try {

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -91,7 +91,15 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 		$user_timezone = isset( $_GET['timezone'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['timezone'] ) ? '' : $_GET['timezone'] ) ) : '';
 
 		if ( $user_timezone ) {
-			return $user_timezone;
+			try {
+				// Validate the requested timezone; accepts IANA identifiers and UTC offsets, rejects anything else.
+				new DateTimeZone( $user_timezone );
+
+				return $user_timezone;
+			} catch ( Exception $e ) {
+				// Invalid timezone requested; fall back to the site's timezone.
+				return wp_timezone_string();
+			}
 		}
 
 		return wp_timezone_string();

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -20,7 +20,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_start_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : '';
+		$start_date = isset( $_GET['start_date'] ) ? sensei_request_text( $_GET['start_date'] ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -54,7 +54,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_end_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
+		$end_date = isset( $_GET['end_date'] ) ? sensei_request_text( $_GET['end_date'] ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}
@@ -88,7 +88,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_timezone(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$user_timezone = isset( $_GET['timezone'] ) ? sanitize_text_field( wp_unslash( $_GET['timezone'] ) ) : '';
+		$user_timezone = isset( $_GET['timezone'] ) ? sensei_request_text( $_GET['timezone'] ) : '';
 
 		if ( $user_timezone ) {
 			try {

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -20,7 +20,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_start_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : '';
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['start_date'] ) ? '' : $_GET['start_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -54,7 +54,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_end_date_filter_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
+		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['end_date'] ) ? '' : $_GET['end_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}
@@ -88,7 +88,7 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 */
 	protected function get_timezone(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
-		$user_timezone = isset( $_GET['timezone'] ) ? sanitize_text_field( wp_unslash( $_GET['timezone'] ) ) : '';
+		$user_timezone = isset( $_GET['timezone'] ) ? sanitize_text_field( wp_unslash( is_array( $_GET['timezone'] ) ? '' : $_GET['timezone'] ) ) : '';
 
 		if ( $user_timezone ) {
 			return $user_timezone;

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -97,8 +97,8 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 
 				return $user_timezone;
 			} catch ( Exception $e ) {
-				// Invalid timezone requested; fall back to the site's timezone.
-				return wp_timezone_string();
+				// Invalid timezone requested; fall through to the site timezone below.
+				unset( $e );
 			}
 		}
 

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -19,8 +19,8 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 * @return string The start date.
 	 */
 	protected function get_start_date_filter_value(): string {
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$start_date = $_GET['start_date'] ?? '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
@@ -53,8 +53,8 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 * @return string The end date or empty string if none.
 	 */
 	protected function get_end_date_filter_value(): string {
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$end_date = $_GET['end_date'] ?? '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
+		$end_date = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : '';
 
 		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}
@@ -87,8 +87,8 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	 * @return string The timezone string.
 	 */
 	protected function get_timezone(): string {
-		// phpcs:ignore WordPress.Security -- The timezone is sanitized by DateTime.
-		$user_timezone = $_GET['timezone'] ?? '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only report filter.
+		$user_timezone = isset( $_GET['timezone'] ) ? sanitize_text_field( wp_unslash( $_GET['timezone'] ) ) : '';
 
 		if ( $user_timezone ) {
 			return $user_timezone;

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -110,7 +110,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 
 		// Handle search.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action, nonce is not required.
-		$search = sanitize_text_field( wp_unslash( $_GET['s'] ?? '' ) );
+		$search = sensei_request_text( $_GET['s'] ?? '' );
 		if ( ! empty( $search ) ) {
 			$args['search'] = esc_html( $search );
 		}
@@ -184,7 +184,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 
 		// Handle search.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action, nonce is not required.
-		$search = sanitize_text_field( wp_unslash( $_GET['s'] ?? '' ) );
+		$search = sensei_request_text( $_GET['s'] ?? '' );
 		if ( ! empty( $search ) ) {
 			$args['search'] = esc_html( $search );
 		}
@@ -489,6 +489,6 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 	 */
 	private function get_search_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
-		return isset( $_GET['s'] ) ? esc_attr( sanitize_text_field( wp_unslash( $_GET['s'] ) ) ) : '';
+		return isset( $_GET['s'] ) ? esc_attr( sensei_request_text( $_GET['s'] ) ) : '';
 	}
 }

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -555,7 +555,7 @@ function sensei_has_translation_or_is_english( $text ) {
  * Intended for values read from the request superglobals ($_GET/$_POST/$_REQUEST),
  * which WordPress slashes and which may arrive as arrays. Arrays are treated as
  * empty so the return value is always a string: callers expecting a single value
- * get one, and array input (typically malformed or malicious) is discarded.
+ * get one, and array input is discarded.
  *
  * Do not use for data that is not slashed by WordPress (e.g. database or option
  * values), since it runs wp_unslash() on the input.

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -548,3 +548,23 @@ function sensei_log_jetpack_event( $event_name, $properties = [] ) {
 function sensei_has_translation_or_is_english( $text ) {
 	return get_locale() === 'en_US' || ( function_exists( 'has_translation' ) && has_translation( $text, 'sensei-lms' ) );
 }
+
+/**
+ * Unslash and sanitize a raw request value into a plain-text string.
+ *
+ * Intended for values read from the request superglobals ($_GET/$_POST/$_REQUEST),
+ * which WordPress slashes and which may arrive as arrays. Arrays are treated as
+ * empty so the return value is always a string: callers expecting a single value
+ * get one, and array input (typically malformed or malicious) is discarded.
+ *
+ * Do not use for data that is not slashed by WordPress (e.g. database or option
+ * values), since it runs wp_unslash() on the input.
+ *
+ * @since $$next-version$$
+ *
+ * @param mixed $raw Raw request value, e.g. `$_GET['orderby'] ?? ''`.
+ * @return string The unslashed, sanitized value, or '' when an array is given.
+ */
+function sensei_request_text( $raw ): string {
+	return is_array( $raw ) ? '' : sanitize_text_field( wp_unslash( $raw ) );
+}

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -115,7 +115,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		if ( $this->is_shortcode_initial_status_all && $wp_query->is_main_query() ) {
 			// Check if we should filter the courses.
 			if ( isset( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) ) {
-				$course_filter_by_status = sanitize_text_field( wp_unslash( is_array( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) ? '' : $_GET[ self::MY_COURSES_STATUS_FILTER ] ) );
+				$course_filter_by_status = sanitize_text_field( wp_unslash( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) );
 
 				if ( ! empty( $course_filter_by_status ) && in_array( $course_filter_by_status, array_keys( $this->get_filter_options() ), true ) ) {
 					$attributes['status'] = $course_filter_by_status;

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -115,7 +115,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		if ( $this->is_shortcode_initial_status_all && $wp_query->is_main_query() ) {
 			// Check if we should filter the courses.
 			if ( isset( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) ) {
-				$course_filter_by_status = sanitize_text_field( wp_unslash( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) );
+				$course_filter_by_status = sensei_request_text( $_GET[ self::MY_COURSES_STATUS_FILTER ] );
 
 				if ( ! empty( $course_filter_by_status ) && in_array( $course_filter_by_status, array_keys( $this->get_filter_options() ), true ) ) {
 					$attributes['status'] = $course_filter_by_status;

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -115,7 +115,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		if ( $this->is_shortcode_initial_status_all && $wp_query->is_main_query() ) {
 			// Check if we should filter the courses.
 			if ( isset( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) ) {
-				$course_filter_by_status = sanitize_text_field( $_GET[ self::MY_COURSES_STATUS_FILTER ] );
+				$course_filter_by_status = sanitize_text_field( wp_unslash( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) );
 
 				if ( ! empty( $course_filter_by_status ) && in_array( $course_filter_by_status, array_keys( $this->get_filter_options() ), true ) ) {
 					$attributes['status'] = $course_filter_by_status;

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -115,7 +115,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		if ( $this->is_shortcode_initial_status_all && $wp_query->is_main_query() ) {
 			// Check if we should filter the courses.
 			if ( isset( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) ) {
-				$course_filter_by_status = sanitize_text_field( wp_unslash( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) );
+				$course_filter_by_status = sanitize_text_field( wp_unslash( is_array( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) ? '' : $_GET[ self::MY_COURSES_STATUS_FILTER ] ) );
 
 				if ( ! empty( $course_filter_by_status ) && in_array( $course_filter_by_status, array_keys( $this->get_filter_options() ), true ) ) {
 					$attributes['status'] = $course_filter_by_status;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,7 +25,26 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 
-	<rule ref="WordPress.Security.ValidatedSanitizedInput" />
+	<!--
+		sensei_request_text() unslashes and sanitizes a request value in a single call.
+		Register it with both sniffs that consult the sanitizing-function list:
+		ValidatedSanitizedInput (so the value counts as unslashed + sanitized) and
+		NonceVerification (so a sanitized read is treated like any other sanitized read).
+	-->
+	<rule ref="WordPress.Security.ValidatedSanitizedInput">
+		<properties>
+			<property name="customUnslashingSanitizingFunctions" type="array">
+				<element value="sensei_request_text"/>
+			</property>
+		</properties>
+	</rule>
+	<rule ref="WordPress.Security.NonceVerification">
+		<properties>
+			<property name="customUnslashingSanitizingFunctions" type="array">
+				<element value="sensei_request_text"/>
+			</property>
+		</properties>
+	</rule>
 	<rule ref="WordPress.DB.DirectDatabaseQuery" />
 
 	<!-- Temporary Rule Exclusions -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,12 +25,6 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 
-	<!--
-		sensei_request_text() unslashes and sanitizes a request value in a single call.
-		Register it with both sniffs that consult the sanitizing-function list:
-		ValidatedSanitizedInput (so the value counts as unslashed + sanitized) and
-		NonceVerification (so a sanitized read is treated like any other sanitized read).
-	-->
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>
 			<property name="customUnslashingSanitizingFunctions" type="array">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,7 +16,7 @@
 	<exclude-pattern type="relative">^tmp/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_wp_version" value="6.2" />
+	<config name="minimum_wp_version" value="6.9" />
 	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules -->

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -332,7 +332,7 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 	private function simulateSettingsRequest() {
 		global $current_screen;
 
-		$this->original_request_method = $_SERVER['REQUEST_METHOD'];
+		$this->original_request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
 		$this->original_screen         = $current_screen;
 
 		// Simulate the request.


### PR DESCRIPTION
## Proposed Changes

The WordPress coding-standard sniff for request-input handling (`WordPress.Security.ValidatedSanitizedInput`) has been enabled in `phpcs.xml.dist` for years, but was only ever run against **changed lines** — never swept across the whole tree. As a result a backlog of inconsistencies built up across `includes/`.

This PR brings request-input handling in line with the coding standard and gates it tree-wide in CI:

- **Routes request superglobals through `wp_unslash()` + the appropriate function** (`sanitize_text_field`/`absint`/`sanitize_email`/`esc_url_raw`/`wp_kses_post`), via a new `sensei_request_text()` helper for the common unslash-and-sanitize case.
- **Intentionally passes a few values through unchanged** (documented inline), because normalizing them would corrupt data.
- **Adds a tree-wide CI step** so the sniff runs across the whole codebase, not just the diff.
- **Tidies stale and over-broad `phpcs` annotations** surfaced by a full audit.
- Bumps the PHPCS `minimum_wp_version` to 6.9 to match the plugin's declared minimum.

For valid input there's no behavior change. The user-facing effect is a set of **edge-case fixes for content containing special characters**, which the previous inconsistent handling could mangle:

- Special-character passwords are no longer altered by the registration form (the field also no longer pre-fills after a failed submit).
- Classic quiz-editor question/answer text with spaces, quotes, accents, or line breaks is preserved on save.
- Report search terms containing characters like `&` are no longer HTML-encoded before querying.
- An invalid `?timezone=` value on a reports page now falls back to the site timezone instead of throwing a fatal.

## Testing Instructions

**Special-character passwords:**

- [x] Register a new account via the Sensei registration form (My Courses page, logged out, registration enabled) with the password `p'a"s\word`. Log out, then log in **through the Sensei login form** with that exact password → succeeds.
- [x] Log in with the **same account via `wp-login.php`** → also succeeds (confirms the stored hash matches core).
- [x] Submit the registration form so it fails validation (e.g. an email already in use) → the password field comes back **empty** (no longer pre-filled).

**Grading feedback keeps HTML:**

- [x] Manually grade a quiz. In a per-question feedback field enter `See <a href="https://example.com">this</a> and <strong>note</strong>`. Save, reload → tags preserved. View as the student → renders as a real link and bold text.

**Backslash / special characters persist in saved content (classic editor):**

- [x] Create a module named `Bob's Section \ Part`. Save and reopen → stored intact.
- [x] Set a course "Course Video" embed value containing a backslash and save → persists unchanged.

**Classic quiz editor — question/answer text preserved:**

- [x] With the classic editor, add a quiz question whose Description contains a space, apostrophe, quote, punctuation, a non-ASCII character (`café`), and a line break; answers with the same. Save and reopen → every character preserved (nothing dropped or run together).
- [x] Remove and reorder questions, and add an existing question → all save correctly.
- [x] For a multiple-choice question with answers containing whitespace/HTML-like characters (`A & B`, `  spaced  `), drag to reorder the answers and save → the order is preserved on reload.

**Reports:**

- [x] Open an Analysis/Reports page with `&timezone=Not/AReal_Zone` → loads normally (falls back to site timezone) instead of a white screen.
- [x] Analysis/Reports (Students, Courses, Lessons): sort columns, search (try a term with `&`), apply date/course filters → correct results.

**Course archive (legacy post-type archive at `/courses/`):**

- [x] `/courses/?course_filter=featured`, `?course_category_filter=<termID>`, `?course-orderby=title`, and (logged in) `?student_course_filter=active` each return the correct filtered/sorted list.

## Changelog entry

<!-- A changelog entry is already committed at changelog/phpcs-security-fix-violations, so the auto-create box is intentionally left unticked to avoid a duplicate. -->

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch - Backward-compatible bug fixes

#### Type

- [x] Changed - Changes existing functionality

#### Message

Made request-input handling consistent across the admin and frontend.

</details>
