### PR TITLE
Fix PHP 8 TypeError when post_updated fires with a null post object

### DIFF
--- a/changelog/fix-null-post-updated-module-teacher-meta
+++ b/changelog/fix-null-post-updated-module-teacher-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a PHP 8 TypeError when `post_updated` fires with a null post object during autosave.

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -122,11 +122,7 @@ class Sensei_Core_Modules {
 	}
 
 	/**
-	 * Update module teacher meta when a course's teacher (author) changes.
-	 *
-	 * WordPress can fire `post_updated` with a null `$post_after` (for example
-	 * during some autosaves). PHP 8+ type hints would fatal before we can ignore
-	 * those requests, so the post objects are nullable.
+	 * Add teacher id as term meta when a module is added to a course.
 	 *
 	 * @since 4.9.0
 	 * @access private

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -122,17 +122,25 @@ class Sensei_Core_Modules {
 	}
 
 	/**
-	 * Add teacher id as term meta when a module is added to a course.
+	 * Update module teacher meta when a course's teacher (author) changes.
+	 *
+	 * WordPress can fire `post_updated` with a null `$post_after` (for example
+	 * during some autosaves). PHP 8+ type hints would fatal before we can ignore
+	 * those requests, so the post objects are nullable.
 	 *
 	 * @since 4.9.0
 	 * @access private
 	 *
-	 * @param int     $post_ID      Post ID.
-	 * @param WP_Post $post_after   Post object following the update.
-	 * @param WP_Post $post_before  Post object before the update.
+	 * @param int          $post_ID     Post ID.
+	 * @param WP_Post|null $post_after  Post object following the update.
+	 * @param WP_Post|null $post_before Post object before the update.
 	 */
-	public function update_module_teacher_id_meta_on_post_teacher_update( int $post_ID, WP_Post $post_after, WP_Post $post_before ) {
-		if ( 'course' !== get_post( $post_ID )->post_type ) {
+	public function update_module_teacher_id_meta_on_post_teacher_update( int $post_ID, ?WP_Post $post_after = null, ?WP_Post $post_before = null ) {
+		if ( ! $post_after instanceof WP_Post || ! $post_before instanceof WP_Post ) {
+			return;
+		}
+
+		if ( 'course' !== $post_after->post_type ) {
 			return;
 		}
 

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -298,6 +298,26 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$this->assertSame( absint( get_term_meta( $module['term_id'], 'module_author', true ) ), wp_get_current_user()->ID, 'Module teacher ID meta not set to the updated Author ID' );
 	}
 
+	public function testUpdateModuleTeacherIdMetaOnPostTeacherUpdate_WhenPostAfterIsNull_DoesNotThrowTypeError() {
+		/* Arrange */
+		$course_id   = $this->factory->course->create();
+		$post_before = get_post( $course_id );
+
+		/* Assert */
+		$this->expectNotToPerformAssertions();
+
+		/* Act */
+		Sensei()->modules->update_module_teacher_id_meta_on_post_teacher_update( $course_id, null, $post_before );
+	}
+
+	public function testPostUpdatedHook_WhenPostAfterIsNull_DoesNotThrowTypeError() {
+		/* Assert */
+		$this->expectNotToPerformAssertions();
+
+		/* Act */
+		do_action( 'post_updated', 1, null, null );
+	}
+
 	public function testFilterModuleTerms_WhenViewedByTeacher_ExcludesOtherUsersModules() {
 		/* Arrange */
 		set_current_screen( 'edit-module' );

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -298,26 +298,6 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		$this->assertSame( absint( get_term_meta( $module['term_id'], 'module_author', true ) ), wp_get_current_user()->ID, 'Module teacher ID meta not set to the updated Author ID' );
 	}
 
-	public function testUpdateModuleTeacherIdMetaOnPostTeacherUpdate_WhenPostAfterIsNull_DoesNotThrowTypeError() {
-		/* Arrange */
-		$course_id   = $this->factory->course->create();
-		$post_before = get_post( $course_id );
-
-		/* Assert */
-		$this->expectNotToPerformAssertions();
-
-		/* Act */
-		Sensei()->modules->update_module_teacher_id_meta_on_post_teacher_update( $course_id, null, $post_before );
-	}
-
-	public function testPostUpdatedHook_WhenPostAfterIsNull_DoesNotThrowTypeError() {
-		/* Assert */
-		$this->expectNotToPerformAssertions();
-
-		/* Act */
-		do_action( 'post_updated', 1, null, null );
-	}
-
 	public function testFilterModuleTerms_WhenViewedByTeacher_ExcludesOtherUsersModules() {
 		/* Arrange */
 		set_current_screen( 'edit-module' );


### PR DESCRIPTION
Resolves #8221

## Proposed Changes

- Allow `Sensei_Core_Modules::update_module_teacher_id_meta_on_post_teacher_update()` to receive a null `$post_after` / `$post_before`.
- Return early when either object is missing instead of fataling on PHP 8.
- Use `$post_after->post_type` rather than `get_post( $post_ID )->post_type`, which would also fatal if `get_post()` returned null.

WordPress fires `post_updated` with `$post_after = get_post( $post_id )`. That can be `null` during some autosaves (Divi Visual Builder Heartbeat is one real-world trigger). The previous `WP_Post` type hint threw before Sensei could ignore non-course updates.

## Testing Instructions

- [ ] Run `tests/unit-tests/test-class-modules.php` (or the full unit suite).
- [ ] Confirm changing a course teacher still updates `module_author` term meta on the course modules.
- [ ] Confirm `do_action( 'post_updated', 1, null, null );` no longer fatals.
- [ ] Optional: edit a page in Divi Visual Builder and confirm Heartbeat autosave no longer emails a fatal from this callback.

## Changelog entry

- [x] Changelog file added in `changelog/fix-null-post-updated-module-teacher-meta`.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message
Fix a PHP 8 TypeError when `post_updated` fires with a null post object during autosave.

</details>

Made with [Cursor](https://cursor.com)