### PR TITLE
Read Courses Overview aggregates from HPPS

### DIFF
--- a/changelog/fix-reports-overview-courses-aggregates-hpps
+++ b/changelog/fix-reports-overview-courses-aggregates-hpps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reports Overview courses aggregates now read HPPS progress tables when tables-based storage is enabled

--- a/includes/internal/services/class-comments-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-comments-based-progress-aggregation-service.php
@@ -233,6 +233,129 @@ class Comments_Based_Progress_Aggregation_Service implements Progress_Aggregatio
 	}
 
 	/**
+	 * Count progress records grouped by post and status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Same shape as count_statuses(); 'type' and 'post__in' honored.
+	 * @return array<int, array<string, int>> Map of post_id => [ status => count ].
+	 */
+	public function count_statuses_by_post( array $args ): array {
+		if ( empty( $args['type'] ) || ! in_array( $args['type'], array( 'course', 'lesson' ), true ) ) {
+			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course" or "lesson".', '$$next-version$$' );
+			return array();
+		}
+
+		$wpdb         = $this->wpdb;
+		$comment_type = 'course' === $args['type'] ? 'sensei_course_status' : 'sensei_lesson_status';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb.
+		$query  = $wpdb->prepare( "SELECT comment_post_ID, comment_approved, COUNT(*) AS total FROM {$wpdb->comments} INNER JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID AND {$wpdb->posts}.post_status IN ( 'publish', 'private' ) WHERE comment_type = %s", $comment_type );
+		$query .= $this->build_post_filter_clause( $args );
+		$query .= $this->build_user_filter_clause( $args );
+		$query .= $this->build_user_exclusion_clause( $args );
+		$query .= ' GROUP BY comment_post_ID, comment_approved';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$results = (array) $wpdb->get_results( $query, ARRAY_A );
+		Utils::log_query_error( $wpdb, 'Comments-based status counts by post' );
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$counts[ (int) $row['comment_post_ID'] ][ $row['comment_approved'] ] = (int) $row['total'];
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Count completed lesson progress per lesson.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $lesson_ids Lesson post IDs.
+	 * @return array<int, int> Map of lesson_id => completion count.
+	 */
+	public function get_lesson_completion_counts( array $lesson_ids ): array {
+		if ( empty( $lesson_ids ) ) {
+			return array();
+		}
+
+		$wpdb         = $this->wpdb;
+		$placeholders = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb. Placeholders created dynamically.
+		$query = $wpdb->prepare(
+			"SELECT wcom.comment_post_id AS lesson_id, COUNT(*) AS completion_count
+			FROM {$wpdb->comments} wcom
+			WHERE wcom.comment_approved IN ('graded', 'ungraded', 'passed', 'failed','complete')
+			AND comment_type IN ('sensei_lesson_status')
+			AND wcom.comment_post_ID IN ( $placeholders )
+			AND wcom.comment_post_ID IN
+			(
+			SELECT wpm.post_id FROM {$wpdb->posts} wpc
+			JOIN {$wpdb->postmeta} wpm ON wpm.meta_value = wpc.id
+			WHERE wpm.meta_key = '_lesson_course'
+			AND wpc.post_status IN ('publish','private')
+			)
+			GROUP BY wcom.comment_post_id",
+			$lesson_ids
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$results = (array) $wpdb->get_results( $query, ARRAY_A );
+		Utils::log_query_error( $wpdb, 'Comments-based lesson completion counts' );
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$counts[ (int) $row['lesson_id'] ] = (int) $row['completion_count'];
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Average days-to-completion across the given courses (AVG of per-course averages).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Course post IDs.
+	 * @return float
+	 */
+	public function get_courses_average_days_to_completion( array $course_ids ): float {
+		if ( empty( $course_ids ) ) {
+			return 0.0;
+		}
+
+		$wpdb         = $this->wpdb;
+		$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb. Placeholders created dynamically. Date format string passed as %s to avoid conflicting with prepare().
+		$query = $wpdb->prepare(
+			"SELECT AVG( aggregated.days_to_completion )
+			FROM (
+				SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, %s ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
+				FROM {$wpdb->comments}
+				LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
+					AND {$wpdb->commentmeta}.meta_key = 'start'
+				WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
+					AND {$wpdb->comments}.comment_approved = 'complete'
+					AND {$wpdb->comments}.comment_post_ID IN ( $placeholders )
+				GROUP BY {$wpdb->comments}.comment_post_ID
+			) AS aggregated",
+			array_merge( array( '%Y-%m-%d %H:%i:%s' ), $course_ids )
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$result = $wpdb->get_var( $query );
+		Utils::log_query_error( $wpdb, 'Comments-based courses average days to completion' );
+
+		return (float) $result;
+	}
+
+	/**
 	 * Build SQL clause for filtering by post ID(s).
 	 *
 	 * @since 4.26.0

--- a/includes/internal/services/class-progress-aggregation-service-interface.php
+++ b/includes/internal/services/class-progress-aggregation-service-interface.php
@@ -87,4 +87,34 @@ interface Progress_Aggregation_Service_Interface {
 	 * @return int Number of ungraded quiz submissions for live (publish or private) lessons.
 	 */
 	public function count_ungraded_quizzes( array $args = array() ): int;
+
+	/**
+	 * Count progress records grouped by post and status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Same shape as count_statuses(); 'type' and 'post__in' honored.
+	 * @return array<int, array<string, int>> Map of post_id => [ status => count ].
+	 */
+	public function count_statuses_by_post( array $args ): array;
+
+	/**
+	 * Count completed lesson progress per lesson.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $lesson_ids Lesson post IDs.
+	 * @return array<int, int> Map of lesson_id => completion count.
+	 */
+	public function get_lesson_completion_counts( array $lesson_ids ): array;
+
+	/**
+	 * Average days-to-completion across the given courses (AVG of per-course averages).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Course post IDs.
+	 * @return float
+	 */
+	public function get_courses_average_days_to_completion( array $course_ids ): float;
 }

--- a/includes/internal/services/class-tables-based-progress-aggregation-service.php
+++ b/includes/internal/services/class-tables-based-progress-aggregation-service.php
@@ -329,6 +329,190 @@ class Tables_Based_Progress_Aggregation_Service implements Progress_Aggregation_
 	}
 
 	/**
+	 * Count progress records grouped by post and status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Same shape as count_statuses(); 'type' and 'post__in' honored.
+	 * @return array<int, array<string, int>> Map of post_id => [ status => count ].
+	 */
+	public function count_statuses_by_post( array $args ): array {
+		if ( empty( $args['type'] ) || ! in_array( $args['type'], array( 'course', 'lesson' ), true ) ) {
+			_doing_it_wrong( __METHOD__, 'The "type" argument must be "course" or "lesson".', '$$next-version$$' );
+			return array();
+		}
+
+		if ( 'lesson' === $args['type'] ) {
+			return $this->count_lesson_statuses_with_quiz_by_post( $args );
+		}
+
+		return $this->count_course_statuses_by_post( $args );
+	}
+
+	/**
+	 * Count completed lesson progress per lesson.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $lesson_ids Lesson post IDs.
+	 * @return array<int, int> Map of lesson_id => completion count.
+	 */
+	public function get_lesson_completion_counts( array $lesson_ids ): array {
+		if ( empty( $lesson_ids ) ) {
+			return array();
+		}
+
+		$wpdb         = $this->wpdb;
+		$table        = $this->get_progress_table_name();
+		$placeholders = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table names from wpdb prefix. Placeholders created dynamically.
+		$query = $wpdb->prepare(
+			"SELECT p.post_id AS lesson_id, COUNT(*) AS completion_count
+			FROM {$table} p
+			LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0
+			LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
+			WHERE p.type = 'lesson'
+			AND p.post_id IN ( $placeholders )
+			AND COALESCE( q.status, p.status ) IN ('graded', 'ungraded', 'passed', 'failed', 'complete')
+			GROUP BY p.post_id",
+			$lesson_ids
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$results = (array) $wpdb->get_results( $query, ARRAY_A );
+		Utils::log_query_error( $wpdb, 'Tables-based lesson completion counts' );
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$counts[ (int) $row['lesson_id'] ] = (int) $row['completion_count'];
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Average days-to-completion across the given courses (AVG of per-course averages).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Course post IDs.
+	 * @return float
+	 */
+	public function get_courses_average_days_to_completion( array $course_ids ): float {
+		if ( empty( $course_ids ) ) {
+			return 0.0;
+		}
+
+		$wpdb         = $this->wpdb;
+		$table        = $this->get_progress_table_name();
+		$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+		$utc_offset   = Utils::get_utc_offset_string();
+
+		// Convert to site-local time before DATEDIFF so results match the comments-based
+		// implementation, which reads already-local comment_date / commentmeta 'start' values.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name from wpdb prefix. Placeholders created dynamically.
+		$query = $wpdb->prepare(
+			"SELECT AVG( aggregated.days_to_completion )
+			FROM (
+				SELECT CEIL( SUM( ABS( DATEDIFF( CONVERT_TZ( p.completed_at, '+00:00', '$utc_offset' ), CONVERT_TZ( p.started_at, '+00:00', '$utc_offset' ) ) ) + 1 ) / COUNT(*) ) AS days_to_completion
+				FROM {$table} p
+				WHERE p.type = 'course'
+					AND p.status = 'complete'
+					AND p.post_id IN ( $placeholders )
+				GROUP BY p.post_id
+			) AS aggregated",
+			$course_ids
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$result = $wpdb->get_var( $query );
+		Utils::log_query_error( $wpdb, 'Tables-based courses average days to completion' );
+
+		return (float) $result;
+	}
+
+	/**
+	 * Count course progress grouped by post and status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments (see count_statuses).
+	 * @return array<int, array<string, int>> Map of post_id => [ status => count ].
+	 */
+	private function count_course_statuses_by_post( array $args ): array {
+		$wpdb  = $this->wpdb;
+		$table = $this->get_progress_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
+		$query  = "SELECT p.post_id, p.status, COUNT(*) AS total FROM {$table} p";
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+
+		$query .= $wpdb->prepare( ' WHERE p.type = %s', $args['type'] );
+		$query .= $this->build_post_filter_clause( $args );
+		$query .= $this->build_user_filter_clause( $args );
+		$query .= $this->build_user_exclusion_clause( $args );
+
+		$query .= ' GROUP BY p.post_id, p.status';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$results = (array) $wpdb->get_results( $query, ARRAY_A );
+		Utils::log_query_error( $wpdb, 'Tables-based course status counts by post' );
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$counts[ (int) $row['post_id'] ][ $row['status'] ] = (int) $row['total'];
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Count lesson statuses grouped by post, using quiz status when a quiz exists.
+	 *
+	 * See count_lesson_statuses_with_quiz() for the rationale behind using
+	 * COALESCE(q.status, p.status).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $args Query arguments (see count_statuses).
+	 * @return array<int, array<string, int>> Map of post_id => [ status => count ].
+	 */
+	private function count_lesson_statuses_with_quiz_by_post( array $args ): array {
+		$wpdb  = $this->wpdb;
+		$table = $this->get_progress_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query = "SELECT p.post_id, COALESCE( q.status, p.status ) AS effective_status, COUNT( * ) AS total FROM {$table} p";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
+		$query .= " LEFT JOIN {$table} q ON q.post_id = pm.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'";
+
+		$query .= $wpdb->prepare( ' WHERE p.type = %s', 'lesson' );
+
+		$query .= $this->build_post_filter_clause( $args );
+		$query .= $this->build_user_filter_clause( $args );
+		$query .= $this->build_user_exclusion_clause( $args, 'COALESCE( q.status, p.status )' );
+
+		$query .= ' GROUP BY p.post_id, effective_status';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- SQL prepared in advance. Caching handled by callers.
+		$results = (array) $wpdb->get_results( $query, ARRAY_A );
+		Utils::log_query_error( $wpdb, 'Tables-based lesson status counts by post' );
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$counts[ (int) $row['post_id'] ][ $row['effective_status'] ] = (int) $row['total'];
+		}
+
+		return $counts;
+	}
+
+	/**
 	 * Build SQL clause for filtering by post ID(s).
 	 *
 	 * @since 4.26.0

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -6,7 +6,6 @@
  */
 
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
-use Sensei\Internal\Services\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -33,7 +32,14 @@ class Sensei_Reports_Overview_Service_Courses {
 			return 0.0;
 		}
 		$lessons_count_per_courses = $this->get_lessons_in_courses( $course_ids );
-		$lessons_completions       = $this->get_lessons_completions();
+
+		$all_lesson_ids = array();
+		foreach ( $lessons_count_per_courses as $course_lessons ) {
+			$all_lesson_ids = array_merge( $all_lesson_ids, array_map( 'intval', explode( ',', $course_lessons->lessons ) ) );
+		}
+		$all_lesson_ids = array_unique( $all_lesson_ids );
+
+		$lessons_completions       = $this->get_lessons_completions( $all_lesson_ids );
 		$student_count_per_courses = $this->get_students_count_in_courses( $course_ids );
 		$total_average_progress    = 0;
 
@@ -108,24 +114,10 @@ class Sensei_Reports_Overview_Service_Courses {
 		if ( empty( $course_ids ) ) {
 			return 0;
 		}
-		global $wpdb;
 
-		$query = "
-		SELECT AVG( aggregated.days_to_completion )
-		FROM (
-			SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
-			FROM {$wpdb->comments}
-			LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
-				AND {$wpdb->commentmeta}.meta_key = 'start'
-			WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
-				AND {$wpdb->comments}.comment_approved = 'complete'
-				AND {$wpdb->comments}.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		. " GROUP BY {$wpdb->comments}.comment_post_ID
-		) AS aggregated
-		";
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		return (float) $wpdb->get_var( $query );
+		return ( new Progress_Query_Service_Factory() )
+			->create_aggregation_service()
+			->get_courses_average_days_to_completion( $course_ids );
 	}
 
 
@@ -155,35 +147,31 @@ class Sensei_Reports_Overview_Service_Courses {
 	}
 
 	/**
-	 * Get all lessons completions.
+	 * Get lessons completions.
 	 *
 	 * @since  4.4.1
 	 *
+	 * @param array $lesson_ids The list of lesson ids to get completions for.
 	 * @return array lessons completions.
 	 */
-	private function get_lessons_completions(): array {
+	private function get_lessons_completions( array $lesson_ids ): array {
+		if ( empty( $lesson_ids ) ) {
+			return array();
+		}
 
-		global $wpdb;
-		$reports_statuses = Utils::get_reports_post_status_sql();
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Statuses come from a fixed constant.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe direct sql.
-		$results = $wpdb->get_results(
-			"SELECT wcom.comment_post_id lesson_id, COUNT(*) completion_count
-						FROM {$wpdb->comments} wcom
-						WHERE wcom.comment_approved IN ('graded', 'ungraded', 'passed', 'failed','complete')
-						AND comment_type IN ('sensei_lesson_status')
-						AND wcom.comment_post_ID IN
-						(
-						SELECT wpm.post_id lesson_id from {$wpdb->posts} wpc
-						JOIN {$wpdb->postmeta} wpm on wpm.meta_value = wpc.id
-						WHERE wpm.meta_key = '_lesson_course'
-						AND wpc.post_status in ( {$reports_statuses} )
-						)
-						GROUP BY wcom.comment_post_id",
-			'OBJECT_K'
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $results;
+		$counts = ( new Progress_Query_Service_Factory() )
+			->create_aggregation_service()
+			->get_lesson_completion_counts( $lesson_ids );
+
+		$result = array();
+		foreach ( $counts as $lesson_id => $completion_count ) {
+			$result[ $lesson_id ] = (object) array(
+				'lesson_id'        => $lesson_id,
+				'completion_count' => $completion_count,
+			);
+		}
+
+		return $result;
 	}
 
 	/**
@@ -217,17 +205,27 @@ class Sensei_Reports_Overview_Service_Courses {
 	 * @return array students in courses.
 	 */
 	private function get_students_count_in_courses( array $course_ids ): array {
+		if ( empty( $course_ids ) ) {
+			return array();
+		}
 
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe direct sql.
-		return $wpdb->get_results(
-			"SELECT c.comment_post_ID as course_id, count(c.comment_post_ID) as students_count
-				FROM {$wpdb->comments} c
-				WHERE c.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )'  // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			. " AND c.comment_type = 'sensei_course_status'
-				AND c.comment_approved IN ( 'in-progress', 'complete' )
-				GROUP BY c.comment_post_ID",
-			'OBJECT_K'
-		);
+		$by_post = ( new Progress_Query_Service_Factory() )
+			->create_aggregation_service()
+			->count_statuses_by_post(
+				array(
+					'type'     => 'course',
+					'post__in' => $course_ids,
+				)
+			);
+
+		$result = array();
+		foreach ( $by_post as $course_id => $statuses ) {
+			$result[ $course_id ] = (object) array(
+				'course_id'      => $course_id,
+				'students_count' => ( $statuses['in-progress'] ?? 0 ) + ( $statuses['complete'] ?? 0 ),
+			);
+		}
+
+		return $result;
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-progress-aggregation-service.php
@@ -734,4 +734,154 @@ class Comments_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase 
 		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
 		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
 	}
+	public function testCountStatusesByPost_CourseType_ReturnsCountsGroupedByPost(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1      = $this->sensei_factory->user->create();
+		$user2      = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		\Sensei_Utils::update_course_status( $user1, $course_id1, 'complete' );
+		\Sensei_Utils::update_course_status( $user2, $course_id1, 'in-progress' );
+		\Sensei_Utils::update_course_status( $user1, $course_id2, 'in-progress' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_post(
+			array(
+				'type'     => 'course',
+				'post__in' => array( $course_id1, $course_id2 ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $course_id1 ]['complete'] );
+		$this->assertSame( 1, $result[ $course_id1 ]['in-progress'] );
+		$this->assertSame( 1, $result[ $course_id2 ]['in-progress'] );
+		$this->assertArrayNotHasKey( 'complete', $result[ $course_id2 ] );
+	}
+
+	public function testCountStatusesByPost_InvalidType_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Comments_Based_Progress_Aggregation_Service::count_statuses_by_post' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_post( array( 'type' => 'invalid' ) );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
+	}
+
+	public function testGetLessonCompletionCounts_ReturnsCorrectPerLessonCounts(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+
+		$ungraded_lesson = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$complete_lesson = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$progress_lesson = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		\Sensei_Utils::update_lesson_status( $user1, $ungraded_lesson, 'ungraded' );
+		\Sensei_Utils::update_lesson_status( $user1, $complete_lesson, 'complete' );
+		\Sensei_Utils::update_lesson_status( $user2, $complete_lesson, 'complete' );
+		\Sensei_Utils::update_lesson_status( $user1, $progress_lesson, 'in-progress' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_completion_counts( array( $ungraded_lesson, $complete_lesson, $progress_lesson ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $ungraded_lesson ], 'Ungraded lesson status should be counted as a completion.' );
+		$this->assertSame( 2, $result[ $complete_lesson ], 'Both completions for the complete lesson should be counted.' );
+		$this->assertArrayNotHasKey( $progress_lesson, $result, 'In-progress lesson should not be counted as a completion.' );
+	}
+
+	public function testGetLessonCompletionCounts_WithEmptyLessonIds_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_completion_counts( array() );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
+	}
+
+	public function testGetCoursesAverageDaysToCompletion_ReturnsCorrectAverage(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1      = $this->sensei_factory->user->create();
+		$user2      = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		$comment1_id = \Sensei_Utils::update_course_status( $user1, $course_id1, 'complete' );
+		wp_update_comment(
+			array(
+				'comment_ID'   => $comment1_id,
+				'comment_date' => '2022-03-11 23:29:06',
+			)
+		);
+		update_comment_meta( $comment1_id, 'start', '2022-03-11 23:27:51' );
+
+		$comment2_id = \Sensei_Utils::update_course_status( $user2, $course_id1, 'complete' );
+		wp_update_comment(
+			array(
+				'comment_ID'   => $comment2_id,
+				'comment_date' => '2022-03-14 21:34:37',
+			)
+		);
+		update_comment_meta( $comment2_id, 'start', '2022-03-14 21:34:27' );
+
+		$comment3_id = \Sensei_Utils::update_course_status( $user1, $course_id2, 'complete' );
+		wp_update_comment(
+			array(
+				'comment_ID'   => $comment3_id,
+				'comment_date' => '2022-03-12 00:22:37',
+			)
+		);
+		update_comment_meta( $comment3_id, 'start', '2022-03-09 00:22:34' );
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_courses_average_days_to_completion( array( $course_id1, $course_id2 ) );
+
+		/* Assert. */
+		// Course 1 average: (1 + 1) / 2 = 1. Course 2 average: 4 / 1 = 4. Total: (1 + 4) / 2 = 2.5.
+		$this->assertSame( 2.5, $result );
+	}
+
+	public function testGetCoursesAverageDaysToCompletion_WithEmptyCourseIds_ReturnsZero(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Comments_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_courses_average_days_to_completion( array() );
+
+		/* Assert. */
+		$this->assertSame( 0.0, $result );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-progress-aggregation-service.php
@@ -1162,4 +1162,199 @@ class Tables_Based_Progress_Aggregation_Service_Test extends \WP_UnitTestCase {
 		$this->assertSame( 1, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'sensei_guest_' ) ) ), 'Matching prefix should exclude the guest user.' );
 		$this->assertSame( 2, $service->count_ungraded_quizzes( array( 'exclude_user_login_prefixes' => array( 'no_match_' ) ) ), 'Non-matching prefix should leave both users counted.' );
 	}
+	public function testCountStatusesByPost_CourseType_ReturnsCountsGroupedByPost(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1      = $this->sensei_factory->user->create();
+		$user2      = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		$this->insert_progress( $course_id1, $user1, 'course', 'complete' );
+		$this->insert_progress( $course_id1, $user2, 'course', 'in-progress' );
+		$this->insert_progress( $course_id2, $user1, 'course', 'in-progress' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_post(
+			array(
+				'type'     => 'course',
+				'post__in' => array( $course_id1, $course_id2 ),
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $course_id1 ]['complete'] );
+		$this->assertSame( 1, $result[ $course_id1 ]['in-progress'] );
+		$this->assertSame( 1, $result[ $course_id2 ]['in-progress'] );
+		$this->assertArrayNotHasKey( 'complete', $result[ $course_id2 ] );
+	}
+
+	public function testCountStatusesByPost_InvalidType_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$this->setExpectedIncorrectUsage( 'Sensei\Internal\Services\Tables_Based_Progress_Aggregation_Service::count_statuses_by_post' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->count_statuses_by_post( array( 'type' => 'invalid' ) );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
+	}
+
+	public function testGetLessonCompletionCounts_ReturnsCorrectPerLessonCounts(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1     = $this->sensei_factory->user->create();
+		$user2     = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+
+		$ungraded_lesson = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$complete_lesson = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$progress_lesson = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$this->insert_progress( $ungraded_lesson, $user1, 'lesson', 'ungraded' );
+		$this->insert_progress( $complete_lesson, $user1, 'lesson', 'complete' );
+		$this->insert_progress( $complete_lesson, $user2, 'lesson', 'complete' );
+		$this->insert_progress( $progress_lesson, $user1, 'lesson', 'in-progress' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_completion_counts( array( $ungraded_lesson, $complete_lesson, $progress_lesson ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $ungraded_lesson ], 'Ungraded lesson status should be counted as a completion.' );
+		$this->assertSame( 2, $result[ $complete_lesson ], 'Both completions for the complete lesson should be counted.' );
+		$this->assertArrayNotHasKey( $progress_lesson, $result, 'In-progress lesson should not be counted as a completion.' );
+	}
+
+	public function testGetLessonCompletionCounts_LessonWithQuiz_UsesQuizStatus(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$quiz_id   = $this->sensei_factory->quiz->create(
+			array(
+				'post_parent' => $lesson_id,
+				'meta_input'  => array( '_quiz_lesson' => $lesson_id ),
+			)
+		);
+		update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+
+		// Lesson row is only in-progress, but quiz progress is 'ungraded' — the
+		// effective (quiz-aware) status should be counted as a completion.
+		$this->insert_progress( $lesson_id, $user_id, 'lesson', 'in-progress' );
+		$this->insert_progress( $quiz_id, $user_id, 'quiz', 'ungraded' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_completion_counts( array( $lesson_id ) );
+
+		/* Assert. */
+		$this->assertSame( 1, $result[ $lesson_id ], 'Quiz-derived ungraded status should be counted as a completion.' );
+	}
+
+	public function testGetLessonCompletionCounts_WithEmptyLessonIds_ReturnsEmptyArray(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_lesson_completion_counts( array() );
+
+		/* Assert. */
+		$this->assertSame( array(), $result );
+	}
+
+	public function testGetCoursesAverageDaysToCompletion_ReturnsCorrectAverage(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$user1      = $this->sensei_factory->user->create();
+		$user2      = $this->sensei_factory->user->create();
+		$course_id1 = $this->sensei_factory->course->create();
+		$course_id2 = $this->sensei_factory->course->create();
+
+		$this->insert_progress_with_dates( $course_id1, $user1, 'course', 'complete', '2022-03-11 23:27:51', '2022-03-11 23:29:06' );
+		$this->insert_progress_with_dates( $course_id1, $user2, 'course', 'complete', '2022-03-14 21:34:27', '2022-03-14 21:34:37' );
+		$this->insert_progress_with_dates( $course_id2, $user1, 'course', 'complete', '2022-03-09 00:22:34', '2022-03-12 00:22:37' );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_courses_average_days_to_completion( array( $course_id1, $course_id2 ) );
+
+		/* Assert. */
+		// Course 1 average: (1 + 1) / 2 = 1. Course 2 average: 4 / 1 = 4. Total: (1 + 4) / 2 = 2.5.
+		$this->assertSame( 2.5, $result );
+	}
+
+	public function testGetCoursesAverageDaysToCompletion_WithUtcDatesNearMidnight_ConvertsToLocalTimeBeforeDatediff(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		// Set site timezone to UTC-5 (e.g. America/New_York EST).
+		$original_offset   = get_option( 'gmt_offset' );
+		$original_timezone = get_option( 'timezone_string' );
+		update_option( 'gmt_offset', -5 );
+		update_option( 'timezone_string', '' );
+
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+
+		// UTC dates span two days (Jan 1 05:00 -> Jan 2 04:00), so a naive
+		// DATEDIFF on the raw UTC columns would compute 1 day difference (+1 = 2 days).
+		// In local time (UTC-5) they fall on the same day (Jan 1 00:00 -> Jan 1 23:00),
+		// which the comments-based implementation would report as 1 day, since
+		// comment_date/commentmeta 'start' are already stored in site-local time.
+		$started_at   = '2024-01-01 05:00:00';
+		$completed_at = '2024-01-02 04:00:00';
+		$this->insert_progress_with_dates( $course_id, $user_id, 'course', 'complete', $started_at, $completed_at );
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_courses_average_days_to_completion( array( $course_id ) );
+
+		/* Assert. */
+		// This pins parity with the comments-based implementation, which would
+		// compute 1 day for the equivalent site-local timestamps.
+		$this->assertSame( 1.0, $result, 'UTC dates spanning midnight should be converted to local time (1 day) before DATEDIFF, matching the comments-based implementation.' );
+
+		/* Cleanup. */
+		update_option( 'gmt_offset', $original_offset );
+		update_option( 'timezone_string', $original_timezone );
+	}
+
+	public function testGetCoursesAverageDaysToCompletion_WithEmptyCourseIds_ReturnsZero(): void {
+		/* Arrange. */
+		global $wpdb;
+
+		$service = new Tables_Based_Progress_Aggregation_Service( $wpdb );
+
+		/* Act. */
+		$result = $service->get_courses_average_days_to_completion( array() );
+
+		/* Assert. */
+		$this->assertSame( 0.0, $result );
+	}
 }

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
@@ -6,6 +6,7 @@
  * @covers Sensei_Reports_Overview_Service_Courses
  */
 class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
+	use Sensei_HPPS_Helpers;
 
 	private static $initial_hook_suffix;
 
@@ -68,6 +69,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 
 		$service = new Sensei_Reports_Overview_Service_Courses();
 
+		$this->maybe_enable_hpps_tables_repository();
+
 		// Complete lesson 1 and lesson 2 with user_1.
 		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_1, true );
 		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_1, true );
@@ -82,6 +85,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 			$service->get_total_average_progress( [ $course_id ] ),
 			'Find totals of lessons completed single course.'
 		);
+
+		$this->maybe_reset_hpps_repository();
 	}
 
 	/**
@@ -115,6 +120,9 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course_id_2 ] ]
 		);
 		$service  = new Sensei_Reports_Overview_Service_Courses();
+
+		$this->maybe_enable_hpps_tables_repository();
+
 		// Complete lesson 1 and lesson 2 with user_1.
 		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_1, true );
 		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_1, true );
@@ -136,6 +144,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 			$service->get_total_average_progress( [ $course_id_1, $course_id_2 ] ),
 			'Find totals of lessons completed multiple courses.'
 		);
+
+		$this->maybe_reset_hpps_repository();
 	}
 
 
@@ -161,6 +171,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		);
 		$service  = new Sensei_Reports_Overview_Service_Courses();
 
+		$this->maybe_enable_hpps_tables_repository();
+
 		// Enroll student 2 to the course and lessons, but don't complete the lessons.
 		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
 		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_2 );
@@ -171,6 +183,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 			$service->get_total_average_progress( [ $course_id_1 ] ),
 			'Find average progress total is 0 when no lesson is completed'
 		);
+
+		$this->maybe_reset_hpps_repository();
 	}
 
 
@@ -224,6 +238,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		);
 		$service  = new Sensei_Reports_Overview_Service_Courses();
 
+		$this->maybe_enable_hpps_tables_repository();
+
 		// Complete lesson 1 and lesson 2 with user_1.
 		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_1, true );
 		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_1, true );
@@ -241,8 +257,39 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 			$service->get_total_average_progress( [ $course_id_1, $course_id_2 ] ),
 			'Find totals of lessons completed single course.'
 		);
+
+		$this->maybe_reset_hpps_repository();
 	}
 
+	/**
+	 * Seed a completed course status with fixed start/completion dates, using
+	 * whichever storage backend is active for the current test run so that the
+	 * seeded fixture is readable by the aggregation service under test.
+	 *
+	 * @param int    $course_id    Course ID.
+	 * @param int    $user_id      User ID.
+	 * @param string $started_at   Start date/time string (site-local).
+	 * @param string $completed_at Completion date/time string (site-local).
+	 */
+	private function seed_course_completion_with_dates( int $course_id, int $user_id, string $started_at, string $completed_at ): void {
+		if ( self::is_hpps_tables_mode() ) {
+			$timezone        = wp_timezone();
+			$course_progress = Sensei()->course_progress_repository->create( $course_id, $user_id );
+			$course_progress->start( new DateTimeImmutable( $started_at, $timezone ) );
+			$course_progress->complete( new DateTimeImmutable( $completed_at, $timezone ) );
+			Sensei()->course_progress_repository->save( $course_progress );
+			return;
+		}
+
+		$comment_id = Sensei_Utils::update_course_status( $user_id, $course_id, 'complete' );
+		wp_update_comment(
+			array(
+				'comment_ID'   => $comment_id,
+				'comment_date' => $completed_at,
+			)
+		);
+		update_comment_meta( $comment_id, 'start', $started_at );
+	}
 
 	public function testGetAverageDaysToCompletionWhenOneCourseExistsReturnsMatchingValue() {
 		$user1_id  = $this->factory->user->create();
@@ -250,32 +297,11 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		$user3_id  = $this->factory->user->create();
 		$course_id = $this->factory->course->create();
 
-		$comment1_id = Sensei_Utils::update_course_status( $user1_id, $course_id, 'complete' );
-		wp_update_comment(
-			[
-				'comment_ID'   => $comment1_id,
-				'comment_date' => '2022-01-07 00:00:00',
-			]
-		);
-		update_comment_meta( $comment1_id, 'start', '2022-01-01 00:00:01' );
+		$this->maybe_enable_hpps_tables_repository();
 
-		$comment2_id = Sensei_Utils::update_course_status( $user2_id, $course_id, 'complete' );
-		wp_update_comment(
-			[
-				'comment_ID'   => $comment2_id,
-				'comment_date' => '2022-01-10 00:00:00',
-			]
-		);
-		update_comment_meta( $comment2_id, 'start', '2022-01-01 00:00:01' );
-
-		$comment3_id = Sensei_Utils::update_course_status( $user3_id, $course_id, 'complete' );
-		wp_update_comment(
-			[
-				'comment_ID'   => $comment3_id,
-				'comment_date' => '2022-01-30 00:00:00',
-			]
-		);
-		update_comment_meta( $comment3_id, 'start', '2022-01-01 00:00:01' );
+		$this->seed_course_completion_with_dates( $course_id, $user1_id, '2022-01-01 00:00:01', '2022-01-07 00:00:00' );
+		$this->seed_course_completion_with_dates( $course_id, $user2_id, '2022-01-01 00:00:01', '2022-01-10 00:00:00' );
+		$this->seed_course_completion_with_dates( $course_id, $user3_id, '2022-01-01 00:00:01', '2022-01-30 00:00:00' );
 
 		$instance = new Sensei_Reports_Overview_Service_Courses();
 		$actual   = $instance->get_average_days_to_completion( [ $course_id ] );
@@ -286,6 +312,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		// As these completions are for the single course:
 		// ceil(7 + 10 + 30/ 3)  = 16 days.
 		self::assertSame( 16.0, $actual );
+
+		$this->maybe_reset_hpps_repository();
 	}
 
 	public function testGetAverageDaysToCompletionWhenMoreThanOneCourseExistReturnsMatchingValue() {
@@ -294,32 +322,11 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		$course1_id = $this->factory->course->create();
 		$course2_id = $this->factory->course->create();
 
-		$comment1_id = Sensei_Utils::update_course_status( $user1_id, $course1_id, 'complete' );
-		wp_update_comment(
-			[
-				'comment_ID'   => $comment1_id,
-				'comment_date' => '2022-03-11 23:29:06',
-			]
-		);
-		update_comment_meta( $comment1_id, 'start', '2022-03-11 23:27:51' );
+		$this->maybe_enable_hpps_tables_repository();
 
-		$comment2_id = Sensei_Utils::update_course_status( $user2_id, $course1_id, 'complete' );
-		wp_update_comment(
-			[
-				'comment_ID'   => $comment2_id,
-				'comment_date' => '2022-03-14 21:34:37',
-			]
-		);
-		update_comment_meta( $comment2_id, 'start', '2022-03-14 21:34:27' );
-
-		$comment3_id = Sensei_Utils::update_course_status( $user1_id, $course2_id, 'complete' );
-		wp_update_comment(
-			[
-				'comment_ID'   => $comment3_id,
-				'comment_date' => '2022-03-12 00:22:37',
-			]
-		);
-		update_comment_meta( $comment3_id, 'start', '2022-03-09 00:22:34' );
+		$this->seed_course_completion_with_dates( $course1_id, $user1_id, '2022-03-11 23:27:51', '2022-03-11 23:29:06' );
+		$this->seed_course_completion_with_dates( $course1_id, $user2_id, '2022-03-14 21:34:27', '2022-03-14 21:34:37' );
+		$this->seed_course_completion_with_dates( $course2_id, $user1_id, '2022-03-09 00:22:34', '2022-03-12 00:22:37' );
 
 		$instance = new Sensei_Reports_Overview_Service_Courses();
 		$actual   = $instance->get_average_days_to_completion( [ $course1_id, $course2_id ] );
@@ -328,6 +335,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 		// Average for the second course: 4 / 1 = 4.
 		// Total: (1 + 4) / 2 = 2.5.
 		self::assertSame( 2.5, $actual );
+
+		$this->maybe_reset_hpps_repository();
 	}
 
 	public function testGetTotalTotalEnrollments_WhenThereWereNoEnrolledStudents_ReturnsZero() {
@@ -356,6 +365,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course2_id ] ]
 		);
 
+		$this->maybe_enable_hpps_tables_repository();
+
 		// Enroll student 2 to the course and lessons, but don't complete the lessons.
 		Sensei_Utils::sensei_start_lesson( $lesson_course_1, $user1_id );
 		Sensei_Utils::sensei_start_lesson( $lesson_course_2, $user1_id );
@@ -367,6 +378,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertSame( 2, $actual );
+
+		$this->maybe_reset_hpps_repository();
 	}
 
 
