### PR TITLE
Detach removed lessons from translated courses on translation completion

### DIFF
--- a/changelog/fix-wpml-detach-removed-lesson-translations
+++ b/changelog/fix-wpml-detach-removed-lesson-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix lessons removed from a course staying in its WPML translations after the translation is updated.

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -139,8 +139,7 @@ class Course_Translation {
 	 * Get the IDs of the lessons attached to a course, whatever their language.
 	 *
 	 * WPML filters queries by the current language, which during a translation
-	 * job is not the language of the course, so the query runs without filters
-	 * (the default of get_posts()).
+	 * job is not the language of the course, so the query runs without filters.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -150,12 +149,13 @@ class Course_Translation {
 	private function get_course_lesson_ids( $course_id ) {
 		$lesson_ids = get_posts(
 			array(
-				'post_type'   => 'lesson',
-				'post_status' => 'any',
-				'numberposts' => -1,
-				'fields'      => 'ids',
-				'meta_key'    => '_lesson_course', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Lessons are attached to their course by meta.
-				'meta_value'  => (int) $course_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- See above.
+				'post_type'        => 'lesson',
+				'post_status'      => 'any',
+				'numberposts'      => -1,
+				'fields'           => 'ids',
+				'suppress_filters' => true,
+				'meta_key'         => '_lesson_course', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Lessons are attached to their course by meta.
+				'meta_value'       => (int) $course_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- See above.
 			)
 		);
 

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -97,6 +97,8 @@ class Course_Translation {
 			$this->sync_custom_field( $lesson_id, '_lesson_course' );
 		}
 
+		$this->detach_lessons_removed_from_original_course( $master_id, $new_course_id, $details['source_language_code'] );
+
 		// One order sync per language instead of one per lesson.
 		foreach ( array_keys( $duplicate_languages ) as $language_code ) {
 			$translated_course_id = $this->get_object_id( $master_id, 'course', false, $language_code );
@@ -104,6 +106,82 @@ class Course_Translation {
 				$this->sync_course_lesson_order( $master_id, $translated_course_id, $language_code );
 			}
 		}
+	}
+
+	/**
+	 * Detach from a translated course the lessons whose original was removed from the original course.
+	 *
+	 * Removing a lesson from a course only detaches it, so the same is done
+	 * to its translation. Lessons of the translated course with no original
+	 * are left alone.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $original_course_id   Original course ID.
+	 * @param int    $translated_course_id Translated course ID.
+	 * @param string $source_language_code Language code of the original course.
+	 */
+	private function detach_lessons_removed_from_original_course( $original_course_id, $translated_course_id, $source_language_code ) {
+		$original_lesson_ids = $this->get_course_lesson_ids( $original_course_id );
+
+		foreach ( $this->get_course_lesson_ids( $translated_course_id ) as $translated_lesson_id ) {
+			$original_lesson_id = $this->get_object_id( $translated_lesson_id, 'lesson', false, $source_language_code );
+
+			if ( ! $original_lesson_id || $original_lesson_id === $translated_lesson_id || in_array( $original_lesson_id, $original_lesson_ids, true ) ) {
+				continue;
+			}
+
+			$this->detach_lesson_from_course( $translated_lesson_id, $translated_course_id );
+		}
+	}
+
+	/**
+	 * Get the IDs of the lessons attached to a course, whatever their language.
+	 *
+	 * WPML filters queries by the current language, which during a translation
+	 * job is not the language of the course, so the query runs without filters
+	 * (the default of get_posts()).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $course_id Course ID.
+	 * @return int[]
+	 */
+	private function get_course_lesson_ids( $course_id ) {
+		$lesson_ids = get_posts(
+			array(
+				'post_type'   => 'lesson',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'meta_key'    => '_lesson_course', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Lessons are attached to their course by meta.
+				'meta_value'  => (int) $course_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- See above.
+			)
+		);
+
+		return array_map( 'intval', $lesson_ids );
+	}
+
+	/**
+	 * Detach a lesson from a course, the same way the course outline does when a lesson is removed.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $lesson_id Lesson ID.
+	 * @param int $course_id Course ID.
+	 */
+	private function detach_lesson_from_course( $lesson_id, $course_id ) {
+		delete_post_meta( $lesson_id, '_lesson_course' );
+		delete_post_meta( $lesson_id, '_order_' . $course_id );
+
+		$modules = get_the_terms( $lesson_id, 'module' );
+		if ( is_array( $modules ) ) {
+			foreach ( $modules as $module ) {
+				delete_post_meta( $lesson_id, '_order_module_' . $module->term_id );
+			}
+		}
+
+		wp_set_object_terms( $lesson_id, array(), 'module' );
 	}
 
 	/**

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -136,7 +136,11 @@ class Course_Translation {
 	}
 
 	/**
-	 * Detach a lesson from a course, the same way the course outline does when a lesson is removed.
+	 * Detach a lesson from a course.
+	 *
+	 * Clears the associations the course outline clears when a lesson is
+	 * removed from it, plus the lesson's order in the course, which the
+	 * outline leaves behind.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -136,6 +136,28 @@ class Course_Translation {
 	}
 
 	/**
+	 * Detach a lesson from a course, the same way the course outline does when a lesson is removed.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $lesson_id Lesson ID.
+	 * @param int $course_id Course ID.
+	 */
+	private function detach_lesson_from_course( $lesson_id, $course_id ) {
+		delete_post_meta( $lesson_id, '_lesson_course' );
+		delete_post_meta( $lesson_id, '_order_' . $course_id );
+
+		$modules = get_the_terms( $lesson_id, 'module' );
+		if ( is_array( $modules ) ) {
+			foreach ( $modules as $module ) {
+				delete_post_meta( $lesson_id, '_order_module_' . $module->term_id );
+			}
+		}
+
+		wp_set_object_terms( $lesson_id, array(), 'module' );
+	}
+
+	/**
 	 * Get the IDs of the lessons attached to a course, whatever their language.
 	 *
 	 * WPML filters queries by the current language, which during a translation
@@ -160,28 +182,6 @@ class Course_Translation {
 		);
 
 		return array_map( 'intval', $lesson_ids );
-	}
-
-	/**
-	 * Detach a lesson from a course, the same way the course outline does when a lesson is removed.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param int $lesson_id Lesson ID.
-	 * @param int $course_id Course ID.
-	 */
-	private function detach_lesson_from_course( $lesson_id, $course_id ) {
-		delete_post_meta( $lesson_id, '_lesson_course' );
-		delete_post_meta( $lesson_id, '_order_' . $course_id );
-
-		$modules = get_the_terms( $lesson_id, 'module' );
-		if ( is_array( $modules ) ) {
-			foreach ( $modules as $module ) {
-				delete_post_meta( $lesson_id, '_order_module_' . $module->term_id );
-			}
-		}
-
-		wp_set_object_terms( $lesson_id, array(), 'module' );
 	}
 
 	/**

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -149,8 +149,13 @@ class Course_Translation {
 
 		// WPML swaps term IDs for their translation in the current language,
 		// which during a translation job is not the lesson's language, so the
-		// lesson's own module terms are read and cleared with that off.
-		add_filter( 'wpml_disable_term_adjust_id', '__return_true' );
+		// lesson's own module terms are read and cleared with that off. The
+		// callback is our own so that removing it leaves any other in place.
+		$disable_term_adjustment = static function (): bool {
+			return true;
+		};
+
+		add_filter( 'wpml_disable_term_adjust_id', $disable_term_adjustment );
 
 		$modules = get_the_terms( $lesson_id, 'module' );
 		if ( is_array( $modules ) ) {
@@ -161,7 +166,7 @@ class Course_Translation {
 
 		wp_set_object_terms( $lesson_id, array(), 'module' );
 
-		remove_filter( 'wpml_disable_term_adjust_id', '__return_true' );
+		remove_filter( 'wpml_disable_term_adjust_id', $disable_term_adjustment );
 	}
 
 	/**

--- a/includes/wpml/class-course-translation.php
+++ b/includes/wpml/class-course-translation.php
@@ -147,6 +147,11 @@ class Course_Translation {
 		delete_post_meta( $lesson_id, '_lesson_course' );
 		delete_post_meta( $lesson_id, '_order_' . $course_id );
 
+		// WPML swaps term IDs for their translation in the current language,
+		// which during a translation job is not the lesson's language, so the
+		// lesson's own module terms are read and cleared with that off.
+		add_filter( 'wpml_disable_term_adjust_id', '__return_true' );
+
 		$modules = get_the_terms( $lesson_id, 'module' );
 		if ( is_array( $modules ) ) {
 			foreach ( $modules as $module ) {
@@ -155,6 +160,8 @@ class Course_Translation {
 		}
 
 		wp_set_object_terms( $lesson_id, array(), 'module' );
+
+		remove_filter( 'wpml_disable_term_adjust_id', '__return_true' );
 	}
 
 	/**

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -177,33 +177,7 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 
 	public function testUpdateLessonPropertiesOnCourseTranslationCreated_LessonRemovedFromTheOriginalCourseGiven_DetachesItsTranslationFromTheTranslatedCourse() {
 		/* Arrange. */
-		$original_course_id   = $this->factory->course->create();
-		$translated_course_id = $this->factory->course->create();
-
-		// The original lesson was removed from its course; its translation still points at the translated course.
-		$original_lesson_id   = $this->factory->lesson->create();
-		$translated_lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $translated_course_id ) ) );
-
-		// WPML: the translated course is in Spanish, translated from English.
-		add_filter(
-			'wpml_element_language_details',
-			fn() => array(
-				'language_code'        => 'es',
-				'source_language_code' => 'en',
-			),
-			10,
-			0
-		);
-		// WPML: which post is the counterpart of which.
-		add_filter(
-			'wpml_object_id',
-			fn( $post_id ) => array(
-				$translated_course_id => $original_course_id,
-				$translated_lesson_id => $original_lesson_id,
-			)[ $post_id ] ?? 0,
-			10,
-			1
-		);
+		list( $translated_course_id, $translated_lesson_id ) = $this->create_translation_with_a_removed_lesson();
 
 		$course_translation = new Course_Translation();
 
