### PR TITLE
Read students per-row course counts from HPPS

### DIFF
--- a/changelog/prime-students-reports-course-counts
+++ b/changelog/prime-students-reports-course-counts
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Reports Overview students per-row course counts now read HPPS progress tables.
+Reports Overview students per-row course counts now read HPPS progress tables when High-Performance Progress Storage is enabled.

--- a/changelog/prime-students-reports-course-counts
+++ b/changelog/prime-students-reports-course-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Reports Overview students per-row course counts now read HPPS progress tables.

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -98,16 +98,16 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	}
 
 	/**
-	 * Count progress records grouped by user and status.
+	 * Count course progress records grouped by user and status.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same $args as count_statuses() ('type' is required).
+	 * @param array $args Same $args as count_statuses(), but 'type' must be 'course'.
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array {
-		if ( empty( $args['type'] ) || ! in_array( $args['type'], array( 'course', 'lesson' ), true ) ) {
-			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course" or "lesson".', '$$next-version$$' );
+		if ( empty( $args['type'] ) || 'course' !== $args['type'] ) {
+			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course". Per-user lesson counts are not supported.', '$$next-version$$' );
 			return array();
 		}
 

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -70,7 +70,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		}
 
 		$wpdb         = $this->wpdb;
-		$comment_type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
+		$comment_type = $this->get_comment_type( $args );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
 		$query = $wpdb->prepare( "SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
@@ -112,7 +112,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		}
 
 		$wpdb         = $this->wpdb;
-		$comment_type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
+		$comment_type = $this->get_comment_type( $args );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
 		$query  = $wpdb->prepare( "SELECT user_id, comment_approved, COUNT(*) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
@@ -220,6 +220,18 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		Utils::log_query_error( $wpdb, 'Comments-based ungraded quizzes count' );
 
 		return $count;
+	}
+
+	/**
+	 * Map the progress type to its comment_type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments with a validated 'type'.
+	 * @return string The comment_type ('sensei_course_status' or 'sensei_lesson_status').
+	 */
+	private function get_comment_type( array $args ): string {
+		return 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
 	}
 
 	/**

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -72,8 +72,10 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		$wpdb         = $this->wpdb;
 		$comment_type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
-		$query = $wpdb->prepare( "SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
+		$query = $wpdb->prepare( "SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( {$reports_statuses} ) WHERE comment_type = %s", $comment_type );
 
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
@@ -114,8 +116,10 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		$wpdb         = $this->wpdb;
 		$comment_type = 'sensei_course_status';
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
-		$query  = $wpdb->prepare( "SELECT user_id, comment_approved, COUNT(*) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
+		$query  = $wpdb->prepare( "SELECT user_id, comment_approved, COUNT(*) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( {$reports_statuses} ) WHERE comment_type = %s", $comment_type );
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
 		$query .= $this->build_user_exclusion_clause( $args );
@@ -159,6 +163,8 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		$completed      = "'" . implode( "','", Grading_Item::COMPLETED_STATUSES ) . "'";
 		$has_completion = "'" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "'";
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb. Placeholders created dynamically. Date format string uses literal %s for MySQL STR_TO_DATE.
 		$query = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
@@ -167,7 +173,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 			, SUM(IF(lesson_students.comment_approved IN ($has_completion), 1, 0)) days_to_complete_count
 			, SUM(IF(lesson_students.comment_approved IN ($has_completion), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM {$wpdb->comments} lesson_students
-			INNER JOIN {$wpdb->posts} post ON post.ID = lesson_students.comment_post_ID AND post.post_status IN ( 'publish', 'private' )
+			INNER JOIN {$wpdb->posts} post ON post.ID = lesson_students.comment_post_ID AND post.post_status IN ( {$reports_statuses} )
 			LEFT JOIN {$wpdb->commentmeta} lesson_start ON lesson_start.comment_id = lesson_students.comment_id
 			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $placeholders )",
 			array_merge( array( '%Y-%m-%d %H:%i:%s' ), $lesson_ids )
@@ -200,11 +206,12 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
 	public function count_ungraded_quizzes( array $args = array() ): int {
-		$wpdb = $this->wpdb;
+		$wpdb             = $this->wpdb;
+		$reports_statuses = Utils::get_reports_post_status_sql();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb. comment_type/comment_approved values are constants.
 		$query = "SELECT COUNT(*) FROM {$wpdb->comments}
-			INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' )
+			INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( {$reports_statuses} )
 			WHERE {$wpdb->comments}.comment_type = 'sensei_lesson_status' AND {$wpdb->comments}.comment_approved = 'ungraded'";
 
 		if ( ! empty( $args['post__in'] ) && is_array( $args['post__in'] ) ) {

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -104,7 +104,12 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same $args as count_statuses(), but 'type' must be 'course'.
+	 * @param array $args {
+	 *     Query arguments.
+	 *
+	 *     @type string    $type    Must be 'course'.
+	 *     @type int|array $user_id Restrict to specific user IDs.
+	 * }
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array {
@@ -120,9 +125,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
 		$query  = $wpdb->prepare( "SELECT user_id, comment_approved, COUNT(*) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( {$reports_statuses} ) WHERE comment_type = %s", $comment_type );
-		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
-		$query .= $this->build_user_exclusion_clause( $args );
 		$query .= ' GROUP BY user_id, comment_approved';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -70,7 +70,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		}
 
 		$wpdb         = $this->wpdb;
-		$comment_type = $this->get_comment_type( $args );
+		$comment_type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
 		$query = $wpdb->prepare( "SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
@@ -112,7 +112,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		}
 
 		$wpdb         = $this->wpdb;
-		$comment_type = $this->get_comment_type( $args );
+		$comment_type = 'sensei_course_status';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
 		$query  = $wpdb->prepare( "SELECT user_id, comment_approved, COUNT(*) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
@@ -220,18 +220,6 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		Utils::log_query_error( $wpdb, 'Comments-based ungraded quizzes count' );
 
 		return $count;
-	}
-
-	/**
-	 * Map the progress type to its comment_type.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param array $args Query arguments with a validated 'type'.
-	 * @return string The comment_type ('sensei_course_status' or 'sensei_lesson_status').
-	 */
-	private function get_comment_type( array $args ): string {
-		return 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
 	}
 
 	/**

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -102,7 +102,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same shape as count_statuses(); 'type' and 'user_id' honored.
+	 * @param array $args Same $args as count_statuses() ('type' is required).
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array {

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -89,9 +89,45 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		$results = (array) $wpdb->get_results( $query, ARRAY_A );
 		Utils::log_query_error( $wpdb, 'Comments-based status counts' );
 
-		$counts = [];
+		$counts = array();
 		foreach ( $results as $row ) {
 			$counts[ $row['comment_approved'] ] = (int) $row['total'];
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Count progress records grouped by user and status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Same shape as count_statuses(); 'type' and 'user_id' honored.
+	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
+	 */
+	public function count_statuses_by_user( array $args ): array {
+		if ( empty( $args['type'] ) || ! in_array( $args['type'], array( 'course', 'lesson' ), true ) ) {
+			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course" or "lesson".', '$$next-version$$' );
+			return array();
+		}
+
+		$wpdb         = $this->wpdb;
+		$comment_type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
+		$query  = $wpdb->prepare( "SELECT user_id, comment_approved, COUNT(*) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
+		$query .= $this->build_post_filter_clause( $args );
+		$query .= $this->build_user_filter_clause( $args );
+		$query .= $this->build_user_exclusion_clause( $args );
+		$query .= ' GROUP BY user_id, comment_approved';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$results = (array) $wpdb->get_results( $query, ARRAY_A );
+		Utils::log_query_error( $wpdb, 'Comments-based status counts by user' );
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$counts[ (int) $row['user_id'] ][ $row['comment_approved'] ] = (int) $row['total'];
 		}
 
 		return $counts;
@@ -106,13 +142,13 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_count, days_to_complete_sum.
 	 */
 	public function get_lesson_totals( array $lesson_ids ): array {
-		$defaults = [
+		$defaults = array(
 			'unique_student_count'   => 0,
 			'lesson_start_count'     => 0,
 			'lesson_completed_count' => 0,
 			'days_to_complete_count' => 0,
 			'days_to_complete_sum'   => 0,
-		];
+		);
 
 		if ( empty( $lesson_ids ) ) {
 			return $defaults;
@@ -134,7 +170,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 			INNER JOIN {$wpdb->posts} post ON post.ID = lesson_students.comment_post_ID AND post.post_status IN ( 'publish', 'private' )
 			LEFT JOIN {$wpdb->commentmeta} lesson_start ON lesson_start.comment_id = lesson_students.comment_id
 			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $placeholders )",
-			array_merge( [ '%Y-%m-%d %H:%i:%s' ], $lesson_ids )
+			array_merge( array( '%Y-%m-%d %H:%i:%s' ), $lesson_ids )
 		);
 		// phpcs:enable
 
@@ -146,13 +182,13 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 			return $defaults;
 		}
 
