### PR TITLE
Pass explicit escape argument to fputcsv for PHP 8.4

### DIFF
--- a/changelog/fix-fputcsv-escape-deprecation
+++ b/changelog/fix-fputcsv-escape-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a PHP 8.4 deprecation notice when exporting CSV files.

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -1023,7 +1023,7 @@ class Sensei_Analysis {
 	public function report_write_download( $report_data = array() ) {
 		$fp = fopen( 'php://output', 'w' );
 		foreach ( $report_data as $row ) {
-			fputcsv( $fp, $row );
+			fputcsv( $fp, $row, ',', '"', '' );
 		}
 		fclose( $fp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 	}

--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -100,7 +100,7 @@ class Sensei_Import_CSV_Reader {
 		$forced_delimiter = apply_filters( 'sensei_import_csv_delimiter', false );
 
 		if ( $forced_delimiter ) {
-			$this->file->setCsvControl( $forced_delimiter );
+			$this->file->setCsvControl( $forced_delimiter, '"', '' );
 			return;
 		}
 
@@ -119,7 +119,7 @@ class Sensei_Import_CSV_Reader {
 		$selected_delimiter = $delimiters[0];
 
 		foreach ( $delimiters as $delimiter ) {
-			$this->file->setCsvControl( $delimiter );
+			$this->file->setCsvControl( $delimiter, '"', '' );
 
 			$columns = $this->get_columns_number();
 
@@ -129,7 +129,7 @@ class Sensei_Import_CSV_Reader {
 			}
 		}
 
-		$this->file->setCsvControl( $selected_delimiter );
+		$this->file->setCsvControl( $selected_delimiter, '"', '' );
 	}
 
 	/**

--- a/includes/data-port/export-tasks/class-sensei-export-task.php
+++ b/includes/data-port/export-tasks/class-sensei-export-task.php
@@ -148,7 +148,7 @@ abstract class Sensei_Export_Task extends Sensei_Data_Port_Task implements Sense
 		foreach ( $posts as $post ) {
 			$serialized_posts = $this->get_serialized_post( $post );
 
-			$output_file->fputcsv( $serialized_posts );
+			$output_file->fputcsv( $serialized_posts, ',', '"', '' );
 			++$this->completed_posts;
 		}
 		$output_file = null;
@@ -197,7 +197,7 @@ abstract class Sensei_Export_Task extends Sensei_Data_Port_Task implements Sense
 
 		$filename = wp_tempnam( 'sensei-export-csv-' . $this->get_content_type() );
 		$file     = new SplFileObject( $filename, 'w' );
-		$file->fputcsv( $headers );
+		$file->fputcsv( $headers, ',', '"', '' );
 		$file = null;
 
 		return $filename;


### PR DESCRIPTION
## Proposed Changes

On PHP 8.4, generating a CSV in Sensei logs a deprecation notice:

> PHP Deprecated: fputcsv(): the $escape parameter must be provided as its default value will change

PHP 8.4 deprecates calling `fputcsv()` (and `SplFileObject::fputcsv()`) without the `$escape` argument because its default (`"\\"`) will change in a future version. Per the PHP docs, the recommended value is an empty string, which produces RFC 4180-compliant output that survives a round trip through the PHP CSV functions.

This passes an explicit empty-string escape in both spots that write CSV — the Reports/Analysis export and the data-port content export — and aligns the data-port import reader (`Sensei_Import_CSV_Reader`) to read with the same empty escape. Aligning the reader is required: the writer no longer backslash-escapes embedded quotes (it doubles them as `""` per the standard), so the reader had to stop using `SplFileObject`'s default backslash escape or the export → import round trip would break for values containing quotes.

For CSVs without embedded quotes or backslashes there is no visible change; for values that do contain them, escaping switches from the non-standard `\"` to the standard `""`.

## Testing Instructions

- [x] On a PHP 8.4 site, go to Sensei LMS → Reports and export a report as CSV.
- [x] Go to Tools → Export (Sensei data export), run an export, and download the resulting CSV.
- [x] Confirm both CSVs download and open correctly, and no `fputcsv` deprecation notice appears in the PHP error log.
- [x] Export questions containing quotes/commas, then import the same file back and confirm the answers round-trip unchanged.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fix a PHP 8.4 deprecation notice when exporting CSV files.

</details>
