### PR TITLE
Read Reports Overview header counts from HPPS

### DIFF
--- a/changelog/fix-reports-overview-header-counts-hpps
+++ b/changelog/fix-reports-overview-header-counts-hpps
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Reports Overview Students and Courses header counts now read HPPS progress tables

--- a/changelog/fix-reports-overview-header-counts-hpps
+++ b/changelog/fix-reports-overview-header-counts-hpps
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Reports Overview Students and Courses header counts now read HPPS progress tables
+Reports Overview Students and Courses header counts now read HPPS progress tables when High-Performance Progress Storage is enabled.

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 /**
  * Courses overview list table class.
  *
@@ -67,13 +69,15 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		$all_course_ids   = $this->get_all_item_ids();
 		$total_completion = 0;
 		if ( ! empty( $all_course_ids ) ) {
-			$total_completion = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'type'     => 'sensei_course_status',
-					'status'   => 'complete',
-					'post__in' => $all_course_ids,
-				)
-			);
+			$counts           = ( new Progress_Query_Service_Factory() )
+				->create_aggregation_service()
+				->count_statuses(
+					array(
+						'type'     => 'course',
+						'post__in' => $all_course_ids,
+					)
+				);
+			$total_completion = $counts['complete'] ?? 0;
 		}
 
 		$total_average_progress = $this->reports_overview_service_courses->get_total_average_progress( $all_course_ids );
@@ -250,7 +254,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 
 		// Output course data.
 		$course_title   = apply_filters( 'the_title', $item->post_title, $item->ID ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
-		$total_enrolled = $this->reports_overview_service_courses->get_total_enrollments( [ $item->ID ] );
+		$total_enrolled = $this->reports_overview_service_courses->get_total_enrollments( array( $item->ID ) );
 
 		if ( ! $this->csv_output ) {
 			$url = add_query_arg(
@@ -379,9 +383,9 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	 * @return array
 	 */
 	protected function get_additional_filters(): array {
-		return [
+		return array(
 			'last_activity_date_from' => $this->get_start_date_and_time(),
 			'last_activity_date_to'   => $this->get_end_date_and_time(),
-		];
+		);
 	}
 }

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use Sensei\Internal\Services\Progress_Query_Service_Factory;
+use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 
 /**
  * Courses overview list table class.
@@ -38,6 +38,12 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	 */
 	private $reports_overview_service_courses;
 
+	/**
+	 * The progress aggregation service.
+	 *
+	 * @var Progress_Aggregation_Service_Interface
+	 */
+	private $aggregation_service;
 
 	/**
 	 * Constructor
@@ -46,14 +52,16 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	 * @param Sensei_Course                                   $course Sensei course related services.
 	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider Report data provider.
 	 * @param Sensei_Reports_Overview_Service_Courses         $reports_overview_service_courses reports courses service.
+	 * @param Progress_Aggregation_Service_Interface          $aggregation_service The progress aggregation service.
 	 */