-		return [
+		return array(
 			'unique_student_count'   => (int) $row->unique_student_count,
 			'lesson_start_count'     => (int) $row->lesson_start_count,
 			'lesson_completed_count' => (int) $row->lesson_completed_count,
 			'days_to_complete_count' => (int) $row->days_to_complete_count,
 			'days_to_complete_sum'   => (int) $row->days_to_complete_sum,
-		];
+		);
 	}
 
 	/**
@@ -255,7 +291,7 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 		}
 
 		$wpdb             = $this->wpdb;
-		$not_like_clauses = [];
+		$not_like_clauses = array();
 		foreach ( $prefixes as $prefix ) {
 			$escaped_prefix     = $wpdb->esc_like( $prefix );
 			$not_like_clauses[] = $wpdb->prepare( 'comment_author NOT LIKE %s', $escaped_prefix . '%' );

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -43,11 +43,11 @@ interface Progress_Aggregation_Service_Interface {
 	public function count_statuses( array $args ): array;
 
 	/**
-	 * Count progress records grouped by user and status.
+	 * Count course progress records grouped by user and status.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same $args as count_statuses() ('type' is required).
+	 * @param array $args Same $args as count_statuses(), but 'type' must be 'course'.
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array;

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -47,7 +47,12 @@ interface Progress_Aggregation_Service_Interface {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same $args as count_statuses(), but 'type' must be 'course'.
+	 * @param array $args {
+	 *     Query arguments.
+	 *
+	 *     @type string    $type    Must be 'course'.
+	 *     @type int|array $user_id Restrict to specific user IDs.
+	 * }
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array;

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -43,6 +43,16 @@ interface Progress_Aggregation_Service_Interface {
 	public function count_statuses( array $args ): array;
 
 	/**
+	 * Count progress records grouped by user and status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Same shape as count_statuses(); 'type' and 'user_id' honored.
+	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
+	 */
+	public function count_statuses_by_user( array $args ): array;
+
+	/**
 	 * Get aggregate totals for a set of lessons.
 	 *
 	 * @since 4.26.0

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -47,7 +47,7 @@ interface Progress_Aggregation_Service_Interface {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same shape as count_statuses(); 'type' and 'user_id' honored.
+	 * @param array $args Same $args as count_statuses() ('type' is required).
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array;

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -100,7 +100,12 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same $args as count_statuses(), but 'type' must be 'course'.
+	 * @param array $args {
+	 *     Query arguments.
+	 *
+	 *     @type string    $type    Must be 'course'.
+	 *     @type int|array $user_id Restrict to specific user IDs.
+	 * }
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array {
@@ -118,9 +123,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$query  = "SELECT p.user_id, p.status, COUNT(*) AS total FROM {$table} p";
 		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( {$reports_statuses} )";
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', $args['type'] );
-		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
-		$query .= $this->build_user_exclusion_clause( $args );
 		$query .= ' GROUP BY p.user_id, p.status';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -112,9 +112,11 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$wpdb  = $this->wpdb;
 		$table = $this->get_progress_table_name();
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
 		$query  = "SELECT p.user_id, p.status, COUNT(*) AS total FROM {$table} p";
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( {$reports_statuses} )";
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', $args['type'] );
 		$query .= $this->build_post_filter_clause( $args );
 		$query .= $this->build_user_filter_clause( $args );
@@ -162,6 +164,8 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$has_completion    = "('" . implode( "','", Grading_Item::STATUSES_WITH_COMPLETION_DATE ) . "')";
 		$utc_offset        = Utils::get_utc_offset_string();
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// Plain COALESCE suffices here because quiz rows are already filtered
 		// by submission existence in the JOIN condition (AND EXISTS ...).
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders and status list created dynamically.
@@ -172,7 +176,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, 1, 0)) AS days_to_complete_count
 			, SUM(IF(COALESCE( q.status, p.status ) IN $has_completion, ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1, 0)) AS days_to_complete_sum
 			FROM {$table} p
-			INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )
+			INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( {$reports_statuses} )
 			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
 			LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
 				AND EXISTS ( SELECT 1 FROM {$submissions_table} qs WHERE qs.quiz_id = q.post_id AND qs.user_id = q.user_id )
@@ -210,10 +214,12 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$wpdb  = $this->wpdb;
 		$table = $this->get_progress_table_name();
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix; status/type values are constants.
 		$query = "SELECT COUNT(*) FROM {$table} p
 			INNER JOIN {$wpdb->postmeta} pm ON pm.meta_key = '_lesson_quiz' AND pm.meta_value = p.post_id
-			INNER JOIN {$wpdb->posts} lesson_post ON lesson_post.ID = pm.post_id AND lesson_post.post_status IN ( 'publish', 'private' )
+			INNER JOIN {$wpdb->posts} lesson_post ON lesson_post.ID = pm.post_id AND lesson_post.post_status IN ( {$reports_statuses} )
 			INNER JOIN {$table} lp ON lp.post_id = pm.post_id AND lp.user_id = p.user_id AND lp.type = 'lesson'
 			WHERE p.type = 'quiz' AND p.status = 'ungraded'";
 
@@ -252,10 +258,12 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$wpdb  = $this->wpdb;
 		$table = $this->get_progress_table_name();
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query = "SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( {$reports_statuses} )";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
@@ -292,9 +300,11 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$wpdb  = $this->wpdb;
 		$table = $this->get_progress_table_name();
 
+		$reports_statuses = Utils::get_reports_post_status_sql();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
 		$query  = "SELECT p.status, COUNT(*) AS total FROM {$table} p";
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( {$reports_statuses} )";
 
 		$query .= $wpdb->prepare( ' WHERE p.type = %s', $args['type'] );
 		$query .= $this->build_post_filter_clause( $args );

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -100,7 +100,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same shape as count_statuses(); 'type' and 'user_id' honored.
+	 * @param array $args Same $args as count_statuses() ('type' is required).
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array {

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -96,6 +96,44 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
+	 * Count progress records grouped by user and status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Same shape as count_statuses(); 'type' and 'user_id' honored.
+	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
+	 */
+	public function count_statuses_by_user( array $args ): array {
+		if ( empty( $args['type'] ) || ! in_array( $args['type'], array( 'course', 'lesson' ), true ) ) {
+			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course" or "lesson".', '$$next-version$$' );
+			return array();
+		}
+
+		$wpdb  = $this->wpdb;
+		$table = $this->get_progress_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
+		$query  = "SELECT p.user_id, p.status, COUNT(*) AS total FROM {$table} p";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+		$query .= $wpdb->prepare( ' WHERE p.type = %s', $args['type'] );
+		$query .= $this->build_post_filter_clause( $args );
+		$query .= $this->build_user_filter_clause( $args );
+		$query .= $this->build_user_exclusion_clause( $args );
+		$query .= ' GROUP BY p.user_id, p.status';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$results = (array) $wpdb->get_results( $query, ARRAY_A );
+		Utils::log_query_error( $wpdb, 'Tables-based status counts by user' );
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$counts[ (int) $row['user_id'] ][ $row['status'] ] = (int) $row['total'];
+		}
+
+		return $counts;
+	}
+
+	/**
 	 * Get aggregate totals for a set of lessons.
 	 *
 	 * @since 4.26.0
@@ -104,13 +142,13 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	 * @return array Associative array with keys: unique_student_count, lesson_start_count, lesson_completed_count, days_to_complete_count, days_to_complete_sum.
 	 */
 	public function get_lesson_totals( array $lesson_ids ): array {
-		$defaults = [
+		$defaults = array(
 			'unique_student_count'   => 0,
 			'lesson_start_count'     => 0,
 			'lesson_completed_count' => 0,
 			'days_to_complete_count' => 0,
 			'days_to_complete_sum'   => 0,
-		];
+		);
 
 		if ( empty( $lesson_ids ) ) {
 			return $defaults;
@@ -151,13 +189,13 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 			return $defaults;
 		}
 
-		return [
+		return array(
 			'unique_student_count'   => (int) $row->unique_student_count,
 			'lesson_start_count'     => (int) $row->lesson_start_count,
 			'lesson_completed_count' => (int) $row->lesson_completed_count,
 			'days_to_complete_count' => (int) $row->days_to_complete_count,
 			'days_to_complete_sum'   => (int) $row->days_to_complete_sum,
-		];
+		);
 	}
 
 	/**
@@ -234,7 +272,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$results = (array) $wpdb->get_results( $query, ARRAY_A );
 		Utils::log_query_error( $wpdb, 'Tables-based lesson status counts' );
 
-		$counts = [];
+		$counts = array();
 		foreach ( $results as $row ) {
 			$counts[ $row['effective_status'] ] = (int) $row['total'];
 		}
@@ -269,7 +307,7 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 		$results = (array) $wpdb->get_results( $query, ARRAY_A );
 		Utils::log_query_error( $wpdb, 'Tables-based course status counts' );
 
-		$counts = [];
+		$counts = array();
 		foreach ( $results as $row ) {
 			$counts[ $row['status'] ] = (int) $row['total'];
 		}

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -96,16 +96,16 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
-	 * Count progress records grouped by user and status.
+	 * Count course progress records grouped by user and status.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Same $args as count_statuses() ('type' is required).
+	 * @param array $args Same $args as count_statuses(), but 'type' must be 'course'.
 	 * @return array<int, array<string, int>> Map of user_id => [ status => count ].
 	 */
 	public function count_statuses_by_user( array $args ): array {
-		if ( empty( $args['type'] ) || ! in_array( $args['type'], array( 'course', 'lesson' ), true ) ) {
-			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course" or "lesson".', '$$next-version$$' );
+		if ( empty( $args['type'] ) || 'course' !== $args['type'] ) {
+			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course". Per-user lesson counts are not supported.', '$$next-version$$' );
 			return array();
 		}
 

--- a/includes/internal/services/class-utils.php
+++ b/includes/internal/services/class-utils.php
@@ -21,6 +21,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Utils {
 
 	/**
+	 * Post statuses that Reports counts as live content: a course or lesson that
+	 * exists and is accessible. Draft, pending, and trashed posts are excluded.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string[]
+	 */
+	public const REPORTS_POST_STATUSES = array( 'publish', 'private' );
+
+	/**
+	 * Get the Reports post statuses as a quoted list for a `post_status IN ( ... )` SQL clause.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string Quoted, comma-separated statuses, e.g. "'publish','private'".
+	 */
+	public static function get_reports_post_status_sql(): string {
+		return "'" . implode( "','", self::REPORTS_POST_STATUSES ) . "'";
+	}
+
+	/**
 	 * Get the site's UTC offset in '+HH:MM' / '-HH:MM' format for CONVERT_TZ.
 	 *
 	 * Uses a numeric offset so that MySQL timezone tables are not required.

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -148,10 +148,10 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 		return $this->data_provider->get_items(
 			array_merge(
 				$this->get_filter_args(),
-				[
+				array(
 					'number' => -1,
 					'fields' => 'ids',
-				]
+				)
 			)
 		);
 	}
@@ -203,12 +203,28 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 
 		$data[]                   = $column_headers;
 		$columns_keys_assoc_array = array_fill_keys( array_keys( $columns ), '' );
+
+		$this->before_generate_report_rows( $this->items );
+
 		// Process each row.
 		foreach ( $this->items as $item ) {
 			$data[] = array_replace( $columns_keys_assoc_array, $this->get_row_data( $item ) );
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Runs after the full (unpaginated) item set for a CSV export is fetched, but before
+	 * row data is generated for each item. Subclasses may override to prime any per-item
+	 * caches needed by get_row_data().
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $items The items that will be exported.
+	 */
+	protected function before_generate_report_rows( array $items ) {
+		// No-op by default. Subclasses may override.
 	}
 
 	/**
@@ -282,7 +298,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 	 */
 	public function output_top_filters() {
 		Sensei_Utils::output_query_params_as_inputs(
-			[
+			array(
 				'course_filter',
 				'start_date',
 				'end_date',
@@ -291,7 +307,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 				'post_type',
 				'page',
 				'search',
-			]
+			)
 		);
 		?>
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -33,6 +33,13 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	private $aggregation_service;
 
 	/**
+	 * Per-user course-count cache for the current page.
+	 *
+	 * @var array<int, array{started:int, completed:int}>
+	 */
+	private $course_counts_by_user = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider Report data provider.
@@ -45,6 +52,64 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 
 		$this->reports_overview_service_students = $reports_overview_service_students;
 		$this->aggregation_service               = $aggregation_service;
+
+		if ( has_filter( 'sensei_analysis_user_courses_started' ) ) {
+			_deprecated_hook( 'sensei_analysis_user_courses_started', '$$next-version$$' );
+		}
+		if ( has_filter( 'sensei_analysis_user_courses_ended' ) ) {
+			_deprecated_hook( 'sensei_analysis_user_courses_ended', '$$next-version$$' );
+		}
+	}
+
+	/**
+	 * Prepare the table items and prime the per-user course-count cache for the current page.
+	 */
+	public function prepare_items() {
+		parent::prepare_items();
+		$this->prime_row_aggregates( $this->items );
+	}
+
+	/**
+	 * Prime the per-user course-count cache before generating CSV report rows.
+	 *
+	 * @param array $items The items that will be exported.
+	 */
+	protected function before_generate_report_rows( array $items ) {
+		$this->prime_row_aggregates( $items );
+	}
+
+	/**
+	 * Prime the per-user course-count cache for the given page items.
+	 *
+	 * @param array $items Current page items (user objects with an ID).
+	 */
+	private function prime_row_aggregates( array $items ) {
+		$user_ids = array_map(
+			static function ( $item ) {
+				return (int) $item->ID;
+			},
+			$items
+		);
+
+		$this->course_counts_by_user = array();
+		if ( empty( $user_ids ) ) {
+			return;
+		}
+
+		$counts = $this->aggregation_service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => $user_ids,
+			)
+		);
+
+		foreach ( $user_ids as $user_id ) {
+			$statuses                                = $counts[ $user_id ] ?? array();
+			$this->course_counts_by_user[ $user_id ] = array(
+				'started'   => array_sum( $statuses ),
+				'completed' => $statuses['complete'] ?? 0,
+			);
+		}
 	}
 
 	/**
@@ -168,42 +233,13 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	 * @throws Exception If date-time conversion fails.
 	 */
 	protected function get_row_data( $item ) {
-		// Get Started Courses.
-		$course_args = array(
-			'user_id' => $item->ID,
-			'type'    => 'sensei_course_status',
-			'status'  => 'any',
+		// Get Started/Completed Courses from the primed per-page cache.
+		$counts               = $this->course_counts_by_user[ (int) $item->ID ] ?? array(
+			'started'   => 0,
+			'completed' => 0,
 		);
-
-		/**
-		 * Filter user progress query arguments for courses: find started courses.
-		 *
-		 * @hook sensei_analysis_user_courses_started
-		 *
-		 * @param {array} $course_args Array of query arguments for started user courses.
-		 * @param {WP_User} $item Current user object.
-		 * @return {array} Filtered array of query arguments for started user courses.
-		*/
-		$course_args          = apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item );
-		$user_courses_started = Sensei_Utils::sensei_check_for_activity( $course_args );
-
-		// Get Completed Courses.
-		$course_args = array(
-			'user_id' => $item->ID,
-			'type'    => 'sensei_course_status',
-			'status'  => 'complete',
-		);
-
-		/**
-		 * Filter user progress query arguments for courses: find completed courses.
-		 *
-		 * @hook sensei_analysis_user_courses_ended
-		 *
-		 * @param {array} $course_args Array of query arguments for ended user courses.
-		 * @param {WP_User} $item Current user object.
-		 * @return {array} Filtered array of query arguments for ended user courses.
-		 */
-		$user_courses_ended = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_ended', $course_args, $item ) );
+		$user_courses_started = $counts['started'];
+		$user_courses_ended   = $counts['completed'];
 
 		// Get Quiz Grades.
 		$grade_args = array(

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -12,7 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 
 /**
- * Students overview list table class.
+ * View (WordPress list table) for the Students tab of Reports → Overview.
+ *
+ * Displays the report table and its totals. The figures come from the data
+ * provider and the students service; this class only arranges and displays them.
  *
  * @since 4.3.0
  */
@@ -35,7 +38,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	/**
 	 * Per-user course-count cache for the current page.
 	 *
-	 * @var array<int, array{started:int, completed:int}>
+	 * @var array<int, array{active:int, completed:int}>
 	 */
 	private $course_counts_by_user = array();
 
@@ -91,25 +94,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			$items
 		);
 
-		$this->course_counts_by_user = array();
-		if ( empty( $user_ids ) ) {
-			return;
-		}
-
-		$counts = $this->aggregation_service->count_statuses_by_user(
-			array(
-				'type'    => 'course',
-				'user_id' => $user_ids,
-			)
-		);
-
-		foreach ( $user_ids as $user_id ) {
-			$statuses                                = $counts[ $user_id ] ?? array();
-			$this->course_counts_by_user[ $user_id ] = array(
-				'started'   => array_sum( $statuses ),
-				'completed' => $statuses['complete'] ?? 0,
-			);
-		}
+		$this->course_counts_by_user = $this->reports_overview_service_students->get_course_counts_by_user( $user_ids );
 	}
 
 	/**
@@ -233,13 +218,13 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	 * @throws Exception If date-time conversion fails.
 	 */
 	protected function get_row_data( $item ) {
-		// Get Started/Completed Courses from the primed per-page cache.
-		$counts               = $this->course_counts_by_user[ (int) $item->ID ] ?? array(
-			'started'   => 0,
+		// Get Active/Completed Courses from the primed per-page cache.
+		$counts            = $this->course_counts_by_user[ (int) $item->ID ] ?? array(
+			'active'    => 0,
 			'completed' => 0,
 		);
-		$user_courses_started = $counts['started'];
-		$user_courses_ended   = $counts['completed'];
+		$active_courses    = $counts['active'];
+		$completed_courses = $counts['completed'];
 
 		// Get Quiz Grades.
 		$grade_args = array(
@@ -296,8 +281,8 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 				'email'             => $user_email,
 				'date_registered'   => $this->format_date_registered( $item->user_registered ),
 				'last_activity'     => $last_activity_date,
-				'active_courses'    => ( $user_courses_started - $user_courses_ended ),
-				'completed_courses' => $user_courses_ended,
+				'active_courses'    => $active_courses,
+				'completed_courses' => $completed_courses,
 				'average_grade'     => $user_average_grade,
 			),
 			$item,

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -12,7 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Students overview service class.
+ * Service (business-logic) class for the Students tab of Reports → Overview.
+ *
+ * Calculates the figures shown there, so the list table that displays them
+ * holds no calculation logic of its own.
  *
  * @since 4.4.1
  */
@@ -33,5 +36,40 @@ class Sensei_Reports_Overview_Service_Students {
 		}
 
 		return ceil( ( new Progress_Query_Service_Factory() )->create_grading_stats_service()->get_users_average_grade( $user_ids ) );
+	}
+
+	/**
+	 * Get the active and completed course counts for each of the given students.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $user_ids Student user IDs.
+	 * @return array<int, array{active:int, completed:int}> Map of user_id => [ active, completed ].
+	 */
+	public function get_course_counts_by_user( array $user_ids ): array {
+		if ( empty( $user_ids ) ) {
+			return array();
+		}
+
+		$counts = ( new Progress_Query_Service_Factory() )
+			->create_aggregation_service()
+			->count_statuses_by_user(
+				array(
+					'type'    => 'course',
+					'user_id' => $user_ids,
+				)
+			);
+
+		$result = array();
+		foreach ( $user_ids as $user_id ) {
+			$statuses           = $counts[ $user_id ] ?? array();
+			$completed          = $statuses['complete'] ?? 0;
+			$result[ $user_id ] = array(
+				'active'    => array_sum( $statuses ) - $completed,
+				'completed' => $completed,
+			);
+		}
+
+		return $result;
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -667,7 +667,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ] );
 	}
 
