### PR TITLE
Read courses per-row Average Grade from HPPS

### DIFF
--- a/changelog/fix-reports-overview-courses-average-grade-hpps
+++ b/changelog/fix-reports-overview-courses-average-grade-hpps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reports Overview courses per-row average grade now reads HPPS progress tables when tables-based storage is enabled

--- a/includes/internal/services/class-comments-based-grading-stats-service.php
+++ b/includes/internal/services/class-comments-based-grading-stats-service.php
@@ -265,6 +265,62 @@ class Comments_Based_Grading_Stats_Service implements Grading_Stats_Service_Inte
 	}
 
 	/**
+	 * Get grade count and sum grouped by course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Course post IDs.
+	 * @return array<int, array{count:int, sum:float}> Map of course_id => totals.
+	 */
+	public function get_grade_totals_by_course( array $course_ids ): array {
+		if ( empty( $course_ids ) ) {
+			return array();
+		}
+
+		$wpdb         = $this->wpdb;
+		$placeholders = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+
+		// The quiz_answers EXISTS check restricts results to attempts where the
+		// student actually submitted answers. This excludes auto-passed students
+		// whose lesson was marked passed without ever taking the quiz.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Statuses from constants. Placeholders created dynamically. Caching handled by callers.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT course.meta_value AS course_id, COUNT(*) AS grade_count, COALESCE( SUM( cm.meta_value ), 0 ) AS grade_sum
+				FROM `{$wpdb->comments}` c
+				INNER JOIN `{$wpdb->commentmeta}` cm ON c.comment_ID = cm.comment_id
+				INNER JOIN `{$wpdb->postmeta}` course ON c.comment_post_ID = course.post_id
+				INNER JOIN `{$wpdb->posts}` p ON p.ID = course.meta_value
+				WHERE c.comment_type = 'sensei_lesson_status'
+					AND c.comment_approved IN " . $this->get_graded_statuses_sql() . "
+					AND cm.meta_key = 'grade'
+					AND course.meta_key = '_lesson_course'
+					AND course.meta_value <> ''
+					AND EXISTS (
+						SELECT 1 FROM `{$wpdb->commentmeta}` cm2
+						WHERE cm2.comment_id = c.comment_ID
+							AND cm2.meta_key = 'quiz_answers'
+					)
+					AND course.meta_value IN ( $placeholders )
+				GROUP BY course.meta_value",
+				$course_ids
+			)
+		);
+		// phpcs:enable
+		Utils::log_query_error( $wpdb, 'Comments-based grade totals by course' );
+
+		$totals = array();
+		foreach ( (array) $rows as $row ) {
+			$totals[ (int) $row->course_id ] = array(
+				'count' => (int) $row->grade_count,
+				'sum'   => (float) $row->grade_sum,
+			);
+		}
+
+		return $totals;
+	}
+
+	/**
 	 * Build SQL clause for filtering by user ID.
 	 *
 	 * @since 4.26.0

--- a/includes/internal/services/class-grading-stats-service-interface.php
+++ b/includes/internal/services/class-grading-stats-service-interface.php
@@ -73,4 +73,13 @@ interface Grading_Stats_Service_Interface {
 	 * @return float
 	 */
 	public function get_users_average_grade( array $user_ids ): float;
+	/**
+	 * Get grade count and sum grouped by course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Course post IDs.
+	 * @return array<int, array{count:int, sum:float}> Map of course_id => totals.
+	 */
+	public function get_grade_totals_by_course( array $course_ids ): array;
 }

