### PR TITLE
Prevent PHP warning when saving a course with no module slugs

### DIFF
--- a/changelog/fix-teacher-meta-box-null-slugs
+++ b/changelog/fix-teacher-meta-box-null-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a PHP warning when saving a course whose module slugs field is empty or invalid.

--- a/changelog/fix-teacher-meta-box-null-slugs
+++ b/changelog/fix-teacher-meta-box-null-slugs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed a PHP warning when saving a course whose module slugs field is empty or invalid.
+Fixed a PHP warning when changing a course's teacher on a course with no modules.

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -385,7 +385,7 @@ class Sensei_Teacher {
 		// If a custom slug is of a module that belongs to another teacher from another course, don't process farther.
 		if ( isset( $_POST['course_module_custom_slugs'] ) ) {
 			$module_custom_slugs = json_decode( sensei_request_text( $_POST['course_module_custom_slugs'] ) );
-			foreach ( $module_custom_slugs as $module_custom_slug ) {
+			foreach ( (array) $module_custom_slugs as $module_custom_slug ) {
 				$course_name = self::is_module_in_use_by_different_course_and_teacher( $module_custom_slug, $course_id, absint( $_POST['sensei-course-teacher-author'] ) );
 				if ( $course_name ) {
 					return;

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -385,7 +385,10 @@ class Sensei_Teacher {
 		// If a custom slug is of a module that belongs to another teacher from another course, don't process farther.
 		if ( isset( $_POST['course_module_custom_slugs'] ) ) {
 			$module_custom_slugs = json_decode( sensei_request_text( $_POST['course_module_custom_slugs'] ) );
-			foreach ( (array) $module_custom_slugs as $module_custom_slug ) {
+			if ( ! is_array( $module_custom_slugs ) ) {
+				$module_custom_slugs = array();
+			}
+			foreach ( $module_custom_slugs as $module_custom_slug ) {
 				$course_name = self::is_module_in_use_by_different_course_and_teacher( $module_custom_slug, $course_id, absint( $_POST['sensei-course-teacher-author'] ) );
 				if ( $course_name ) {
 					return;

--- a/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
@@ -104,7 +104,7 @@ class Sensei_REST_API_Course_Utils_Controller extends \WP_REST_Controller {
 		// If a custom slug is of a module that belongs to another teacher from another course, don't process farther.
 		if ( isset( $module_custom_slugs ) ) {
 			$module_custom_slugs = json_decode( sanitize_text_field( wp_unslash( $module_custom_slugs ) ) );
-			foreach ( $module_custom_slugs as $module_custom_slug ) {
+			foreach ( (array) $module_custom_slugs as $module_custom_slug ) {
 				$course_name = Sensei()->teacher::is_module_in_use_by_different_course_and_teacher( $module_custom_slug, $post_id, $teacher );
 				if ( $course_name ) {
 					return new WP_REST_Response(

--- a/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-utils-controller.php
@@ -104,7 +104,10 @@ class Sensei_REST_API_Course_Utils_Controller extends \WP_REST_Controller {
 		// If a custom slug is of a module that belongs to another teacher from another course, don't process farther.
 		if ( isset( $module_custom_slugs ) ) {
 			$module_custom_slugs = json_decode( sanitize_text_field( wp_unslash( $module_custom_slugs ) ) );
-			foreach ( (array) $module_custom_slugs as $module_custom_slug ) {
+			if ( ! is_array( $module_custom_slugs ) ) {
+				$module_custom_slugs = array();
+			}
+			foreach ( $module_custom_slugs as $module_custom_slug ) {
 				$course_name = Sensei()->teacher::is_module_in_use_by_different_course_and_teacher( $module_custom_slug, $post_id, $teacher );
 				if ( $course_name ) {
 					return new WP_REST_Response(


### PR DESCRIPTION
## Proposed Changes

Changing a course's teacher could emit `PHP Warning: foreach() argument must be of type array|object` when the course has no Course Outline block. The teacher-save code decodes the posted module slugs and loops over the result, but `json_decode()` can return `null` or `bool` (empty/invalid value), which `foreach` can't iterate. This happens on two paths:

- **Classic Editor** — `Sensei_Teacher::save_teacher_meta_box()`. The hidden `course_module_custom_slugs` field is posted empty (the block-editor JS that fills it never runs), so `json_decode('')` is `null`.
- **Block Editor** — `Sensei_REST_API_Course_Utils_Controller::update_teacher()`. The sidebar posts `custom_slugs` as `JSON.stringify(moduleSlugs)`; with no outline block `moduleSlugs` is falsy, so the value decodes to `bool`/`null`.

Both spots now cast the decoded value to an array before the loop, so an empty/invalid value iterates zero times instead of warning. A valid slug array is unaffected.

## Testing Instructions

### Block Editor (default)

- [x] Turn on `WP_DEBUG` / `WP_DEBUG_LOG`.
- [x] Edit a course that has **no** Course Outline block, change the teacher in the course sidebar, and save.
- [x] Confirm no `foreach() ...` warning appears in `wp-content/debug.log` for `class-sensei-rest-api-course-utils-controller.php`.
- [x] Confirm the teacher actually changed (course list "Teacher" column, or `wp post get <course_id> --field=post_author`).

### Classic Editor

Requires the Classic Editor plugin.

- [x] Turn on `WP_DEBUG` / `WP_DEBUG_LOG`.
- [x] Edit a course in the Classic Editor, change the value in the **Teacher** metabox, and click **Update**.
- [x] Confirm no `foreach() ... null given` warning appears in `wp-content/debug.log` for `class-sensei-teacher.php`.
- [x] Confirm the teacher actually changed — check the course list "Teacher" column, or `wp post get <course_id> --field=post_author`.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message
Fixed a PHP warning when changing a course's teacher on a course with no modules.

</details>