-	public function testCountStatusesByUser_InvalidType_ReturnsEmptyArray(): void {
+	public function testCountStatusesByUser_LessonType_ReturnsEmptyArray(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -676,7 +676,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->count_statuses_by_user( array( 'type' => 'invalid' ) );
+		$result = $service->count_statuses_by_user( array( 'type' => 'lesson' ) );
 
 		/* Assert. */
 		$this->assertSame( array(), $result );

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -30,7 +30,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
@@ -39,9 +39,9 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -55,10 +55,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson1, 'in-progress' );
@@ -68,10 +68,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'    => 'lesson',
 				'post_id' => $lesson1,
-			)
+			]
 		);
 
 		/* Assert. */
@@ -85,11 +85,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			array( 'user_login' => 'sensei_guest_12345' )
+			[ 'user_login' => 'sensei_guest_12345' ]
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		\Sensei_Utils::update_lesson_status( $regular_user, $lesson_id, 'in-progress' );
@@ -99,10 +99,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
-			)
+				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
+			]
 		);
 
 		/* Assert. */
@@ -117,7 +117,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed' );
@@ -126,9 +126,9 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -142,10 +142,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson1, 'complete' );
@@ -155,10 +155,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'     => 'lesson',
-				'post__in' => array( $lesson1 ),
-			)
+				'post__in' => [ $lesson1 ],
+			]
 		);
 
 		/* Assert. */
