### PR TITLE
Give WPML-duplicated lessons their own quiz

### DIFF
--- a/changelog/fix-wpml-duplicated-lesson-quiz
+++ b/changelog/fix-wpml-duplicated-lesson-quiz
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed edits to a WPML-duplicated lesson's quiz landing on the original language's quiz and questions.

--- a/includes/wpml/class-custom-fields.php
+++ b/includes/wpml/class-custom-fields.php
@@ -32,6 +32,8 @@ class Custom_Fields {
 		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_quiz_id_before_copied' ), 10, 4 );
 		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_course_woocommerce_product_before_copied' ), 10, 4 );
 		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_lesson_prerequisite_before_copied' ), 10, 4 );
+		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_lesson_quiz_before_copied' ), 10, 4 );
+		add_filter( 'wpml_sync_custom_field_copied_value', array( $this, 'update_quiz_lesson_before_copied' ), 10, 4 );
 	}
 
 	/**
@@ -198,5 +200,72 @@ class Custom_Fields {
 		}
 
 		return $this->get_object_id( $lesson_id, 'lesson', false, $target_language_code );
+	}
+
+	/**
+	 * Update the lesson quiz before copied.
+	 *
+	 * When the quiz is not translated, the meta keeps pointing at the original
+	 * quiz. Emptying it would leave the translated lesson without a quiz.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param mixed  $copied_value Copied value.
+	 * @param int    $post_id_from Post ID from.
+	 * @param int    $post_id_to   Post ID to.
+	 * @param string $meta_key     Meta key.
+	 * @return mixed
+	 */
+	public function update_lesson_quiz_before_copied( $copied_value, $post_id_from, $post_id_to, $meta_key ) {
+		if ( '_lesson_quiz' !== $meta_key ) {
+			return $copied_value;
+		}
+
+		if ( empty( $copied_value ) ) {
+			return $copied_value;
+		}
+
+		$quiz_id = (int) $copied_value;
+
+		$target_language_code = $this->get_element_language_code( $post_id_to, 'lesson' );
+		if ( ! $target_language_code ) {
+			$target_language_code = $this->get_current_language();
+		}
+
+		return $this->get_object_id( $quiz_id, 'quiz', true, $target_language_code );
+	}
+
+	/**
+	 * Update the quiz lesson before copied.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param mixed  $copied_value Copied value.
+	 * @param int    $post_id_from Post ID from.
+	 * @param int    $post_id_to   Post ID to.
+	 * @param string $meta_key     Meta key.
+	 * @return mixed
+	 */
+	public function update_quiz_lesson_before_copied( $copied_value, $post_id_from, $post_id_to, $meta_key ) {
+		if ( '_quiz_lesson' !== $meta_key ) {
+			return $copied_value;
+		}
+
+		if ( empty( $copied_value ) ) {
+			return $copied_value;
+		}
+
+		$lesson_id = (int) $copied_value;
+
+		$target_language_code = $this->get_element_language_code( $post_id_to, 'quiz' );
+		if ( ! $target_language_code ) {
+			$target_language_code = $this->get_current_language();
+		}
+
+		return $this->get_object_id( $lesson_id, 'lesson', true, $target_language_code );
 	}
 }

