### PR TITLE
Remove orphaned color-studio and calypso-color-schemes deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "4.26.3",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@automattic/calypso-color-schemes": "3.1.1",
-        "@automattic/color-studio": "2.5.0",
         "@wordpress/api-fetch": "7.33.1",
         "@wordpress/base-styles": "6.9.1",
         "@wordpress/block-editor": "15.6.9",
@@ -218,18 +216,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@automattic/calypso-color-schemes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@automattic/calypso-color-schemes/-/calypso-color-schemes-3.1.1.tgz",
-      "integrity": "sha512-jPSMyaYn79MZRvBokkfmL/yeqYQJZEVXpKyzY/aoo/oCW5EjAQsERsQY+aQKsOrMrd5Es+Gf9tbq9OMrzzCb8g==",
-      "license": "GPL-2.0-or-later"
-    },
-    "node_modules/@automattic/color-studio": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.5.0.tgz",
-      "integrity": "sha512-gZWaJbx3p1oennAIoJtMGluTmoM95Efk4rc44TSBxWSZZ8gH3Am2eh1o3i1NhrZmg2Zt3AiVFeZZ4AJccIpBKQ==",
-      "license": "GPL-2.0+"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "node": ">=22.10.0"
   },
   "dependencies": {
-    "@automattic/calypso-color-schemes": "3.1.1",
-    "@automattic/color-studio": "2.5.0",
     "@wordpress/api-fetch": "7.33.1",
     "@wordpress/base-styles": "6.9.1",
     "@wordpress/block-editor": "15.6.9",


### PR DESCRIPTION
## Proposed Changes

`@automattic/color-studio` and `@automattic/calypso-color-schemes` were added in #7487 as companions of `@automattic/tour-kit`. When the onboarding tours were removed (commit 0bb8345b4), tour-kit was dropped but these two dependencies were left behind. Nothing in the source imports either package, so they are dead dependencies.

This removes both from `package.json` and `package-lock.json`. This also closes out Dependabot PR #8196, which was bumping one of these now-unused packages.

## Testing Instructions

No manual surface — dependency-only change. Verify CI is green (build + tests unaffected, since nothing imports the removed packages).