@@ -174,7 +174,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete' );
@@ -184,10 +184,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'    => 'lesson',
-				'user_id' => array( $user1 ),
-			)
+				'user_id' => [ $user1 ],
+			]
 		);
 
 		/* Assert. */
@@ -208,12 +208,12 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
-		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', array( 'start' => $start_date ) );
-		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', [ 'start' => $start_date ] );
+		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', [ 'start' => $start_date ] );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
@@ -222,7 +222,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
@@ -239,16 +239,16 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$start_date = current_time( 'mysql' );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded', [ 'start' => $start_date ] );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Ungraded status should count as completed.' );
@@ -263,16 +263,16 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$start_date = current_time( 'mysql' );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'failed', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'failed', [ 'start' => $start_date ] );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Failed status should count as completed.' );
@@ -287,16 +287,16 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-3 days' ) );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed', [ 'start' => $start_date ] );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed status should count as completed.' );
@@ -311,7 +311,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array() );
+		$result = $service->get_lesson_totals( [] );
 
 		/* Assert. */
 		$this->assertSame( 0, $result['unique_student_count'] );
@@ -364,11 +364,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			array( 'user_login' => 'sensei_guest_12345' )
+			[ 'user_login' => 'sensei_guest_12345' ]
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		\Sensei_Utils::update_lesson_status( $regular_user, $lesson_id, 'in-progress' );
@@ -378,11 +378,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
-				'include_statuses_override'   => array( 'ungraded' ),
-			)
+				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
+				'include_statuses_override'   => [ 'ungraded' ],
+			]
 		);
 
 		/* Assert. */
@@ -468,13 +468,13 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -484,13 +484,111 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
 		$this->assertSame( 1, $result['complete'], 'Completed lesson with quiz but no answers should be included by default.' );