@@ -387,6 +400,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 			[ 'meta_input' => [ '_lesson_course' => $course2_id ] ]
 		);
 
+		$this->maybe_enable_hpps_tables_repository();
+
 		// Enroll student 2 to the course and lessons, but don't complete the lessons.
 		Sensei_Utils::sensei_start_lesson( $lesson_course_1, $user1_id );
 		Sensei_Utils::sensei_start_lesson( $lesson_course_2, $user2_id );
@@ -398,6 +413,8 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		self::assertSame( 2, $actual );
+
+		$this->maybe_reset_hpps_repository();
 	}
 
 	/**


### PR DESCRIPTION
[SEN-83: HPPS: Reports Overview aggregates → table-aware](https://linear.app/a8c/issue/SEN-83/hpps-reports-overview-aggregates-table-aware)

Part of the Reports → Overview HPPS effort. Stacked on `hpps-reports-students-last-activity`.

## Proposed Changes
* **Courses** tab header columns — **Completions, Completion Rate, Average Progress, Average Grade, Days to Completion**: their aggregate calculations now go through the aggregation service so they read HPPS tables.

## Testing Instructions
Use an existing site with progress synchronized between comments and the HPPS tables. The data should include a course with lessons, several enrolled students, partial progress, at least one completed course, and graded work.

- [ ] On `trunk`, open **Reports → Overview → Courses** with HPPS off. Record the course header values for **Completions**, **Completion Rate**, **Average Progress**, **Average Grade**, and **Days to Completion**. This is the baseline; `trunk` does not need to be checked with HPPS on because these aggregates always read comment-based data there.
- [ ] Check out this PR with HPPS off. Confirm all five course header values match the `trunk` baseline.
- [ ] Keep this PR checked out and turn HPPS on, selecting the HPPS tables as the progress repository. Confirm all five course header values match this PR with HPPS off.
