### PR TITLE
Read courses per-row Completions and Average Progress from HPPS

### DIFF
--- a/changelog/fix-reports-overview-courses-completions-progress-hpps
+++ b/changelog/fix-reports-overview-courses-completions-progress-hpps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reports Overview courses per-row completions and progress now read HPPS progress tables

--- a/changelog/fix-reports-overview-courses-completions-progress-hpps
+++ b/changelog/fix-reports-overview-courses-completions-progress-hpps
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: changed
 
-Reports Overview courses per-row completions and progress now read HPPS progress tables
+Reports Overview courses per-row completions and progress now read HPPS progress tables when tables-based storage is enabled

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -336,8 +336,12 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			$course_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . $course_title . '</a></strong>';
 		}
 
-		$average_course_progress = $this->average_progress_by_course[ (int) $item->ID ] ?? 0;
-		$average_course_progress = esc_html( sprintf( '%d%%', round( $average_course_progress ) ) );
+		// A course with no enrolled students or no lessons has no computable average, so show N/A rather than 0%.
+		if ( isset( $this->average_progress_by_course[ (int) $item->ID ] ) ) {
+			$average_course_progress = esc_html( sprintf( '%d%%', round( $this->average_progress_by_course[ (int) $item->ID ] ) ) );
+		} else {
+			$average_course_progress = __( 'N/A', 'sensei-lms' );
+		}
 
 		/**
 		 * Filter the row data for the Analysis Overview list table.

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -54,6 +54,20 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	private $grade_totals_by_course = array();
 
 	/**
+	 * Per-course completions count cache for the current page.
+	 *
+	 * @var array<int, int>
+	 */
+	private $completions_by_course = array();
+
+	/**
+	 * Per-course average progress percentage cache for the current page.
+	 *
+	 * @var array<int, float>
+	 */
+	private $average_progress_by_course = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param Sensei_Grading                                  $grading Sensei grading related services.
@@ -73,6 +87,10 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 
 		if ( has_filter( 'sensei_analysis_course_percentage' ) ) {
 			_deprecated_hook( 'sensei_analysis_course_percentage', '$$next-version$$' );
+		}
+
+		if ( has_filter( 'sensei_analysis_course_completions' ) ) {
+			_deprecated_hook( 'sensei_analysis_course_completions', '$$next-version$$' );
 		}
 	}
 
@@ -106,7 +124,10 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			$items
 		);
 
-		$this->grade_totals_by_course = array();
+		$this->grade_totals_by_course     = array();
+		$this->completions_by_course      = array();
+		$this->average_progress_by_course = array();
+
 		if ( empty( $course_ids ) ) {
 			return;
 		}
@@ -114,6 +135,21 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		$this->grade_totals_by_course = ( new Progress_Query_Service_Factory() )
 			->create_grading_stats_service()
 			->get_grade_totals_by_course( $course_ids );
+
+		$completion_counts_by_course = ( new Progress_Query_Service_Factory() )
+			->create_aggregation_service()
+			->count_statuses_by_post(
+				array(
+					'type'     => 'course',
+					'post__in' => $course_ids,
+				)
+			);
+
+		foreach ( $completion_counts_by_course as $course_id => $statuses ) {
+			$this->completions_by_course[ (int) $course_id ] = $statuses['complete'] ?? 0;
+		}
+
+		$this->average_progress_by_course = $this->reports_overview_service_courses->get_average_progress_per_course( $course_ids );
 	}
 
 	/**
@@ -259,21 +295,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		$lessons = $this->course->course_lessons( $item->ID, 'any', 'ids' );
 
 		// Get Course Completions.
-		$course_args = array(
-			'post_id' => $item->ID,
-			'type'    => 'sensei_course_status',
-			'status'  => 'complete',
-		);
-		/**
-		 * Filter the course completions query arguments.
-		 *
-		 * @hook sensei_analysis_course_completions
-		 *
-		 * @param {array} $course_args Array of query arguments for course completions.
-		 * @param {WP_Post} $item Current course post object.
-		 * @return {array} Filtered array of query arguments for course completions.
-		 */
-		$course_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_completions', $course_args, $item ) );
+		$course_completions = $this->completions_by_course[ (int) $item->ID ] ?? 0;
 
 		// Average Grade will be N/A if the course has no lessons or quizzes, if none of the lessons
 		// have a status of 'graded', 'passed' or 'failed', or if none of the quizzes have grades.
@@ -314,7 +336,8 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			$course_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . $course_title . '</a></strong>';
 		}
 