+	}
+
+	public function testCountStatusesByUser_CourseType_ReturnsCountsGroupedByUser(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_a     = $this->sensei_factory->user->create();
+		$user_b     = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		\Sensei_Utils::update_course_status( $user_a, $course_id1, 'complete' );
+		\Sensei_Utils::update_course_status( $user_a, $course_id2, 'in-progress' );
+		\Sensei_Utils::update_course_status( $user_b, $course_id1, 'in-progress' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $user_a, $user_b ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $user_a ]['complete'], 'User A should have one completed course.' );
+		$this->assertSame( 1, $result[ $user_a ]['in-progress'], 'User A should have one in-progress course.' );
+		$this->assertSame( 1, $result[ $user_b ]['in-progress'], 'User B should have one in-progress course.' );
+		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ], 'User B should have no completed course.' );
+	}
+
+	public function testCountStatusesByUser_WithUserIdArray_FiltersToSpecifiedUsers(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$included_user = $this->sensei_factory->user->create();
+		$excluded_user = $this->sensei_factory->user->create();
+		$course_id     = $this->sensei_factory->course->create();
+
+		\Sensei_Utils::update_course_status( $included_user, $course_id, 'complete' );
+		\Sensei_Utils::update_course_status( $excluded_user, $course_id, 'in-progress' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $included_user ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $included_user ]['complete'], 'Requested user should be counted.' );
+		$this->assertArrayNotHasKey( $excluded_user, $result, 'User not in user_id should be excluded.' );
+	}
+
+	public function testCountStatusesByUser_TrashedCourse_ExcludedFromCounts(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$published = $this->sensei_factory->course->create();
+		$trashed   = $this->sensei_factory->course->create();
+
+		\Sensei_Utils::update_course_status( $user_id, $published, 'complete' );
+		\Sensei_Utils::update_course_status( $user_id, $trashed, 'in-progress' );
+		wp_trash_post( $trashed );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $user_id ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $user_id ]['complete'], 'Published course should be counted.' );
+		$this->assertArrayNotHasKey( 'in-progress', $result[ $user_id ], 'Trashed course should be excluded.' );
+	}
+
+	public function testCountStatusesByUser_LessonType_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Comments_Based_Progress_Aggregation_Service::count_statuses_by_user' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
 	}
 
 	public function testCountUngradedQuizzes_NoUngradedComments_ReturnsZero(): void {
@@ -635,50 +733,5 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Act & Assert. */
 		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
 		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
-	}
-
-	public function testCountStatusesByUser_CourseType_ReturnsCountsGroupedByUser(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_a     = $this->sensei_factory->user->create();
-		$user_b     = $this->sensei_factory->user->create();
-		$course_id1 = $this->sensei_factory->course->create();
-		$course_id2 = $this->sensei_factory->course->create();
-
-		\Sensei_Utils::update_course_status( $user_a, $course_id1, 'complete' );
-		\Sensei_Utils::update_course_status( $user_a, $course_id2, 'in-progress' );
-		\Sensei_Utils::update_course_status( $user_b, $course_id1, 'in-progress' );
-
-		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses_by_user(
-			array(
-				'type'    => 'course',
-				'user_id' => array( $user_a, $user_b ),
-			)
-		);
-
-		/* Assert. */
-		$this->assertSame( 1, $result[ $user_a ]['complete'] );
-		$this->assertSame( 1, $result[ $user_a ]['in-progress'] );
-		$this->assertSame( 1, $result[ $user_b ]['in-progress'] );
-		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ] );
-	}
-
-	public function testCountStatusesByUser_LessonType_ReturnsEmptyArray(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Comments_Based_Progress_Aggregation_Service::count_statuses_by_user' );
-
-		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses_by_user( array( 'type' => 'lesson' ) );
-
-		/* Assert. */
-		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -30,7 +30,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'in-progress' );
@@ -39,9 +39,9 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -55,10 +55,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson1, 'in-progress' );
@@ -68,10 +68,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'    => 'lesson',
 				'post_id' => $lesson1,
-			]
+			)
 		);
 
 		/* Assert. */
@@ -85,11 +85,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			[ 'user_login' => 'sensei_guest_12345' ]
+			array( 'user_login' => 'sensei_guest_12345' )
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		\Sensei_Utils::update_lesson_status( $regular_user, $lesson_id, 'in-progress' );
@@ -99,10 +99,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
-			]
+				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
+			)
 		);
 
 		/* Assert. */
@@ -117,7 +117,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed' );
@@ -126,9 +126,9 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -142,10 +142,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		\Sensei_Utils::update_lesson_status( $user_id, $lesson1, 'complete' );
@@ -155,10 +155,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'     => 'lesson',
-				'post__in' => [ $lesson1 ],
-			]
+				'post__in' => array( $lesson1 ),
+			)
 		);
 
 		/* Assert. */
@@ -174,7 +174,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete' );
@@ -184,10 +184,10 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'    => 'lesson',
-				'user_id' => [ $user1 ],
-			]
+				'user_id' => array( $user1 ),
+			)
 		);
 
 		/* Assert. */
@@ -208,12 +208,12 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
-		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', [ 'start' => $start_date ] );
-		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', [ 'start' => $start_date ] );
+		\Sensei_Utils::update_lesson_status( $user1, $lesson_id, 'complete', array( 'start' => $start_date ) );
+		\Sensei_Utils::update_lesson_status( $user2, $lesson_id, 'in-progress', array( 'start' => $start_date ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bypass WP filters to test SQL post_status filter directly.
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $included_status ), array( 'ID' => $lesson_id ) );
@@ -222,7 +222,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
@@ -239,16 +239,16 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$start_date = current_time( 'mysql' );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded', [ 'start' => $start_date ] );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded', array( 'start' => $start_date ) );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Ungraded status should count as completed.' );
@@ -263,16 +263,16 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$start_date = current_time( 'mysql' );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'failed', [ 'start' => $start_date ] );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'failed', array( 'start' => $start_date ) );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Failed status should count as completed.' );
@@ -287,16 +287,16 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$start_date = wp_date( 'Y-m-d H:i:s', strtotime( '-3 days' ) );
-		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed', [ 'start' => $start_date ] );
+		\Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed', array( 'start' => $start_date ) );
 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed status should count as completed.' );
@@ -311,7 +311,7 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [] );
+		$result = $service->get_lesson_totals( array() );
 
 		/* Assert. */
 		$this->assertSame( 0, $result['unique_student_count'] );
@@ -364,11 +364,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			[ 'user_login' => 'sensei_guest_12345' ]
+			array( 'user_login' => 'sensei_guest_12345' )
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		\Sensei_Utils::update_lesson_status( $regular_user, $lesson_id, 'in-progress' );
@@ -378,11 +378,11 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
-				'include_statuses_override'   => [ 'ungraded' ],
-			]
+				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
+				'include_statuses_override'   => array( 'ungraded' ),
+			)
 		);
 
 		/* Assert. */
@@ -468,13 +468,13 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -484,9 +484,9 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -635,5 +635,50 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		/* Act & Assert. */
 		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
 		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
+	}
+
+	public function testCountStatusesByUser_CourseType_ReturnsCountsGroupedByUser(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_a     = $this->sensei_factory->user->create();
+		$user_b     = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		\Sensei_Utils::update_course_status( $user_a, $course_id1, 'complete' );
+		\Sensei_Utils::update_course_status( $user_a, $course_id2, 'in-progress' );
+		\Sensei_Utils::update_course_status( $user_b, $course_id1, 'in-progress' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $user_a, $user_b ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $user_a ]['complete'] );
+		$this->assertSame( 1, $result[ $user_a ]['in-progress'] );
+		$this->assertSame( 1, $result[ $user_b ]['in-progress'] );
+		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ] );
+	}
+
+	public function testCountStatusesByUser_InvalidType_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Comments_Based_Progress_Aggregation_Service::count_statuses_by_user' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user( array( 'type' => 'invalid' ) );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -1094,7 +1094,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ] );
 	}
 
