### PR TITLE
Query student progress by the original language's IDs on the admin screens

### DIFF
--- a/changelog/fix-wpml-progress-queries-language
+++ b/changelog/fix-wpml-progress-queries-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the student management and grading screens showing no students when the WPML admin language is not the original one.

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -85,6 +85,8 @@ class Sensei_Db_Query_Learners {
 		/**
 		 * Filter the arguments used to query the learners.
 		 *
+		 * A result that is not an array is ignored and the original arguments are kept.
+		 *
 		 * @hook sensei_learners_query_args
 		 *
 		 * @since $$next-version$$

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -82,6 +82,18 @@ class Sensei_Db_Query_Learners {
 	 * @param array $args Arguments to build query.
 	 */
 	public function __construct( $args ) {
+		/**
+		 * Filter the arguments used to query the learners.
+		 *
+		 * @hook sensei_learners_query_args
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param {array} $args Query arguments.
+		 * @return {array} Filtered query arguments.
+		 */
+		$args = apply_filters( 'sensei_learners_query_args', $args );
+
 		$this->per_page            = isset( $args['per_page'] ) ? absint( $args['per_page'] ) : 25;
 		$this->offset              = isset( $args['offset'] ) ? absint( $args['offset'] ) : 0;
 		$this->course_id           = isset( $args['course_id'] ) ? intval( $args['course_id'] ) : 0;

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -92,7 +92,10 @@ class Sensei_Db_Query_Learners {
 		 * @param {array} $args Query arguments.
 		 * @return {array} Filtered query arguments.
 		 */
-		$args = apply_filters( 'sensei_learners_query_args', $args );
+		$filtered_args = apply_filters( 'sensei_learners_query_args', $args );
+		if ( is_array( $filtered_args ) ) {
+			$args = $filtered_args;
+		}
 
 		$this->per_page            = isset( $args['per_page'] ) ? absint( $args['per_page'] ) : 25;
 		$this->offset              = isset( $args['offset'] ) ? absint( $args['offset'] ) : 0;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -137,6 +137,21 @@ class Sensei_Utils {
 	 * @return mixed | int
 	 */
 	public static function sensei_check_for_activity( $args = array(), $return_comments = false ) {
+		/**
+		 * Filter the arguments used to query the activity.
+		 *
+		 * @hook sensei_check_for_activity_args
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param {array} $args Search arguments.
+		 * @return {array} Filtered search arguments.
+		 */
+		$filtered_args = apply_filters( 'sensei_check_for_activity_args', $args );
+		if ( is_array( $filtered_args ) ) {
+			$args = $filtered_args;
+		}
+
 		if ( ! $return_comments ) {
 			$args['count'] = true;
 		}
@@ -150,18 +165,6 @@ class Sensei_Utils {
 		if ( ! isset( $args['status'] ) ) {
 			$args['status'] = 'any';
 		}
-
-		/**
-		 * Filter the arguments used to query the activity.
-		 *
-		 * @hook sensei_check_for_activity_args
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param {array} $args Search arguments.
-		 * @return {array} Filtered search arguments.
-		 */
-		$args = apply_filters( 'sensei_check_for_activity_args', $args );
 
 		/**
 		 * This action runs before getting the comments for the given request.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -152,6 +152,18 @@ class Sensei_Utils {
 		}
 
 		/**
+		 * Filter the arguments used to query the activity.
+		 *
+		 * @hook sensei_check_for_activity_args
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param {array} $args Search arguments.
+		 * @return {array} Filtered search arguments.
+		 */
+		$args = apply_filters( 'sensei_check_for_activity_args', $args );
+
+		/**
 		 * This action runs before getting the comments for the given request.
 		 *
 		 * @hook sensei_utils_check_for_activity_before_get_comments

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -140,6 +140,8 @@ class Sensei_Utils {
 		/**
 		 * Filter the arguments used to query the activity.
 		 *
+		 * A result that is not an array is ignored and the original arguments are kept.
+		 *
 		 * @hook sensei_check_for_activity_args
 		 *
 		 * @since $$next-version$$

--- a/includes/wpml/class-course-progress.php
+++ b/includes/wpml/class-course-progress.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @internal
  */
 class Course_Progress {
+	use Progress_Query_Helper;
 	use WPML_API;
 
 	/**
@@ -41,6 +42,8 @@ class Course_Progress {
 		add_filter( 'sensei_course_start_course_id', array( $this, 'translate_course_id' ) );
 		add_filter( 'sensei_learner_get_course_ids_by_progress_status_course_ids', array( $this, 'translate_course_ids' ) );
 		add_filter( 'sensei_learner_get_enrolled_courses_query_args_term_id', array( $this, 'translate_term_id' ) );
+		// The student management screens query course progress with the ID of the course they show.
+		add_filter( 'sensei_check_for_activity_args', array( $this, 'translate_course_query_args' ) );
 
 		add_action( 'sensei_manual_enrolment_learner_enrolled', array( $this, 'enrol_learner' ), 10, 2 );
 		add_action( 'sensei_manual_enrolment_learner_withdrawn', array( $this, 'withdraw_learner' ), 10, 2 );
@@ -100,6 +103,24 @@ class Course_Progress {
 
 		add_action( 'sensei_manual_enrolment_learner_withdrawn', array( $this, 'withdraw_learner' ), 10, 2 );
 		add_filter( 'sensei_course_is_user_enrolled_course_id', array( $this, 'translate_course_id' ) );
+	}
+
+	/**
+	 * Point the course IDs of a progress query at the original language.
+	 *
+	 * Progress is stored against the original language, but the admin screens
+	 * query it with the ID of the course they are showing, which in a secondary
+	 * language is the translation, so the query finds nothing.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param mixed $args Query arguments.
+	 * @return mixed
+	 */
+	public function translate_course_query_args( $args ) {
+		return $this->translate_query_post_ids( $args, 'course', array( $this, 'translate_course_id' ) );
 	}
 
 	/**

--- a/includes/wpml/class-course-progress.php
+++ b/includes/wpml/class-course-progress.php
@@ -106,11 +106,13 @@ class Course_Progress {
 	}
 
 	/**
-	 * Point the course IDs of a progress query at the original language.
+	 * Translate the course IDs of a progress query to the original language.
 	 *
-	 * Progress is stored against the original language, but the admin screens
-	 * query it with the ID of the course they are showing, which in a secondary
-	 * language is the translation, so the query finds nothing.
+	 * A course and its translations share one progress, stored against the
+	 * original language's ID. The admin screens query it with the ID of the
+	 * course they are showing, which in a secondary language is a translation,
+	 * so the query would find nothing. Translating the ID first makes the same
+	 * query hit the stored progress whatever the admin language is.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -124,7 +126,11 @@ class Course_Progress {
 	}
 
 	/**
-	 * Point the course filter of a learners query at the original language.
+	 * Translate the course filter of a learners query to the original language.
+	 *
+	 * The Students screen filters by the course it is showing, which in a
+	 * secondary language is a translation, while the progress it lists is
+	 * stored against the original language's ID.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/wpml/class-course-progress.php
+++ b/includes/wpml/class-course-progress.php
@@ -44,6 +44,8 @@ class Course_Progress {
 		add_filter( 'sensei_learner_get_enrolled_courses_query_args_term_id', array( $this, 'translate_term_id' ) );
 		// The student management screens query course progress with the ID of the course they show.
 		add_filter( 'sensei_check_for_activity_args', array( $this, 'translate_course_query_args' ) );
+		// The Students screen filters its learners query with the ID of the course it shows.
+		add_filter( 'sensei_learners_query_args', array( $this, 'translate_learners_query_args' ) );
 
 		add_action( 'sensei_manual_enrolment_learner_enrolled', array( $this, 'enrol_learner' ), 10, 2 );
 		add_action( 'sensei_manual_enrolment_learner_withdrawn', array( $this, 'withdraw_learner' ), 10, 2 );
@@ -121,6 +123,26 @@ class Course_Progress {
 	 */
 	public function translate_course_query_args( $args ) {
 		return $this->translate_query_post_ids( $args, 'course', array( $this, 'translate_course_id' ) );
+	}
+
+	/**
+	 * Point the course filter of a learners query at the original language.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param mixed $args Query arguments.
+	 * @return mixed
+	 */
+	public function translate_learners_query_args( $args ) {
+		if ( ! is_array( $args ) || empty( $args['filter_by_course_id'] ) || ! $this->get_current_language() ) {
+			return $args;
+		}
+
+		$args['filter_by_course_id'] = $this->translate_course_id( $args['filter_by_course_id'] );
+
+		return $args;
 	}
 
 	/**

--- a/includes/wpml/class-course-progress.php
+++ b/includes/wpml/class-course-progress.php
@@ -42,9 +42,7 @@ class Course_Progress {
 		add_filter( 'sensei_course_start_course_id', array( $this, 'translate_course_id' ) );
 		add_filter( 'sensei_learner_get_course_ids_by_progress_status_course_ids', array( $this, 'translate_course_ids' ) );
 		add_filter( 'sensei_learner_get_enrolled_courses_query_args_term_id', array( $this, 'translate_term_id' ) );
-		// The student management screens query course progress with the ID of the course they show.
 		add_filter( 'sensei_check_for_activity_args', array( $this, 'translate_course_query_args' ) );
-		// The Students screen filters its learners query with the ID of the course it shows.
 		add_filter( 'sensei_learners_query_args', array( $this, 'translate_learners_query_args' ) );
 
 		add_action( 'sensei_manual_enrolment_learner_enrolled', array( $this, 'enrol_learner' ), 10, 2 );

--- a/includes/wpml/class-lesson-progress.php
+++ b/includes/wpml/class-lesson-progress.php
@@ -44,11 +44,13 @@ class Lesson_Progress {
 	}
 
 	/**
-	 * Point the lesson IDs of a progress query at the original language.
+	 * Translate the lesson IDs of a progress query to the original language.
 	 *
-	 * Progress is stored against the original language, but the admin screens
-	 * query it with the ID of the lesson they are showing, which in a secondary
-	 * language is the translation, so the query finds nothing.
+	 * A lesson and its translations share one progress, stored against the
+	 * original language's ID. The admin screens query it with the ID of the
+	 * lesson they are showing, which in a secondary language is a translation,
+	 * so the query would find nothing. Translating the ID first makes the same
+	 * query hit the stored progress whatever the admin language is.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/wpml/class-lesson-progress.php
+++ b/includes/wpml/class-lesson-progress.php
@@ -38,8 +38,8 @@ class Lesson_Progress {
 
 		add_filter( 'sensei_check_for_activity_args', array( $this, 'translate_lesson_query_args' ) );
 		add_filter( 'sensei_grading_filter_statuses', array( $this, 'translate_lesson_query_args' ) );
-		// A teacher's own lessons come from the current language, and the grading
-		// screen intersects them with the query above, so they need the same IDs.
+		// Teachers only see their own lessons, and that list is built in the current
+		// language before this runs. It needs translating like the rest of the query.
 		add_filter( 'sensei_count_statuses_args', array( $this, 'translate_lesson_query_args' ), 20 );
 	}
 

--- a/includes/wpml/class-lesson-progress.php
+++ b/includes/wpml/class-lesson-progress.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @internal
  */
 class Lesson_Progress {
+	use Progress_Query_Helper;
 	use WPML_API;
 
 	/**
@@ -34,6 +35,32 @@ class Lesson_Progress {
 		add_filter( 'sensei_lesson_progress_delete_for_lesson_lesson_id', array( $this, 'translate_lesson_id' ) );
 		add_filter( 'sensei_lesson_progress_find_lesson_id', array( $this, 'translate_lesson_id' ) );
 		add_filter( 'sensei_quiz_cache_key_lesson_id', array( $this, 'translate_lesson_id' ) );
+
+		// The student management screens query lesson progress with the ID of the lesson they show.
+		add_filter( 'sensei_check_for_activity_args', array( $this, 'translate_lesson_query_args' ) );
+		// The grading screen queries it through the progress query services.
+		add_filter( 'sensei_grading_filter_statuses', array( $this, 'translate_lesson_query_args' ) );
+		// A teacher's own lessons come from the current language, and the grading
+		// screen intersects them with the query above, so they need the same IDs.
+		add_filter( 'sensei_count_statuses_args', array( $this, 'translate_lesson_query_args' ), 20 );
+	}
+
+	/**
+	 * Point the lesson IDs of a progress query at the original language.
+	 *
+	 * Progress is stored against the original language, but the admin screens
+	 * query it with the ID of the lesson they are showing, which in a secondary
+	 * language is the translation, so the query finds nothing.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @internal
+	 *
+	 * @param mixed $args Query arguments.
+	 * @return mixed
+	 */
+	public function translate_lesson_query_args( $args ) {
+		return $this->translate_query_post_ids( $args, 'lesson', array( $this, 'translate_lesson_id' ) );
 	}
 
 	/**

--- a/includes/wpml/class-lesson-progress.php
+++ b/includes/wpml/class-lesson-progress.php
@@ -36,9 +36,7 @@ class Lesson_Progress {
 		add_filter( 'sensei_lesson_progress_find_lesson_id', array( $this, 'translate_lesson_id' ) );
 		add_filter( 'sensei_quiz_cache_key_lesson_id', array( $this, 'translate_lesson_id' ) );
 
-		// The student management screens query lesson progress with the ID of the lesson they show.
 		add_filter( 'sensei_check_for_activity_args', array( $this, 'translate_lesson_query_args' ) );
-		// The grading screen queries it through the progress query services.
 		add_filter( 'sensei_grading_filter_statuses', array( $this, 'translate_lesson_query_args' ) );
 		// A teacher's own lessons come from the current language, and the grading
 		// screen intersects them with the query above, so they need the same IDs.

--- a/includes/wpml/trait-progress-query-helper.php
+++ b/includes/wpml/trait-progress-query-helper.php
@@ -14,8 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Trait Progress_Query_Helper
  *
- * Translates the IDs of progress queries to the original language. Meant for
- * the compatibility classes that already use the WPML_API trait.
+ * Translates the IDs of progress queries to the original language.
  *
  * @since $$next-version$$
  */

--- a/includes/wpml/trait-progress-query-helper.php
+++ b/includes/wpml/trait-progress-query-helper.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Trait Progress_Query_Helper
  *
- * Shared by the compatibility classes that point progress queries at the original language.
+ * Translates the IDs of progress queries to the original language. Meant for
+ * the compatibility classes that already use the WPML_API trait.
  *
  * @since $$next-version$$
  */

--- a/includes/wpml/trait-progress-query-helper.php
+++ b/includes/wpml/trait-progress-query-helper.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * File containing the \Sensei\WPML\Progress_Query_Helper trait.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\WPML;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Trait Progress_Query_Helper
+ *
+ * Shared by the compatibility classes that point progress queries at the original language.
+ *
+ * @since $$next-version$$
+ */
+trait Progress_Query_Helper {
+	/**
+	 * Translate the post IDs of a progress query with the given callback.
+	 *
+	 * Only the IDs of the given post type are translated; the rest are kept as is.
+	 *
+	 * @param mixed    $args         Query arguments, with an optional `post_id` and `post__in`.
+	 * @param string   $post_type    Post type whose IDs to translate.
+	 * @param callable $translate_id Callback translating one ID.
+	 * @return mixed
+	 */
+	private function translate_query_post_ids( $args, $post_type, callable $translate_id ) {
+		if ( ! is_array( $args ) || ! $this->get_current_language() ) {
+			return $args;
+		}
+
+		if ( ! empty( $args['post_id'] ) ) {
+			$args['post_id'] = $this->translate_query_post_id( $args['post_id'], $post_type, $translate_id );
+		}
+
+		if ( ! empty( $args['post__in'] ) ) {
+			$post_ids = (array) $args['post__in'];
+			foreach ( $post_ids as $index => $post_id ) {
+				$post_ids[ $index ] = $this->translate_query_post_id( $post_id, $post_type, $translate_id );
+			}
+			$args['post__in'] = $post_ids;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Translate one ID when it belongs to the given post type.
+	 *
+	 * @param int|string $post_id      Post ID.
+	 * @param string     $post_type    Post type whose IDs to translate.
+	 * @param callable   $translate_id Callback translating one ID.
+	 * @return int
+	 */
+	private function translate_query_post_id( $post_id, $post_type, callable $translate_id ): int {
+		$post_id = (int) $post_id;
+
+		return get_post_type( $post_id ) === $post_type ? (int) $translate_id( $post_id ) : $post_id;
+	}
+}

--- a/tests/unit-tests/wpml/test-class-course-progress.php
+++ b/tests/unit-tests/wpml/test-class-course-progress.php
@@ -5,6 +5,25 @@ namespace SenseiTest\WPML;
 use Sensei\WPML\Course_Progress;
 
 class Course_Progress_Test extends \WP_UnitTestCase {
+	/**
+	 * Sensei Factory.
+	 *
+	 * @var \Sensei_Factory
+	 */
+	protected $factory;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->factory = new \Sensei_Factory();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'wpml_current_language' );
+		remove_all_filters( 'wpml_element_language_details' );
+		remove_all_filters( 'wpml_object_id' );
+		parent::tear_down();
+		$this->factory->tearDown();
+	}
 
 	public function testInit_WhenCalled_AddsFilters() {
 		/* Arrange. */
@@ -23,6 +42,46 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'sensei_course_progress_find_course_id', array( $course_progress, 'translate_course_id' ) ) );
 		$this->assertEquals( 10, has_filter( 'sensei_lesson_progress_count_course_id', array( $course_progress, 'translate_course_id' ) ) );
 		$this->assertEquals( 10, has_filter( 'sensei_course_start_course_id', array( $course_progress, 'translate_course_id' ) ) );
+		$this->assertEquals( 10, has_filter( 'sensei_check_for_activity_args', array( $course_progress, 'translate_course_query_args' ) ) );
+	}
+
+	public function testTranslateCourseQueryArgs_TranslatedCourseQueried_FindsTheOriginalCourseProgress() {
+		/* Arrange. */
+		$user_id              = $this->factory->user->create();
+		$original_course_id   = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		\Sensei_Utils::update_course_status( $user_id, $original_course_id, 'complete' );
+
+		$this->stub_translations( array( $translated_course_id => $original_course_id ) );
+		( new Course_Progress() )->init();
+
+		/* Act. */
+		$actual = \Sensei_Utils::sensei_check_for_activity(
+			array(
+				'post_id' => $translated_course_id,
+				'type'    => 'sensei_course_status',
+				'status'  => 'any',
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $actual );
+	}
+
+	public function testTranslateCourseQueryArgs_LessonGiven_KeepsTheLessonId() {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create();
+
+		$this->stub_translations( array( $lesson_id => 999 ) );
+
+		$course_progress = new Course_Progress();
+
+		/* Act. */
+		$actual = $course_progress->translate_course_query_args( array( 'post_id' => $lesson_id ) );
+
+		/* Assert. */
+		$this->assertSame( array( 'post_id' => $lesson_id ), $actual );
 	}
 
 	public function testTranslateCourseId_WhenCalled_ReturnsMatchingValue() {
@@ -61,5 +120,40 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertEquals( 2, $actual );
+	}
+
+	/**
+	 * Make the given translated IDs resolve to their originals.
+	 *
+	 * @param array $map Translated ID => original ID.
+	 */
+	private function stub_translations( array $map ) {
+		add_filter(
+			'wpml_current_language',
+			function () {
+				return 'es';
+			}
+		);
+
+		add_filter(
+			'wpml_element_language_details',
+			function () {
+				return array(
+					'source_language_code' => 'en',
+					'language_code'        => 'es',
+				);
+			},
+			10,
+			0
+		);
+
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id ) use ( $map ) {
+				return $map[ $object_id ] ?? $object_id;
+			},
+			10,
+			1
+		);
 	}
 }

--- a/tests/unit-tests/wpml/test-class-course-progress.php
+++ b/tests/unit-tests/wpml/test-class-course-progress.php
@@ -52,7 +52,7 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 		$original_course_id   = $this->factory->course->create();
 		$translated_course_id = $this->factory->course->create();
 
-		\Sensei_Utils::update_course_status( $user_id, $original_course_id, 'in-progress' );
+		\Sensei_Utils::update_course_status( $user_id, $original_course_id, 'complete' );
 
 		$this->stub_translations( array( $translated_course_id => $original_course_id ) );
 		( new Course_Progress() )->init();
@@ -61,7 +61,7 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 		$learners = ( new \Sensei_Db_Query_Learners( array( 'filter_by_course_id' => $translated_course_id ) ) )->get_all();
 
 		/* Assert. */
-		$this->assertSame( array( $user_id ), array_map( 'intval', wp_list_pluck( $learners, 'user_id' ) ) );
+		$this->assertEquals( array( $user_id ), wp_list_pluck( $learners, 'user_id' ) );
 	}
 
 	public function testTranslateCourseQueryArgs_TranslatedCourseQueried_FindsTheOriginalCourseProgress() {
@@ -80,7 +80,6 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 			array(
 				'post_id' => $translated_course_id,
 				'type'    => 'sensei_course_status',
-				'status'  => 'any',
 			)
 		);
 

--- a/tests/unit-tests/wpml/test-class-course-progress.php
+++ b/tests/unit-tests/wpml/test-class-course-progress.php
@@ -43,6 +43,25 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'sensei_lesson_progress_count_course_id', array( $course_progress, 'translate_course_id' ) ) );
 		$this->assertEquals( 10, has_filter( 'sensei_course_start_course_id', array( $course_progress, 'translate_course_id' ) ) );
 		$this->assertEquals( 10, has_filter( 'sensei_check_for_activity_args', array( $course_progress, 'translate_course_query_args' ) ) );
+		$this->assertEquals( 10, has_filter( 'sensei_learners_query_args', array( $course_progress, 'translate_learners_query_args' ) ) );
+	}
+
+	public function testTranslateLearnersQueryArgs_TranslatedCourseFiltered_FindsTheOriginalCourseStudents() {
+		/* Arrange. */
+		$user_id              = $this->factory->user->create();
+		$original_course_id   = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		\Sensei_Utils::update_course_status( $user_id, $original_course_id, 'in-progress' );
+
+		$this->stub_translations( array( $translated_course_id => $original_course_id ) );
+		( new Course_Progress() )->init();
+
+		/* Act. */
+		$learners = ( new \Sensei_Db_Query_Learners( array( 'filter_by_course_id' => $translated_course_id ) ) )->get_all();
+
+		/* Assert. */
+		$this->assertSame( array( $user_id ), array_map( 'intval', wp_list_pluck( $learners, 'user_id' ) ) );
 	}
 
 	public function testTranslateCourseQueryArgs_TranslatedCourseQueried_FindsTheOriginalCourseProgress() {

--- a/tests/unit-tests/wpml/test-class-course-progress.php
+++ b/tests/unit-tests/wpml/test-class-course-progress.php
@@ -54,7 +54,7 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 
 		\Sensei_Utils::update_course_status( $user_id, $original_course_id, 'complete' );
 
-		$this->stub_translations( array( $translated_course_id => $original_course_id ) );
+		$this->simulate_wpml_translations( array( $translated_course_id => $original_course_id ) );
 		( new Course_Progress() )->init();
 
 		/* Act. */
@@ -72,7 +72,7 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 
 		\Sensei_Utils::update_course_status( $user_id, $original_course_id, 'complete' );
 
-		$this->stub_translations( array( $translated_course_id => $original_course_id ) );
+		$this->simulate_wpml_translations( array( $translated_course_id => $original_course_id ) );
 		( new Course_Progress() )->init();
 
 		/* Act. */
@@ -91,7 +91,7 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 		/* Arrange. */
 		$lesson_id = $this->factory->lesson->create();
 
-		$this->stub_translations( array( $lesson_id => 999 ) );
+		$this->simulate_wpml_translations( array( $lesson_id => 999 ) );
 
 		$course_progress = new Course_Progress();
 
@@ -145,7 +145,7 @@ class Course_Progress_Test extends \WP_UnitTestCase {
 	 *
 	 * @param array $map Translated ID => original ID.
 	 */
-	private function stub_translations( array $map ) {
+	private function simulate_wpml_translations( array $map ) {
 		add_filter(
 			'wpml_current_language',
 			function () {

--- a/tests/unit-tests/wpml/test-class-lesson-progress.php
+++ b/tests/unit-tests/wpml/test-class-lesson-progress.php
@@ -18,6 +18,7 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
+		remove_all_filters( 'wpml_current_language' );
 		remove_all_filters( 'wpml_element_language_details' );
 		remove_all_filters( 'wpml_object_id' );
 		parent::tear_down();
@@ -39,6 +40,63 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'sensei_lesson_progress_delete_for_lesson_lesson_id', array( $lesson_progress, 'translate_lesson_id' ) ) );
 		$this->assertEquals( 10, has_filter( 'sensei_lesson_progress_find_lesson_id', array( $lesson_progress, 'translate_lesson_id' ) ) );
 		$this->assertEquals( 10, has_filter( 'sensei_quiz_cache_key_lesson_id', array( $lesson_progress, 'translate_lesson_id' ) ) );
+		$this->assertEquals( 10, has_filter( 'sensei_check_for_activity_args', array( $lesson_progress, 'translate_lesson_query_args' ) ) );
+		$this->assertEquals( 10, has_filter( 'sensei_grading_filter_statuses', array( $lesson_progress, 'translate_lesson_query_args' ) ) );
+		$this->assertEquals( 20, has_filter( 'sensei_count_statuses_args', array( $lesson_progress, 'translate_lesson_query_args' ) ), 'The grading totals hook should run after the teacher restrictions.' );
+	}
+
+	public function testTranslateLessonQueryArgs_TranslatedLessonQueried_FindsTheOriginalLessonProgress() {
+		/* Arrange. */
+		$user_id              = $this->factory->user->create();
+		$original_lesson_id   = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+
+		\Sensei_Utils::update_lesson_status( $user_id, $original_lesson_id, 'complete' );
+
+		$this->stub_translations( array( $translated_lesson_id => $original_lesson_id ) );
+		( new Lesson_Progress() )->init();
+
+		/* Act. */
+		$actual = \Sensei_Utils::sensei_check_for_activity(
+			array(
+				'post_id' => $translated_lesson_id,
+				'type'    => 'sensei_lesson_status',
+				'status'  => 'any',
+			)
+		);
+
+		/* Assert. */
+		$this->assertSame( 1, $actual );
+	}
+
+	public function testTranslateLessonQueryArgs_TranslatedLessonsGivenInPostIn_ReturnsTheOriginalLessonIds() {
+		/* Arrange. */
+		$original_lesson_id   = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create();
+
+		$this->stub_translations( array( $translated_lesson_id => $original_lesson_id ) );
+
+		$lesson_progress = new Lesson_Progress();
+
+		/* Act. */
+		$actual = $lesson_progress->translate_lesson_query_args( array( 'post__in' => array( $translated_lesson_id ) ) );
+
+		/* Assert. */
+		$this->assertSame( array( 'post__in' => array( $original_lesson_id ) ), $actual );
+	}
+
+	public function testTranslateLessonQueryArgs_NoLessonsSentinelGiven_KeepsTheSentinel() {
+		/* Arrange. */
+		// Anything that translated the sentinel would turn it into a real ID.
+		$this->stub_translations( array( 0 => 123 ) );
+
+		$lesson_progress = new Lesson_Progress();
+
+		/* Act. */
+		$actual = $lesson_progress->translate_lesson_query_args( array( 'post__in' => array( 0 ) ) );
+
+		/* Assert. */
+		$this->assertSame( array( 'post__in' => array( 0 ) ), $actual, 'The "no lessons" restriction must keep matching nothing.' );
 	}
 
 	public function testTranslateLessonId_QuizCacheReadWithTranslatedLesson_ReadsTheOriginalLessonKey() {
@@ -119,5 +177,40 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertEquals( 2, $actual );
+	}
+
+	/**
+	 * Make the given translated IDs resolve to their originals.
+	 *
+	 * @param array $map Translated ID => original ID.
+	 */
+	private function stub_translations( array $map ) {
+		add_filter(
+			'wpml_current_language',
+			function () {
+				return 'es';
+			}
+		);
+
+		add_filter(
+			'wpml_element_language_details',
+			function () {
+				return array(
+					'source_language_code' => 'en',
+					'language_code'        => 'es',
+				);
+			},
+			10,
+			0
+		);
+
+		add_filter(
+			'wpml_object_id',
+			function ( $object_id ) use ( $map ) {
+				return $map[ $object_id ] ?? $object_id;
+			},
+			10,
+			1
+		);
 	}
 }

--- a/tests/unit-tests/wpml/test-class-lesson-progress.php
+++ b/tests/unit-tests/wpml/test-class-lesson-progress.php
@@ -53,7 +53,7 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 
 		\Sensei_Utils::update_lesson_status( $user_id, $original_lesson_id, 'complete' );
 
-		$this->stub_translations( array( $translated_lesson_id => $original_lesson_id ) );
+		$this->simulate_wpml_translations( array( $translated_lesson_id => $original_lesson_id ) );
 		( new Lesson_Progress() )->init();
 
 		/* Act. */
@@ -73,7 +73,7 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 		$original_lesson_id   = $this->factory->lesson->create();
 		$translated_lesson_id = $this->factory->lesson->create();
 
-		$this->stub_translations( array( $translated_lesson_id => $original_lesson_id ) );
+		$this->simulate_wpml_translations( array( $translated_lesson_id => $original_lesson_id ) );
 
 		$lesson_progress = new Lesson_Progress();
 
@@ -169,7 +169,7 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 	 *
 	 * @param array $map Translated ID => original ID.
 	 */
-	private function stub_translations( array $map ) {
+	private function simulate_wpml_translations( array $map ) {
 		add_filter(
 			'wpml_current_language',
 			function () {

--- a/tests/unit-tests/wpml/test-class-lesson-progress.php
+++ b/tests/unit-tests/wpml/test-class-lesson-progress.php
@@ -84,20 +84,6 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 		$this->assertSame( array( 'post__in' => array( $original_lesson_id ) ), $actual );
 	}
 
-	public function testTranslateLessonQueryArgs_NoLessonsSentinelGiven_KeepsTheSentinel() {
-		/* Arrange. */
-		// Anything that translated the sentinel would turn it into a real ID.
-		$this->stub_translations( array( 0 => 123 ) );
-
-		$lesson_progress = new Lesson_Progress();
-
-		/* Act. */
-		$actual = $lesson_progress->translate_lesson_query_args( array( 'post__in' => array( 0 ) ) );
-
-		/* Assert. */
-		$this->assertSame( array( 'post__in' => array( 0 ) ), $actual, 'The "no lessons" restriction must keep matching nothing.' );
-	}
-
 	public function testTranslateLessonId_QuizCacheReadWithTranslatedLesson_ReadsTheOriginalLessonKey() {
 		/* Arrange. */
 		$user_id              = $this->factory->user->create();

--- a/tests/unit-tests/wpml/test-class-lesson-progress.php
+++ b/tests/unit-tests/wpml/test-class-lesson-progress.php
@@ -61,7 +61,6 @@ class Lesson_Progress_Test extends \WP_UnitTestCase {
 			array(
 				'post_id' => $translated_lesson_id,
 				'type'    => 'sensei_lesson_status',
-				'status'  => 'any',
 			)
 		);
 


### PR DESCRIPTION
Closes [SEN-191](https://linear.app/a8c/issue/SEN-191)

## Proposed Changes

With WPML, student progress is always stored against the original language's course and lesson IDs, but the admin screens query it with the ID of the course or lesson they show. In a secondary language that ID is the translation, so the query finds nothing: the Students screens, the Grading listing and the Students column of the course list come up empty even though the data is there. A teacher working in a secondary language cannot see who is enrolled, reset progress or grade.

The fix translates the IDs to the original language before those queries run, the same way the progress repositories have done since 4.23.1. Two new filters expose the query arguments (`sensei_check_for_activity_args` for the activity helper, `sensei_learners_query_args` for the Students screen's learners query), and the WPML `Course_Progress` and `Lesson_Progress` classes translate the course and lesson IDs in them. `Lesson_Progress` also covers the two filters the Grading screen already had for its tables-backed query, including the teacher's own-lessons restriction.

## Testing Instructions

On a site with WPML active (English default, Spanish secondary):

1. Create a course with three lessons. Give the first lesson a quiz with one question. Publish everything.
2. Translate the course into Spanish and deliver the translation, so the lessons and the quiz are translated too.
3. As a student, take the course in English, complete the three lessons and pass the quiz.
4. In the admin bar, switch the language to Spanish.
5. Go to **Sensei LMS → Students** and click on the Spanish course name on the `Enrolled courses` column. Without this PR it shows "No students found"; with it, the student is listed with the course completed.
6. Open the **Lessons** tab of that course. The "# Students" column shows 1 for each lesson instead of 0.
7. Click **Manage students** on the first lesson. The student is listed.
8. Go to **Sensei LMS → Grading**, pick the Spanish course in the first dropdown and its first lesson in the second one, and filter. The submission is listed and the counters are no longer all 0.
9. Switch the admin bar back to English and repeat steps 5 to 8. Everything shows the same as before this PR.
10. Go to **Sensei LMS → Courses** in Spanish. The Students column of the Spanish course shows 1 student.
11. Go to **Sensei LMS → Students** in Spanish and filter by the Spanish course. The student is listed.

## New/Updated Hooks

* `sensei_check_for_activity_args` (filter, new): filters the arguments `Sensei_Utils::sensei_check_for_activity()` passes to `get_comments()`, right before the query. Receives and returns the arguments array.
* `sensei_learners_query_args` (filter, new): filters the arguments `Sensei_Db_Query_Learners` is built with, before it reads them. Receives and returns the arguments array.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
<!-- Choose only one -->
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
<!-- Choose only one -->
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message <!-- Add the changelog message here -->
Fixed the student management and grading screens showing no students when the WPML admin language is not the original one.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


