### PR TITLE
Remove the dead sensei_question_slug filter registration

### DIFF
--- a/changelog/fix-wpml-remove-dead-question-slug-filter
+++ b/changelog/fix-wpml-remove-dead-question-slug-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: development
+
+Remove the unused sensei_question_slug filter registration from the WPML compatibility class.

--- a/includes/wpml/class-slug.php
+++ b/includes/wpml/class-slug.php
@@ -34,7 +34,6 @@ class Slug {
 		add_filter( 'sensei_course_slug', array( $this, 'get_course_slug' ) );
 		add_filter( 'sensei_lesson_slug', array( $this, 'get_lesson_slug' ) );
 		add_filter( 'sensei_quiz_slug', array( $this, 'get_quiz_slug' ) );
-		add_filter( 'sensei_question_slug', array( $this, 'get_question_slug' ) );
 	}
 
 	/**
@@ -68,24 +67,6 @@ class Slug {
 	public function get_lesson_slug( $slug ) {
 		if ( Sensei()->settings->get( 'wpml_slug_translation' ) ) {
 			return 'lesson';
-		}
-
-		return $slug;
-	}
-
-	/**
-	 * Get question slug.
-	 *
-	 * @since 4.23.1
-	 *
-	 * @internal
-	 *
-	 * @param string $slug Question slug.
-	 * @return string
-	 */
-	public function get_question_slug( $slug ) {
-		if ( Sensei()->settings->get( 'wpml_slug_translation' ) ) {
-			return 'question';
 		}
 
 		return $slug;


### PR DESCRIPTION
Closes [SEN-185](https://linear.app/a8c/issue/SEN-185/wpml-remove-the-dead-sensei-question-slug-filter-registration)

## Proposed Changes

The WPML compatibility class registers a callback for the `sensei_question_slug` filter, but the filter is never applied: its `apply_filters` was removed together with the question post type's `rewrite` in #6347 (commit 029534a3f, January 2023, announced in that PR's "Removed hooks" section), and the question CPT has been non-public with `rewrite => false` since, so there is no slug to filter. The listener was added later by the WPML settings tab (#7569) against the pre-2023 set of slug filters. This removes the dead registration and its callback. Flagged by the WPML team's code review (SEN-185).

## Testing Instructions

No manual surface: the removed callback could never run.