-	public function testCountStatusesByUser_InvalidType_ReturnsEmptyArray(): void {
+	public function testCountStatusesByUser_LessonType_ReturnsEmptyArray(): void {
 		/* Arrange. */
 		global $wpdb;
 
@@ -1103,7 +1103,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->count_statuses_by_user( array( 'type' => 'invalid' ) );
+		$result = $service->count_statuses_by_user( array( 'type' => 'lesson' ) );
 
 		/* Assert. */
 		$this->assertSame( array(), $result );

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -35,7 +35,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$wpdb  = $GLOBALS['wpdb'];
 		$table = $wpdb->prefix . 'sensei_lms_progress';
 		$now   = current_time( 'mysql' );
-		$data  = array(
+		$data  = [
 			'post_id'      => $post_id,
 			'user_id'      => $user_id,
 			'type'         => $type,
@@ -44,9 +44,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			'completed_at' => $completed_at,
 			'created_at'   => $now,
 			'updated_at'   => $now,
-		);
+		];
 
-		$format = array( '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' );
+		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' ];
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper inserting directly into custom table.
 		$wpdb->insert( $table, $data, $format );
@@ -56,7 +56,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
-		$data   = array(
+		$data   = [
 			'post_id'    => $post_id,
 			'user_id'    => $user_id,
 			'type'       => $type,
@@ -64,8 +64,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			'started_at' => $now,
 			'created_at' => $now,
 			'updated_at' => $now,
-		);
-		$format = array( '%d', '%d', '%s', '%s', '%s', '%s', '%s' );
+		];
+		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
 
 		if ( null !== $completed_at ) {
 			$data['completed_at'] = $completed_at;
@@ -89,13 +89,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper inserting directly into custom table.
 		$wpdb->insert(
 			$table,
-			array(
+			[
 				'quiz_id'    => $quiz_id,
 				'user_id'    => $user_id,
 				'created_at' => $now,
 				'updated_at' => $now,
-			),
-			array( '%d', '%d', '%s', '%s' )
+			],
+			[ '%d', '%d', '%s', '%s' ]
 		);
 	}
 
@@ -106,7 +106,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
@@ -115,9 +115,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -131,10 +131,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress' );
@@ -144,10 +144,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'    => 'lesson',
 				'post_id' => $lesson1,
-			)
+			]
 		);
 
 		/* Assert. */
@@ -162,10 +162,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$this->insert_progress( $lesson1, $user_id, 'lesson', 'complete' );
@@ -175,10 +175,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'     => 'lesson',
-				'post__in' => array( $lesson1 ),
-			)
+				'post__in' => [ $lesson1 ],
+			]
 		);
 
 		/* Assert. */
@@ -194,7 +194,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete' );
@@ -204,11 +204,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'    => 'lesson',
 				'post_id' => $lesson_id,
-				'user_id' => array( $user1 ),
-			)
+				'user_id' => [ $user1 ],
+			]
 		);
 
 		/* Assert. */
@@ -222,11 +222,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			array( 'user_login' => 'sensei_guest_12345' )
+			[ 'user_login' => 'sensei_guest_12345' ]
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress' );
@@ -236,10 +236,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
-			)
+				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
+			]
 		);
 
 		/* Assert. */
@@ -254,13 +254,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -273,9 +273,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -290,7 +290,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
@@ -299,9 +299,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -319,13 +319,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user3     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -344,9 +344,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -430,7 +430,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$started_at   = '2024-01-01 10:00:00';
@@ -445,7 +445,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
@@ -462,13 +462,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -482,7 +482,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['unique_student_count'], 'Expected one student.' );
@@ -497,13 +497,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -515,7 +515,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Ungraded quiz status should count as completed.' );
@@ -547,13 +547,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -565,7 +565,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Failed quiz status should count as completed.' );
@@ -580,13 +580,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -599,7 +599,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed quiz should count as completed.' );
@@ -614,7 +614,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array() );
+		$result = $service->get_lesson_totals( [] );
 
 		/* Assert. */
 		$this->assertSame( 0, $result['unique_student_count'] );
@@ -675,7 +675,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		// UTC dates span two days (Jan 1 05:00 → Jan 2 04:00),
@@ -687,7 +687,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( array( $lesson_id ) );
+		$result = $service->get_lesson_totals( [ $lesson_id ] );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['days_to_complete_sum'], 'UTC dates spanning midnight should be 1 day in local time (UTC-5).' );
@@ -703,11 +703,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			array( 'user_login' => 'sensei_guest_12345' )
+			[ 'user_login' => 'sensei_guest_12345' ]
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 
 		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress' );
@@ -717,11 +717,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
-				'include_statuses_override'   => array( 'ungraded' ),
-			)
+				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
+				'include_statuses_override'   => [ 'ungraded' ],
+			]
 		);
 
 		/* Assert. */
@@ -736,13 +736,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			array(
+			[
 				'post_parent' => $lesson_id,
-				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
-			)
+				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
+			]
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -755,9 +755,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'lesson',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -778,9 +778,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'course',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -802,9 +802,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'course',
-			)
+			]
 		);
 
 		/* Assert. */
@@ -829,14 +829,113 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			array(
+			[
 				'type' => 'course',
-			)
+			]
 		);
 
 		/* Assert. */
 		$this->assertSame( 1, $result['complete'], 'Non-trashed course should be counted.' );
 		$this->assertArrayNotHasKey( 'in-progress', $result, 'Trashed course status should not appear.' );