--- a/includes/internal/services/class-tables-based-grading-stats-service.php
+++ b/includes/internal/services/class-tables-based-grading-stats-service.php
@@ -272,6 +272,59 @@ class Tables_Based_Grading_Stats_Service implements Grading_Stats_Service_Interf
 	}
 
 	/**
+	 * Get grade count and sum grouped by course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $course_ids Course post IDs.
+	 * @return array<int, array{count:int, sum:float}> Map of course_id => totals.
+	 */
+	public function get_grade_totals_by_course( array $course_ids ): array {
+		if ( empty( $course_ids ) ) {
+			return array();
+		}
+
+		$wpdb              = $this->wpdb;
+		$table             = $this->get_progress_table_name();
+		$submissions_table = $this->get_submissions_table_name();
+		$placeholders      = implode( ', ', array_fill( 0, count( $course_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Statuses from constants; placeholders dynamic; caching by callers.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT lesson_course.meta_value AS course_id, COUNT(*) AS grade_count, COALESCE( SUM( qs.final_grade ), 0 ) AS grade_sum
+				FROM `$table` p
+				INNER JOIN `{$wpdb->postmeta}` lesson_course ON lesson_course.post_id = p.post_id
+					AND lesson_course.meta_key = '_lesson_course'
+					AND lesson_course.meta_value <> ''
+				INNER JOIN `{$wpdb->postmeta}` lesson_quiz ON lesson_quiz.post_id = p.post_id
+					AND lesson_quiz.meta_key = '_lesson_quiz'
+					AND lesson_quiz.meta_value > 0
+				INNER JOIN `$table` q ON q.post_id = lesson_quiz.meta_value AND q.user_id = p.user_id AND q.type = 'quiz'
+				INNER JOIN `$submissions_table` qs ON qs.quiz_id = q.post_id AND qs.user_id = p.user_id
+				WHERE p.type = 'lesson'
+					AND q.status IN " . $this->get_graded_statuses_sql() . "
+					AND qs.final_grade IS NOT NULL
+					AND lesson_course.meta_value IN ( $placeholders )
+				GROUP BY lesson_course.meta_value",
+				$course_ids
+			)
+		);
+		// phpcs:enable
+		Utils::log_query_error( $wpdb, 'Tables-based grade totals by course' );
+
+		$totals = array();
+		foreach ( (array) $rows as $row ) {
+			$totals[ (int) $row->course_id ] = array(
+				'count' => (int) $row->grade_count,
+				'sum'   => (float) $row->grade_sum,
+			);
+		}
+
+		return $totals;
+	}
+
+	/**
 	 * Build SQL clause for filtering by user ID.
 	 *
 	 * @since 4.26.0

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
 
 /**
  * Courses overview list table class.
@@ -46,6 +47,13 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	private $aggregation_service;
 
 	/**
+	 * Per-course grade totals cache for the current page.
+	 *
+	 * @var array<int, array{count:int, sum:float}>
+	 */
+	private $grade_totals_by_course = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param Sensei_Grading                                  $grading Sensei grading related services.
@@ -62,6 +70,50 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		$this->course                           = $course;
 		$this->reports_overview_service_courses = $reports_overview_service_courses;
 		$this->aggregation_service              = $aggregation_service;
+
+		if ( has_filter( 'sensei_analysis_course_percentage' ) ) {
+			_deprecated_hook( 'sensei_analysis_course_percentage', '$$next-version$$' );
+		}
+	}
+
+	/**
+	 * Prepare the table items and prime the per-course grade totals cache for the current page.
+	 */
+	public function prepare_items() {
+		parent::prepare_items();
+		$this->prime_row_aggregates( $this->items );
+	}
+
+	/**
+	 * Prime the per-course grade totals cache before generating CSV report rows.
+	 *
+	 * @param array $items The items that will be exported.
+	 */
+	protected function before_generate_report_rows( array $items ) {
+		$this->prime_row_aggregates( $items );
+	}
+
+	/**
+	 * Prime the per-course grade totals cache for the given page items.
+	 *
+	 * @param array $items Current page items (course post objects with an ID).
+	 */
+	private function prime_row_aggregates( array $items ) {
+		$course_ids = array_map(
+			static function ( $item ) {
+				return (int) $item->ID;
+			},
+			$items
+		);
+
+		$this->grade_totals_by_course = array();
+		if ( empty( $course_ids ) ) {
+			return;
+		}
+
+		$this->grade_totals_by_course = ( new Progress_Query_Service_Factory() )
+			->create_grading_stats_service()
+			->get_grade_totals_by_course( $course_ids );
 	}
 
 	/**
@@ -229,24 +281,12 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 
 		// Get grades only if the course has lessons and quizzes.
 		if ( ! empty( $lessons ) && $this->course->course_quizzes( $item->ID, true ) ) {
-			$grade_args = array(
-				'post__in' => $lessons,
-				'type'     => 'sensei_lesson_status',
-				'status'   => array( 'graded', 'passed', 'failed' ),
-				'meta_key' => 'grade', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$grade_totals  = $this->grade_totals_by_course[ (int) $item->ID ] ?? array(
+				'count' => 0,
+				'sum'   => 0,
 			);
-
-			/**
-			 * Filter the course completion percentage query arguments.
-			 *
-			 * @hook sensei_analysis_course_percentage
-			 *
-			 * @param {array} $grade_args Array of query arguments for course percentage.
-			 * @param {WP_Post} $item Current course post object.
-			 * @return {array} Filtered array of query arguments for course percentage.
-			 */
-			$percent_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_percentage', $grade_args, $item ), false );
-			$percent_total = $this->grading::get_course_users_grades_sum( $item->ID );
+			$percent_count = $grade_totals['count'];
+			$percent_total = $grade_totals['sum'];
 
 			if ( $percent_count > 0 && $percent_total >= 0 ) {
 				$average_grade = Sensei_Utils::quotient_as_absolute_rounded_number( $percent_total, $percent_count, 2 ) . '%';

--- a/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-comments-based-grading-stats-service.php
@@ -487,4 +487,147 @@ class Comments_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 		$this->assertSame( 80.0, $result );
 	}
