### PR TITLE
Inject Reports Overview progress services via constructor

### DIFF
--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -5,13 +5,13 @@
  * @package sensei
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-
 use Sensei\Internal\Services\Grading_Stats_Service_Interface;
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 /**
  * Courses overview list table class.

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 
@@ -40,13 +41,6 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	private $reports_overview_service_courses;
 
 	/**
-	 * The progress aggregation service.
-	 *
-	 * @var Progress_Aggregation_Service_Interface
-	 */
-	private $aggregation_service;
-
-	/**
 	 * Per-course grade totals cache for the current page.
 	 *
 	 * @var array<int, array{count:int, sum:float}>
@@ -68,22 +62,38 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 	private $average_progress_by_course = array();
 
 	/**
+	 * The progress aggregation service.
+	 *
+	 * @var Progress_Aggregation_Service_Interface
+	 */
+	private Progress_Aggregation_Service_Interface $aggregation_service;
+
+	/**
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface
+	 */
+	private Grading_Stats_Service_Interface $grading_stats_service;
+
+	/**
 	 * Constructor
 	 *
 	 * @param Sensei_Grading                                  $grading Sensei grading related services.
 	 * @param Sensei_Course                                   $course Sensei course related services.
 	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider Report data provider.
 	 * @param Sensei_Reports_Overview_Service_Courses         $reports_overview_service_courses reports courses service.
-	 * @param Progress_Aggregation_Service_Interface          $aggregation_service The progress aggregation service.
+	 * @param Progress_Aggregation_Service_Interface|null     $aggregation_service The progress aggregation service.
+	 * @param Grading_Stats_Service_Interface|null            $grading_stats_service The grading stats service.
 	 */
-	public function __construct( Sensei_Grading $grading, Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Courses $reports_overview_service_courses, Progress_Aggregation_Service_Interface $aggregation_service ) {
+	public function __construct( Sensei_Grading $grading, Sensei_Course $course, Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Courses $reports_overview_service_courses, ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
 		// Load Parent token into constructor.
 		parent::__construct( 'courses', $data_provider );
 
 		$this->grading                          = $grading;
 		$this->course                           = $course;
 		$this->reports_overview_service_courses = $reports_overview_service_courses;
-		$this->aggregation_service              = $aggregation_service;
+		$this->aggregation_service              = $aggregation_service ?? ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+		$this->grading_stats_service            = $grading_stats_service ?? ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
 
 		if ( has_filter( 'sensei_analysis_course_percentage' ) ) {
 			_deprecated_hook( 'sensei_analysis_course_percentage', '$$next-version$$' );
@@ -132,18 +142,14 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			return;
 		}
 
-		$this->grade_totals_by_course = ( new Progress_Query_Service_Factory() )
-			->create_grading_stats_service()
-			->get_grade_totals_by_course( $course_ids );
+		$this->grade_totals_by_course = $this->grading_stats_service->get_grade_totals_by_course( $course_ids );
 
-		$completion_counts_by_course = ( new Progress_Query_Service_Factory() )
-			->create_aggregation_service()
-			->count_statuses_by_post(
-				array(
-					'type'     => 'course',
-					'post__in' => $course_ids,
-				)
-			);
+		$completion_counts_by_course = $this->aggregation_service->count_statuses_by_post(
+			array(
+				'type'     => 'course',
+				'post__in' => $course_ids,
+			)
+		);
 
 		foreach ( $completion_counts_by_course as $course_id => $statuses ) {
 			$this->completions_by_course[ (int) $course_id ] = $statuses['complete'] ?? 0;

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -5,6 +5,8 @@
  * @package sensei
  */
 
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
+use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,6 +19,31 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.4.1
  */
 class Sensei_Reports_Overview_Service_Courses {
+
+	/**
+	 * The progress aggregation service.
+	 *
+	 * @var Progress_Aggregation_Service_Interface
+	 */
+	private Progress_Aggregation_Service_Interface $aggregation_service;
+
+	/**
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface
+	 */
+	private Grading_Stats_Service_Interface $grading_stats_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Progress_Aggregation_Service_Interface|null $aggregation_service The progress aggregation service.
+	 * @param Grading_Stats_Service_Interface|null        $grading_stats_service The grading stats service.
+	 */
+	public function __construct( ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
+		$this->aggregation_service   = $aggregation_service ?? ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+		$this->grading_stats_service = $grading_stats_service ?? ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+	}
 
 	/**
 	 * Get total average progress value for courses.
@@ -121,7 +148,7 @@ class Sensei_Reports_Overview_Service_Courses {
 			return 0;
 		}
 
-		return ( new Progress_Query_Service_Factory() )->create_grading_stats_service()->get_courses_average_grade( $course_ids );
+		return $this->grading_stats_service->get_courses_average_grade( $course_ids );
 	}
 
 	/**
@@ -138,9 +165,7 @@ class Sensei_Reports_Overview_Service_Courses {
 			return 0;
 		}
 
-		return ( new Progress_Query_Service_Factory() )
-			->create_aggregation_service()
-			->get_courses_average_days_to_completion( $course_ids );
+		return $this->aggregation_service->get_courses_average_days_to_completion( $course_ids );
 	}
 
 
@@ -182,9 +207,7 @@ class Sensei_Reports_Overview_Service_Courses {
 			return array();
 		}
 
-		$counts = ( new Progress_Query_Service_Factory() )
-			->create_aggregation_service()
-			->get_lesson_completion_counts( $lesson_ids );
+		$counts = $this->aggregation_service->get_lesson_completion_counts( $lesson_ids );
 
 		$result = array();
 		foreach ( $counts as $lesson_id => $completion_count ) {
@@ -232,14 +255,12 @@ class Sensei_Reports_Overview_Service_Courses {
 			return array();
 		}
 
-		$by_post = ( new Progress_Query_Service_Factory() )
-			->create_aggregation_service()
-			->count_statuses_by_post(
-				array(
-					'type'     => 'course',
-					'post__in' => $course_ids,
-				)
-			);
+		$by_post = $this->aggregation_service->count_statuses_by_post(
+			array(
+				'type'     => 'course',
+				'post__in' => $course_ids,
+			)
+		);
 
 		$result = array();
 		foreach ( $by_post as $course_id => $statuses ) {


### PR DESCRIPTION
[SEN-83: HPPS: Reports Overview aggregates → table-aware](https://linear.app/a8c/issue/SEN-83/hpps-reports-overview-aggregates-table-aware)

Part of the Reports → Overview HPPS effort. Stacked on `hpps-reports-courses-completions-progress`.

Internal cleanup only — no user-facing change.

## Proposed Changes
* Inject the progress query services into the Reports Overview list tables and services via the constructor (with a factory fallback) to match the repository's dependency convention.
* Move the `use` imports above the `ABSPATH` guard in the two list tables for consistency with the sibling lessons list table.
* No columns or values change.

## Testing Instructions
Use an existing site with progress synchronized between comments and the HPPS tables. The data should include student and course progress, completed courses, and graded work.

- [ ] On `trunk`, open the **Students** and **Courses** tabs under **Reports → Overview** with HPPS off. Record the displayed values and export both CSVs. This is the comments-based baseline.
- [ ] Check out this PR with HPPS off. Compare both tabs and CSV exports with the `trunk` baseline, accounting for the intentional behavior changes documented by the PRs in this stack.
- [ ] Keep this PR checked out and turn HPPS on, selecting the HPPS tables as the progress repository. Confirm both tabs and CSV exports match this PR with HPPS off.