-		$average_course_progress = $this->get_average_progress_for_courses_table( $item->ID );
+		$average_course_progress = $this->average_progress_by_course[ (int) $item->ID ] ?? 0;
+		$average_course_progress = esc_html( sprintf( '%d%%', round( $average_course_progress ) ) );
 
 		/**
 		 * Filter the row data for the Analysis Overview list table.
@@ -367,51 +390,6 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 		}
 
 		return Sensei_Utils::quotient_as_absolute_rounded_percentage( $total_completion, $total_enrollments ) . '%';
-	}
-
-	/**
-	 * Calculate average lesson progress per student for course.
-	 *
-	 * @since 4.3.0
-	 *
-	 * @param int $course_id Id of the course for which average progress is calculated.
-	 *
-	 * @return string The average progress for the course, or N/A if none.
-	 */
-	private function get_average_progress_for_courses_table( $course_id ) {
-		// Fetch learners in course.
-		$course_args = array(
-			'post_id' => $course_id,
-			'type'    => 'sensei_course_status',
-			'status'  => array( 'in-progress', 'complete' ),
-		);
-
-		$course_students_count = Sensei_Utils::sensei_check_for_activity( $course_args );
-
-		// Get all course lessons.
-		$lessons        = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
-		$course_lessons = is_array( $lessons ) ? $lessons : array( $lessons );
-		$total_lessons  = count( $course_lessons );
-
-		// Get all completed lessons.
-		$lesson_args     = array(
-			'post__in' => $course_lessons,
-			'type'     => 'sensei_lesson_status',
-			'status'   => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
-			'count'    => true,
-		);
-		$completed_count = (int) Sensei_Utils::sensei_check_for_activity( $lesson_args );
-		// Calculate average progress.
-		$average_course_progress = __( 'N/A', 'sensei-lms' );
-		if ( $course_students_count && $total_lessons ) {
-			// Average course progress is calculated based on lessons completed for the course
-			// divided by the total possible lessons completed.
-			$average_course_progress_value = $completed_count / ( $course_students_count * $total_lessons ) * 100;
-			$average_course_progress       = esc_html(
-				sprintf( '%d%%', round( $average_course_progress_value ) )
-			);
-		}
-		return $average_course_progress;
 	}
 
 	/**

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -31,6 +31,34 @@ class Sensei_Reports_Overview_Service_Courses {
 		if ( empty( $course_ids ) ) {
 			return 0.0;
 		}
+
+		$progress_by_course = $this->get_average_progress_per_course( $course_ids );
+
+		if ( empty( $progress_by_course ) ) {
+			return 0.0;
+		}
+
+		$total_average_progress = array_sum( $progress_by_course );
+
+		// Divide total value to get average total value for average progress for courses.
+		return ceil( $total_average_progress / count( $course_ids ) );
+	}
+
+	/**
+	 * Average progress percentage per course.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $course_ids Course IDs.
+	 * @return array<int, float> Map of course_id => average progress percent (0-100).
+	 */
+	public function get_average_progress_per_course( array $course_ids ): array {
+		$progress_by_course = array();
+
+		if ( empty( $course_ids ) ) {
+			return $progress_by_course;
+		}
+
 		$lessons_count_per_courses = $this->get_lessons_in_courses( $course_ids );
 
 		$all_lesson_ids = array();
@@ -41,7 +69,6 @@ class Sensei_Reports_Overview_Service_Courses {
 
 		$lessons_completions       = $this->get_lessons_completions( $all_lesson_ids );
 		$student_count_per_courses = $this->get_students_count_in_courses( $course_ids );
-		$total_average_progress    = 0;
 
 		foreach ( $course_ids as $course_id ) {
 			if ( ! isset( $lessons_count_per_courses[ $course_id ] ) || ! isset( $student_count_per_courses[ $course_id ] ) ) {
@@ -74,14 +101,10 @@ class Sensei_Reports_Overview_Service_Courses {
 			);
 
 			// Calculate average progress for a course.
-			$course_average_progress = $completed_count / ( $students_count * count( $lessons ) ) * 100;
-
-			// Add value to the total average progress.
-			$total_average_progress += $course_average_progress;
+			$progress_by_course[ $course_id ] = $completed_count / ( $students_count * count( $lessons ) ) * 100;
 		}
-		// Divide total value to get average total value for average progress for courses.
-		$average_total_average_progress = ceil( $total_average_progress / count( $course_ids ) );
-		return $average_total_average_progress;
+
+		return $progress_by_course;
 	}
 
 	/**

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -222,6 +222,69 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		}
 	}
 
+	public function testGetRowData_WhenCalledAfterPrepareItems_UsesPrimedCompletionsAndAverageProgress() {
+		/* Arrange. */
+		if ( self::is_hpps_tables_mode() ) {
+			$this->enable_hpps_tables_repository();
+		}
+
+		$course_id = $this->factory->course->create();
+		$user_1    = $this->factory->user->create();
+		$user_2    = $this->factory->user->create();
+
+		$lesson_1 = $this->factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+		$lesson_2 = $this->factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		// Enroll and complete the course for user_1, and complete both lessons.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_1, true );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_1, true );
+		Sensei_Utils::update_course_status( $user_1, $course_id, 'complete' );
+
+		// Enroll user_2 in the course, but don't complete any lessons or the course.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_2 );
+		Sensei_Utils::update_course_status( $user_2, $course_id, 'in-progress' );
+
+		$item                       = new stdClass();
+		$item->ID                   = $course_id;
+		$item->post_title           = get_the_title( $course_id );
+		$item->count_of_completions = 0;
+		$item->days_to_completion   = 0;
+		$item->last_activity_date   = null;
+
+		$course = $this->createMock( Sensei_Course::class );
+		$course->method( 'course_lessons' )->willReturn( array( $lesson_1, $lesson_2 ) );
+		$course->method( 'course_quizzes' )->willReturn( false );
+
+		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
+		$data_provider->method( 'get_items' )->willReturn( array( $item ) );
+		$data_provider->method( 'get_last_total_items' )->willReturn( 1 );
+
+		$list_table = new Sensei_Reports_Overview_List_Table_Courses(
+			$this->createMock( Sensei_Grading::class ),
+			$course,
+			$data_provider,
+			new Sensei_Reports_Overview_Service_Courses()
+		);
+
+		/* Act. */
+		$list_table->prepare_items();
+		$row = $this->invoke_get_row_data( $list_table, $item );
+
+		/* Assert. */
+		self::assertSame( '1', $row['completions'], 'One student completed the course.' );
+		self::assertSame( '50%', $row['completion_rate'], '1 of 2 enrolled students completed the course.' );
+		self::assertSame( '50%', $row['average_progress'], '2 of 4 possible lesson completions were made.' );
+
+		if ( self::is_hpps_tables_mode() ) {
+			$this->reset_hpps_repository();
+		}
+	}
+
 	/**
 	 * Seed a graded lesson (with a quiz submission and grade) belonging to a
 	 * course, for a user, via the progress/quiz submission repositories so

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -285,6 +285,51 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		}
 	}
 
+	public function testGetRowData_CourseWithNoEnrolledStudents_ReturnsNAForAverageProgress() {
+		/* Arrange. */
+		if ( self::is_hpps_tables_mode() ) {
+			$this->enable_hpps_tables_repository();
+		}
+
+		$course_id = $this->factory->course->create();
+		$lesson    = $this->factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id ) )
+		);
+
+		$item                       = new stdClass();
+		$item->ID                   = $course_id;
+		$item->post_title           = get_the_title( $course_id );
+		$item->count_of_completions = 0;
+		$item->days_to_completion   = 0;
+		$item->last_activity_date   = null;
+
+		$course = $this->createMock( Sensei_Course::class );
+		$course->method( 'course_lessons' )->willReturn( array( $lesson ) );
+		$course->method( 'course_quizzes' )->willReturn( false );
+
+		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
+		$data_provider->method( 'get_items' )->willReturn( array( $item ) );
+		$data_provider->method( 'get_last_total_items' )->willReturn( 1 );
+
+		$list_table = new Sensei_Reports_Overview_List_Table_Courses(
+			$this->createMock( Sensei_Grading::class ),
+			$course,
+			$data_provider,
+			new Sensei_Reports_Overview_Service_Courses()
+		);
+
+		/* Act. */
+		$list_table->prepare_items();
+		$row = $this->invoke_get_row_data( $list_table, $item );
+
+		/* Assert. */
+		self::assertSame( 'N/A', $row['average_progress'], 'A course with no enrolled students has no computable average progress.' );
+
+		if ( self::is_hpps_tables_mode() ) {
+			$this->reset_hpps_repository();
+		}
+	}
+
 	/**
 	 * Seed a graded lesson (with a quiz submission and grade) belonging to a
 	 * course, for a user, via the progress/quiz submission repositories so

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
@@ -440,4 +440,82 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 
 		self::assertSame( 0.0, $actual );
 	}
+
+	/**
+	 * Tests that get_average_progress_per_course returns the correct percentage
+	 * per course, and that get_total_average_progress still returns the same
+	 * value as its per-course average when averaged manually.
+	 *
+	 * @covers Sensei_Reports_Overview_Service_Courses::get_average_progress_per_course
+	 */
+	public function testGetAverageProgressPerCourse_WhenCalledWithMultipleCourses_ReturnsMatchingPerCoursePercentages() {
+		/* Arrange. */
+		$course_id_1 = $this->factory->course->create();
+		$course_id_2 = $this->factory->course->create();
+
+		$user_id_1 = $this->factory->user->create();
+		$user_id_2 = $this->factory->user->create();
+
+		$lesson_1 = $this->factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id_1 ) )
+		);
+		$lesson_2 = $this->factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id_1 ) )
+		);
+		$lesson_3 = $this->factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id_2 ) )
+		);
+		$lesson_4 = $this->factory->lesson->create(
+			array( 'meta_input' => array( '_lesson_course' => $course_id_2 ) )
+		);
+
+		$service = new Sensei_Reports_Overview_Service_Courses();
+
+		$this->maybe_enable_hpps_tables_repository();
+
+		// Course 1: user_1 completes both lessons, user_2 completes none (50% progress).
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_1, true );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_1, true );
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_2 );
+
+		// Course 2: user_1 completes lesson_3 only (25% progress across both students).
+		Sensei_Utils::sensei_start_lesson( $lesson_3, $user_id_1, true );
+		Sensei_Utils::sensei_start_lesson( $lesson_4, $user_id_1 );
+		Sensei_Utils::sensei_start_lesson( $lesson_3, $user_id_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_4, $user_id_2 );
+
+		/* Act. */
+		$actual = $service->get_average_progress_per_course( array( $course_id_1, $course_id_2 ) );
+
+		/* Assert. */
+		self::assertSame( 50.0, $actual[ $course_id_1 ], 'Course 1 average progress should be 50%.' );
+		self::assertSame( 25.0, $actual[ $course_id_2 ], 'Course 2 average progress should be 25%.' );
+
+		// get_total_average_progress should equal the ceil'd average of the per-course values.
+		self::assertSame(
+			(float) ceil( array_sum( $actual ) / 2 ),
+			$service->get_total_average_progress( array( $course_id_1, $course_id_2 ) ),
+			'Total average progress should equal the average of the per-course values.'
+		);
+
+		$this->maybe_reset_hpps_repository();
+	}
+
+	/**
+	 * Tests that get_average_progress_per_course returns an empty array when
+	 * no course ids are given.
+	 *
+	 * @covers Sensei_Reports_Overview_Service_Courses::get_average_progress_per_course
+	 */
+	public function testGetAverageProgressPerCourse_WhenNoCourseIds_ReturnsEmptyArray() {
+		/* Arrange. */
+		$service = new Sensei_Reports_Overview_Service_Courses();
+
+		/* Act. */
+		$actual = $service->get_average_progress_per_course( array() );
+
+		/* Assert. */
+		self::assertSame( array(), $actual );
+	}
 }