--- a/includes/wpml/class-lesson-translation.php
+++ b/includes/wpml/class-lesson-translation.php
@@ -38,6 +38,32 @@ class Lesson_Translation {
 		// "icl_make_duplicate" is WPML-internal but the WPML team confirmed it's safe to rely on.
 		// It also fires on duplicate refresh, so the handler must stay idempotent.
 		add_action( 'icl_make_duplicate', array( $this, 'update_lesson_properties_on_lesson_duplicated' ), 10, 4 );
+		// Give the duplicate its own quiz, or writes from it would land on the master's.
+		add_action( 'icl_make_duplicate', array( $this, 'update_quiz_on_lesson_duplicated' ), 10, 4 );
+	}
+
+	/**
+	 * Copy the master lesson's quiz for a duplicated lesson.
+	 *
+	 * A duplicate copies the `_lesson_quiz` meta but not the quiz itself, so it
+	 * would point at the master lesson's quiz and any edit made from the duplicate
+	 * would land on the master's quiz and questions.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param int    $master_post_id Master lesson ID.
+	 * @param string $lang           Language of the duplicate.
+	 * @param array  $post_array     Post data of the duplicate.
+	 * @param int    $new_lesson_id  Duplicated lesson ID.
+	 */
+	public function update_quiz_on_lesson_duplicated( $master_post_id, $lang, $post_array, $new_lesson_id ) {
+		if ( 'lesson' !== get_post_type( $new_lesson_id ) || empty( $lang ) ) {
+			return;
+		}
+
+		$this->update_quiz_translations( (int) $master_post_id, $lang );
 	}
 
 	/**

--- a/tests/unit-tests/wpml/test-class-custom-fields.php
+++ b/tests/unit-tests/wpml/test-class-custom-fields.php
@@ -183,6 +183,34 @@ class Custom_Fields_Test extends \WP_UnitTestCase {
 		$this->assertSame( 9, $actual );
 	}
 
+	public function testUpdateQuizLessonBeforeCopied_LessonWithoutATranslationGiven_KeepsTheOriginalLesson() {
+		/* Arrange. */
+		$master_quiz_id     = $this->factory->quiz->create();
+		$translated_quiz_id = $this->factory->quiz->create();
+
+		$custom_fields = new Custom_Fields();
+
+		$language_code_filter = function () {
+			return 'es';
+		};
+		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
+
+		// WPML returns the original ID only when asked to, and null otherwise.
+		$object_id_filter = function ( $object_id, $element_type, $return_original_if_missing ) {
+			return $return_original_if_missing ? $object_id : null;
+		};
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 3 );
+
+		/* Act. */
+		$actual = $custom_fields->update_quiz_lesson_before_copied( 3, $master_quiz_id, $translated_quiz_id, '_quiz_lesson' );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $language_code_filter );
+		remove_filter( 'wpml_object_id', $object_id_filter );
+
+		$this->assertSame( 3, $actual, 'Without a lesson translation the meta must keep the original lesson.' );
+	}
+
 	public function testUpdateLessonPrerequisiteBeforeCopied_WhenCalled_ReturnsMatchingPrerequisiteForNewLesson() {
 		/* Arrange. */
 		$custom_fields = new Custom_Fields();

--- a/tests/unit-tests/wpml/test-class-custom-fields.php
+++ b/tests/unit-tests/wpml/test-class-custom-fields.php
@@ -140,11 +140,11 @@ class Custom_Fields_Test extends \WP_UnitTestCase {
 		};
 		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
 
-		// WPML returns the original ID when the element has no translation and it is asked to.
-		$object_id_filter = function ( $object_id ) {
-			return $object_id;
+		// WPML returns the original ID only when asked to, and null otherwise.
+		$object_id_filter = function ( $object_id, $element_type, $return_original_if_missing ) {
+			return $return_original_if_missing ? $object_id : null;
 		};
-		add_filter( 'wpml_object_id', $object_id_filter, 10, 1 );
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 3 );
 
 		/* Act. */
 		$actual = $custom_fields->update_lesson_quiz_before_copied( 5, $master_lesson_id, $translated_lesson_id, '_lesson_quiz' );

--- a/tests/unit-tests/wpml/test-class-custom-fields.php
+++ b/tests/unit-tests/wpml/test-class-custom-fields.php
@@ -101,6 +101,88 @@ class Custom_Fields_Test extends \WP_UnitTestCase {
 		$this->assertSame( 4, $actual );
 	}
 
+	public function testUpdateLessonQuizBeforeCopied_QuizWithATranslationGiven_ReturnsTheTranslatedQuiz() {
+		/* Arrange. */
+		$master_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+
+		$custom_fields = new Custom_Fields();
+
+		$language_code_filter = function () {
+			return 'es';
+		};
+		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
+
+		$object_id_filter = function () {
+			return 7;
+		};
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 0 );
+
+		/* Act. */
+		$actual = $custom_fields->update_lesson_quiz_before_copied( 5, $master_lesson_id, $translated_lesson_id, '_lesson_quiz' );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $language_code_filter );
+		remove_filter( 'wpml_object_id', $object_id_filter );
+
+		$this->assertSame( 7, $actual );
+	}
+
+	public function testUpdateLessonQuizBeforeCopied_QuizWithoutATranslationGiven_KeepsTheOriginalQuiz() {
+		/* Arrange. */
+		$master_lesson_id     = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+
+		$custom_fields = new Custom_Fields();
+
+		$language_code_filter = function () {
+			return 'es';
+		};
+		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
+
+		// WPML returns the original ID when the element has no translation and it is asked to.
+		$object_id_filter = function ( $object_id ) {
+			return $object_id;
+		};
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 1 );
+
+		/* Act. */
+		$actual = $custom_fields->update_lesson_quiz_before_copied( 5, $master_lesson_id, $translated_lesson_id, '_lesson_quiz' );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $language_code_filter );
+		remove_filter( 'wpml_object_id', $object_id_filter );
+
+		$this->assertSame( 5, $actual, 'Without a quiz translation the meta must keep the original quiz, which is what the lesson falls back to.' );
+	}
+
+	public function testUpdateQuizLessonBeforeCopied_LessonWithATranslationGiven_ReturnsTheTranslatedLesson() {
+		/* Arrange. */
+		$master_quiz_id     = $this->factory->quiz->create();
+		$translated_quiz_id = $this->factory->quiz->create();
+
+		$custom_fields = new Custom_Fields();
+
+		$language_code_filter = function () {
+			return 'es';
+		};
+		add_filter( 'wpml_element_language_code', $language_code_filter, 10, 0 );
+
+		$object_id_filter = function () {
+			return 9;
+		};
+		add_filter( 'wpml_object_id', $object_id_filter, 10, 0 );
+
+		/* Act. */
+		$actual = $custom_fields->update_quiz_lesson_before_copied( 3, $master_quiz_id, $translated_quiz_id, '_quiz_lesson' );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_element_language_code', $language_code_filter );
+		remove_filter( 'wpml_object_id', $object_id_filter );
+
+		$this->assertSame( 9, $actual );
+	}
+
 	public function testUpdateLessonPrerequisiteBeforeCopied_WhenCalled_ReturnsMatchingPrerequisiteForNewLesson() {
 		/* Arrange. */
 		$custom_fields = new Custom_Fields();

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -351,6 +351,54 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( $translated_course_id, (int) get_post_meta( $duplicated_lesson_id, '_lesson_course', true ) );
 	}
 