@@ -211,10 +185,54 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
 
 		/* Clean up & Assert. */
-		remove_all_filters( 'wpml_element_language_details' );
-		remove_all_filters( 'wpml_object_id' );
+		$this->remove_wpml_stubs();
 
 		$this->assertSame( '', get_post_meta( $translated_lesson_id, '_lesson_course', true ) );
+	}
+
+	public function testUpdateLessonPropertiesOnCourseTranslationCreated_LessonRemovedFromTheOriginalCourseGiven_ClearsItsOrderInTheTranslatedCourse() {
+		/* Arrange. */
+		list( $translated_course_id, $translated_lesson_id ) = $this->create_translation_with_a_removed_lesson();
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+
+		$this->assertSame( '', get_post_meta( $translated_lesson_id, '_order_' . $translated_course_id, true ) );
+	}
+
+	public function testUpdateLessonPropertiesOnCourseTranslationCreated_LessonRemovedFromTheOriginalCourseGiven_ClearsItsOrderInTheModule() {
+		/* Arrange. */
+		list( $translated_course_id, $translated_lesson_id, $module_id ) = $this->create_translation_with_a_removed_lesson();
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+
+		$this->assertSame( '', get_post_meta( $translated_lesson_id, '_order_module_' . $module_id, true ) );
+	}
+
+	public function testUpdateLessonPropertiesOnCourseTranslationCreated_LessonRemovedFromTheOriginalCourseGiven_RemovesItsTranslationFromTheModule() {
+		/* Arrange. */
+		list( $translated_course_id, $translated_lesson_id ) = $this->create_translation_with_a_removed_lesson();
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
+
+		/* Clean up & Assert. */
+		$this->remove_wpml_stubs();
+
+		$this->assertSame( array(), wp_get_object_terms( $translated_lesson_id, 'module', array( 'fields' => 'ids' ) ) );
 	}
 
 	public function testUpdateLessonPropertiesOnCourseTranslationCreated_LessonWithoutAnOriginalGiven_LeavesItInTheTranslatedCourse() {
@@ -225,23 +243,8 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		// A lesson that only exists in the translated course.
 		$untranslated_lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $translated_course_id ) ) );
 
