### PR TITLE
Read students Last Activity from HPPS tables

### DIFF
--- a/changelog/fix-reports-overview-students-last-activity-hpps
+++ b/changelog/fix-reports-overview-students-last-activity-hpps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reports Overview students last activity now reads HPPS progress tables when tables-based storage is enabled

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
@@ -5,6 +5,8 @@
  * @package sensei
  */
 
+use Sensei\Internal\Services\Progress_Storage_Settings;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -205,14 +207,29 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 
 		$query->query_fields .= ', last_activity_date';
 
-		$query->query_from .= "
-			LEFT JOIN (
-				SELECT {$wpdb->comments}.user_id, MAX({$wpdb->comments}.comment_date_gmt) AS last_activity_date
-				FROM {$wpdb->comments}
-				WHERE {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
-				AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
-				GROUP BY {$wpdb->comments}.user_id
-			) AS l ON {$wpdb->users}.ID = l.user_id";
+		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+			$progress_table = $wpdb->prefix . 'sensei_lms_progress';
+
+			$query->query_from .= "
+				LEFT JOIN (
+					SELECT p.user_id, MAX(COALESCE(q.completed_at, p.completed_at)) AS last_activity_date
+					FROM {$progress_table} p
+					LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
+					LEFT JOIN {$progress_table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
+					WHERE p.type = 'lesson'
+					AND COALESCE(q.status, p.status) IN ('complete', 'passed', 'graded')
+					GROUP BY p.user_id
+				) AS l ON {$wpdb->users}.ID = l.user_id";
+		} else {
+			$query->query_from .= "
+				LEFT JOIN (
+					SELECT {$wpdb->comments}.user_id, MAX({$wpdb->comments}.comment_date_gmt) AS last_activity_date
+					FROM {$wpdb->comments}
+					WHERE {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
+					AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
+					GROUP BY {$wpdb->comments}.user_id
+				) AS l ON {$wpdb->users}.ID = l.user_id";
+		}
 	}
 
 	/**

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
@@ -7,6 +7,7 @@
  */
 class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;
+	use Sensei_HPPS_Helpers;
 
 	/**
 	 * Factory for setting up testing data.
@@ -24,13 +25,21 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 
 		$this->factory = new Sensei_Factory();
 
-		add_filter( 'sensei_analysis_overview_filter_users', [ $this, 'excludeAdminFromUserQuery' ] );
+		add_filter( 'sensei_analysis_overview_filter_users', array( $this, 'excludeAdminFromUserQuery' ) );
+
+		// Keep the HPPS feature and repositories in sync with the requested test mode.
+		if ( self::is_hpps_tables_mode() ) {
+			Sensei()->settings->settings['experimental_progress_storage'] = true;
+		}
+		$this->maybe_enable_hpps_tables_repository();
 	}
 
 	/**
 	 * Tear down after each test.
 	 */
 	public function tearDown(): void {
+		$this->maybe_reset_hpps_repository();
+
 		parent::tearDown();
 
 		$this->factory->tearDown();
@@ -44,7 +53,7 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
 
 		/* Act. */
-		$students = $data_provider->get_items( [ 'number' => -1 ] );
+		$students = $data_provider->get_items( array( 'number' => -1 ) );
 
 		/* Assert. */
 		$this->assertCount( 2, $students );
@@ -54,18 +63,18 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 		/* Arrange. */
 		$user_id = $this->createUserWithActivity(
 			'2022-03-01 00:00:00',
-			[
+			array(
 				'user_login'      => 'test',
 				'user_email'      => 'test@example.org',
 				'display_name'    => 'test',
 				'user_registered' => '2022-03-01 00:00:00',
-			]
+			)
 		);
 
 		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
 
 		/* Act. */
-		$students = $data_provider->get_items( [ 'number' => -1 ] );
+		$students = $data_provider->get_items( array( 'number' => -1 ) );
 
 		/* Assert. */
 		$this->assertEquals( $user_id, $students[0]->ID );
@@ -78,21 +87,21 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 
 	public function testGetItems_FiltersWithSearchGiven_ReturnsTheSearchedStudents() {
 		/* Arrange. */
-		$searched_user = $this->createUserWithCourseEnrollment( [ 'user_login' => 'awesome_nickname' ] );
-		$other_user    = $this->createUserWithCourseEnrollment( [ 'user_login' => 'cool_nickname' ] );
+		$searched_user = $this->createUserWithCourseEnrollment( array( 'user_login' => 'awesome_nickname' ) );
+		$other_user    = $this->createUserWithCourseEnrollment( array( 'user_login' => 'cool_nickname' ) );
 
 		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
 
 		/* Act. */
-		$students = $data_provider->get_items( [ 'search' => 'awesome_nickname' ] );
+		$students = $data_provider->get_items( array( 'search' => 'awesome_nickname' ) );
 
 		/* Assert. */
-		$expected = [
-			[
+		$expected = array(
+			array(
 				'id'                 => $searched_user,
 				'last_activity_date' => null,
-			],
-		];
+			),
+		);
 
 		$this->assertEquals( $expected, $this->exportStudents( $students ) );
 	}
@@ -106,18 +115,18 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 
 		/* Act. */
 		$students = $data_provider->get_items(
-			[
+			array(
 				'last_activity_date_from' => '2022-03-01',
-			]
+			)
 		);
 
 		/* Assert. */
-		$expected = [
-			[
+		$expected = array(
+			array(
 				'id'                 => $user_with_activity,
 				'last_activity_date' => '2022-03-01 00:00:00',
-			],
-		];
+			),
+		);
 
 		$this->assertEquals( $expected, $this->exportStudents( $students ) );
 	}
@@ -131,19 +140,19 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 
 		/* Act. */
 		$students = $data_provider->get_items(
-			[
+			array(
 				'last_activity_date_from' => '2022-03-01',
 				'last_activity_date_to'   => '2022-03-01',
-			]
+			)
 		);
 
 		/* Assert. */
-		$expected = [
-			[
+		$expected = array(
+			array(
 				'id'                 => $user_1,
 				'last_activity_date' => '2022-03-01 00:00:00',
-			],
-		];
+			),
+		);
 
 		$this->assertEquals( $expected, $this->exportStudents( $students ) );
 	}
