### PR TITLE
Fix/user completed lesson empty lesson quiz

### DIFF
--- a/changelog/fix-user-completed-lesson-empty-quiz
+++ b/changelog/fix-user-completed-lesson-empty-quiz
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a lesson incorrectly showing as incomplete when its quiz has a stale in-progress attempt but no actual questions.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1825,7 +1825,7 @@ class Sensei_Utils {
 			// In the comments-based progress we use one entry to store both the lesson progress and the quiz progress.
 			// In the tables-based progress we split them. Here is important to use the quiz proress if the quiz pass is required.
 			$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
-			if ( $lesson_quiz_id ) {
+			if ( $lesson_quiz_id && Sensei_Lesson::lesson_quiz_has_questions( $lesson_id ) ) {
 				$pass_required = get_post_meta( $lesson_quiz_id, '_pass_required', true );
 				if ( $pass_required ) {
 					$quiz_progress = Sensei()->quiz_progress_repository->get( $lesson_quiz_id, $user_id );


### PR DESCRIPTION
Resolves #

## Proposed Changes
* Fixes a bug where the lesson incorrectly shows as incomplete when its quiz has a stale in-progress attempt but no actual questions. 

## Screenshots
<!-- For visual changes, fill the Before/After table below. For net-new UI with no "before", drop the table and paste a single screenshot or short video. Remove this whole section if the change has no visual surface. -->

| Before | After |
| --- | --- |
|  |  |

## Testing Instructions
<!-- List the manual steps a reviewer follows to verify the change; they tick each as they test. Replace the placeholders below. -->

- Viewing the quiz page (not even answering) creates a quiz-type progress
- If the student never submits, that row never advances past in-progress.
- Later, an editor removes all the questions from that quiz.
- Because the quiz now has no questions, Sensei's own lesson template treats it as "no quiz" and shows a plain Complete Lesson button. The student clicks it, and lesson_progress becomes complete.
- The stale quiz progress row from step 1 is still sitting at in-progress
- user_completed_lesson() now sees: lesson row complete, but _pass_required = on, and will return false

## New/Updated Hooks
<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

## Deprecated Code
<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->

*

## Changelog entry
<!-- Tick the box below to have CI create the changelog/ entry from the details here (only available for branches in this repository; forks should run `make changelog`).
Otherwise run `make changelog` locally, or apply the "No Changelog" label for internal-only changes. -->

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
<!-- Choose only one -->
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
<!-- Choose only one -->
- [ ] Added - Adds new functionality
- [ ] Changed - Changes existing functionality
- [x] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message <!-- Add the changelog message here -->
Fix a lesson incorrectly showing as incomplete when its quiz has a stale in-progress attempt but no actual questions.

</details>
