### PR TITLE
Remove @faker-js/faker dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
       },
       "devDependencies": {
         "@es-joy/jsdoccomment": "0.96.0",
-        "@faker-js/faker": "8.0.2",
         "@lifeomic/attempt": "3.1.0",
         "@playwright/test": "1.62.1",
         "@svgr/webpack": "6.1.2",
@@ -3020,24 +3019,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@faker-js/faker": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
-      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==",
-      "deprecated": "Please update to a newer version",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@es-joy/jsdoccomment": "0.96.0",
-    "@faker-js/faker": "8.0.2",
     "@lifeomic/attempt": "3.1.0",
     "@playwright/test": "1.62.1",
     "@svgr/webpack": "6.1.2",

--- a/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
+++ b/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.ts
@@ -9,7 +9,6 @@ import { test, expect } from '@playwright/test';
 import { asAdmin, createCourse, createCourseCategory } from '@e2e/helpers/api';
 import PostType from '@e2e/pages/admin/post-type';
 import { editorRole } from '@e2e/helpers/context';
-import { faker } from '@faker-js/faker';
 
 const { describe, use, beforeAll } = test;
 
@@ -18,19 +17,19 @@ describe( 'Courses List Block', () => {
 
 	const courses = [
 		{
-			title: faker.lorem.sentence( 2 ),
-			excerpt: faker.lorem.sentence( 3 ),
-			category: faker.lorem.slug( 2 ),
+			title: 'Intro to Astronomy',
+			excerpt: 'Learn the basics of stargazing.',
+			category: 'Science',
 		},
 		{
-			title: faker.lorem.sentence( 2 ),
-			excerpt: faker.lorem.sentence( 3 ),
-			category: faker.lorem.slug( 2 ),
+			title: 'Creative Writing Workshop',
+			excerpt: 'Craft compelling short stories.',
+			category: 'Arts',
 		},
 		{
-			title: faker.lorem.sentence( 2 ),
-			excerpt: faker.lorem.sentence( 3 ),
-			category: faker.lorem.slug( 2 ),
+			title: 'Home Gardening Essentials',
+			excerpt: 'Grow vegetables year round.',
+			category: 'Lifestyle',
 		},
 	];
 


### PR DESCRIPTION
## Proposed Changes

Removes the `@faker-js/faker` dev dependency. It had a single consumer — the course list block e2e spec — which used it only to generate three course titles, excerpts, and categories. Those are now plain static literals, so the test data is deterministic and the dependency is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)