+	}
+
+	public function testCountStatusesByUser_CourseType_ReturnsCountsGroupedByUser(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_a     = $this->sensei_factory->user->create();
+		$user_b     = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		$this->insert_progress( $course_id1, $user_a, 'course', 'complete' );
+		$this->insert_progress( $course_id2, $user_a, 'course', 'in-progress' );
+		$this->insert_progress( $course_id1, $user_b, 'course', 'in-progress' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $user_a, $user_b ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $user_a ]['complete'], 'User A should have one completed course.' );
+		$this->assertSame( 1, $result[ $user_a ]['in-progress'], 'User A should have one in-progress course.' );
+		$this->assertSame( 1, $result[ $user_b ]['in-progress'], 'User B should have one in-progress course.' );
+		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ], 'User B should have no completed course.' );
+	}
+
+	public function testCountStatusesByUser_WithUserIdArray_FiltersToSpecifiedUsers(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$included_user = $this->sensei_factory->user->create();
+		$excluded_user = $this->sensei_factory->user->create();
+		$course_id     = $this->sensei_factory->course->create();
+
+		$this->insert_progress( $course_id, $included_user, 'course', 'complete' );
+		$this->insert_progress( $course_id, $excluded_user, 'course', 'in-progress' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $included_user ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $included_user ]['complete'], 'Requested user should be counted.' );
+		$this->assertArrayNotHasKey( $excluded_user, $result, 'User not in user_id should be excluded.' );
+	}
+
+	public function testCountStatusesByUser_TrashedCourse_ExcludedFromCounts(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$published = $this->sensei_factory->course->create();
+		$trashed   = $this->sensei_factory->course->create();
+
+		$this->insert_progress( $published, $user_id, 'course', 'complete' );
+		$this->insert_progress( $trashed, $user_id, 'course', 'in-progress' );
+
+		wp_trash_post( $trashed );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $user_id ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $user_id ]['complete'], 'Published course should be counted.' );
+		$this->assertArrayNotHasKey( 'in-progress', $result[ $user_id ], 'Trashed course should be excluded.' );
+	}
+
+	public function testCountStatusesByUser_LessonType_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Tables_Based_Progress_Aggregation_Service::count_statuses_by_user' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user( array( 'type' => 'lesson' ) );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
 	}
 
 	public function testCountUngradedQuizzes_NoUngradedQuizzes_ReturnsZero(): void {
@@ -1062,50 +1161,5 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Act & Assert. */
 		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
 		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
-	}
-
-	public function testCountStatusesByUser_CourseType_ReturnsCountsGroupedByUser(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$user_a     = $this->sensei_factory->user->create();
-		$user_b     = $this->sensei_factory->user->create();
-		$course_id1 = $this->sensei_factory->course->create();
-		$course_id2 = $this->sensei_factory->course->create();
-
-		$this->insert_progress( $course_id1, $user_a, 'course', 'complete' );
-		$this->insert_progress( $course_id2, $user_a, 'course', 'in-progress' );
-		$this->insert_progress( $course_id1, $user_b, 'course', 'in-progress' );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses_by_user(
-			array(
-				'type'    => 'course',
-				'user_id' => array( $user_a, $user_b ),
-			)
-		);
-
-		/* Assert. */
-		$this->assertSame( 1, $result[ $user_a ]['complete'] );
-		$this->assertSame( 1, $result[ $user_a ]['in-progress'] );
-		$this->assertSame( 1, $result[ $user_b ]['in-progress'] );
-		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ] );
-	}
-
-	public function testCountStatusesByUser_LessonType_ReturnsEmptyArray(): void {
-		/* Arrange. */
-		global $wpdb;
-
-		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Tables_Based_Progress_Aggregation_Service::count_statuses_by_user' );
-
-		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
-
-		/* Act. */
-		$result = $service->count_statuses_by_user( array( 'type' => 'lesson' ) );
-
-		/* Assert. */
-		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -35,7 +35,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$wpdb  = $GLOBALS['wpdb'];
 		$table = $wpdb->prefix . 'sensei_lms_progress';
 		$now   = current_time( 'mysql' );
-		$data  = [
+		$data  = array(
 			'post_id'      => $post_id,
 			'user_id'      => $user_id,
 			'type'         => $type,
@@ -44,9 +44,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			'completed_at' => $completed_at,
 			'created_at'   => $now,
 			'updated_at'   => $now,
-		];
+		);
 
-		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' ];
+		$format = array( '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper inserting directly into custom table.
 		$wpdb->insert( $table, $data, $format );
@@ -56,7 +56,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$wpdb   = $GLOBALS['wpdb'];
 		$table  = $wpdb->prefix . 'sensei_lms_progress';
 		$now    = current_time( 'mysql' );
-		$data   = [
+		$data   = array(
 			'post_id'    => $post_id,
 			'user_id'    => $user_id,
 			'type'       => $type,
@@ -64,8 +64,8 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 			'started_at' => $now,
 			'created_at' => $now,
 			'updated_at' => $now,
-		];
-		$format = [ '%d', '%d', '%s', '%s', '%s', '%s', '%s' ];
+		);
+		$format = array( '%d', '%d', '%s', '%s', '%s', '%s', '%s' );
 
 		if ( null !== $completed_at ) {
 			$data['completed_at'] = $completed_at;
@@ -89,13 +89,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper inserting directly into custom table.
 		$wpdb->insert(
 			$table,
-			[
+			array(
 				'quiz_id'    => $quiz_id,
 				'user_id'    => $user_id,
 				'created_at' => $now,
 				'updated_at' => $now,
-			],
-			[ '%d', '%d', '%s', '%s' ]
+			),
+			array( '%d', '%d', '%s', '%s' )
 		);
 	}
 
@@ -106,7 +106,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
@@ -115,9 +115,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -131,10 +131,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson1, $user_id, 'lesson', 'in-progress' );
@@ -144,10 +144,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'    => 'lesson',
 				'post_id' => $lesson1,
-			]
+			)
 		);
 
 		/* Assert. */
@@ -162,10 +162,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson1   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$lesson2   = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson1, $user_id, 'lesson', 'complete' );
@@ -175,10 +175,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'     => 'lesson',
-				'post__in' => [ $lesson1 ],
-			]
+				'post__in' => array( $lesson1 ),
+			)
 		);
 
 		/* Assert. */
@@ -194,7 +194,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $user1, 'lesson', 'complete' );
@@ -204,11 +204,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'    => 'lesson',
 				'post_id' => $lesson_id,
-				'user_id' => [ $user1 ],
-			]
+				'user_id' => array( $user1 ),
+			)
 		);
 
 		/* Assert. */
@@ -222,11 +222,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			[ 'user_login' => 'sensei_guest_12345' ]
+			array( 'user_login' => 'sensei_guest_12345' )
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress' );
@@ -236,10 +236,10 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
-			]
+				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
+			)
 		);
 
 		/* Assert. */
@@ -254,13 +254,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -273,9 +273,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -290,7 +290,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
@@ -299,9 +299,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -319,13 +319,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user3     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -344,9 +344,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -430,7 +430,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user2     = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$started_at   = '2024-01-01 10:00:00';
@@ -445,7 +445,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 2, $result['unique_student_count'], 'Expected two distinct students.' );
@@ -462,13 +462,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -482,7 +482,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['unique_student_count'], 'Expected one student.' );
@@ -497,13 +497,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -515,7 +515,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Ungraded quiz status should count as completed.' );
@@ -547,13 +547,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -565,7 +565,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Failed quiz status should count as completed.' );
@@ -580,13 +580,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 
@@ -599,7 +599,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['lesson_completed_count'], 'Passed quiz should count as completed.' );
@@ -614,7 +614,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [] );
+		$result = $service->get_lesson_totals( array() );
 
 		/* Assert. */
 		$this->assertSame( 0, $result['unique_student_count'] );
@@ -675,7 +675,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		// UTC dates span two days (Jan 1 05:00 → Jan 2 04:00),
@@ -687,7 +687,7 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
 
 		/* Act. */
-		$result = $service->get_lesson_totals( [ $lesson_id ] );
+		$result = $service->get_lesson_totals( array( $lesson_id ) );
 
 		/* Assert. */
 		$this->assertSame( 1, $result['days_to_complete_sum'], 'UTC dates spanning midnight should be 1 day in local time (UTC-5).' );
@@ -703,11 +703,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		$regular_user = $this->sensei_factory->user->create();
 		$guest_user   = $this->sensei_factory->user->create(
-			[ 'user_login' => 'sensei_guest_12345' ]
+			array( 'user_login' => 'sensei_guest_12345' )
 		);
 		$course_id    = $this->sensei_factory->course->create();
 		$lesson_id    = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 
 		$this->insert_progress( $lesson_id, $regular_user, 'lesson', 'in-progress' );
@@ -717,11 +717,11 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type'                        => 'lesson',
-				'exclude_user_login_prefixes' => [ 'sensei_guest_' ],
-				'include_statuses_override'   => [ 'ungraded' ],
-			]
+				'exclude_user_login_prefixes' => array( 'sensei_guest_' ),
+				'include_statuses_override'   => array( 'ungraded' ),
+			)
 		);
 
 		/* Assert. */
