### PR TITLE
Move GitHub Actions Dependabot updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,8 +98,7 @@ updates:
       - "/"
       - "/.github/actions/**"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
     open-pull-requests-limit: 10
     labels:
       - "No Changelog"


### PR DESCRIPTION
Move GitHub Actions Dependabot updates from weekly to monthly. npm and Composer stay weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)