### PR TITLE
Guard ucfirst against null answers in quiz grading view

### DIFF
--- a/changelog/fix-ucfirst-null-grading-deprecation
+++ b/changelog/fix-ucfirst-null-grading-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a PHP deprecation notice when reviewing a grade for an unanswered True/False question.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -148,8 +148,8 @@ class Sensei_Grading_User_Quiz {
 				switch ( $type ) {
 					case 'boolean':
 						$type_name           = __( 'True/False', 'sensei-lms' );
-						$right_answer        = ucfirst( $right_answer );
-						$user_answer_content = ucfirst( $user_answer_content );
+						$right_answer        = ucfirst( (string) $right_answer );
+						$user_answer_content = ucfirst( (string) $user_answer_content );
 						$grade_type          = 'auto-grade';
 						break;
 					case 'multiple-choice':


### PR DESCRIPTION
## Proposed Changes

Reviewing a True/False question with no stored student answer emitted a PHP Deprecated notice — `ucfirst(): Passing null to parameter #1 ($string)` — on the grade review page under PHP 8.1+. Casting the right answer and user answer to string before `ucfirst()` stops the notice; output is unchanged.

## Testing Instructions

- [x] On PHP 8.1+, take a quiz with a True/False question but leave it unanswered (or find a submission missing that answer).
- [x] As admin, go to Sensei → Grading and open that quiz submission's grade review.
- [x] Confirm the True/False row renders and no `ucfirst(): Passing null` deprecation notice appears in the PHP error log.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message
Fixed a PHP deprecation notice when reviewing a grade for an unanswered True/False question.

</details>