-		// WPML: the translated course is in Spanish, translated from English.
-		add_filter(
-			'wpml_element_language_details',
-			fn() => array(
-				'language_code'        => 'es',
-				'source_language_code' => 'en',
-			),
-			10,
-			0
-		);
-		// WPML: only the course has a counterpart.
-		add_filter(
-			'wpml_object_id',
-			fn( $post_id ) => $post_id === $translated_course_id ? $original_course_id : 0,
-			10,
-			1
-		);
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map( array( $translated_course_id => $original_course_id ) );
 
 		$course_translation = new Course_Translation();
 
@@ -249,8 +252,7 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
 
 		/* Clean up & Assert. */
-		remove_all_filters( 'wpml_element_language_details' );
-		remove_all_filters( 'wpml_object_id' );
+		$this->remove_wpml_stubs();
 
 		$this->assertSame( (string) $translated_course_id, get_post_meta( $untranslated_lesson_id, '_lesson_course', true ) );
 	}
@@ -681,6 +683,44 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 	private function remove_wpml_stubs() {
 		remove_all_filters( 'wpml_element_language_details' );
 		remove_all_filters( 'wpml_object_id' );
+	}
+
+	/**
+	 * Create a translated course keeping a lesson whose original was removed
+	 * from the original course. The translation is ordered in the course and
+	 * placed in a module, so the whole detach can be checked.
+	 *
+	 * @return array Translated course ID, translated lesson ID and module term ID.
+	 */
+	private function create_translation_with_a_removed_lesson() {
+		$original_course_id   = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		// The original lesson is no longer in the original course, while its
+		// translation is still in the translated course.
+		$original_lesson_id   = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create(
+			array(
+				'meta_input' => array(
+					'_lesson_course'                  => $translated_course_id,
+					'_order_' . $translated_course_id => 1,
+				),
+			)
+		);
+
+		$module_id = $this->factory->term->create( array( 'taxonomy' => 'module' ) );
+		wp_set_object_terms( $translated_lesson_id, array( $module_id ), 'module' );
+		update_post_meta( $translated_lesson_id, '_order_module_' . $module_id, 1 );
+
+		$this->stub_course_language( 'es', 'en' );
+		$this->stub_object_id_map(
+			array(
+				$translated_course_id => $original_course_id,
+				$translated_lesson_id => $original_lesson_id,
+			)
+		);
+
+		return array( $translated_course_id, $translated_lesson_id, $module_id );
 	}
 
 	/**

--- a/tests/unit-tests/wpml/test-class-course-translation.php
+++ b/tests/unit-tests/wpml/test-class-course-translation.php
@@ -175,6 +175,86 @@ class Course_Translation_Test extends \WP_UnitTestCase {
 		$this->assertSame( $master_lesson_ids, array_map( fn( $id ) => $id_map[ $id ], Sensei()->course->course_lessons( $translated_course_id, 'any', 'ids' ) ) );
 	}
 
+	public function testUpdateLessonPropertiesOnCourseTranslationCreated_LessonRemovedFromTheOriginalCourseGiven_DetachesItsTranslationFromTheTranslatedCourse() {
+		/* Arrange. */
+		$original_course_id   = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		// The original lesson was removed from its course; its translation still points at the translated course.
+		$original_lesson_id   = $this->factory->lesson->create();
+		$translated_lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $translated_course_id ) ) );
+
+		// WPML: the translated course is in Spanish, translated from English.
+		add_filter(
+			'wpml_element_language_details',
+			fn() => array(
+				'language_code'        => 'es',
+				'source_language_code' => 'en',
+			),
+			10,
+			0
+		);
+		// WPML: which post is the counterpart of which.
+		add_filter(
+			'wpml_object_id',
+			fn( $post_id ) => array(
+				$translated_course_id => $original_course_id,
+				$translated_lesson_id => $original_lesson_id,
+			)[ $post_id ] ?? 0,
+			10,
+			1
+		);
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
+
+		/* Clean up & Assert. */
+		remove_all_filters( 'wpml_element_language_details' );
+		remove_all_filters( 'wpml_object_id' );
+
+		$this->assertSame( '', get_post_meta( $translated_lesson_id, '_lesson_course', true ) );
+	}
+
+	public function testUpdateLessonPropertiesOnCourseTranslationCreated_LessonWithoutAnOriginalGiven_LeavesItInTheTranslatedCourse() {
+		/* Arrange. */
+		$original_course_id   = $this->factory->course->create();
+		$translated_course_id = $this->factory->course->create();
+
+		// A lesson that only exists in the translated course.
+		$untranslated_lesson_id = $this->factory->lesson->create( array( 'meta_input' => array( '_lesson_course' => $translated_course_id ) ) );
+
+		// WPML: the translated course is in Spanish, translated from English.
+		add_filter(
+			'wpml_element_language_details',
+			fn() => array(
+				'language_code'        => 'es',
+				'source_language_code' => 'en',
+			),
+			10,
+			0
+		);
+		// WPML: only the course has a counterpart.
+		add_filter(
+			'wpml_object_id',
+			fn( $post_id ) => $post_id === $translated_course_id ? $original_course_id : 0,
+			10,
+			1
+		);
+
+		$course_translation = new Course_Translation();
+
+		/* Act. */
+		$course_translation->update_lesson_properties_on_course_translation_created( $translated_course_id );
+
+		/* Clean up & Assert. */
+		remove_all_filters( 'wpml_element_language_details' );
+		remove_all_filters( 'wpml_object_id' );
+
+		$this->assertSame( (string) $translated_course_id, get_post_meta( $untranslated_lesson_id, '_lesson_course', true ) );
+	}
+
 	public function testTranslateOutlineLessonIdsOnCourseTranslationCreated_OutlineWithSourceLessonIdsGiven_RewritesThemToTheCourseLanguage() {
 		/* Arrange. */
 		$source_lesson_id     = $this->factory->lesson->create();


### PR DESCRIPTION
Closes [SEN-197](https://linear.app/a8c/issue/SEN-197/wpml-a-lesson-removed-from-the-original-course-stays-in-the-translated)

## Proposed Changes

Removing a lesson from a course never reached its translations: the translated copy stayed attached to the translated course and visible to students, even after the translation was updated. Completing a translation only synced the lessons still in the original course.

Now, when a course translation is completed, the lessons of the translated course whose original is no longer in the original course are detached from it, the same way the original lesson was (course, order and module associations). The lesson post is not deleted, and lessons without an original are left alone.

## Testing Instructions

Requires a WPML site with English as the default language and Spanish as a secondary language.

1. Create a course in English with three lessons through the Course Outline block and publish everything.
2. Translate the course into Spanish and complete the translation in the Translation Editor.
3. Edit the English course, remove the second lesson from the outline and click Update.
4. Open the Spanish translation job again and complete it.
5. Check the Spanish copy of the second lesson: its Course field is now empty.
6. Browse the Spanish course as a student: it lists two lessons, like the English one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
