### PR TITLE
Define wpdb return-format constants for Psalm

### DIFF
--- a/config/psalm/psalm-baseline.xml
+++ b/config/psalm/psalm-baseline.xml
@@ -1440,9 +1440,6 @@
       <code><![CDATA[$courses_url_base]]></code>
       <code><![CDATA[WooThemes_Sensei_Course_Results]]></code>
     </PropertyNotSetInConstructor>
-    <UndefinedConstant>
-      <code><![CDATA[OBJECT]]></code>
-    </UndefinedConstant>
   </file>
   <file src="includes/class-sensei-course-structure.php">
     <DocblockTypeContradiction>
@@ -1759,9 +1756,6 @@
     <MissingClosureReturnType>
       <code><![CDATA[function( $row ) use ( $last_activity_date_by_users ) {]]></code>
     </MissingClosureReturnType>
-    <UndefinedConstant>
-      <code><![CDATA[OBJECT_K]]></code>
-    </UndefinedConstant>
   </file>
   <file src="includes/class-sensei-dependency-checker.php">
     <PossiblyNullPropertyFetch>
@@ -3193,7 +3187,6 @@
       <code><![CDATA[empty( $this->teacher_role )]]></code>
     </TypeDoesNotContainType>
     <UndefinedConstant>
-      <code><![CDATA[ARRAY_A]]></code>
       <code><![CDATA[DOING_AJAX]]></code>
     </UndefinedConstant>
     <UndefinedPropertyFetch>
@@ -3282,9 +3275,6 @@
     <TypeDoesNotContainType>
       <code><![CDATA[null]]></code>
     </TypeDoesNotContainType>
-    <UndefinedConstant>
-      <code><![CDATA[ARRAY_A]]></code>
-    </UndefinedConstant>
   </file>
   <file src="includes/class-sensei-usage-tracking-data.php">
     <DocblockTypeContradiction>
@@ -3688,7 +3678,6 @@
       <code><![CDATA[init]]></code>
     </TooManyArguments>
     <UndefinedConstant>
-      <code><![CDATA[ARRAY_A]]></code>
       <code><![CDATA[WP_LANG_DIR]]></code>
     </UndefinedConstant>
     <UnresolvableInclude>
@@ -5199,9 +5188,6 @@
       <code><![CDATA[$row->lesson_start_count]]></code>
       <code><![CDATA[$row->unique_student_count]]></code>
     </PossiblyInvalidPropertyFetch>
-    <UndefinedConstant>
-      <code><![CDATA[ARRAY_A]]></code>
-    </UndefinedConstant>
   </file>
   <file src="includes/internal/services/class-progress-aggregation-service-interface.php">
     <InvalidDocblock>
@@ -5219,9 +5205,6 @@
       <code><![CDATA[$row->updated_at]]></code>
       <code><![CDATA[$row->user_id]]></code>
     </PossiblyInvalidPropertyFetch>
-    <UndefinedConstant>
-      <code><![CDATA[ARRAY_A]]></code>
-    </UndefinedConstant>
   </file>
   <file src="includes/internal/services/class-tables-based-grading-stats-service.php">
     <PossiblyInvalidPropertyFetch>
@@ -5240,10 +5223,6 @@
       <code><![CDATA[$row->lesson_start_count]]></code>
       <code><![CDATA[$row->unique_student_count]]></code>
     </PossiblyInvalidPropertyFetch>
-    <UndefinedConstant>
-      <code><![CDATA[ARRAY_A]]></code>
-      <code><![CDATA[ARRAY_A]]></code>
-    </UndefinedConstant>
   </file>
   <file src="includes/internal/services/class-tables-based-reports-listing-service.php">
     <PossiblyInvalidCast>
@@ -6504,9 +6483,6 @@
     <ParamNameMismatch>
       <code><![CDATA[$post_to_copy]]></code>
     </ParamNameMismatch>
-    <UndefinedConstant>
-      <code><![CDATA[OBJECT]]></code>
-    </UndefinedConstant>
   </file>
   <file src="includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php">
     <InvalidArgument>

--- a/config/psalm/psalm-loader.php
+++ b/config/psalm/psalm-loader.php
@@ -17,3 +17,10 @@ if ( ! defined( 'SENSEI_LMS_PLUGIN_PATH' ) ) {
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../vendor/php-stubs/wordpress-stubs/wordpress-stubs.php';
 require_once __DIR__ . '/../../vendor/woocommerce/action-scheduler/functions.php';
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+define( 'OBJECT', 'OBJECT' );
+define( 'OBJECT_K', 'OBJECT_K' );
+define( 'ARRAY_A', 'ARRAY_A' );
+define( 'ARRAY_N', 'ARRAY_N' );
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound


### PR DESCRIPTION
## Proposed Changes
`php-stubs/wordpress-stubs` references the wpdb return-format constants (`OBJECT`, `OBJECT_K`, `ARRAY_A`, `ARRAY_N`) in its docblocks but never defines them. Psalm therefore reports `UndefinedConstant` on every `$wpdb->get_results( …, ARRAY_A )` call, and the codebase has been silencing each one in `config/psalm/psalm-baseline.xml` — so any new query needs a fresh baseline entry (or an inline suppression) just to pass CI.

- Define the four constants in the Psalm loader (`config/psalm/psalm-loader.php`), matching how sibling Automattic repos handle it: WP-Job-Manager defines them in the same loader; jetpack and woocommerce-payments in equivalent bootstrap stubs.
- Drop the now-dead `UndefinedConstant` entries for these constants from the baseline (seven single-constant blocks removed; two blocks shared with `DOING_AJAX` / `WP_LANG_DIR` trimmed to keep those).

The constant now resolves everywhere, so future `ARRAY_A` usages need no baseline churn or suppression.

## Testing Instructions
No runtime or manual surface — the loader is loaded only by Psalm. CI Psalm passing (with the smaller baseline) is the check.