-	public function __construct( Sensei_Grading $grading, Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Courses $reports_overview_service_courses ) {
+	public function __construct( Sensei_Grading $grading, Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Courses $reports_overview_service_courses, Progress_Aggregation_Service_Interface $aggregation_service ) {
 		// Load Parent token into constructor.
 		parent::__construct( 'courses', $data_provider );
 
 		$this->grading                          = $grading;
 		$this->course                           = $course;
 		$this->reports_overview_service_courses = $reports_overview_service_courses;
+		$this->aggregation_service              = $aggregation_service;
 	}
 
 	/**
@@ -69,14 +77,12 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		$all_course_ids   = $this->get_all_item_ids();
 		$total_completion = 0;
 		if ( ! empty( $all_course_ids ) ) {
-			$counts           = ( new Progress_Query_Service_Factory() )
-				->create_aggregation_service()
-				->count_statuses(
-					array(
-						'type'     => 'course',
-						'post__in' => $all_course_ids,
-					)
-				);
+			$counts           = $this->aggregation_service->count_statuses(
+				array(
+					'type'     => 'course',
+					'post__in' => $all_course_ids,
+				)
+			);
 			$total_completion = $counts['complete'] ?? 0;
 		}
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 /**
  * Overview list table factory.
  *
@@ -26,24 +28,29 @@ class Sensei_Reports_Overview_List_Table_Factory {
 	 * @throws InvalidArgumentException If the report type is not supported.
 	 */
 	public function create( string $type ) {
+		$aggregation_service = ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+
 		switch ( $type ) {
 			case 'users':
 			case 'students':
 				return new Sensei_Reports_Overview_List_Table_Students(
 					new Sensei_Reports_Overview_Data_Provider_Students(),
-					new Sensei_Reports_Overview_Service_Students()
+					new Sensei_Reports_Overview_Service_Students(),
+					$aggregation_service
 				);
 			case 'courses':
 				return new Sensei_Reports_Overview_List_Table_Courses(
 					Sensei()->grading,
 					Sensei()->course,
 					new Sensei_Reports_Overview_Data_Provider_Courses(),
-					new Sensei_Reports_Overview_Service_Courses()
+					new Sensei_Reports_Overview_Service_Courses(),
+					$aggregation_service
 				);
 			case 'lessons':
 				return new Sensei_Reports_Overview_List_Table_Lessons(
 					Sensei()->course,
-					new Sensei_Reports_Overview_Data_Provider_Lessons( Sensei()->course )
+					new Sensei_Reports_Overview_Data_Provider_Lessons( Sensei()->course ),
+					$aggregation_service
 				);
 			default:
 				throw new InvalidArgumentException( 'Unknown list table type' );

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
@@ -49,8 +49,7 @@ class Sensei_Reports_Overview_List_Table_Factory {
 			case 'lessons':
 				return new Sensei_Reports_Overview_List_Table_Lessons(
 					Sensei()->course,
-					new Sensei_Reports_Overview_Data_Provider_Lessons( Sensei()->course ),
-					$aggregation_service
+					new Sensei_Reports_Overview_Data_Provider_Lessons( Sensei()->course )
 				);
 			default:
 				throw new InvalidArgumentException( 'Unknown list table type' );

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 /**
  * Students overview list table class.
  *
@@ -53,23 +55,17 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 
 		$user_ids = $this->get_all_item_ids();
 		if ( $user_ids ) {
-			// Get total value for Courses Completed column in users table.
-			$total_completed_courses = Sensei_Utils::sensei_check_for_activity(
-				[
-					'user_id' => $user_ids,
-					'type'    => 'sensei_course_status',
-					'status'  => 'complete',
-				]
-			);
-
-			// Get the number of the courses that users have started.
-			$total_courses_started = Sensei_Utils::sensei_check_for_activity(
-				[
-					'user_id' => $user_ids,
-					'type'    => 'sensei_course_status',
-					'status'  => 'any',
-				]
-			);
+			// Header totals for the Completed Courses and Active Courses (started - completed) columns.
+			$counts                  = ( new Progress_Query_Service_Factory() )
+				->create_aggregation_service()
+				->count_statuses(
+					array(
+						'type'    => 'course',
+						'user_id' => $user_ids,
+					)
+				);
+			$total_completed_courses = $counts['complete'] ?? 0;
+			$total_courses_started   = array_sum( $counts );
 
 			// Get total average students grade.
 			$total_average_grade = $this->reports_overview_service_students->get_graded_lessons_average_grade( $user_ids );
@@ -123,12 +119,12 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	 * @return array The array of columns to use with the table
 	 */
 	public function get_sortable_columns() {
-		$columns = [
+		$columns = array(
 			'title'           => array( 'display_name', false ),
 			'email'           => array( 'user_email', false ),
 			'date_registered' => array( 'user_registered', false ),
 			'last_activity'   => array( 'last_activity_date', false ),
-		];
+		);
 
 		// Backwards compatible filter name, moving forward should have single filter name.
 		/**
@@ -289,10 +285,10 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	 * @return array
 	 */
 	protected function get_additional_filters(): array {
-		return [
+		return array(
 			'last_activity_date_from' => $this->get_start_date_and_time(),
 			'last_activity_date_to'   => $this->get_end_date_and_time(),
-		];
+		);
 	}
 
 	/**

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use Sensei\Internal\Services\Progress_Query_Service_Factory;
+use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 
 /**
  * Students overview list table class.
@@ -26,16 +26,25 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	private $reports_overview_service_students;
 
 	/**
+	 * The progress aggregation service.
+	 *
+	 * @var Progress_Aggregation_Service_Interface
+	 */
+	private $aggregation_service;
+
+	/**
 	 * Constructor
 	 *
 	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider Report data provider.
 	 * @param Sensei_Reports_Overview_Service_Students        $reports_overview_service_students reports students service.
+	 * @param Progress_Aggregation_Service_Interface          $aggregation_service The progress aggregation service.
 	 */
-	public function __construct( Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Students $reports_overview_service_students ) {
+	public function __construct( Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Students $reports_overview_service_students, Progress_Aggregation_Service_Interface $aggregation_service ) {
 		// Load Parent token into constructor.
 		parent::__construct( 'users', $data_provider );
 
 		$this->reports_overview_service_students = $reports_overview_service_students;
+		$this->aggregation_service               = $aggregation_service;
 	}
 
 	/**
@@ -56,14 +65,12 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		$user_ids = $this->get_all_item_ids();
 		if ( $user_ids ) {
 			// Header totals for the Completed Courses and Active Courses (started - completed) columns.
-			$counts                  = ( new Progress_Query_Service_Factory() )
-				->create_aggregation_service()
-				->count_statuses(
-					array(
-						'type'    => 'course',
-						'user_id' => $user_ids,
-					)
-				);
+			$counts                  = $this->aggregation_service->count_statuses(
+				array(
+					'type'    => 'course',
+					'user_id' => $user_ids,
+				)
+			);
 			$total_completed_courses = $counts['complete'] ?? 0;
 			$total_courses_started   = array_sum( $counts );
 

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -1,5 +1,8 @@
 <?php
 
+use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 /**
  * Tests for Sensei_Reports_Overview_List_Table_Courses class.
  *
@@ -62,7 +65,8 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			$this->createMock( Sensei_Grading::class ),
 			$course,
 			$data_provider,
-			$service
+			$service,
+			( new Progress_Query_Service_Factory() )->create_aggregation_service()
 		);
 
 		$list_table->total_items = 1;
@@ -112,7 +116,8 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			$this->createMock( Sensei_Grading::class ),
 			$course,
 			$data_provider,
-			$service
+			$service,
+			( new Progress_Query_Service_Factory() )->create_aggregation_service()
 		);
 
 		/* Act. */
@@ -143,7 +148,8 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			$this->createMock( Sensei_Grading::class ),
 			$this->createMock( Sensei_Course::class ),
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Courses::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Courses::class ),
+			$this->createMock( Progress_Aggregation_Service_Interface::class )
 		);
 
 		/* Act. */
@@ -163,7 +169,8 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			$this->createMock( Sensei_Grading::class ),
 			$this->createMock( Sensei_Course::class ),
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Courses::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Courses::class ),
+			$this->createMock( Progress_Aggregation_Service_Interface::class )
 		);
 
 		/* Act. */

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -38,12 +38,15 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
+		$this->maybe_enable_hpps_tables_repository();
 	}
 
 	/**
 	 * Tear down after each test.
 	 */
 	public function tearDown(): void {
+		$this->maybe_reset_hpps_repository();
+
 		parent::tearDown();
 
 		$this->factory->tearDown();
@@ -91,10 +94,6 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 
 	public function testGetColumns_CompletionsFound_ReturnsMatchingArray() {
 		/* Arrange. */
-		if ( self::is_hpps_tables_mode() ) {
-			$this->enable_hpps_tables_repository();
-		}
-
 		$user_id = $this->factory->user->create();
 
 		$course_id = $this->factory->course->create();
@@ -136,10 +135,6 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		);
 
 		self::assertSame( $expected, $actual );
-
-		if ( self::is_hpps_tables_mode() ) {
-			$this->reset_hpps_repository();
-		}
 	}
 
 	public function testGetSortableColumns_WhenCalled_ReturnsMatchingArray() {

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -6,6 +6,7 @@
  * @covers Sensei_Reports_Overview_List_Table_Courses
  */
 class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
+	use Sensei_HPPS_Helpers;
 
 	private static $initial_hook_suffix;
 
@@ -53,7 +54,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$course        = $this->createMock( Sensei_Course::class );
 		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
-		$data_provider->method( 'get_items' )->willReturn( [ $course_id ] );
+		$data_provider->method( 'get_items' )->willReturn( array( $course_id ) );
 		$service = $this->createMock( Sensei_Reports_Overview_Service_Courses::class );
 		$service->method( 'get_courses_average_grade' )->willReturn( 2 );
 
@@ -70,7 +71,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$actual = $list_table->get_columns();
 
 		/* Assert. */
-		$expected = [
+		$expected = array(
 			'title'              => 'Course (1)',
 			'last_activity'      => 'Last Activity',
 			'enrolled'           => 'Enrolled (0)',
@@ -79,17 +80,24 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			'average_progress'   => 'Average Progress (0%)',
 			'average_percent'    => 'Average Grade (2%)',
 			'days_to_completion' => 'Days to Completion (0)',
-		];
+		);
 
 		self::assertSame( $expected, $actual );
 	}
 
 	public function testGetColumns_CompletionsFound_ReturnsMatchingArray() {
 		/* Arrange. */
+		if ( self::is_hpps_tables_mode() ) {
+			$this->enable_hpps_tables_repository();
+		}
+
 		$user_id = $this->factory->user->create();
 
 		$course_id = $this->factory->course->create();
-		Sensei_Utils::update_course_status( $user_id, $course_id, 'complete' );
+
+		$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
+		$course_progress->complete();
+		Sensei()->course_progress_repository->save( $course_progress );
 
 		$service = $this->createMock( Sensei_Reports_Overview_Service_Courses::class );
 		$service->method( 'get_courses_average_grade' )->willReturn( 2 );
@@ -98,7 +106,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$course = $this->createMock( Sensei_Course::class );
 
 		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
-		$data_provider->method( 'get_items' )->willReturn( [ $course_id ] );
+		$data_provider->method( 'get_items' )->willReturn( array( $course_id ) );
 
 		$list_table = new Sensei_Reports_Overview_List_Table_Courses(
 			$this->createMock( Sensei_Grading::class ),
@@ -111,7 +119,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$actual = $list_table->get_columns();
 
 		/* Assert. */
-		$expected = [
+		$expected = array(
 			'title'              => 'Course (1)',
 			'last_activity'      => 'Last Activity',
 			'enrolled'           => 'Enrolled (4)',
@@ -120,9 +128,13 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			'average_progress'   => 'Average Progress (0%)',
 			'average_percent'    => 'Average Grade (2%)',
 			'days_to_completion' => 'Days to Completion (0)',
-		];
+		);
 
 		self::assertSame( $expected, $actual );
+
+		if ( self::is_hpps_tables_mode() ) {
+			$this->reset_hpps_repository();
+		}
 	}
 
 	public function testGetSortableColumns_WhenCalled_ReturnsMatchingArray() {
@@ -138,10 +150,10 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$actual = $list_table->get_sortable_columns();
 
 		/* Assert. */
-		$expected = [
-			'title'       => [ 'title', false ],
-			'completions' => [ 'count_of_completions', false ],
-		];
+		$expected = array(
+			'title'       => array( 'title', false ),
+			'completions' => array( 'count_of_completions', false ),
+		);
 		self::assertSame( $expected, $actual );
 	}
 

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -25,12 +25,15 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
+		$this->maybe_enable_hpps_tables_repository();
 	}
 
 	/**
 	 * Tear down after each test.
 	 */
 	public function tearDown(): void {
+		$this->maybe_reset_hpps_repository();
+
 		parent::tearDown();
 
 		$this->factory->tearDown();
@@ -38,10 +41,6 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 
 	public function testGetColumns_WithGradingAndCompletions_ReturnsColumnsWithCorrectTotals() {
 		/* Arrange. */
-		if ( self::is_hpps_tables_mode() ) {
-			$this->enable_hpps_tables_repository();
-		}
-
 		$user_id             = $this->factory->user->create();
 		$active_course_id    = $this->factory->course->create();
 		$completed_course_id = $this->factory->course->create();
@@ -78,10 +77,6 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		);
 
 		self::assertSame( $expected, $actual );
-
-		if ( self::is_hpps_tables_mode() ) {
-			$this->reset_hpps_repository();
-		}
 	}
 
 	public function testGetSortableColumns_WhenCalled_ReturnsMatchingArray() {

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -1,5 +1,8 @@
 <?php
 
+use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 /**
  * Tests for Sensei_Reports_Overview_List_Table_Students class.
  *
@@ -56,7 +59,8 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		$data_provider->method( 'get_items' )->willReturn( array( $user_id ) );
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$data_provider,
-			$student_service
+			$student_service,
+			( new Progress_Query_Service_Factory() )->create_aggregation_service()
 		);
 
 		/* Act. */
@@ -84,7 +88,8 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Students::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
+			$this->createMock( Progress_Aggregation_Service_Interface::class )
 		);
 
 		/* Act. */
@@ -107,7 +112,8 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Students::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
+			$this->createMock( Progress_Aggregation_Service_Interface::class )
 		);
 
 		/* Act. */