+	public function testUpdateQuizOnLessonDuplicated_DuplicatedLessonGiven_GivesItItsOwnQuiz() {
+		/* Arrange. */
+		$master_lesson_id     = $this->factory->get_lesson_with_quiz_and_questions();
+		$master_quiz_id       = Sensei()->lesson->lesson_quizzes( $master_lesson_id );
+		$duplicated_lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_quiz' => $master_quiz_id ) ) );
+
+		$this->simulate_wpml_language_pair( array( $master_lesson_id => $duplicated_lesson_id ) );
+		$copied_quiz_id   = $this->factory->quiz->create();
+		$copy_to_language = function () use ( $copied_quiz_id ) {
+			return $copied_quiz_id;
+		};
+		add_filter( 'wpml_copy_post_to_language', $copy_to_language );
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_quiz_on_lesson_duplicated( $master_lesson_id, 'es', array(), $duplicated_lesson_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_copy_post_to_language', $copy_to_language );
+		$this->remove_wpml_language_pair_filters();
+		$this->assertSame( $copied_quiz_id, (int) get_post_meta( $duplicated_lesson_id, '_lesson_quiz', true ), 'The duplicated lesson should own the quiz copied for its language, not the master one.' );
+	}
+
+	public function testUpdateQuizOnLessonDuplicated_DuplicatedCourseGiven_DoesNothing() {
+		/* Arrange. */
+		$master_lesson_id     = $this->factory->lesson->create();
+		$duplicated_course_id = $this->factory->course->create();
+
+		$this->simulate_wpml_language_pair( array( $master_lesson_id => $duplicated_course_id ) );
+		$copies           = 0;
+		$copy_to_language = function ( $post_id ) use ( &$copies ) {
+			++$copies;
+			return $post_id;
+		};
+		add_filter( 'wpml_copy_post_to_language', $copy_to_language );
+
+		$lesson_translation = new Lesson_Translation();
+
+		/* Act. */
+		$lesson_translation->update_quiz_on_lesson_duplicated( $master_lesson_id, 'es', array(), $duplicated_course_id );
+
+		/* Clean up & Assert. */
+		remove_filter( 'wpml_copy_post_to_language', $copy_to_language );
+		$this->remove_wpml_language_pair_filters();
+		$this->assertSame( 0, $copies, 'Duplicating something that is not a lesson should not copy quizzes.' );
+	}
+
 	public function testUpdateLessonPropertiesOnLessonDuplicated_TranslatedLessonsWithoutOrderMetaGiven_PlacesDuplicateLast() {
 		/* Arrange. */
 		$master_course_id     = $this->factory->course->create();

--- a/tests/unit-tests/wpml/test-class-lesson-translation.php
+++ b/tests/unit-tests/wpml/test-class-lesson-translation.php
@@ -375,30 +375,6 @@ class Lesson_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( $copied_quiz_id, (int) get_post_meta( $duplicated_lesson_id, '_lesson_quiz', true ), 'The duplicated lesson should own the quiz copied for its language, not the master one.' );
 	}
 
-	public function testUpdateQuizOnLessonDuplicated_DuplicatedCourseGiven_DoesNothing() {
-		/* Arrange. */
-		$master_lesson_id     = $this->factory->lesson->create();
-		$duplicated_course_id = $this->factory->course->create();
-
-		$this->simulate_wpml_language_pair( array( $master_lesson_id => $duplicated_course_id ) );
-		$copies           = 0;
-		$copy_to_language = function ( $post_id ) use ( &$copies ) {
-			++$copies;
-			return $post_id;
-		};
-		add_filter( 'wpml_copy_post_to_language', $copy_to_language );
-
-		$lesson_translation = new Lesson_Translation();
-
-		/* Act. */
-		$lesson_translation->update_quiz_on_lesson_duplicated( $master_lesson_id, 'es', array(), $duplicated_course_id );
-
-		/* Clean up & Assert. */
-		remove_filter( 'wpml_copy_post_to_language', $copy_to_language );
-		$this->remove_wpml_language_pair_filters();
-		$this->assertSame( 0, $copies, 'Duplicating something that is not a lesson should not copy quizzes.' );
-	}
-
 	public function testUpdateLessonPropertiesOnLessonDuplicated_TranslatedLessonsWithoutOrderMetaGiven_PlacesDuplicateLast() {
 		/* Arrange. */
 		$master_course_id     = $this->factory->course->create();


### PR DESCRIPTION
Closes [SEN-183](https://linear.app/a8c/issue/SEN-183)

## Proposed Changes

A lesson duplicated with WPML copied the lesson-quiz meta but not the quiz itself, so the duplicate resolved the original language's quiz: editing the quiz from the duplicate renamed the original's questions and switched their language, saving reassigned the quiz to the duplicate, and trashing the duplicate could take the original's quiz with it.

The duplicate now gets its own quiz and questions at duplication time, reusing the helper the translation route already runs on delivery. WPML's custom-field sync, which re-copied the `_lesson_quiz` / `_quiz_lesson` pair from the source on every save and undid that, now converts the pair to the target language instead; when the quiz has no translation the original is kept, so a translated lesson never loses the quiz it falls back to.

## Testing Instructions

1. On a site with WPML active (English default plus Spanish), create a course with one lesson that has a quiz with one question. Publish everything.
2. In WPML → Translation Management, select the course and the lesson and run "Duplicate content" to Spanish.
3. Open the duplicated Spanish lesson in the editor, rename the question to something Spanish, and Update.
4. Verify the English lesson's question keeps its English title (Questions admin, English filter), and that the Spanish lesson shows the Spanish question.
5. Update the Spanish lesson again without changes and verify it still shows its Spanish question: the pairing survives saves.
6. Trash the Spanish lesson and verify the English lesson still has its quiz and question.
7. ATE route regression: on a second course with a lesson and quiz, translate the course and the lesson with the Advanced Translation Editor, verify the Spanish lesson gets its own Spanish quiz and question, then Update the Spanish lesson and verify nothing reverts.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fixed edits to a WPML-duplicated lesson's quiz landing on the original language's quiz and questions.

</details>
