### PR TITLE
Let WPML translate the Sensei slugs when the slug translation option is on

### DIFF
--- a/changelog/fix-wpml-wire-slug-translation
+++ b/changelog/fix-wpml-wire-slug-translation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Let WPML translate the course, lesson, and quiz URL slugs when the WPML slug translation setting is enabled.

--- a/includes/wpml/class-settings.php
+++ b/includes/wpml/class-settings.php
@@ -66,8 +66,8 @@ class Settings {
 	 */
 	public function add_fields( $fields ) {
 		$fields['wpml_slug_translation'] = array(
-			'name'        => __( 'Don\'t translate Sensei slugs', 'sensei-lms' ),
-			'description' => __( 'Sensei slugs will not be translated. Enable this setting if your translated courses return a 404 page.', 'sensei-lms' ),
+			'name'        => __( 'Use WPML slug translation', 'sensei-lms' ),
+			'description' => __( 'Sensei stops translating its course, lesson, and quiz URL slugs and registers them with WPML String Translation instead. Translate the "URL slug" strings there to localize your URLs. Enable this if your translated courses return a 404 page.', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => false,
 			'section'     => 'sensei-wpml-settings',

--- a/includes/wpml/class-slug.php
+++ b/includes/wpml/class-slug.php
@@ -68,11 +68,10 @@ class Slug {
 			$slug_settings['types'][ $post_type ] = 1;
 		}
 
-		// Turn the master switch on only when no other post type was configured before:
-		// re-enabling it on a site that deliberately disabled slug translation would
-		// change the URLs of those other post types.
-		$foreign_types = array_diff_key( $original['types'] ?? array(), array_flip( $sensei_types ) );
-		if ( empty( $slug_settings['on'] ) && empty( $foreign_types ) ) {
+		// Turn the master switch on only when it was never set: an explicit off is an
+		// admin decision, and re-enabling it would change the URLs of every post type
+		// with a translated slug behind the admin's back.
+		if ( ! isset( $original['on'] ) && empty( $slug_settings['on'] ) ) {
 			$slug_settings['on'] = 1;
 		}
 

--- a/includes/wpml/class-slug.php
+++ b/includes/wpml/class-slug.php
@@ -35,6 +35,65 @@ class Slug {
 		add_filter( 'sensei_lesson_slug', array( $this, 'get_lesson_slug' ) );
 		add_filter( 'sensei_quiz_slug', array( $this, 'get_quiz_slug' ) );
 		add_filter( 'sensei_question_slug', array( $this, 'get_question_slug' ) );
+
+		add_action( 'init', array( $this, 'maybe_activate_wpml_slug_translation' ), 20 );
+	}
+
+	/**
+	 * Enable WPML's slug translation for the Sensei post types when the option is on.
+	 *
+	 * With the option enabled, Sensei registers fixed base slugs (see the filters
+	 * below), and this wires the WPML side so those slugs can be translated per
+	 * language in String Translation instead.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 */
+	public function maybe_activate_wpml_slug_translation() {
+		if ( ! Sensei()->settings->get( 'wpml_slug_translation' ) ) {
+			return;
+		}
+
+		$sensei_types = array( 'course', 'lesson', 'quiz' );
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$original      = apply_filters( 'wpml_setting', array(), 'posts_slug_translation' );
+		$slug_settings = is_array( $original ) ? $original : array();
+
+		foreach ( $sensei_types as $post_type ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			do_action( 'wpml_register_single_string', 'WordPress', 'URL slug: ' . $post_type, $post_type );
+
+			$slug_settings['types'][ $post_type ] = 1;
+		}
+
+		// Turn the master switch on only when no other post type was configured before:
+		// re-enabling it on a site that deliberately disabled slug translation would
+		// change the URLs of those other post types.
+		$foreign_types = array_diff_key( $original['types'] ?? array(), array_flip( $sensei_types ) );
+		if ( empty( $slug_settings['on'] ) && empty( $foreign_types ) ) {
+			$slug_settings['on'] = 1;
+		}
+
+		if ( $slug_settings !== $original ) {
+			$this->save_slug_translation_settings( $slug_settings );
+		}
+	}
+
+	/**
+	 * Persist WPML's slug translation settings.
+	 *
+	 * @param array $slug_settings The `posts_slug_translation` WPML setting.
+	 */
+	protected function save_slug_translation_settings( $slug_settings ) {
+		global $sitepress;
+
+		if ( ! $sitepress || ! method_exists( $sitepress, 'set_setting' ) ) {
+			return;
+		}
+
+		$sitepress->set_setting( 'posts_slug_translation', $slug_settings, true );
 	}
 
 	/**

--- a/includes/wpml/class-slug.php
+++ b/includes/wpml/class-slug.php
@@ -70,9 +70,12 @@ class Slug {
 
 		// Turn the master switch on only when it was never set: an explicit off is an
 		// admin decision, and re-enabling it would change the URLs of every post type
-		// with a translated slug behind the admin's back.
-		if ( ! isset( $original['on'] ) && empty( $slug_settings['on'] ) ) {
+		// with a translated slug behind the admin's back. The runtime reads the
+		// standalone `wpml_base_slug_translation` option (the `on` flag is legacy,
+		// kept in sync by WPML's own UI), so both are set together.
+		if ( ! isset( $original['on'] ) ) {
 			$slug_settings['on'] = 1;
+			update_option( 'wpml_base_slug_translation', 1 );
 		}
 
 		if ( $slug_settings !== $original ) {

--- a/tests/unit-tests/wpml/test-class-slug.php
+++ b/tests/unit-tests/wpml/test-class-slug.php
@@ -1,0 +1,193 @@
+<?php
+namespace SenseiTest\WPML;
+
+use Sensei\WPML\Slug;
+
+/**
+ * Class Slug_Test
+ *
+ * @covers \Sensei\WPML\Slug
+ */
+class Slug_Test extends \WP_UnitTestCase {
+
+	public function tear_down(): void {
+		unset( \Sensei()->settings->settings['wpml_slug_translation'] );
+		parent::tear_down();
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_OptionEnabledGiven_RegistersTheSlugStrings() {
+		/* Arrange. */
+		$slug = new Slug();
+		\Sensei()->settings->settings['wpml_slug_translation'] = true;
+
+		$registered      = array();
+		$register_filter = function ( $context, $name, $value ) use ( &$registered ) {
+			$registered[] = array( $context, $name, $value );
+		};
+		add_action( 'wpml_register_single_string', $register_filter, 10, 3 );
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Clean up & Assert. */
+		remove_action( 'wpml_register_single_string', $register_filter );
+		$this->assertSame(
+			array(
+				array( 'WordPress', 'URL slug: course', 'course' ),
+				array( 'WordPress', 'URL slug: lesson', 'lesson' ),
+				array( 'WordPress', 'URL slug: quiz', 'quiz' ),
+			),
+			$registered
+		);
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_OptionDisabledGiven_RegistersNothing() {
+		/* Arrange. */
+		$slug = new Slug();
+
+		$registered      = array();
+		$register_filter = function ( $context, $name, $value ) use ( &$registered ) {
+			$registered[] = array( $context, $name, $value );
+		};
+		add_action( 'wpml_register_single_string', $register_filter, 10, 3 );
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Clean up & Assert. */
+		remove_action( 'wpml_register_single_string', $register_filter );
+		$this->assertSame( array(), $registered );
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_NoPriorSlugSettingsGiven_SavesTheTypesWithTheMasterSwitchOn() {
+		/* Arrange. */
+		$slug = $this->create_slug_with_settings_spy( $saved );
+		\Sensei()->settings->settings['wpml_slug_translation'] = true;
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Assert. */
+		$this->assertSame(
+			array(
+				array(
+					'types' => array(
+						'course' => 1,
+						'lesson' => 1,
+						'quiz'   => 1,
+					),
+					'on'    => 1,
+				),
+			),
+			$saved
+		);
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_MasterSwitchOffWithAForeignTypeGiven_KeepsTheMasterSwitchOff() {
+		/* Arrange. */
+		$slug = $this->create_slug_with_settings_spy( $saved );
+		\Sensei()->settings->settings['wpml_slug_translation'] = true;
+
+		$setting_filter = $this->stub_wpml_slug_setting(
+			array(
+				'on'    => 0,
+				'types' => array( 'product' => 1 ),
+			)
+		);
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_setting', $setting_filter );
+		$this->assertSame(
+			array(
+				array(
+					'on'    => 0,
+					'types' => array(
+						'product' => 1,
+						'course'  => 1,
+						'lesson'  => 1,
+						'quiz'    => 1,
+					),
+				),
+			),
+			$saved
+		);
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_SlugTranslationAlreadyActiveGiven_SavesNothing() {
+		/* Arrange. */
+		$slug = $this->create_slug_with_settings_spy( $saved );
+		\Sensei()->settings->settings['wpml_slug_translation'] = true;
+
+		$setting_filter = $this->stub_wpml_slug_setting(
+			array(
+				'on'    => 1,
+				'types' => array(
+					'course' => 1,
+					'lesson' => 1,
+					'quiz'   => 1,
+				),
+			)
+		);
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_setting', $setting_filter );
+		$this->assertSame( array(), $saved );
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_OptionDisabledGiven_SavesNothing() {
+		/* Arrange. */
+		$slug = $this->create_slug_with_settings_spy( $saved );
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Assert. */
+		$this->assertSame( array(), $saved );
+	}
+
+	/**
+	 * Stub the `wpml_setting` filter for `posts_slug_translation`.
+	 *
+	 * @param array $slug_settings The stubbed setting value.
+	 * @return callable The filter, so the test can remove it.
+	 */
+	private function stub_wpml_slug_setting( array $slug_settings ) {
+		$setting_filter = function ( $default_value, $key ) use ( $slug_settings ) {
+			if ( 'posts_slug_translation' === $key ) {
+				return $slug_settings;
+			}
+			return $default_value;
+		};
+		add_filter( 'wpml_setting', $setting_filter, 10, 2 );
+
+		return $setting_filter;
+	}
+
+	/**
+	 * Build a Slug instance whose settings write records into $saved.
+	 *
+	 * @param array|null $saved Filled with each saved settings array (by reference).
+	 * @return Slug
+	 */
+	private function create_slug_with_settings_spy( &$saved ) {
+		$saved = array();
+
+		return new class( $saved ) extends Slug {
+			private $saved;
+
+			public function __construct( &$saved ) {
+				$this->saved = &$saved;
+			}
+
+			protected function save_slug_translation_settings( $slug_settings ) {
+				$this->saved[] = $slug_settings;
+			}
+		};
+	}
+}

--- a/tests/unit-tests/wpml/test-class-slug.php
+++ b/tests/unit-tests/wpml/test-class-slug.php
@@ -116,6 +116,33 @@ class Slug_Test extends \WP_UnitTestCase {
 		);
 	}
 
+	public function testMaybeActivateWpmlSlugTranslation_MasterSwitchExplicitlyOffWithOnlySenseiTypesGiven_KeepsTheMasterSwitchOff() {
+		/* Arrange. */
+		$slug = $this->create_slug_with_settings_spy( $saved );
+		\Sensei()->settings->settings['wpml_slug_translation'] = true;
+
+		$setting_filter = $this->stub_wpml_slug_setting( array( 'on' => 0 ) );
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_setting', $setting_filter );
+		$this->assertSame(
+			array(
+				array(
+					'on'    => 0,
+					'types' => array(
+						'course' => 1,
+						'lesson' => 1,
+						'quiz'   => 1,
+					),
+				),
+			),
+			$saved
+		);
+	}
+
 	public function testMaybeActivateWpmlSlugTranslation_SlugTranslationAlreadyActiveGiven_SavesNothing() {
 		/* Arrange. */
 		$slug = $this->create_slug_with_settings_spy( $saved );

--- a/tests/unit-tests/wpml/test-class-slug.php
+++ b/tests/unit-tests/wpml/test-class-slug.php
@@ -12,6 +12,7 @@ class Slug_Test extends \WP_UnitTestCase {
 
 	public function tear_down(): void {
 		unset( \Sensei()->settings->settings['wpml_slug_translation'] );
+		delete_option( 'wpml_base_slug_translation' );
 		parent::tear_down();
 	}
 
@@ -114,6 +115,35 @@ class Slug_Test extends \WP_UnitTestCase {
 			),
 			$saved
 		);
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_NoPriorSlugSettingsGiven_EnablesTheRuntimeOption() {
+		/* Arrange. */
+		$slug = $this->create_slug_with_settings_spy( $saved );
+		\Sensei()->settings->settings['wpml_slug_translation'] = true;
+		delete_option( 'wpml_base_slug_translation' );
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Assert. */
+		$this->assertSame( 1, (int) get_option( 'wpml_base_slug_translation' ) );
+	}
+
+	public function testMaybeActivateWpmlSlugTranslation_MasterSwitchExplicitlyOffGiven_KeepsTheRuntimeOptionOff() {
+		/* Arrange. */
+		$slug = $this->create_slug_with_settings_spy( $saved );
+		\Sensei()->settings->settings['wpml_slug_translation'] = true;
+		update_option( 'wpml_base_slug_translation', 0 );
+
+		$setting_filter = $this->stub_wpml_slug_setting( array( 'on' => 0 ) );
+
+		/* Act. */
+		$slug->maybe_activate_wpml_slug_translation();
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_setting', $setting_filter );
+		$this->assertSame( 0, (int) get_option( 'wpml_base_slug_translation' ) );
 	}
 
 	public function testMaybeActivateWpmlSlugTranslation_MasterSwitchExplicitlyOffWithOnlySenseiTypesGiven_KeepsTheMasterSwitchOff() {


### PR DESCRIPTION
Closes [SEN-184](https://linear.app/a8c/issue/SEN-184/wpml-revisit-the-dont-translate-sensei-slugs-option-and-its-default)

## Proposed Changes

The WPML settings tab option shipped in #7569 was designed to pin Sensei's base slugs so WPML could translate them per language, but the WPML side was never wired: the post types were not enabled for WPML's slug translation and the slug strings were never registered, so enabling the option left every language on the English slugs. This wires that missing half: when the option is on, Sensei registers the `URL slug: course/lesson/quiz` strings with WPML String Translation and enables slug translation for the three post types, so translating those strings localizes the URLs (`/es/curso/…`), with the old base 301-redirecting to the translated one.

Production URLs cannot change on update: untranslated strings fall back to the current English base, and the settings write never re-enables WPML's global slug translation switch when other post types were configured on the site (covered by a unit test). Localized URLs only appear after an admin translates the strings.

The option's label and description are updated to describe this ("Use WPML slug translation"), close to its original #7569 naming.

Turning the option OFF stops the wiring and writes nothing, and deliberately leaves WPML's own configuration untouched (Sensei never unconfigures WPML); slug translation is fully retired from WPML's side with its global checkbox ("Translate base slugs of custom post types and taxonomies" in WPML → Settings), which the wiring also never re-enables once it was explicitly turned off.

## Testing Instructions

On a site with WPML and WPML String Translation active (English default plus Spanish).

1. Go to Sensei LMS → Settings → WPML: the option now reads "Use WPML slug translation". Enable it and save.
2. Create and publish a course, translate it into Spanish, and note the Spanish post slug.
3. Visit the English course at `/course/{slug}/` and the Spanish one at `/es/course/{spanish-slug}/`: both load, no 404s, English base everywhere.
4. Go to WPML → String Translation and search for "URL slug": the `course`, `lesson`, and `quiz` strings are registered. Translate `URL slug: course` into Spanish as `curso`.
5. Visit `/es/curso/{spanish-slug}/`: it loads. The previous `/es/course/{spanish-slug}/` now redirects to it, and the English URL is unchanged.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
<!-- Choose only one -->
- [ ] Patch - Backward-compatible bug fixes
- [x] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
<!-- Choose only one -->
- [ ] Added - Adds new functionality
- [x] Changed - Changes existing functionality
- [ ] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message <!-- Add the changelog message here -->
Let WPML translate the course, lesson, and quiz URL slugs when the WPML slug translation setting is enabled.

</details>