@@ -121,7 +127,8 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Students::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
+			$this->createMock( Progress_Aggregation_Service_Interface::class )
 		);
 
 		/* Act. */

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -6,6 +6,7 @@
  * @covers Sensei_Reports_Overview_List_Table_Students
  */
 class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
+	use Sensei_HPPS_Helpers;
 
 	/**
 	 * Factory for setting up testing data.
@@ -34,18 +35,25 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 
 	public function testGetColumns_WithGradingAndCompletions_ReturnsColumnsWithCorrectTotals() {
 		/* Arrange. */
+		if ( self::is_hpps_tables_mode() ) {
+			$this->enable_hpps_tables_repository();
+		}
+
 		$user_id             = $this->factory->user->create();
 		$active_course_id    = $this->factory->course->create();
 		$completed_course_id = $this->factory->course->create();
 
-		Sensei_Utils::update_course_status( $user_id, $active_course_id, 'in-progress' );
-		Sensei_Utils::update_course_status( $user_id, $completed_course_id, 'complete' );
+		Sensei()->course_progress_repository->save( Sensei()->course_progress_repository->create( $active_course_id, $user_id ) );
+
+		$completed_course_progress = Sensei()->course_progress_repository->create( $completed_course_id, $user_id );
+		$completed_course_progress->complete();
+		Sensei()->course_progress_repository->save( $completed_course_progress );
 
 		$student_service = $this->createMock( Sensei_Reports_Overview_Service_Students::class );
 		$student_service->method( 'get_graded_lessons_average_grade' )->willReturn( 50 );
 
 		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
