### PR TITLE
Remap delivered course outlines to the lessons of the course language

### DIFF
--- a/changelog/fix-wpml-course-structure-save-language
+++ b/changelog/fix-wpml-course-structure-save-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed saving a translated course overwriting and stealing the original course's lessons on WPML sites.

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -220,6 +220,20 @@ class Course_Translation {
 	 */
 	private function outline_item_to_language( array $block, $language_code ) {
 		if ( 'sensei-lms/course-outline-module' === $block['blockName'] ) {
+			$module_id = (int) ( $block['attrs']['id'] ?? 0 );
+
+			if ( $module_id ) {
+				$translated_module_id = $this->get_object_id( $module_id, 'module', false, $language_code );
+
+				if ( $translated_module_id ) {
+					$block['attrs']['id'] = (int) $translated_module_id;
+				} else {
+					// Without id and slug the structure save creates the course's own
+					// module instead of renaming or adopting the source language's term.
+					unset( $block['attrs']['id'], $block['attrs']['slug'] );
+				}
+			}
+
 			return $this->map_inner_blocks( $block, array( $this, 'outline_item_to_language' ), $language_code );
 		}
 

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -198,6 +198,12 @@ class Course_Translation {
 		foreach ( $blocks as $i => $block ) {
 			if ( 'sensei-lms/course-outline' === $block['blockName'] ) {
 				$blocks[ $i ] = $this->map_inner_blocks( $block, array( $this, 'outline_item_to_language' ), $language_code );
+				continue;
+			}
+
+			// The outline can sit inside wrapper blocks such as groups or columns.
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$blocks[ $i ]['innerBlocks'] = $this->translate_outline_blocks( $block['innerBlocks'], $language_code );
 			}
 		}
 

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -126,7 +126,7 @@ class Course_Translation {
 		}
 
 		$details = $this->get_element_language_details( $new_course_id, 'course' );
-		if ( empty( $details ) || empty( $details['language_code'] ) ) {
+		if ( empty( $details ) || empty( $details['language_code'] ) || empty( $details['source_language_code'] ) ) {
 			return;
 		}
 
@@ -225,6 +225,13 @@ class Course_Translation {
 
 				if ( $translated_module_id ) {
 					$block['attrs']['id'] = (int) $translated_module_id;
+
+					// The slug travels with the block too, and a stale source slug would
+					// point a later save back at the source language's term.
+					$translated_term = get_term( (int) $translated_module_id, 'module' );
+					if ( $translated_term && ! is_wp_error( $translated_term ) ) {
+						$block['attrs']['slug'] = $translated_term->slug;
+					}
 				} else {
 					// Without id and slug the structure save creates the course's own
 					// module instead of renaming or adopting the source language's term.

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -235,9 +235,11 @@ class Course_Translation {
 		$block['attrs']['id'] = (int) $translated_id;
 
 		// The translated title lives in the block attribute; the lesson translation
-		// was created with the source title, so hand it the delivered one.
-		$title = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
-		if ( '' !== $title && get_the_title( $translated_id ) !== $title ) {
+		// was created with the source title, so hand it the delivered one. Compared
+		// raw: display filters on the title would defeat the check.
+		$title            = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
+		$translated_title = get_post( $translated_id ) ? get_post( $translated_id )->post_title : '';
+		if ( '' !== $title && $translated_title !== $title ) {
 			wp_update_post(
 				wp_slash(
 					array(

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -233,6 +233,8 @@ class Course_Translation {
 					$translated_term = get_term( (int) $translated_module_id, 'module' );
 					if ( $translated_term && ! is_wp_error( $translated_term ) ) {
 						$block['attrs']['slug'] = $translated_term->slug;
+					} else {
+						unset( $block['attrs']['slug'] );
 					}
 				} else {
 					// Without id and slug the structure save creates the course's own

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -228,6 +228,20 @@ class Course_Translation {
 
 		$block['attrs']['id'] = (int) $translated_id;
 
+		// The translated title lives in the block attribute; the lesson translation
+		// was created with the source title, so hand it the delivered one.
+		$title = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
+		if ( '' !== $title && get_the_title( $translated_id ) !== $title ) {
+			wp_update_post(
+				wp_slash(
+					array(
+						'ID'         => (int) $translated_id,
+						'post_title' => $title,
+					)
+				)
+			);
+		}
+
 		return $block;
 	}
 

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -275,10 +275,16 @@ class Course_Translation {
 
 		foreach ( $this->get_outline_lesson_blocks( parse_blocks( $course->post_content ) ) as $block ) {
 			$lesson_id = (int) ( $block['attrs']['id'] ?? 0 );
-			$title     = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
 			$lesson    = $lesson_id ? get_post( $lesson_id ) : null;
 
-			if ( '' === $title || ! $lesson || $lesson->post_title === $title ) {
+			if ( ! $lesson || 'lesson' !== $lesson->post_type ) {
+				continue;
+			}
+
+			// Sanitized like the structure save does, so both write the same title.
+			$title = isset( $block['attrs']['title'] ) ? trim( sanitize_text_field( $block['attrs']['title'] ) ) : '';
+
+			if ( '' === $title || $lesson->post_title === $title ) {
 				continue;
 			}
 
@@ -318,8 +324,6 @@ class Course_Translation {
 
 	/**
 	 * Map the inner blocks of a block, dropping the ones mapped to false.
-	 *
-	 * Mirror of `Sensei_Import_Block_Migrator::map_inner_blocks()`.
 	 *
 	 * @param array    $block         The block whose inner blocks to map.
 	 * @param callable $map           Map receiving the inner block and the language code.

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -32,6 +32,13 @@ class Course_Translation {
 	public function init() {
 		// Create translations for lessons and update lesson properties on course translation created.
 		add_action( 'wpml_pro_translation_completed', array( $this, 'update_lesson_properties_on_course_translation_created' ) );
+
+		// After the lesson translations above exist, point the delivered outline at them.
+		add_action( 'wpml_pro_translation_completed', array( $this, 'translate_outline_lesson_ids_on_course_translation_created' ), 20 );
+
+		// The Duplicate feature copies the outline verbatim too.
+		// "icl_make_duplicate" is WPML-internal but the WPML team confirmed it's safe to rely on.
+		add_action( 'icl_make_duplicate', array( $this, 'translate_outline_lesson_ids_on_course_duplicated' ), 10, 4 );
 	}
 
 	/**
@@ -99,5 +106,173 @@ class Course_Translation {
 				$this->sync_course_lesson_order( $master_id, $translated_course_id, $language_code );
 			}
 		}
+	}
+
+	/**
+	 * Rewrite the delivered course outline to the lesson IDs of the course language.
+	 *
+	 * WPML delivers translated content with the source-language lesson IDs (its ID
+	 * conversion runs at render time only), so the stored outline points at another
+	 * language's lessons and a later editor save adopts them. Remapping the stored
+	 * outline right after delivery keeps every consumer of the content safe.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param int $new_course_id New course ID.
+	 */
+	public function translate_outline_lesson_ids_on_course_translation_created( $new_course_id ) {
+		if ( 'course' !== get_post_type( $new_course_id ) ) {
+			return;
+		}
+
+		$details = $this->get_element_language_details( $new_course_id, 'course' );
+		if ( empty( $details ) || empty( $details['language_code'] ) ) {
+			return;
+		}
+
+		$this->translate_outline_to_language( $new_course_id, $details['language_code'] );
+	}
+
+	/**
+	 * Rewrite a duplicated course outline to the lesson IDs of the duplicate's language.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param int    $master_post_id Master course ID.
+	 * @param string $lang           Language of the duplicate.
+	 * @param array  $post_array     Post data of the duplicate.
+	 * @param int    $new_course_id  Duplicated course ID.
+	 */
+	public function translate_outline_lesson_ids_on_course_duplicated( $master_post_id, $lang, $post_array, $new_course_id ) {
+		if ( 'course' !== get_post_type( $new_course_id ) || empty( $lang ) ) {
+			return;
+		}
+
+		$this->translate_outline_to_language( (int) $new_course_id, $lang );
+	}
+
+	/**
+	 * Rewrite a course's stored outline to the lesson IDs of the given language.
+	 *
+	 * @param int    $course_id     Course ID.
+	 * @param string $language_code Language to map the outline to.
+	 */
+	private function translate_outline_to_language( $course_id, $language_code ) {
+		$course = get_post( $course_id );
+		if ( ! $course || ! has_block( 'sensei-lms/course-outline', $course ) ) {
+			return;
+		}
+
+		$blocks  = parse_blocks( $course->post_content );
+		$blocks  = $this->translate_outline_blocks( $blocks, $language_code );
+		$content = serialize_blocks( $blocks );
+
+		if ( $content === $course->post_content ) {
+			return;
+		}
+
+		// Slashed, or wp_update_post strips the backslashes of the escaped block attributes.
+		wp_update_post(
+			wp_slash(
+				array(
+					'ID'           => $course_id,
+					'post_content' => $content,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Map outline lesson blocks to the given language, dropping untranslated ones.
+	 *
+	 * @param array  $blocks        Parsed blocks.
+	 * @param string $language_code Language to map the lesson IDs to.
+	 *
+	 * @return array
+	 */
+	private function translate_outline_blocks( array $blocks, $language_code ) {
+		foreach ( $blocks as $i => $block ) {
+			if ( 'sensei-lms/course-outline' === $block['blockName'] ) {
+				$blocks[ $i ] = $this->map_inner_blocks( $block, array( $this, 'outline_item_to_language' ), $language_code );
+			}
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Map one outline item to the course language.
+	 *
+	 * @param array  $block         The outline item block.
+	 * @param string $language_code Language to map the item to.
+	 *
+	 * @return array|false The mapped block, or false to drop it.
+	 */
+	private function outline_item_to_language( array $block, $language_code ) {
+		if ( 'sensei-lms/course-outline-module' === $block['blockName'] ) {
+			return $this->map_inner_blocks( $block, array( $this, 'outline_item_to_language' ), $language_code );
+		}
+
+		if ( 'sensei-lms/course-outline-lesson' !== $block['blockName'] || empty( $block['attrs']['id'] ) ) {
+			return $block;
+		}
+
+		$translated_id = $this->get_object_id( (int) $block['attrs']['id'], 'lesson', false, $language_code );
+		if ( ! $translated_id ) {
+			return false;
+		}
+
+		$block['attrs']['id'] = (int) $translated_id;
+
+		return $block;
+	}
+
+	/**
+	 * Map the inner blocks of a block, dropping the ones mapped to false.
+	 *
+	 * Mirror of `Sensei_Import_Block_Migrator::map_inner_blocks()`.
+	 *
+	 * @param array    $block         The block whose inner blocks to map.
+	 * @param callable $map           Map receiving the inner block and the language code.
+	 * @param string   $language_code Language passed through to the map.
+	 *
+	 * @return array The block with its inner blocks mapped.
+	 */
+	private function map_inner_blocks( array $block, callable $map, $language_code ) {
+		if ( empty( $block['innerBlocks'] ) ) {
+			return $block;
+		}
+
+		// Inner blocks are represented as an entry in the 'innerBlocks' array and a null value in the 'innerContent' array.
+		$inner_block_index   = 0;
+		$mapped_inner_blocks = array();
+		$inner_content       = array();
+
+		foreach ( $block['innerContent'] as $chunk ) {
+			// If the content is not an inner block there is nothing to do.
+			if ( is_string( $chunk ) ) {
+				$inner_content[] = $chunk;
+				continue;
+			}
+
+			$mapped_block = $map( $block['innerBlocks'][ $inner_block_index ], $language_code );
+
+			// Add the entries in 'innerBlocks' and 'innerContent' only if the block was not dropped.
+			if ( false !== $mapped_block ) {
+				$mapped_inner_blocks[] = $mapped_block;
+				$inner_content[]       = $chunk;
+			}
+
+			++$inner_block_index;
+		}
+
+		$block['innerBlocks']  = $mapped_inner_blocks;
+		$block['innerContent'] = $inner_content;
+
+		return $block;
 	}
 }

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -107,12 +107,12 @@ class Course_Translation {
 	}
 
 	/**
-	 * Rewrite the delivered course outline to the lesson IDs of the course language.
+	 * Rewrite the delivered course outline to the lesson and module IDs of the course language.
 	 *
-	 * WPML delivers translated content with the source-language lesson IDs (its ID
-	 * conversion runs at render time only), so the stored outline points at another
-	 * language's lessons and a later editor save adopts them. Remapping the stored
-	 * outline right after delivery keeps every consumer of the content safe.
+	 * WPML delivers translated content with the source language's lesson and module
+	 * IDs (its ID conversion runs at render time only), so the stored outline points
+	 * at another language's content and a later editor save adopts it. Remapping the
+	 * stored outline right after delivery keeps every consumer of the content safe.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -134,7 +134,7 @@ class Course_Translation {
 	}
 
 	/**
-	 * Rewrite a duplicated course outline to the lesson IDs of the duplicate's language.
+	 * Rewrite a duplicated course outline to the lesson and module IDs of the duplicate's language.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -249,9 +249,9 @@ class Course_Translation {
 		// The lesson translation is created with the source language's title, and the
 		// translated title only exists in this block attribute, so apply it to the
 		// lesson here.
-		$title            = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
-		$translated_title = get_post( $translated_id ) ? get_post( $translated_id )->post_title : '';
-		if ( '' !== $title && $translated_title !== $title ) {
+		$title             = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
+		$translated_lesson = get_post( $translated_id );
+		if ( '' !== $title && $translated_lesson && $translated_lesson->post_title !== $title ) {
 			wp_update_post(
 				wp_slash(
 					array(

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -131,6 +131,8 @@ class Course_Translation {
 		}
 
 		$this->translate_outline_to_language( $new_course_id, $details['language_code'] );
+
+		$this->apply_outline_titles_to_lessons( $new_course_id );
 	}
 
 	/**
@@ -253,23 +255,65 @@ class Course_Translation {
 
 		$block['attrs']['id'] = (int) $translated_id;
 
-		// The lesson translation is created with the source language's title, and the
-		// translated title only exists in this block attribute, so apply it to the
-		// lesson here.
-		$title             = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
-		$translated_lesson = get_post( $translated_id );
-		if ( '' !== $title && $translated_lesson && $translated_lesson->post_title !== $title ) {
+		return $block;
+	}
+
+	/**
+	 * Rename a course's lessons to the titles held in its outline.
+	 *
+	 * Lesson translations are created with the source language's title, and the
+	 * translated title only exists in the outline block attribute, so it is applied
+	 * to the lessons here.
+	 *
+	 * @param int $course_id Course ID.
+	 */
+	private function apply_outline_titles_to_lessons( $course_id ) {
+		$course = get_post( $course_id );
+		if ( ! $course ) {
+			return;
+		}
+
+		foreach ( $this->get_outline_lesson_blocks( parse_blocks( $course->post_content ) ) as $block ) {
+			$lesson_id = (int) ( $block['attrs']['id'] ?? 0 );
+			$title     = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
+			$lesson    = $lesson_id ? get_post( $lesson_id ) : null;
+
+			if ( '' === $title || ! $lesson || $lesson->post_title === $title ) {
+				continue;
+			}
+
 			wp_update_post(
 				wp_slash(
 					array(
-						'ID'         => (int) $translated_id,
+						'ID'         => $lesson_id,
 						'post_title' => $title,
 					)
 				)
 			);
 		}
+	}
 
-		return $block;
+	/**
+	 * Collect the outline lesson blocks held anywhere in the given blocks.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 *
+	 * @return array The lesson blocks.
+	 */
+	private function get_outline_lesson_blocks( array $blocks ) {
+		$lesson_blocks = array();
+		foreach ( $blocks as $block ) {
+			if ( 'sensei-lms/course-outline-lesson' === $block['blockName'] ) {
+				$lesson_blocks[] = $block;
+				continue;
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$lesson_blocks = array_merge( $lesson_blocks, $this->get_outline_lesson_blocks( $block['innerBlocks'] ) );
+			}
+		}
+
+		return $lesson_blocks;
 	}
 
 	/**

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -154,7 +154,7 @@ class Course_Translation {
 	}
 
 	/**
-	 * Rewrite a course's stored outline to the lesson IDs of the given language.
+	 * Rewrite a course's stored outline to the lesson and module IDs of the given language.
 	 *
 	 * @param int    $course_id     Course ID.
 	 * @param string $language_code Language to map the outline to.
@@ -185,10 +185,10 @@ class Course_Translation {
 	}
 
 	/**
-	 * Map outline lesson blocks to the given language, dropping untranslated ones.
+	 * Map outline lesson and module blocks to the given language, dropping untranslated lessons.
 	 *
 	 * @param array  $blocks        Parsed blocks.
-	 * @param string $language_code Language to map the lesson IDs to.
+	 * @param string $language_code Language to map the outline IDs to.
 	 *
 	 * @return array
 	 */

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -35,9 +35,7 @@ class Course_Translation {
 
 		// After the lesson translations above exist, point the delivered outline at them.
 		add_action( 'wpml_pro_translation_completed', array( $this, 'translate_outline_lesson_ids_on_course_translation_created' ), 20 );
-
 		// The Duplicate feature copies the outline verbatim too.
-		// "icl_make_duplicate" is WPML-internal but the WPML team confirmed it's safe to rely on.
 		add_action( 'icl_make_duplicate', array( $this, 'translate_outline_lesson_ids_on_course_duplicated' ), 10, 4 );
 	}
 
@@ -248,9 +246,9 @@ class Course_Translation {
 
 		$block['attrs']['id'] = (int) $translated_id;
 
-		// The translated title lives in the block attribute; the lesson translation
-		// was created with the source title, so hand it the delivered one. Compared
-		// raw: display filters on the title would defeat the check.
+		// The lesson translation is created with the source language's title, and the
+		// translated title only exists in this block attribute, so apply it to the
+		// lesson here.
 		$title            = isset( $block['attrs']['title'] ) ? (string) $block['attrs']['title'] : '';
 		$translated_title = get_post( $translated_id ) ? get_post( $translated_id )->post_title : '';
 		if ( '' !== $title && $translated_title !== $title ) {

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -351,6 +351,49 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( 'Titulo entregado', get_post( $translated_lesson_id )->post_title, 'The delivered outline title should land on the lesson translation.' );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_DeliveredTitleAlreadyApplied_DoesNotRewriteTheLessonAgain() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$course_id            = $this->factory->course->create(
+			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Titulo especial' ) ) ) )
+		);
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map(
+			array(
+				$source_lesson_id     => $translated_lesson_id,
+				$translated_lesson_id => $translated_lesson_id,
+			)
+		);
+
+		$course_translation = new Course_Translation();
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		// Display filters (wptexturize, plugins) must not defeat the comparison.
+		$title_filter = function ( $title ) {
+			return $title . ' [filtered]';
+		};
+		add_filter( 'the_title', $title_filter );
+
+		$lesson_updates = 0;
+		$count_updates  = function ( $post_id ) use ( $translated_lesson_id, &$lesson_updates ) {
+			if ( $post_id === $translated_lesson_id ) {
+				++$lesson_updates;
+			}
+		};
+		add_action( 'post_updated', $count_updates );
+
+		/* Act: a re-delivery runs the handler again with the same titles. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		remove_action( 'post_updated', $count_updates );
+		remove_filter( 'the_title', $title_filter );
+		$this->remove_wpml_stubs();
+		$this->assertSame( 0, $lesson_updates, 'A re-delivery with an unchanged title should not rewrite the lesson.' );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_OutlineNestedInAWrapperBlockGiven_RewritesItsLessonIds() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -461,7 +461,7 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		/* Clean up & Assert. */
 		$this->remove_wpml_stubs();
 		$module_attrs = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0]['attrs'];
-		$this->assertSame( get_term( $translated_term['term_id'], 'module' )->slug, $module_attrs['slug'], 'The remapped module should carry the translated term slug, not the source one.' );
+		$this->assertSame( 'el-modulo', $module_attrs['slug'], 'The remapped module should carry the translated term slug, not the source one.' );
 	}
 
 	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_CourseWithoutASourceLanguageGiven_LeavesTheContentUntouched() {

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -414,6 +414,47 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '"id":' . $translated_lesson_id, get_post( $course_id )->post_content, 'An outline nested inside a wrapper block should be remapped too.' );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_ModuleWithATranslationGiven_RewritesTheModuleId() {
+		/* Arrange. */
+		$content   = '<!-- wp:sensei-lms/course-outline --><!-- wp:sensei-lms/course-outline-module {"id":91,"title":"Modulo"} --><!-- /wp:sensei-lms/course-outline-module --><!-- /wp:sensei-lms/course-outline -->';
+		$course_id = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( 91 => 95 ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertStringContainsString( '"id":95', get_post( $course_id )->post_content, 'A module with a translation in the course language should be remapped to it.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_ModuleWithoutATranslationGiven_DropsItsIdAndSlug() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$content              = '<!-- wp:sensei-lms/course-outline --><!-- wp:sensei-lms/course-outline-module {"id":91,"slug":"modulo","title":"Modulo"} --><!-- wp:sensei-lms/course-outline-lesson {"id":' . $source_lesson_id . ',"title":"Anidada"} /--><!-- /wp:sensei-lms/course-outline-module --><!-- /wp:sensei-lms/course-outline -->';
+		$course_id            = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$content_after = get_post( $course_id )->post_content;
+		$this->assertStringNotContainsString( '"id":91', $content_after, 'A module without a translation should lose its source term id.' );
+		$this->assertStringNotContainsString( '"slug":"modulo"', $content_after, 'A module without a translation should lose its source slug.' );
+		$this->assertStringContainsString( '"id":' . $translated_lesson_id, $content_after, 'The module lessons should still be remapped.' );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceLessonIdsGiven_RewritesThemToTheDuplicateLanguage() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -306,18 +306,10 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 				'title' => $title,
 			)
 		) . ' /--><!-- /wp:sensei-lms/course-outline -->';
-		$course_id            = self::factory()->post->create(
-			array(
-				'post_type'    => 'course',
-				'post_content' => wp_slash( $content ),
-			)
-		);
+		$course_id            = $this->factory->course->create( array( 'post_content' => wp_slash( $content ) ) );
 
 		$this->stub_course_language( 'es', 'en' );
 		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
-
-		$stored_title = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0]['attrs']['title'];
-		$this->assertStringContainsString( '<br', $stored_title, 'Fixture check: the stored title should carry the escaped HTML.' );
 
 		$course_translation = new Course_Translation();
 
@@ -326,8 +318,7 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 
 		/* Clean up & Assert. */
 		$this->remove_wpml_stubs();
-		$block = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0];
-		$this->assertSame( $stored_title, $block['attrs']['title'], 'The title attribute should survive the remap round trip unmangled.' );
+		$this->assertStringContainsString( '\u003cbr', get_post( $course_id )->post_content, 'The escaped attribute encoding should survive the remap round trip.' );
 	}
 
 	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_DeliveredTitleGiven_RenamesTheLessonTranslation() {
@@ -449,17 +440,14 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 
 		/* Clean up & Assert. */
 		$this->remove_wpml_stubs();
-		$content_after = get_post( $course_id )->post_content;
-		$this->assertStringNotContainsString( '"id":91', $content_after, 'A module without a translation should lose its source term id.' );
-		$this->assertStringNotContainsString( '"slug":"modulo"', $content_after, 'A module without a translation should lose its source slug.' );
-		$this->assertStringContainsString( '"id":' . $translated_lesson_id, $content_after, 'The module lessons should still be remapped.' );
+		$module_attrs = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0]['attrs'];
+		$this->assertSame( array( 'title' => 'Modulo' ), $module_attrs, 'A module without a translation should keep its title but lose its source term id and slug.' );
 	}
 
 	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceLessonIdsGiven_RewritesThemToTheDuplicateLanguage() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();
 		$translated_lesson_id = $this->factory->lesson->create();
-		$master_course_id     = $this->factory->course->create();
 		$duplicate_course_id  = $this->factory->course->create(
 			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Duplicada' ) ) ) )
 		);
@@ -469,7 +457,7 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$course_translation = new Course_Translation();
 
 		/* Act. */
-		$course_translation->translate_outline_lesson_ids_on_course_duplicated( $master_course_id, 'es', array(), $duplicate_course_id );
+		$course_translation->translate_outline_lesson_ids_on_course_duplicated( 123, 'es', array(), $duplicate_course_id );
 
 		/* Clean up & Assert. */
 		$this->remove_wpml_stubs();

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -351,6 +351,26 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( 'Titulo entregado', get_post( $translated_lesson_id )->post_title, 'The delivered outline title should land on the lesson translation.' );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_OutlineNestedInAWrapperBlockGiven_RewritesItsLessonIds() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$content              = '<!-- wp:group --><div class="wp-block-group">' . $this->outline_content( array( array( $source_lesson_id, 'Anidado' ) ) ) . '</div><!-- /wp:group -->';
+		$course_id            = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertStringContainsString( '"id":' . $translated_lesson_id, get_post( $course_id )->post_content, 'An outline nested inside a wrapper block should be remapped too.' );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceLessonIdsGiven_RewritesThemToTheDuplicateLanguage() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -330,6 +330,27 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( $stored_title, $block['attrs']['title'], 'The title attribute should survive the remap round trip unmangled.' );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_DeliveredTitleGiven_RenamesTheLessonTranslation() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create( array( 'post_title' => 'Source title' ) );
+		$course_id            = $this->factory->course->create(
+			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Titulo entregado' ) ) ) )
+		);
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertSame( 'Titulo entregado', get_post( $translated_lesson_id )->post_title, 'The delivered outline title should land on the lesson translation.' );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceLessonIdsGiven_RewritesThemToTheDuplicateLanguage() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -175,6 +175,242 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( $master_lesson_ids, array_map( fn( $id ) => $id_map[ $id ], Sensei()->course->course_lessons( $translated_course_id, 'any', 'ids' ) ) );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_OutlineWithSourceLessonIdsGiven_RewritesThemToTheCourseLanguage() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$course_id            = $this->factory->course->create(
+			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Titulo ES' ) ) ) )
+		);
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$content = get_post( $course_id )->post_content;
+		$this->assertStringContainsString( '"id":' . $translated_lesson_id, $content, 'The outline should reference the lesson translation in the course language.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_OutlineWithSourceLessonIdsGiven_KeepsTheSubmittedTitle() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$course_id            = $this->factory->course->create(
+			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Titulo ES' ) ) ) )
+		);
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertStringContainsString( 'Titulo ES', get_post( $course_id )->post_content, 'The delivered title should stay with the remapped outline item.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_LessonWithoutTranslationGiven_DropsTheOutlineItem() {
+		/* Arrange. */
+		$source_lesson_id = $this->factory->lesson->create();
+		$course_id        = $this->factory->course->create(
+			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Sin traduccion' ) ) ) )
+		);
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array() );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertStringNotContainsString( '"id":' . $source_lesson_id, get_post( $course_id )->post_content, 'An outline item without a translation in the course language should be dropped.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_LessonAlreadyInCourseLanguageGiven_LeavesTheContentUntouched() {
+		/* Arrange. */
+		$own_lesson_id = $this->factory->lesson->create();
+		$content       = $this->outline_content( array( array( $own_lesson_id, 'Propia' ) ) );
+		$course_id     = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $own_lesson_id => $own_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertSame( $content, get_post( $course_id )->post_content, 'A lesson already in the course language should leave the content untouched.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_ContentWithoutAnOutlineGiven_LeavesTheContentUntouched() {
+		/* Arrange. */
+		$content   = '<!-- wp:paragraph --><p>Course description.</p><!-- /wp:paragraph -->';
+		$course_id = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array() );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertSame( $content, get_post( $course_id )->post_content, 'Content without an outline should not be touched.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_ModuleWithNestedSourceLessonGiven_RewritesTheNestedLessonId() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$content              = '<!-- wp:sensei-lms/course-outline --><!-- wp:sensei-lms/course-outline-module {"id":7,"title":"Modulo"} --><!-- wp:sensei-lms/course-outline-lesson {"id":' . $source_lesson_id . ',"title":"Anidada"} /--><!-- /wp:sensei-lms/course-outline-module --><!-- /wp:sensei-lms/course-outline -->';
+		$course_id            = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertStringContainsString( '"id":' . $translated_lesson_id, get_post( $course_id )->post_content, 'A lesson nested in a module should be remapped too.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_TitleWithEscapedHtmlGiven_KeepsTheAttributeEncoding() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$title                = 'Lección <br/>escapada';
+		$content              = '<!-- wp:sensei-lms/course-outline --><!-- wp:sensei-lms/course-outline-lesson ' . serialize_block_attributes(
+			array(
+				'id'    => $source_lesson_id,
+				'title' => $title,
+			)
+		) . ' /--><!-- /wp:sensei-lms/course-outline -->';
+		$course_id            = self::factory()->post->create(
+			array(
+				'post_type'    => 'course',
+				'post_content' => wp_slash( $content ),
+			)
+		);
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$stored_title = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0]['attrs']['title'];
+		$this->assertStringContainsString( '<br', $stored_title, 'Fixture check: the stored title should carry the escaped HTML.' );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$block = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0];
+		$this->assertSame( $stored_title, $block['attrs']['title'], 'The title attribute should survive the remap round trip unmangled.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceLessonIdsGiven_RewritesThemToTheDuplicateLanguage() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+		$master_course_id     = $this->factory->course->create();
+		$duplicate_course_id  = $this->factory->course->create(
+			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Duplicada' ) ) ) )
+		);
+
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_duplicated( $master_course_id, 'es', array(), $duplicate_course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertStringContainsString( '"id":' . $translated_lesson_id, get_post( $duplicate_course_id )->post_content, 'The duplicated outline should reference the lessons of the duplicate language.' );
+	}
+
+	/**
+	 * Build course content with an outline block holding the given lessons.
+	 *
+	 * @param array[] $lessons Pairs of lesson ID and title.
+	 *
+	 * @return string
+	 */
+	private function outline_content( array $lessons ) {
+		$items = '';
+		foreach ( $lessons as list( $lesson_id, $title ) ) {
+			$items .= '<!-- wp:sensei-lms/course-outline-lesson {"id":' . $lesson_id . ',"title":"' . $title . '"} /-->';
+		}
+
+		return '<!-- wp:sensei-lms/course-outline -->' . $items . '<!-- /wp:sensei-lms/course-outline -->';
+	}
+
+	/**
+	 * Stub the WPML language details for any element.
+	 *
+	 * @param string $language_code        Language of the translated course.
+	 * @param string $source_language_code Language it was translated from.
+	 */
+	private function stub_course_language( $language_code, $source_language_code ) {
+		add_filter(
+			'wpml_element_language_details',
+			function () use ( $language_code, $source_language_code ) {
+				return array(
+					'language_code'        => $language_code,
+					'source_language_code' => $source_language_code,
+				);
+			},
+			10,
+			0
+		);
+	}
+
+	/**
+	 * Stub wpml_object_id with a fixed map; unmapped IDs resolve to nothing.
+	 *
+	 * @param array $map Object ID to translated object ID.
+	 */
+	private function stub_object_id_map( array $map ) {
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id ) use ( $map ) {
+				return $map[ $object_id ] ?? null;
+			},
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Remove the WPML stubs added by the helpers above.
+	 */
+	private function remove_wpml_stubs() {
+		remove_all_filters( 'wpml_element_language_details' );
+		remove_all_filters( 'wpml_object_id' );
+	}
+
 	/**
 	 * Create lessons attached to a course, one per post date, in the given
 	 * order, without `_order_{course_id}` metas.

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -444,6 +444,45 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( array( 'title' => 'Modulo' ), $module_attrs, 'A module without a translation should keep its title but lose its source term id and slug.' );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_ModuleWithATranslationGiven_SyncsTheModuleSlug() {
+		/* Arrange. */
+		$translated_term = wp_insert_term( 'El modulo', 'module' );
+		$content         = '<!-- wp:sensei-lms/course-outline --><!-- wp:sensei-lms/course-outline-module {"id":91,"slug":"the-module","title":"El modulo"} --><!-- /wp:sensei-lms/course-outline-module --><!-- /wp:sensei-lms/course-outline -->';
+		$course_id       = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( 91 => $translated_term['term_id'] ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$module_attrs = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0]['attrs'];
+		$this->assertSame( get_term( $translated_term['term_id'], 'module' )->slug, $module_attrs['slug'], 'The remapped module should carry the translated term slug, not the source one.' );
+	}
+
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_CourseWithoutASourceLanguageGiven_LeavesTheContentUntouched() {
+		/* Arrange. */
+		$source_lesson_id = $this->factory->lesson->create();
+		$content          = $this->outline_content( array( array( $source_lesson_id, 'Original' ) ) );
+		$course_id        = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'en', '' );
+		$this->stub_object_id_map( array() );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertSame( $content, get_post( $course_id )->post_content, 'A course that is not a translation should not have its outline touched.' );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceLessonIdsGiven_RewritesThemToTheDuplicateLanguage() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -483,6 +483,26 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( $content, get_post( $course_id )->post_content, 'A course that is not a translation should not have its outline touched.' );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceTitlesGiven_LeavesTheLessonTitleAlone() {
+		/* Arrange. */
+		$source_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create( array( 'post_title' => 'Titulo traducido' ) );
+		$duplicate_course_id  = $this->factory->course->create(
+			array( 'post_content' => $this->outline_content( array( array( $source_lesson_id, 'Source title' ) ) ) )
+		);
+
+		$this->stub_object_id_map( array( $source_lesson_id => $translated_lesson_id ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_duplicated( 123, 'es', array(), $duplicate_course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$this->assertSame( 'Titulo traducido', get_post( $translated_lesson_id )->post_title, 'A duplicate carries source-language titles, so it must not rename the lesson translation.' );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseDuplicated_DuplicateWithSourceLessonIdsGiven_RewritesThemToTheDuplicateLanguage() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -423,6 +423,26 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '"id":95', get_post( $course_id )->post_content, 'A module with a translation in the course language should be remapped to it.' );
 	}
 
+	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_ModuleTranslationMissingItsTermGiven_DropsTheSourceSlug() {
+		/* Arrange. */
+		$content   = '<!-- wp:sensei-lms/course-outline --><!-- wp:sensei-lms/course-outline-module {"id":91,"slug":"the-module","title":"Modulo"} --><!-- /wp:sensei-lms/course-outline-module --><!-- /wp:sensei-lms/course-outline -->';
+		$course_id = $this->factory->course->create( array( 'post_content' => $content ) );
+
+		$this->stub_course_language( 'es', 'en' );
+		// WPML maps the module to a term that no longer exists.
+		$this->stub_object_id_map( array( 91 => 99999 ) );
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->translate_outline_lesson_ids_on_course_translation_created( $course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+		$module_attrs = parse_blocks( get_post( $course_id )->post_content )[0]['innerBlocks'][0]['attrs'];
+		$this->assertArrayNotHasKey( 'slug', $module_attrs, 'A slug that cannot be confirmed for the course language would send a later save back to the source term.' );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_ModuleWithoutATranslationGiven_DropsItsIdAndSlug() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();


### PR DESCRIPTION
Closes [SEN-188](https://linear.app/a8c/issue/SEN-188/wpml-saving-a-translated-course-in-the-editor-steals-and-renames-the)

## Proposed Changes

Editing a translated course could destroy the original one: WPML stores the translation's outline with the original language's lesson and module IDs, and saving the translation in the editor adopted them, renaming the original course's lessons, moving them to the translation, and leaving the original course empty.

This PR rewrites the outline as soon as WPML delivers or duplicates a course translation, pointing it at the lessons and modules of the course's own language. Items with no translation are dropped instead of adopted, and the lesson titles typed in the translation editor now land on the translated lessons too. Courses translated before this fix are left as is; they heal on their next delivery.

## Testing Instructions

1. On a site with WPML active (English default plus Spanish), create a course with three lessons, at least one of them inside a module. Publish everything.
2. In the Courses admin list, click the + icon in the Spanish column for the course and complete the job in the Advanced Translation Editor, translating the lesson titles and the module name.
3. Go to the Lessons admin list, switch the language filter to Spanish, and verify the Spanish lessons were created with the titles you typed and are assigned to the Spanish course.
4. Open the Spanish course in the WordPress editor ("Edit Anyway" in the WPML dialog), click into a lesson from the outline, navigate back with the browser, and click Update once.
5. Switch the admin language back to English and verify nothing was stolen: the English course still shows its three lessons with their English titles, and the module keeps its English name.
6. Duplicate route: create a second course with one lesson and use Translation Management's "Duplicate content" to Spanish for both. Verify the English course is untouched and the Spanish duplicate shows its own lesson, not the English one.
7. Duplicate refresh: translate the duplicated Spanish lesson from step 6 (the + icon in its Spanish column) giving it a Spanish title, then run "Duplicate content" for that course again. Verify the Spanish lesson keeps the title you typed.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fixed saving a translated course overwriting and stealing the original course's lessons on WPML sites.

</details>