@@ -736,13 +736,13 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$user_id   = $this->sensei_factory->user->create();
 		$course_id = $this->sensei_factory->course->create();
 		$lesson_id = $this->sensei_factory->lesson->create(
-			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
 		);
 		$quiz_id   = $this->sensei_factory->quiz->create(
-			[
+			array(
 				'post_parent' => $lesson_id,
-				'meta_input'  => [ '_quiz_lesson' => $lesson_id ],
-			]
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
 		);
 		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
 		update_post_meta( $lesson_id, '_quiz_has_questions', 1 );
@@ -755,9 +755,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'lesson',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -778,9 +778,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'course',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -802,9 +802,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'course',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -829,9 +829,9 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 
 		/* Act. */
 		$result = $service->count_statuses(
-			[
+			array(
 				'type' => 'course',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -1062,5 +1062,50 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		/* Act & Assert. */
 		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
 		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
+	}
+
+	public function testCountStatusesByUser_CourseType_ReturnsCountsGroupedByUser(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_a     = $this->sensei_factory->user->create();
+		$user_b     = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		$this->insert_progress( $course_id1, $user_a, 'course', 'complete' );
+		$this->insert_progress( $course_id2, $user_a, 'course', 'in-progress' );
+		$this->insert_progress( $course_id1, $user_b, 'course', 'in-progress' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => array( $user_a, $user_b ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $user_a ]['complete'] );
+		$this->assertSame( 1, $result[ $user_a ]['in-progress'] );
+		$this->assertSame( 1, $result[ $user_b ]['in-progress'] );
+		$this->assertArrayNotHasKey( 'complete', $result[ $user_b ] );
+	}
+
+	public function testCountStatusesByUser_InvalidType_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Tables_Based_Progress_Aggregation_Service::count_statuses_by_user' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_user( array( 'type' => 'invalid' ) );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -138,7 +138,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$data_provider,
-			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
+			new Sensei_Reports_Overview_Service_Students(),
 			( new Progress_Query_Service_Factory() )->create_aggregation_service()
 		);
 

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -118,54 +118,6 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		$this->assertFalse( isset( $actual['last_activity'] ) );
 	}
 
-	public function testGetRowData_WhenCalledAfterPrepareItems_UsesPrimedCourseCounts() {
-		/* Arrange. */
-		$user_id               = $this->factory->user->create();
-		$completed_course_id   = $this->factory->course->create();
-		$in_progress_course_id = $this->factory->course->create();
-
-		$completed_course_progress = Sensei()->course_progress_repository->create( $completed_course_id, $user_id );
-		$completed_course_progress->complete();
-		Sensei()->course_progress_repository->save( $completed_course_progress );
-
-		Sensei()->course_progress_repository->save( Sensei()->course_progress_repository->create( $in_progress_course_id, $user_id ) );
-
-		$user = get_user_by( 'id', $user_id );
-
-		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
-		$data_provider->method( 'get_items' )->willReturn( array( $user ) );
-		$data_provider->method( 'get_last_total_items' )->willReturn( 1 );
-
-		$list_table = new Sensei_Reports_Overview_List_Table_Students(
-			$data_provider,
-			new Sensei_Reports_Overview_Service_Students(),
-			( new Progress_Query_Service_Factory() )->create_aggregation_service()
-		);
-
-		/* Act. */
-		$list_table->prepare_items();
-		$row = $this->invoke_get_row_data( $list_table, $user );
-
-		/* Assert. */
-		self::assertSame( '1', (string) $row['completed_courses'] );
-		self::assertSame( '1', (string) $row['active_courses'] );
-	}
-
-	/**
-	 * Helper to call the protected get_row_data() method.
-	 *
-	 * @param Sensei_Reports_Overview_List_Table_Students $list_table List table instance.
-	 * @param WP_User                                      $item Row item.
-	 *
-	 * @return array
-	 */
-	private function invoke_get_row_data( $list_table, $item ) {
-		$method = new ReflectionMethod( $list_table, 'get_row_data' );
-		$method->setAccessible( true );
-
-		return $method->invoke( $list_table, $item );
-	}
-
 	public function testSearchButton_WhenCalled_ReturnsMatchingString() {
 		/* Arrange. */
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -118,6 +118,54 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		$this->assertFalse( isset( $actual['last_activity'] ) );
 	}
 
+	public function testGetRowData_WhenCalledAfterPrepareItems_UsesPrimedCourseCounts() {
+		/* Arrange. */
+		$user_id               = $this->factory->user->create();
+		$completed_course_id   = $this->factory->course->create();
+		$in_progress_course_id = $this->factory->course->create();
+
+		$completed_course_progress = Sensei()->course_progress_repository->create( $completed_course_id, $user_id );
+		$completed_course_progress->complete();
+		Sensei()->course_progress_repository->save( $completed_course_progress );
+
+		Sensei()->course_progress_repository->save( Sensei()->course_progress_repository->create( $in_progress_course_id, $user_id ) );
+
+		$user = get_user_by( 'id', $user_id );
+
+		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
+		$data_provider->method( 'get_items' )->willReturn( array( $user ) );
+		$data_provider->method( 'get_last_total_items' )->willReturn( 1 );
+
+		$list_table = new Sensei_Reports_Overview_List_Table_Students(
+			$data_provider,
+			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
+			( new Progress_Query_Service_Factory() )->create_aggregation_service()
+		);
+
+		/* Act. */
+		$list_table->prepare_items();
+		$row = $this->invoke_get_row_data( $list_table, $user );
+
+		/* Assert. */
+		self::assertSame( '1', (string) $row['completed_courses'] );
+		self::assertSame( '1', (string) $row['active_courses'] );
+	}
+
+	/**
+	 * Helper to call the protected get_row_data() method.
+	 *
+	 * @param Sensei_Reports_Overview_List_Table_Students $list_table List table instance.
+	 * @param WP_User                                      $item Row item.
+	 *
+	 * @return array
+	 */
+	private function invoke_get_row_data( $list_table, $item ) {
+		$method = new ReflectionMethod( $list_table, 'get_row_data' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $list_table, $item );
+	}
+
 	public function testSearchButton_WhenCalled_ReturnsMatchingString() {
 		/* Arrange. */
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-students.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-students.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Tests for Sensei_Reports_Overview_Service_Students class.
+ *
+ * @covers Sensei_Reports_Overview_Service_Students
+ */
+class Sensei_Reports_Overview_Service_Students_Test extends WP_UnitTestCase {
+	use Sensei_HPPS_Helpers;
+
+	/**
+	 * Factory for setting up testing data.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+		$this->maybe_enable_hpps_tables_repository();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		$this->maybe_reset_hpps_repository();
+
+		parent::tearDown();
+
+		$this->factory->tearDown();
+	}
+
+	public function testGetCourseCountsByUser_UserWithActiveAndCompletedCourses_ReturnsActiveAndCompletedCounts() {
+		/* Arrange. */
+		$user_id             = $this->factory->user->create();
+		$active_course_id    = $this->factory->course->create();
+		$completed_course_id = $this->factory->course->create();
+
+		Sensei()->course_progress_repository->save( Sensei()->course_progress_repository->create( $active_course_id, $user_id ) );
+
+		$completed_course_progress = Sensei()->course_progress_repository->create( $completed_course_id, $user_id );
+		$completed_course_progress->complete();
+		Sensei()->course_progress_repository->save( $completed_course_progress );
+
+		$service = new Sensei_Reports_Overview_Service_Students();
+
+		/* Act. */
+		$actual = $service->get_course_counts_by_user( array( $user_id ) );
+
+		/* Assert. */
+		$expected = array(
+			$user_id => array(
+				'active'    => 1,
+				'completed' => 1,
+			),
+		);
+		self::assertSame( $expected, $actual );
+	}
+
+	public function testGetCourseCountsByUser_UserWithoutCourses_ReturnsZeroCounts() {
+		/* Arrange. */
+		$user_id = $this->factory->user->create();
+		$service = new Sensei_Reports_Overview_Service_Students();
+
+		/* Act. */
+		$actual = $service->get_course_counts_by_user( array( $user_id ) );
+
+		/* Assert. */
+		$expected = array(
+			$user_id => array(
+				'active'    => 0,
+				'completed' => 0,
+			),
+		);
+		self::assertSame( $expected, $actual );
+	}
+
+	public function testGetCourseCountsByUser_EmptyUserIds_ReturnsEmptyArray() {
+		/* Arrange. */
+		$service = new Sensei_Reports_Overview_Service_Students();
+
+		/* Act. */
+		$actual = $service->get_course_counts_by_user( array() );
+
+		/* Assert. */
+		self::assertSame( array(), $actual );
+	}
+}


### PR DESCRIPTION
[SEN-83: HPPS: Reports Overview aggregates → table-aware](https://linear.app/a8c/issue/SEN-83/hpps-reports-overview-aggregates-table-aware)

Part of the Reports → Overview HPPS effort.

## Proposed Changes
* **Students** tab, per-row **Active Courses** and **Completed Courses** columns: replaces the two per-row queries (2N per page) with a single batched aggregation query per page — 2N→1 — cached for row rendering and CSV export. Reads HPPS progress tables when High-Performance Progress Storage is enabled.


## Testing Instructions
Setup (HPPS enabled):
- Create Course A and Course B.
- Create a student, enrol them in both, and mark Course A complete (leave Course B in progress).

Verify at **Reports → Overview → Students**:
- [x] That student's row shows Active Courses = 1 and Completed Courses = 1.
- [x] Export the CSV; the same two values appear for that student.
- [x] Turn HPPS off, reload, and confirm the values are identical.

## Deprecated Code
These per-row filters no longer run (values now come from one batched query per page). No replacement:
* `sensei_analysis_user_courses_started`
* `sensei_analysis_user_courses_ended`

