### PR TITLE
Fix garbled text in button blocks with non-Latin characters when the button URL is set at render time

### DIFF
--- a/changelog/fix-button-block-utf8-encoding
+++ b/changelog/fix-button-block-utf8-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix garbled text in button blocks whose text uses non-Latin characters when the button URL is set at render time.

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -222,7 +222,7 @@ class Sensei_Blocks {
 		}
 
 		$dom = new DomDocument();
-		$dom->loadHTML( $block_content );
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $block_content );
 		$parent_node = $dom->getElementsByTagName( 'div' )->length > 0 ? $dom->getElementsByTagName( 'div' )[0] : '';
 
 		if ( ! $parent_node || ! $parent_node->hasAttributes() ) {

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -222,7 +222,7 @@ class Sensei_Blocks {
 		}
 
 		$dom = new DomDocument();
-		$dom->loadHTML( '<?xml encoding="UTF-8">' . $block_content );
+		$dom->loadHTML( '<?xml encoding="UTF-8"?>' . $block_content );
 		$parent_node = $dom->getElementsByTagName( 'div' )->length > 0 ? $dom->getElementsByTagName( 'div' )[0] : '';
 
 		if ( ! $parent_node || ! $parent_node->hasAttributes() ) {

--- a/tests/unit-tests/blocks/test-class-sensei-blocks.php
+++ b/tests/unit-tests/blocks/test-class-sensei-blocks.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Tests for Sensei_Blocks class.
+ */
+class Sensei_Blocks_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test that the anchor href is set to the given URL.
+	 */
+	public function testUpdateButtonBlockUrl_UrlGiven_SetsAnchorHref() {
+		$block_content = '<div class="wp-block-button view-certificate"><a class="wp-block-button__link">View Certificate</a></div>';
+		$block         = array(
+			'blockName' => 'core/button',
+			'attrs'     => array( 'className' => 'view-certificate' ),
+		);
+
+		$actual = Sensei_Blocks::update_button_block_url( $block_content, $block, 'view-certificate', 'https://example.com/certificate' );
+
+		$this->assertStringContainsString( 'href="https://example.com/certificate"', $actual );
+	}
+}


### PR DESCRIPTION
Resolves woocommerce/sensei-certificates#322.

## Proposed Changes

Buttons whose text uses non-Latin characters (e.g. Greek) rendered as garbled characters on the front end when their URL was injected at render time — the "View Certificate" button on the Course Completed page was the reported case (woocommerce/sensei-certificates#322).

`Sensei_Blocks::update_button_block_url()` parses the button markup with `DOMDocument::loadHTML()` to set the anchor's `href`. Without an encoding hint, `loadHTML()` assumes Latin-1 and corrupts multibyte UTF-8 text. Prepending an XML encoding declaration tells libxml to parse the content as UTF-8, so the button text survives the round-trip.

## Testing Instructions

- [x] With Sensei LMS and Sensei Certificates active, assign a certificate template to a course a student can complete.
- [x] Edit the Course Completed page, change the "View Certificate" button text to non-Latin text (e.g. `Προβολή πιστοποιητικού`), and save.
- [x] As a student, complete the course and open the Course Completed page.
- [x] Confirm the button text renders correctly (no garbled characters) and the button links to the certificate.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes

#### Type
- [x] Fixed - Fixes a bug

#### Message

Fix garbled text in button blocks whose text uses non-Latin characters when the button URL is set at render time.

</details>