@@ -157,18 +166,18 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 
 		/* Act. */
 		$students = $data_provider->get_items(
-			[
+			array(
 				'last_activity_date_from' => '2022-03-02',
-			]
+			)
 		);
 
 		/* Assert. */
-		$expected = [
-			[
+		$expected = array(
+			array(
 				'id'                 => $user_2,
 				'last_activity_date' => '2022-03-02 00:00:00',
-			],
-		];
+			),
+		);
 
 		$this->assertEquals( $expected, $this->exportStudents( $students ) );
 	}
@@ -182,18 +191,18 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 
 		/* Act. */
 		$students = $data_provider->get_items(
-			[
+			array(
 				'last_activity_date_to' => '2022-03-01',
-			]
+			)
 		);
 
 		/* Assert. */
-		$expected = [
-			[
+		$expected = array(
+			array(
 				'id'                 => $user_1,
 				'last_activity_date' => '2022-03-01 00:00:00',
-			],
-		];
+			),
+		);
 
 		$this->assertEquals( $expected, $this->exportStudents( $students ) );
 	}
@@ -207,10 +216,10 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 
 		/* Act. */
 		$students = $data_provider->get_items(
-			[
+			array(
 				'last_activity_date_from' => '2022-03-02',
 				'last_activity_date_to'   => '2022-03-01',
-			]
+			)
 		);
 
 		/* Assert. */
@@ -225,15 +234,15 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
 
 		/* Act. */
-		$students = $data_provider->get_items( [] );
+		$students = $data_provider->get_items( array() );
 
 		/* Assert. */
-		$expected = [
-			[
+		$expected = array(
+			array(
 				'id'                 => $course_enrolled_user,
 				'last_activity_date' => null,
-			],
-		];
+			),
+		);
 
 		$this->assertEquals( $expected, $this->exportStudents( $students ) );
 	}