+	/**
+	 * Test testGetGradeTotalsByCourse_WithNoCourseIds_ReturnsEmptyArray.
+	 */
+	public function testGetGradeTotalsByCourse_WithNoCourseIds_ReturnsEmptyArray(): void {
+		global $wpdb;
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_grade_totals_by_course( array() );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithMultipleStudents_GroupsByCourse.
+	 */
+	public function testGetGradeTotalsByCourse_WithMultipleStudents_GroupsByCourse(): void {
+		global $wpdb;
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+
+		$this->create_lesson_status_with_grade( $lesson_id, $user_1, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_id, $user_2, 'passed', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_id ) );
+
+		$this->assertSame( 2, $result[ $course_id ]['count'] );
+		$this->assertSame( 140.0, $result[ $course_id ]['sum'] );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithMultipleCourses_ReturnsSeparateTotals.
+	 */
+	public function testGetGradeTotalsByCourse_WithMultipleCourses_ReturnsSeparateTotals(): void {
+		global $wpdb;
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_1,
+				),
+			)
+		);
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_2,
+				),
+			)
+		);
+
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'failed', 90 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_1, $course_2 ) );
+
+		$this->assertSame( 1, $result[ $course_1 ]['count'] );
+		$this->assertSame( 80.0, $result[ $course_1 ]['sum'] );
+		$this->assertSame( 1, $result[ $course_2 ]['count'] );
+		$this->assertSame( 90.0, $result[ $course_2 ]['sum'] );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithCourseIdsFilter_ExcludesUnrequestedCourses.
+	 */
+	public function testGetGradeTotalsByCourse_WithCourseIdsFilter_ExcludesUnrequestedCourses(): void {
+		global $wpdb;
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_1,
+				),
+			)
+		);
+		$lesson_2 = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_2,
+				),
+			)
+		);
+
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 60 );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_1 ) );
+
+		$this->assertArrayHasKey( $course_1, $result );
+		$this->assertArrayNotHasKey( $course_2, $result, 'Only the requested course should be present in the result.' );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithAutoPassedLesson_ExcludesFromTotals.
+	 *
+	 * Pins parity with the tables-based implementation: an auto-passed lesson
+	 * (graded, but with no quiz_answers meta because the student never took the
+	 * quiz) must not be counted, mirroring how the tables-based implementation
+	 * excludes lessons without a quiz submission row.
+	 */
+	public function testGetGradeTotalsByCourse_WithAutoPassedLesson_ExcludesFromTotals(): void {
+		global $wpdb;
+		$user_id   = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_1  = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+		$lesson_2  = $this->sensei_factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course' => $course_id,
+				),
+			)
+		);
+
+		$this->create_lesson_status_with_grade( $lesson_1, $user_id, 'graded', 80 );
+		// Auto-passed lesson: graded, but no quiz_answers meta.
+		$this->create_lesson_status_with_grade( $lesson_2, $user_id, 'graded', 100, false );
+
+		$service = new Comments_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_id ) );
+
+		$this->assertSame( 1, $result[ $course_id ]['count'], 'Auto-passed lesson without quiz_answers should be excluded.' );
+		$this->assertSame( 80.0, $result[ $course_id ]['sum'] );
+	}
 }

--- a/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
+++ b/tests/unit-tests/internal/services/test-class-tables-based-grading-stats-service.php
@@ -543,4 +543,116 @@ class Tables_Based_Grading_Stats_Service_Test extends \WP_UnitTestCase {
 
 		$this->assertSame( 80.0, $result );
 	}
