### PR TITLE
HPPS Reports and Grading clean-up

### DIFF
--- a/includes/internal/services/class-comments-based-grading-listing-service.php
+++ b/includes/internal/services/class-comments-based-grading-listing-service.php
@@ -31,7 +31,7 @@ class Comments_Based_Grading_Listing_Service implements Grading_Listing_Service_
 	 * @return array{ items: Grading_Item[], total_count: int }
 	 */
 	public function get_lesson_progress_items( array $args ): array {
-		$args['post_status'] = array( 'publish', 'private' );
+		$args['post_status'] = Utils::GRADING_POST_STATUSES;
 
 		// WP_Comment_Query doesn't support SQL_CALC_FOUND_ROWS, so run
 		// a separate count query first with no limit/offset.

--- a/includes/internal/services/class-tables-based-grading-listing-service.php
+++ b/includes/internal/services/class-tables-based-grading-listing-service.php
@@ -144,12 +144,13 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 	 * @return string SQL query.
 	 */
 	private function build_base_query( string $table, string $submissions_table, array $args ): string {
-		$wpdb = $this->wpdb;
+		$wpdb             = $this->wpdb;
+		$grading_statuses = Utils::get_grading_post_status_sql();
 
 		$query  = 'SELECT p.post_id, p.user_id, p.updated_at, COALESCE( q.status, p.status ) AS effective_status, qs.final_grade';
 		$query .= " FROM {$table} p";
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix; statuses come from a fixed constant.
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( {$grading_statuses} )";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";
@@ -179,12 +180,13 @@ class Tables_Based_Grading_Listing_Service implements Grading_Listing_Service_In
 	 * @return string SQL query.
 	 */
 	private function build_count_query( string $table, string $submissions_table, array $args ): string {
-		$wpdb = $this->wpdb;
+		$wpdb             = $this->wpdb;
+		$grading_statuses = Utils::get_grading_post_status_sql();
 
 		$query  = 'SELECT COALESCE( q.status, p.status ) AS effective_status, COUNT(*) AS total';
 		$query .= " FROM {$table} p";
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix.
-		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( 'publish', 'private' )";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from wpdb prefix; statuses come from a fixed constant.
+		$query .= " INNER JOIN {$wpdb->posts} post ON post.ID = p.post_id AND post.post_status IN ( {$grading_statuses} )";
 		$query .= " LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.post_id AND pm.meta_key = '_lesson_quiz' AND pm.meta_value > 0";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from wpdb prefix.
 		$query .= " LEFT JOIN {$submissions_table} qs ON qs.quiz_id = pm.meta_value AND qs.user_id = p.user_id";

--- a/includes/internal/services/class-utils.php
+++ b/includes/internal/services/class-utils.php
@@ -22,13 +22,22 @@ class Utils {
 
 	/**
 	 * Post statuses that Reports counts as live content: a course or lesson that
-	 * exists and is accessible. Draft, pending, and trashed posts are excluded.
+	 * exists and is accessible.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @var string[]
 	 */
 	public const REPORTS_POST_STATUSES = array( 'publish', 'private' );
+
+	/**
+	 * Post statuses that Grading counts as live content.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string[]
+	 */
+	public const GRADING_POST_STATUSES = array( 'publish', 'private' );
 
 	/**
 	 * Get the Reports post statuses as a quoted list for a `post_status IN ( ... )` SQL clause.
@@ -39,6 +48,17 @@ class Utils {
 	 */
 	public static function get_reports_post_status_sql(): string {
 		return "'" . implode( "','", self::REPORTS_POST_STATUSES ) . "'";
+	}
+
+	/**
+	 * Get the Grading post statuses as a quoted list for a `post_status IN ( ... )` SQL clause.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string Quoted, comma-separated statuses.
+	 */
+	public static function get_grading_post_status_sql(): string {
+		return "'" . implode( "','", self::GRADING_POST_STATUSES ) . "'";
 	}
 
 	/**

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
@@ -7,6 +7,7 @@
 
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 use Sensei\Internal\Services\Progress_Clauses_Service_Interface;
+use Sensei\Internal\Services\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -71,7 +72,7 @@ class Sensei_Reports_Overview_Data_Provider_Courses implements Sensei_Reports_Ov
 
 		$course_args = array(
 			'post_type'        => 'course',
-			'post_status'      => array( 'publish', 'private' ),
+			'post_status'      => Utils::REPORTS_POST_STATUSES,
 			'posts_per_page'   => $filters['number'],
 			'offset'           => $filters['offset'],
 			'fields'           => $filters['fields'] ?? '',

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -7,6 +7,7 @@
 
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
 use Sensei\Internal\Services\Progress_Clauses_Service_Interface;
+use Sensei\Internal\Services\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -69,7 +70,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 
 		$lessons_args = array(
 			'post_type'        => 'lesson',
-			'post_status'      => array( 'publish', 'private' ),
+			'post_status'      => Utils::REPORTS_POST_STATUSES,
 			'posts_per_page'   => $filters['number'],
 			'offset'           => $filters['offset'],
 			'orderby'          => $filters['orderby'] ?? '',

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
@@ -28,15 +28,17 @@ class Sensei_Reports_Overview_List_Table_Factory {
 	 * @throws InvalidArgumentException If the report type is not supported.
 	 */
 	public function create( string $type ) {
-		$aggregation_service = ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+		$query_service_factory = new Progress_Query_Service_Factory();
 
 		switch ( $type ) {
 			case 'users':
 			case 'students':
 				return new Sensei_Reports_Overview_List_Table_Students(
 					new Sensei_Reports_Overview_Data_Provider_Students(),
-					new Sensei_Reports_Overview_Service_Students(),
-					$aggregation_service
+					new Sensei_Reports_Overview_Service_Students(
+						$query_service_factory->create_aggregation_service(),
+						$query_service_factory->create_grading_stats_service()
+					)
 				);
 			case 'courses':
 				return new Sensei_Reports_Overview_List_Table_Courses(
@@ -44,7 +46,7 @@ class Sensei_Reports_Overview_List_Table_Factory {
 					Sensei()->course,
 					new Sensei_Reports_Overview_Data_Provider_Courses(),
 					new Sensei_Reports_Overview_Service_Courses(),
-					$aggregation_service
+					$query_service_factory->create_aggregation_service()
 				);
 			case 'lessons':
 				return new Sensei_Reports_Overview_List_Table_Lessons(

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -8,6 +8,7 @@
 use Sensei\Internal\Services\Grading_Item;
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
+use Sensei\Internal\Services\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -338,7 +339,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$query_args['s'] = esc_html( $_GET['s'] );
 		}
-		$lessons = $this->course->course_lessons( $course_id, array( 'publish', 'private' ), 'ids', $query_args );
+		$lessons = $this->course->course_lessons( $course_id, Utils::REPORTS_POST_STATUSES, 'ids', $query_args );
 
 		$lesson_count = count( $lessons );
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -9,8 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
-
 /**
  * View (WordPress list table) for the Students tab of Reports → Overview.
  *
@@ -29,13 +27,6 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	private $reports_overview_service_students;
 
 	/**
-	 * The progress aggregation service.
-	 *
-	 * @var Progress_Aggregation_Service_Interface
-	 */
-	private $aggregation_service;
-
-	/**
 	 * Per-user course-count cache for the current page.
 	 *
 	 * @var array<int, array{active:int, completed:int}>
@@ -47,14 +38,12 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	 *
 	 * @param Sensei_Reports_Overview_Data_Provider_Interface $data_provider Report data provider.
 	 * @param Sensei_Reports_Overview_Service_Students        $reports_overview_service_students reports students service.
-	 * @param Progress_Aggregation_Service_Interface          $aggregation_service The progress aggregation service.
 	 */
-	public function __construct( Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Students $reports_overview_service_students, Progress_Aggregation_Service_Interface $aggregation_service ) {
+	public function __construct( Sensei_Reports_Overview_Data_Provider_Interface $data_provider, Sensei_Reports_Overview_Service_Students $reports_overview_service_students ) {
 		// Load Parent token into constructor.
 		parent::__construct( 'users', $data_provider );
 
 		$this->reports_overview_service_students = $reports_overview_service_students;
-		$this->aggregation_service               = $aggregation_service;
 
 		if ( has_filter( 'sensei_analysis_user_courses_started' ) ) {
 			_deprecated_hook( 'sensei_analysis_user_courses_started', '$$next-version$$' );
@@ -108,21 +97,15 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			return $this->columns;
 		}
 
+		$total_active_courses    = 0;
 		$total_completed_courses = 0;
-		$total_courses_started   = 0;
 		$total_average_grade     = 0;
 
 		$user_ids = $this->get_all_item_ids();
 		if ( $user_ids ) {
-			// Header totals for the Completed Courses and Active Courses (started - completed) columns.
-			$counts                  = $this->aggregation_service->count_statuses(
-				array(
-					'type'    => 'course',
-					'user_id' => $user_ids,
-				)
-			);
-			$total_completed_courses = $counts['complete'] ?? 0;
-			$total_courses_started   = array_sum( $counts );
+			$course_counts           = $this->reports_overview_service_students->get_total_course_counts( $user_ids );
+			$total_active_courses    = $course_counts['active'];
+			$total_completed_courses = $course_counts['completed'];
 
 			// Get total average students grade.
 			$total_average_grade = $this->reports_overview_service_students->get_graded_lessons_average_grade( $user_ids );
@@ -135,7 +118,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			'date_registered'   => __( 'Date Registered', 'sensei-lms' ),
 			'last_activity'     => __( 'Last Activity', 'sensei-lms' ),
 			// translators: Placeholder value is all active courses.
-			'active_courses'    => sprintf( __( 'Active Courses (%d)', 'sensei-lms' ), $total_courses_started - $total_completed_courses ),
+			'active_courses'    => sprintf( __( 'Active Courses (%d)', 'sensei-lms' ), $total_active_courses ),
 			// translators: Placeholder value is all completed courses.
 			'completed_courses' => sprintf( __( 'Completed Courses (%d)', 'sensei-lms' ), $total_completed_courses ),
 			// translators: Placeholder value is graded average value.

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -165,8 +165,9 @@ class Sensei_Reports_Overview_Service_Courses {
 
 		global $wpdb;
 		$reports_statuses = Utils::get_reports_post_status_sql();
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Safe direct sql; statuses come from a fixed constant.
-		return $wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Statuses come from a fixed constant.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe direct sql.
+		$results = $wpdb->get_results(
 			"SELECT wcom.comment_post_id lesson_id, COUNT(*) completion_count
 						FROM {$wpdb->comments} wcom
 						WHERE wcom.comment_approved IN ('graded', 'ungraded', 'passed', 'failed','complete')
@@ -181,6 +182,8 @@ class Sensei_Reports_Overview_Service_Courses {
 						GROUP BY wcom.comment_post_id",
 			'OBJECT_K'
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $results;
 	}
 
 	/**

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -6,6 +6,7 @@
  */
 
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
+use Sensei\Internal\Services\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -163,7 +164,8 @@ class Sensei_Reports_Overview_Service_Courses {
 	private function get_lessons_completions(): array {
 
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe direct sql.
+		$reports_statuses = Utils::get_reports_post_status_sql();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Safe direct sql; statuses come from a fixed constant.
 		return $wpdb->get_results(
 			"SELECT wcom.comment_post_id lesson_id, COUNT(*) completion_count
 						FROM {$wpdb->comments} wcom
@@ -174,7 +176,7 @@ class Sensei_Reports_Overview_Service_Courses {
 						SELECT wpm.post_id lesson_id from {$wpdb->posts} wpc
 						JOIN {$wpdb->postmeta} wpm on wpm.meta_value = wpc.id
 						WHERE wpm.meta_key = '_lesson_course'
-						AND wpc.post_status in ('publish','private')
+						AND wpc.post_status in ( {$reports_statuses} )
 						)
 						GROUP BY wcom.comment_post_id",
 			'OBJECT_K'

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -5,7 +5,8 @@
  * @package sensei
  */
 
-use Sensei\Internal\Services\Progress_Query_Service_Factory;
+use Sensei\Internal\Services\Grading_Stats_Service_Interface;
+use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -22,6 +23,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Reports_Overview_Service_Students {
 
 	/**
+	 * The progress aggregation service.
+	 *
+	 * @var Progress_Aggregation_Service_Interface
+	 */
+	private Progress_Aggregation_Service_Interface $aggregation_service;
+
+	/**
+	 * The grading stats service.
+	 *
+	 * @var Grading_Stats_Service_Interface
+	 */
+	private Grading_Stats_Service_Interface $grading_stats_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param Progress_Aggregation_Service_Interface $aggregation_service   Progress aggregation service.
+	 * @param Grading_Stats_Service_Interface        $grading_stats_service Grading stats service.
+	 */
+	public function __construct( Progress_Aggregation_Service_Interface $aggregation_service, Grading_Stats_Service_Interface $grading_stats_service ) {
+		$this->aggregation_service   = $aggregation_service;
+		$this->grading_stats_service = $grading_stats_service;
+	}
+
+	/**
 	 * Get average grade of all lessons graded in all the courses filtered by students.
 	 *
 	 * @since 4.4.1
@@ -35,7 +63,7 @@ class Sensei_Reports_Overview_Service_Students {
 			return 0;
 		}
 
-		return ceil( ( new Progress_Query_Service_Factory() )->create_grading_stats_service()->get_users_average_grade( $user_ids ) );
+		return ceil( $this->grading_stats_service->get_users_average_grade( $user_ids ) );
 	}
 
 	/**
@@ -51,14 +79,12 @@ class Sensei_Reports_Overview_Service_Students {
 			return array();
 		}
 
-		$counts = ( new Progress_Query_Service_Factory() )
-			->create_aggregation_service()
-			->count_statuses_by_user(
-				array(
-					'type'    => 'course',
-					'user_id' => $user_ids,
-				)
-			);
+		$counts = $this->aggregation_service->count_statuses_by_user(
+			array(
+				'type'    => 'course',
+				'user_id' => $user_ids,
+			)
+		);
 
 		$result = array();
 		foreach ( $user_ids as $user_id ) {
@@ -71,5 +97,38 @@ class Sensei_Reports_Overview_Service_Students {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Get the active and completed course totals across all the given students.
+	 *
+	 * Powers the Active/Completed Courses column headers.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int[] $user_ids Student user IDs.
+	 * @return array{active:int, completed:int} Totals for active and completed courses.
+	 */
+	public function get_total_course_counts( array $user_ids ): array {
+		if ( empty( $user_ids ) ) {
+			return array(
+				'active'    => 0,
+				'completed' => 0,
+			);
+		}
+
+		$counts = $this->aggregation_service->count_statuses(
+			array(
+				'type'    => 'course',
+				'user_id' => $user_ids,
+			)
+		);
+
+		$completed = $counts['complete'] ?? 0;
+
+		return array(
+			'active'    => array_sum( $counts ) - $completed,
+			'completed' => $completed,
+		);
 	}
 }

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -7,6 +7,7 @@
 
 use Sensei\Internal\Services\Grading_Stats_Service_Interface;
 use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -41,12 +42,12 @@ class Sensei_Reports_Overview_Service_Students {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param Progress_Aggregation_Service_Interface $aggregation_service   Progress aggregation service.
-	 * @param Grading_Stats_Service_Interface        $grading_stats_service Grading stats service.
+	 * @param Progress_Aggregation_Service_Interface|null $aggregation_service   Progress aggregation service.
+	 * @param Grading_Stats_Service_Interface|null        $grading_stats_service Grading stats service.
 	 */
-	public function __construct( Progress_Aggregation_Service_Interface $aggregation_service, Grading_Stats_Service_Interface $grading_stats_service ) {
-		$this->aggregation_service   = $aggregation_service;
-		$this->grading_stats_service = $grading_stats_service;
+	public function __construct( ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
+		$this->aggregation_service   = $aggregation_service ?? ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+		$this->grading_stats_service = $grading_stats_service ?? ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
 	}
 
 	/**

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -1,8 +1,5 @@
 <?php
 
-use Sensei\Internal\Services\Progress_Aggregation_Service_Interface;
-use Sensei\Internal\Services\Progress_Query_Service_Factory;
-
 /**
  * Tests for Sensei_Reports_Overview_List_Table_Students class.
  *
@@ -41,25 +38,22 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 
 	public function testGetColumns_WithGradingAndCompletions_ReturnsColumnsWithCorrectTotals() {
 		/* Arrange. */
-		$user_id             = $this->factory->user->create();
-		$active_course_id    = $this->factory->course->create();
-		$completed_course_id = $this->factory->course->create();
-
-		Sensei()->course_progress_repository->save( Sensei()->course_progress_repository->create( $active_course_id, $user_id ) );
-
-		$completed_course_progress = Sensei()->course_progress_repository->create( $completed_course_id, $user_id );
-		$completed_course_progress->complete();
-		Sensei()->course_progress_repository->save( $completed_course_progress );
+		$user_id = $this->factory->user->create();
 
 		$student_service = $this->createMock( Sensei_Reports_Overview_Service_Students::class );
 		$student_service->method( 'get_graded_lessons_average_grade' )->willReturn( 50 );
+		$student_service->method( 'get_total_course_counts' )->willReturn(
+			array(
+				'active'    => 1,
+				'completed' => 1,
+			)
+		);
 
 		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
 		$data_provider->method( 'get_items' )->willReturn( array( $user_id ) );
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$data_provider,
-			$student_service,
-			( new Progress_Query_Service_Factory() )->create_aggregation_service()
+			$student_service
 		);
 
 		/* Act. */
@@ -83,8 +77,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
-			$this->createMock( Progress_Aggregation_Service_Interface::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Students::class )
 		);
 
 		/* Act. */
@@ -107,8 +100,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
-			$this->createMock( Progress_Aggregation_Service_Interface::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Students::class )
 		);
 
 		/* Act. */
@@ -122,8 +114,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 		/* Arrange. */
 		$list_table = new Sensei_Reports_Overview_List_Table_Students(
 			$this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class ),
-			$this->createMock( Sensei_Reports_Overview_Service_Students::class ),
-			$this->createMock( Progress_Aggregation_Service_Interface::class )
+			$this->createMock( Sensei_Reports_Overview_Service_Students::class )
 		);
 
 		/* Act. */

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-students.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-students.php
@@ -1,5 +1,7 @@
 <?php
 
+use Sensei\Internal\Services\Progress_Query_Service_Factory;
+
 /**
  * Tests for Sensei_Reports_Overview_Service_Students class.
  *
@@ -36,6 +38,20 @@ class Sensei_Reports_Overview_Service_Students_Test extends WP_UnitTestCase {
 		$this->factory->tearDown();
 	}
 
+	/**
+	 * Build the service with real progress services from the factory.
+	 *
+	 * @return Sensei_Reports_Overview_Service_Students
+	 */
+	private function create_service(): Sensei_Reports_Overview_Service_Students {
+		$query_service_factory = new Progress_Query_Service_Factory();
+
+		return new Sensei_Reports_Overview_Service_Students(
+			$query_service_factory->create_aggregation_service(),
+			$query_service_factory->create_grading_stats_service()
+		);
+	}
+
 	public function testGetCourseCountsByUser_UserWithActiveAndCompletedCourses_ReturnsActiveAndCompletedCounts() {
 		/* Arrange. */
 		$user_id             = $this->factory->user->create();
@@ -48,7 +64,7 @@ class Sensei_Reports_Overview_Service_Students_Test extends WP_UnitTestCase {
 		$completed_course_progress->complete();
 		Sensei()->course_progress_repository->save( $completed_course_progress );
 
-		$service = new Sensei_Reports_Overview_Service_Students();
+		$service = $this->create_service();
 
 		/* Act. */
 		$actual = $service->get_course_counts_by_user( array( $user_id ) );
@@ -66,7 +82,7 @@ class Sensei_Reports_Overview_Service_Students_Test extends WP_UnitTestCase {
 	public function testGetCourseCountsByUser_UserWithoutCourses_ReturnsZeroCounts() {
 		/* Arrange. */
 		$user_id = $this->factory->user->create();
-		$service = new Sensei_Reports_Overview_Service_Students();
+		$service = $this->create_service();
 
 		/* Act. */
 		$actual = $service->get_course_counts_by_user( array( $user_id ) );
@@ -83,12 +99,71 @@ class Sensei_Reports_Overview_Service_Students_Test extends WP_UnitTestCase {
 
 	public function testGetCourseCountsByUser_EmptyUserIds_ReturnsEmptyArray() {
 		/* Arrange. */
-		$service = new Sensei_Reports_Overview_Service_Students();
+		$service = $this->create_service();
 
 		/* Act. */
 		$actual = $service->get_course_counts_by_user( array() );
 
 		/* Assert. */
 		self::assertSame( array(), $actual );
+	}
+
+	public function testGetTotalCourseCounts_UsersWithActiveAndCompletedCourses_ReturnsSummedCounts() {
+		/* Arrange. */
+		$user_one            = $this->factory->user->create();
+		$user_two            = $this->factory->user->create();
+		$active_course_id    = $this->factory->course->create();
+		$completed_course_id = $this->factory->course->create();
+
+		Sensei()->course_progress_repository->save( Sensei()->course_progress_repository->create( $active_course_id, $user_one ) );
+
+		foreach ( array( $user_one, $user_two ) as $user_id ) {
+			$completed_course_progress = Sensei()->course_progress_repository->create( $completed_course_id, $user_id );
+			$completed_course_progress->complete();
+			Sensei()->course_progress_repository->save( $completed_course_progress );
+		}
+
+		$service = $this->create_service();
+
+		/* Act. */
+		$actual = $service->get_total_course_counts( array( $user_one, $user_two ) );
+
+		/* Assert. */
+		$expected = array(
+			'active'    => 1,
+			'completed' => 2,
+		);
+		self::assertSame( $expected, $actual );
+	}
+
+	public function testGetTotalCourseCounts_UsersWithoutCourses_ReturnsZeroCounts() {
+		/* Arrange. */
+		$user_id = $this->factory->user->create();
+		$service = $this->create_service();
+
+		/* Act. */
+		$actual = $service->get_total_course_counts( array( $user_id ) );
+
+		/* Assert. */
+		$expected = array(
+			'active'    => 0,
+			'completed' => 0,
+		);
+		self::assertSame( $expected, $actual );
+	}
+
+	public function testGetTotalCourseCounts_EmptyUserIds_ReturnsZeroCounts() {
+		/* Arrange. */
+		$service = $this->create_service();
+
+		/* Act. */
+		$actual = $service->get_total_course_counts( array() );
+
+		/* Assert. */
+		$expected = array(
+			'active'    => 0,
+			'completed' => 0,
+		);
+		self::assertSame( $expected, $actual );
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Follow-up clean-ups from the Reports → Overview HPPS work. No behavior change — the reports render identical figures; this reduces duplication and keeps calculation logic out of the views.

- Reuse the centralized "live content" post-status list (`Utils::REPORTS_POST_STATUSES` / `Utils::get_reports_post_status_sql()`) in the remaining Reports → Overview instances instead of the hardcoded `('publish','private')` pair.
- Give Grading its own `Utils::GRADING_POST_STATUSES` constant (and matching SQL helper) rather than sharing the reports one, and use it in the tables-based and comments-based grading listing services, so the two areas can diverge independently.
- Move the Active/Completed Courses header totals out of `Sensei_Reports_Overview_List_Table_Students` into the students service, so the list table does no arithmetic. The progress aggregation and grading stats services are now injected into the students service via its constructor instead of being built inline.

## Testing Instructions

- [x] Go to **Sensei LMS → Reports → Students** and confirm the **Student**, **Active Courses**, **Completed Courses**, and **Average Grade** column headers show the same counts as before (enrol/complete a course for a student to populate them).
- [x] Switch to the **Courses** and **Lessons** report tabs and confirm they list published and private courses/lessons and render totals as before.
- [x] Go to **Sensei LMS → Grading** and confirm the lesson listing and status filter counts are unchanged.
- [x] Repeat the above with the HPPS tables repository enabled to confirm parity across both storage backends.

## Changelog entry

- [ ] Automatically create a changelog entry from the details below.