@@ -254,10 +263,96 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
 
 		/* Act. */
-		$students = $data_provider->get_items( [ 'number' => -1 ] );
+		$students = $data_provider->get_items( array( 'number' => -1 ) );
 
 		/* Assert. */
 		$this->assertSame( 2, $data_provider->get_last_total_items() );
+	}
+
+	public function testGetItems_LessonCompletedWithoutQuiz_ReturnsLastActivityDateFromProgressRepository() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $course_id ) ) );
+
+		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
+
+		$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+		$lesson_progress->complete( new DateTimeImmutable( '2022-03-01 00:00:00', new DateTimeZone( 'UTC' ) ) );
+		Sensei()->lesson_progress_repository->save( $lesson_progress );
+
+		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
+
+		/* Act. */
+		$students = $data_provider->get_items( array( 'number' => -1 ) );
+
+		/* Assert. */
+		$this->assertEquals( '2022-03-01 00:00:00', $students[0]->last_activity_date );
+	}
+
+	public function testGetItems_QuizGraded_ReturnsLastActivityDateFromQuizCompletion() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $course_id ) ) );
+		$quiz_id   = $this->factory->quiz->create( array( 'post_parent' => $lesson_id ) );
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
+
+		$graded_at = new DateTimeImmutable( '2022-03-05 00:00:00', new DateTimeZone( 'UTC' ) );
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+
+		$quiz_progress = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id );
+		$quiz_progress->grade( $graded_at );
+		Sensei()->quiz_progress_repository->save( $quiz_progress );
+
+		if ( \Sensei\Internal\Services\Progress_Storage_Settings::is_comments_repository() ) {
+			// Legacy storage keeps the last activity date on the lesson status comment.
+			$activity = Sensei_Utils::sensei_check_for_activity(
+				array(
+					'post_id' => $lesson_id,
+					'user_id' => $user_id,
+					'type'    => 'sensei_lesson_status',
+				),
+				true
+			);
+			wp_update_comment(
+				array(
+					'comment_ID'   => $activity->comment_ID,
+					'comment_date' => $graded_at->format( 'Y-m-d H:i:s' ),
+				)
+			);
+		}
+
+		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
+
+		/* Act. */
+		$students = $data_provider->get_items( array( 'number' => -1 ) );
+
+		/* Assert. */
+		$this->assertEquals( '2022-03-05 00:00:00', $students[0]->last_activity_date );
+	}
+
+	public function testGetItems_SortedByLastActivityDate_SortsUsersCorrectly() {
+		/* Arrange. */
+		$user_1 = $this->createUserWithCompletedLessonProgress( '2022-03-01 00:00:00' );
+		$user_2 = $this->createUserWithCompletedLessonProgress( '2022-03-05 00:00:00' );
+
+		$data_provider = new Sensei_Reports_Overview_Data_Provider_Students();
+
+		/* Act. */
+		$students = $data_provider->get_items(
+			array(
+				'number'  => -1,
+				'orderby' => 'last_activity_date',
+				'order'   => 'DESC',
+			)
+		);
+
+		/* Assert. */
+		$this->assertEquals( $user_2, $students[0]->ID );
+		$this->assertEquals( $user_1, $students[1]->ID );
 	}
 
 	public function testGetItems_NoUsersRelationship_ReturnsNoLastActivityDate() {
@@ -269,10 +364,31 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 		$data_provider           = new Sensei_Reports_Overview_Data_Provider_Students();
 
 		/* Act. */
-		$students = $data_provider->get_items( [ 'number' => -1 ] );
+		$students = $data_provider->get_items( array( 'number' => -1 ) );
 
 		/* Assert. */
 		$this->assertFalse( isset( $students[0]->last_activity_date ) );
+	}
+
+	/**
+	 * Create a user with a completed lesson and no quiz.
+	 *
+	 * @param string $completed_at The completion date, in 'Y-m-d H:i:s' format (UTC).
+	 *
+	 * @return int The user ID.
+	 */
+	private function createUserWithCompletedLessonProgress( string $completed_at ): int {
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $course_id ) ) );
+
+		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
+
+		$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+		$lesson_progress->complete( new DateTimeImmutable( $completed_at, new DateTimeZone( 'UTC' ) ) );
+		Sensei()->lesson_progress_repository->save( $lesson_progress );
+
+		return $user_id;
 	}
 
 	/**
@@ -283,13 +399,13 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	 * @return array
 	 */
 	private function exportStudents( array $students ): array {
-		$result = [];
+		$result = array();
 
 		foreach ( $students as $student ) {
-			$result[] = [
+			$result[] = array(
 				'id'                 => $student->ID,
 				'last_activity_date' => $student->last_activity_date,
-			];
+			);
 		}
 
 		return $result;
@@ -303,25 +419,32 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	 *
 	 * @return int The user ID.
 	 */
-	private function createUserWithActivity( string $activity_date, array $user_args = [] ): int {
+	private function createUserWithActivity( string $activity_date, array $user_args = array() ): int {
 		$user_id   = $this->factory->user->create( $user_args );
 		$course_id = $this->factory->course->create();
 
 		$lesson_id = $this->factory->lesson->create(
-			[
-				'meta_input' => [ '_lesson_course' => $course_id ],
-			]
+			array(
+				'meta_input' => array( '_lesson_course' => $course_id ),
+			)
 		);
 
 		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
-		$activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id, true );
 
-		wp_update_comment(
-			[
-				'comment_ID'   => $activity_comment_id,
-				'comment_date' => $activity_date,
-			]
-		);
+		if ( \Sensei\Internal\Services\Progress_Storage_Settings::is_tables_repository() ) {
+			$lesson_progress = Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+			$lesson_progress->complete( new DateTimeImmutable( $activity_date, new DateTimeZone( 'UTC' ) ) );
+			Sensei()->lesson_progress_repository->save( $lesson_progress );
+		} else {
+			$activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id, true );
+
+			wp_update_comment(
+				array(
+					'comment_ID'   => $activity_comment_id,
+					'comment_date' => $activity_date,
+				)
+			);
+		}
 
 		return $user_id;
 	}