+	/**
+	 * Test testGetGradeTotalsByCourse_WithNoCourseIds_ReturnsEmptyArray.
+	 */
+	public function testGetGradeTotalsByCourse_WithNoCourseIds_ReturnsEmptyArray(): void {
+		global $wpdb;
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+
+		$result = $service->get_grade_totals_by_course( array() );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithMultipleStudents_GroupsByCourse.
+	 */
+	public function testGetGradeTotalsByCourse_WithMultipleStudents_GroupsByCourse(): void {
+		global $wpdb;
+		$user_1    = $this->sensei_factory->user->create();
+		$user_2    = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_id = $this->sensei_factory->lesson->create();
+		$quiz_id   = $this->sensei_factory->quiz->create();
+
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_1, $course_id, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_id, $quiz_id, $user_2, $course_id, 'passed', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_id ) );
+
+		$this->assertSame( 2, $result[ $course_id ]['count'] );
+		$this->assertSame( 140.0, $result[ $course_id ]['sum'] );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithMultipleCourses_ReturnsSeparateTotals.
+	 */
+	public function testGetGradeTotalsByCourse_WithMultipleCourses_ReturnsSeparateTotals(): void {
+		global $wpdb;
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$quiz_1   = $this->sensei_factory->quiz->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$quiz_2   = $this->sensei_factory->quiz->create();
+
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_1, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_2, 'failed', 90 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_1, $course_2 ) );
+
+		$this->assertSame( 1, $result[ $course_1 ]['count'] );
+		$this->assertSame( 80.0, $result[ $course_1 ]['sum'] );
+		$this->assertSame( 1, $result[ $course_2 ]['count'] );
+		$this->assertSame( 90.0, $result[ $course_2 ]['sum'] );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithCourseIdsFilter_ExcludesUnrequestedCourses.
+	 */
+	public function testGetGradeTotalsByCourse_WithCourseIdsFilter_ExcludesUnrequestedCourses(): void {
+		global $wpdb;
+		$user_id  = $this->sensei_factory->user->create();
+		$course_1 = $this->sensei_factory->course->create();
+		$course_2 = $this->sensei_factory->course->create();
+		$lesson_1 = $this->sensei_factory->lesson->create();
+		$quiz_1   = $this->sensei_factory->quiz->create();
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$quiz_2   = $this->sensei_factory->quiz->create();
+
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user_id, $course_1, 'graded', 80 );
+		$this->create_graded_lesson( $lesson_2, $quiz_2, $user_id, $course_2, 'graded', 60 );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_1 ) );
+
+		$this->assertArrayHasKey( $course_1, $result );
+		$this->assertArrayNotHasKey( $course_2, $result, 'Only the requested course should be present in the result.' );
+	}
+
+	/**
+	 * Test testGetGradeTotalsByCourse_WithLessonWithoutSubmission_ExcludesFromTotals.
+	 *
+	 * Pins parity with the comments-based implementation: a lesson that was
+	 * auto-passed (no quiz submission) must not be counted, mirroring how the
+	 * comments-based implementation excludes lessons without quiz_answers.
+	 */
+	public function testGetGradeTotalsByCourse_WithLessonWithoutSubmission_ExcludesFromTotals(): void {
+		global $wpdb;
+		$user      = $this->sensei_factory->user->create();
+		$course_id = $this->sensei_factory->course->create();
+		$lesson_1  = $this->sensei_factory->lesson->create();
+		$quiz_1    = $this->sensei_factory->quiz->create();
+
+		// Graded lesson with a quiz submission.
+		$this->create_graded_lesson( $lesson_1, $quiz_1, $user, $course_id, 'graded', 80 );
+
+		// Auto-passed lesson: progress marked graded, but no quiz submission row.
+		$lesson_2 = $this->sensei_factory->lesson->create();
+		$quiz_2   = $this->sensei_factory->quiz->create();
+		update_post_meta( $lesson_2, '_lesson_course', $course_id );
+		update_post_meta( $lesson_2, '_lesson_quiz', $quiz_2 );
+		$this->insert_progress( $lesson_2, $user, 'lesson', 'graded' );
+		$this->insert_progress( $quiz_2, $user, 'quiz', 'graded' );
+
+		$service = new Tables_Based_Grading_Stats_Service( $wpdb );
+		$result  = $service->get_grade_totals_by_course( array( $course_id ) );
+
+		$this->assertSame( 1, $result[ $course_id ]['count'], 'Auto-passed lesson without a submission should be excluded.' );
+		$this->assertSame( 80.0, $result[ $course_id ]['sum'] );
+	}
 }

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -174,4 +174,105 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		/* Assert. */
 		self::assertSame( 'Search Courses', $actual );
 	}