-		$data_provider->method( 'get_items' )->willReturn( [ $user_id ] );
+		$data_provider->method( 'get_items' )->willReturn( array( $user_id ) );
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$data_provider,
 			$student_service
@@ -55,7 +63,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		$actual = $list_table->get_columns();
 
 		/* Assert. */
-		$expected = [
+		$expected = array(
 			'title'             => 'Student (1)',
 			'email'             => 'Email',
 			'date_registered'   => 'Date Registered',
@@ -63,9 +71,13 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 			'active_courses'    => 'Active Courses (1)',
 			'completed_courses' => 'Completed Courses (1)',
 			'average_grade'     => 'Average Grade (50%)',
-		];
+		);
 
 		self::assertSame( $expected, $actual );
+
+		if ( self::is_hpps_tables_mode() ) {
+			$this->reset_hpps_repository();
+		}
 	}
 
 	public function testGetSortableColumns_WhenCalled_ReturnsMatchingArray() {
@@ -79,12 +91,12 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		$actual = $list_table->get_sortable_columns();
 
 		/* Assert. */
-		$expected = [
-			'title'           => [ 'display_name', false ],
-			'email'           => [ 'user_email', false ],
-			'date_registered' => [ 'user_registered', false ],
-			'last_activity'   => [ 'last_activity_date', false ],
-		];
+		$expected = array(
+			'title'           => array( 'display_name', false ),
+			'email'           => array( 'user_email', false ),
+			'date_registered' => array( 'user_registered', false ),
+			'last_activity'   => array( 'last_activity_date', false ),
+		);
 		self::assertSame( $expected, $actual );
 	}
 


### PR DESCRIPTION
[SEN-83: HPPS: Reports Overview aggregates → table-aware](https://linear.app/a8c/issue/SEN-83/hpps-reports-overview-aggregates-table-aware)

Part of the effort to make Reports → Overview read progress from High-Performance Progress Storage (HPPS). Stacked on `trunk`.

## Proposed Changes
* Route the header column counts on **both** Reports Overview tabs through the progress aggregation service so they read HPPS tables when enabled.
* Columns affected — **Students** header: Active Courses, Completed Courses. **Courses** header: Completions, Completion Rate. These are the header totals derived from course status counts.


## Testing Instructions
Setup (HPPS enabled):
- Create Course A (2 lessons) and Course B (1 lesson).
- Create 3 students. Enrol all 3 in Course A; enrol 1 of them in Course B.
- As student 1, complete both lessons in Course A and mark Course A complete.

Verify at **Sensei LMS → Reports → Overview**:
- [x] **Students** tab header shows Active Courses and Completed Courses totals consistent with the above (1 completed course, the rest active).
- [x] **Courses** tab header shows the matching totals (e.g. Completions = 1, and a Completion Rate consistent with it).
- [x] Turn HPPS off, reload, and confirm the numbers are identical.