@@ -334,7 +457,7 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	 *
 	 * @return int The user ID.
 	 */
-	private function createUserWithCourseEnrollment( array $user_args = [], int $course_id = null ): int {
+	private function createUserWithCourseEnrollment( array $user_args = array(), int $course_id = null ): int {
 		$user_id   = $this->factory->user->create( $user_args );
 		$course_id = $course_id ?? $this->factory->course->create();
 
@@ -351,7 +474,7 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	 * @return array
 	 */
 	public function excludeAdminFromUserQuery( array $query_args ): array {
-		$query_args['exclude'] = [ 1 ];
+		$query_args['exclude'] = array( 1 );
 
 		return $query_args;
 	}


### PR DESCRIPTION
[SEN-83: HPPS: Reports Overview aggregates → table-aware](https://linear.app/a8c/issue/SEN-83/hpps-reports-overview-aggregates-table-aware)

Part of the Reports → Overview HPPS effort. Stacked on `hpps-reports-students-avg-grade`.

## Proposed Changes
* **Students** tab, **Last Activity** column: derived from the HPPS progress tables when enabled — the column value, its sorting, and the date-range filter all read HPPS data.

## Testing Instructions
Use an existing site with progress synchronized between comments and the HPPS tables. The data should include at least two students whose latest activity occurred on different days.

- [ ] On `trunk`, open **Reports → Overview → Students** with HPPS off. Record each student's **Last Activity**, verify sorting in both directions, and apply a date-range filter that excludes the older activity. This is the baseline; `trunk` does not need to be checked with HPPS on because these values always read comment-based data there.
- [ ] Check out this PR with HPPS off. Confirm the **Last Activity** values, sorting, and date-range filtering match the `trunk` baseline.
- [ ] Keep this PR checked out and turn HPPS on, selecting the HPPS tables as the progress repository. Confirm the **Last Activity** values, sorting, and date-range filtering match this PR with HPPS off.