+
+	public function testGetRowData_WhenCalledAfterPrepareItems_UsesPrimedGradeTotals() {
+		/* Arrange. */
+		if ( self::is_hpps_tables_mode() ) {
+			$this->enable_hpps_tables_repository();
+		}
+
+		$course_id = $this->factory->course->create();
+		$user_1    = $this->factory->user->create();
+		$user_2    = $this->factory->user->create();
+
+		$lesson_id = $this->grade_lesson_for_course( $course_id, $user_1, 80 );
+		$this->grade_lesson_for_course( $course_id, $user_2, 60, $lesson_id );
+
+		$item                       = new stdClass();
+		$item->ID                   = $course_id;
+		$item->post_title           = get_the_title( $course_id );
+		$item->count_of_completions = 0;
+		$item->days_to_completion   = 0;
+		$item->last_activity_date   = null;
+
+		$course = $this->createMock( Sensei_Course::class );
+		$course->method( 'course_lessons' )->willReturn( array( $lesson_id ) );
+		$course->method( 'course_quizzes' )->willReturn( true );
+
+		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
+		$data_provider->method( 'get_items' )->willReturn( array( $item ) );
+		$data_provider->method( 'get_last_total_items' )->willReturn( 1 );
+
+		$list_table = new Sensei_Reports_Overview_List_Table_Courses(
+			$this->createMock( Sensei_Grading::class ),
+			$course,
+			$data_provider,
+			$this->createMock( Sensei_Reports_Overview_Service_Courses::class )
+		);
+
+		/* Act. */
+		$list_table->prepare_items();
+		$row = $this->invoke_get_row_data( $list_table, $item );
+
+		/* Assert. */
+		self::assertSame( '70%', $row['average_percent'] );
+
+		if ( self::is_hpps_tables_mode() ) {
+			$this->reset_hpps_repository();
+		}
+	}
+
+	/**
+	 * Seed a graded lesson (with a quiz submission and grade) belonging to a
+	 * course, for a user, via the progress/quiz submission repositories so
+	 * both storage modes have data.
+	 *
+	 * @param int      $course_id Course ID.
+	 * @param int      $user_id   User ID.
+	 * @param int      $grade     Grade to assign.
+	 * @param int|null $lesson_id Optional. Reuse an existing lesson/quiz.
+	 *
+	 * @return int The lesson ID.
+	 */
+	private function grade_lesson_for_course( int $course_id, int $user_id, int $grade, ?int $lesson_id = null ): int {
+		if ( null === $lesson_id ) {
+			$lesson_id = $this->factory->lesson->create(
+				array(
+					'meta_input' => array(
+						'_lesson_course' => $course_id,
+					),
+				)
+			);
+			$quiz_id   = $this->factory->quiz->create( array( 'post_parent' => $lesson_id ) );
+			update_post_meta( $lesson_id, '_lesson_quiz', $quiz_id );
+		} else {
+			$quiz_id = get_post_meta( $lesson_id, '_lesson_quiz', true );
+		}
+
+		Sensei()->lesson_progress_repository->create( $lesson_id, $user_id );
+
+		$submission = Sensei()->quiz_submission_repository->get_or_create( $quiz_id, $user_id, $grade );
+		Sensei()->quiz_answer_repository->create( $submission, 0, 'answer' );
+
+		$quiz_progress = Sensei()->quiz_progress_repository->create( $quiz_id, $user_id );
+		$quiz_progress->grade();
+		Sensei()->quiz_progress_repository->save( $quiz_progress );
+
+		return $lesson_id;
+	}
+
+	/**
+	 * Helper to call the protected get_row_data() method.
+	 *
+	 * @param Sensei_Reports_Overview_List_Table_Courses $list_table List table instance.
+	 * @param object                                      $item Row item.
+	 *
+	 * @return array
+	 */
+	private function invoke_get_row_data( $list_table, $item ) {
+		$method = new ReflectionMethod( $list_table, 'get_row_data' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $list_table, $item );
+	}
 }


### PR DESCRIPTION
[SEN-83: HPPS: Reports Overview aggregates → table-aware](https://linear.app/a8c/issue/SEN-83/hpps-reports-overview-aggregates-table-aware)

Part of the Reports → Overview HPPS effort. Stacked on `hpps-reports-courses-aggregates`.

## Proposed Changes
* **Courses** tab, per-row **Average Grade** column: primed from the grading stats service instead of per-row queries.

## Testing Instructions
Use an existing site with progress synchronized between comments and the HPPS tables. The data should include at least one course with graded work and one course without any grades.

- [ ] On `trunk`, open **Reports → Overview → Courses** with HPPS off. Record each course's **Average Grade**, then export the CSV and record the corresponding values. This is the baseline; `trunk` does not need to be checked with HPPS on because this per-row value always reads comment-based data there.
- [ ] Check out this PR with HPPS off. Confirm the on-screen and exported **Average Grade** values match the `trunk` baseline, including `N/A` for a course without grades.
- [ ] Keep this PR checked out and turn HPPS on, selecting the HPPS tables as the progress repository. Confirm the on-screen and exported **Average Grade** values match this PR with HPPS off.

## Deprecated Code
This per-row filter no longer runs. No replacement:
* `sensei_analysis_course_percentage`