### PR DESCRIPTION
[SEN-83: HPPS: Reports Overview aggregates → table-aware](https://linear.app/a8c/issue/SEN-83/hpps-reports-overview-aggregates-table-aware)

Part of the Reports → Overview HPPS effort. Stacked on `hpps-reports-courses-avg-grade`.

## Proposed Changes
* **Courses** tab, per-row **Completions** and **Average Progress** columns: primed from the progress tables instead of per-row queries.
* **Average Progress** shows `N/A` (not `0%`) for a course with no enrolled students or no lessons.

## Testing Instructions
Use an existing site with progress synchronized between comments and the HPPS tables. The data should include a course with enrolled students and partial progress, plus a course with no enrolled students or no lessons.

- [ ] On `trunk`, open **Reports → Overview → Courses** with HPPS off. Record each course's **Completions** and **Average Progress**, then export the CSV and record the corresponding values. This is the baseline; `trunk` does not need to be checked with HPPS on because these per-row values always read comment-based data there.
- [ ] Check out this PR with HPPS off. Compare the on-screen and exported values with the `trunk` baseline. Confirm **Completions** matches and account for the expected change from `0%` to `N/A` for **Average Progress** when a course has no enrolled students or no lessons.
- [ ] Keep this PR checked out and turn HPPS on, selecting the HPPS tables as the progress repository. Confirm the on-screen and exported **Completions** and **Average Progress** values match this PR with HPPS off.

## Deprecated Code
This per-row filter no longer runs. No replacement:
* `sensei_analysis_course_completions`
