### PR TITLE
Fix JSDoc Prettier plugin corrupting wrapped @param descriptions

### DIFF
--- a/scripts/prettier/prettier-plugin-jsdoc.js
+++ b/scripts/prettier/prettier-plugin-jsdoc.js
@@ -62,6 +62,7 @@ const getParserWithJSDoc = ( parser ) => ( {
 					indent,
 					tags: [ 'param', 'arg', 'argument', 'property', 'prop' ],
 					preserveMainDescriptionPostDelimiter: true,
+					wrapIndent: '',
 				} )
 			);
 


### PR DESCRIPTION
## Problem

Running `npm run format` on any file with a **wrapped (multi-line) `@param` description** corrupts the comment, inserting a literal `undefined`:

```
 * @param {Object} attrs The attributes stored in local storage
 * undefined              that are going to be used as initial state.
```

## Cause

`scripts/prettier/prettier-plugin-jsdoc.js` runs comments through `eslint-plugin-jsdoc`'s `alignTransform`. Newer versions of that transform append its `wrapIndent` option to the post-delimiter of wrapped tag lines (`alignTransform.js`: `tokens.postDelimiter += wrapIndent`). The plugin never passed `wrapIndent`, so `undefined` was appended and then stringified into the comment. Single-line `@param`s have no continuation line, so only wrapped descriptions were affected — which is why it went unnoticed.

## Fix

Pass an explicit `wrapIndent: ''` to `alignTransform`.

Verified: `npm run format` on a fixture with a wrapped `@param` now preserves and aligns the description with no `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)