### PR TITLE
Fix PHP 8.4 implicitly-nullable parameter deprecations

### DIFF
--- a/changelog/fix-php84-implicit-nullable-params
+++ b/changelog/fix-php84-implicit-nullable-params
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.4 deprecation warnings from implicitly nullable function parameters.

--- a/includes/admin/home/class-sensei-home-remote-data-api.php
+++ b/includes/admin/home/class-sensei-home-remote-data-api.php
@@ -58,7 +58,7 @@ class Sensei_Home_Remote_Data_API {
 	 *
 	 * @return array|\WP_Error
 	 */
-	public function fetch( int $max_age = null ) {
+	public function fetch( ?int $max_age = null ) {
 		$url       = $this->get_api_url();
 		$cache_key = self::CACHE_KEY_PREFIX . md5( $url );
 		$data      = $this->remote_data[ $cache_key ] ?? get_transient( $cache_key );

--- a/includes/admin/home/class-sensei-home-remote-data-api.php
+++ b/includes/admin/home/class-sensei-home-remote-data-api.php
@@ -54,7 +54,7 @@ class Sensei_Home_Remote_Data_API {
 	/**
 	 * Fetch data from SenseiLMS.com.
 	 *
-	 * @param int $max_age Maximum age of the cached data in seconds. Max is 1 day (in seconds).
+	 * @param int|null $max_age Maximum age of the cached data in seconds. Max is 1 day (in seconds).
 	 *
 	 * @return array|\WP_Error
 	 */

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -88,7 +88,7 @@ class Sensei_Notices {
 	 *
 	 * @return void
 	 */
-	public function add_notice( string $content, string $type = 'alert', string $key = null ) {
+	public function add_notice( string $content, string $type = 'alert', ?string $key = null ) {
 		$notice = [
 			'content' => $content,
 			'type'    => $type,

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -82,9 +82,9 @@ class Sensei_Notices {
 	/**
 	 *  Add a notice to the array of notices for display at a later stage.
 	 *
-	 * @param string $content Content.
-	 * @param string $type    Defaults to alert options( alert, tick , download , info   ).
-	 * @param string $key     Notices with the same key will be overwritten.
+	 * @param string      $content Content.
+	 * @param string      $type    Defaults to alert options( alert, tick , download , info   ).
+	 * @param string|null $key     Notices with the same key will be overwritten.
 	 *
 	 * @return void
 	 */

--- a/includes/clock/class-clock-interface.php
+++ b/includes/clock/class-clock-interface.php
@@ -21,5 +21,5 @@ interface Clock_Interface {
 	 * @param DateTimeZone|null $timezone The timezone to use. Uses the default timezone if not provided.
 	 * @return \DateTimeImmutable
 	 */
-	public function now( DateTimeZone $timezone = null );
+	public function now( ?DateTimeZone $timezone = null );
 }

--- a/includes/clock/class-clock.php
+++ b/includes/clock/class-clock.php
@@ -41,7 +41,7 @@ class Clock implements Clock_Interface {
 	 * @param DateTimeZone|null $timezone The timezone to use.
 	 * @return \DateTimeImmutable
 	 */
-	public function now( DateTimeZone $timezone = null ) {
+	public function now( ?DateTimeZone $timezone = null ) {
 		return new \DateTimeImmutable( 'now', $timezone ?? $this->timezone );
 	}
 }

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -84,7 +84,7 @@ abstract class Sensei_Import_Model {
 	 *
 	 * @return static
 	 */
-	public static function from_source_array( $line_number, $data, Sensei_Data_Port_Schema $schema, Sensei_Import_File_Process_Task $task = null ) {
+	public static function from_source_array( $line_number, $data, Sensei_Data_Port_Schema $schema, ?Sensei_Import_File_Process_Task $task = null ) {
 		$self                 = new static();
 		$self->line_number    = $line_number;
 		$self->schema         = $schema;

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -77,10 +77,10 @@ abstract class Sensei_Import_Model {
 	/**
 	 * Set up item from an array.
 	 *
-	 * @param int                             $line_number Line number.
-	 * @param array                           $data        Data to restore item from.
-	 * @param Sensei_Data_Port_Schema         $schema      The schema for the item.
-	 * @param Sensei_Import_File_Process_Task $task        The import task.
+	 * @param int                                  $line_number Line number.
+	 * @param array                                $data        Data to restore item from.
+	 * @param Sensei_Data_Port_Schema              $schema      The schema for the item.
+	 * @param Sensei_Import_File_Process_Task|null $task        The import task.
 	 *
 	 * @return static
 	 */

--- a/includes/internal/action-scheduler/class-action-scheduler.php
+++ b/includes/internal/action-scheduler/class-action-scheduler.php
@@ -100,7 +100,7 @@ class Action_Scheduler {
 	 * @param array|null $args  Args that have been passed to the action. Null will matches any args.
 	 * @return bool True if a matching action is pending or in-progress, false otherwise.
 	 */
-	public function has_scheduled_action( string $hook, array $args = null ): bool {
+	public function has_scheduled_action( string $hook, ?array $args = null ): bool {
 		return as_has_scheduled_action( $hook, $args, self::GROUP_ID );
 	}
 

--- a/includes/internal/emails/class-email-repository.php
+++ b/includes/internal/emails/class-email-repository.php
@@ -192,7 +192,7 @@ class Email_Repository {
 	 *     total_pages: int,
 	 * }
 	 */
-	public function get_all( string $type = null, $per_page = 10, $offset = 0 ) {
+	public function get_all( ?string $type = null, $per_page = 10, $offset = 0 ) {
 		$query_args = [
 			'post_type'      => Email_Post_Type::POST_TYPE,
 			'posts_per_page' => $per_page,

--- a/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-comments-based-grade-repository.php
@@ -37,7 +37,7 @@ class Comments_Based_Grade_Repository implements Grade_Repository_Interface {
 	 *
 	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, string $feedback = null ): Grade_Interface {
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade_Interface {
 		/**
 		 * Filters the submission ID when quiz grade is created.
 		 *

--- a/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-grade-repository-interface.php
@@ -36,7 +36,7 @@ interface Grade_Repository_Interface {
 	 *
 	 * @return Grade_Interface The grade.
 	 */
-	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, string $feedback = null ): Grade_Interface;
+	public function create( Submission_Interface $submission, Answer_Interface $answer, int $question_id, int $points, ?string $feedback = null ): Grade_Interface;
 
 	/**
 	 * Get all grades for a quiz submission.


### PR DESCRIPTION
## Proposed Changes

On PHP 8.4, Sensei emits deprecation warnings for typed function parameters that have a `null` default but no explicit nullable type — e.g. `string $type = null`. This prefixes the nine affected parameters across the plugin with `?` (e.g. `?string $type = null`) so Sensei runs cleanly on PHP 8.4. The parameters were already nullable in practice, so there is no behavior change; interface and implementation signatures are kept in sync.

## Testing Instructions

- [ ] On a PHP 8.4 site with `WP_DEBUG` enabled, exercise Sensei — load the admin, trigger a course email (e.g. complete a course), and grade a quiz submission.
- [ ] Check the debug log and confirm no "Implicitly marking parameter ... as nullable is deprecated" warnings appear from Sensei classes.
