### PR TITLE
Extend dependency update cooldown to 30 days for patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,7 @@ updates:
           - "patch"
     cooldown:
       default-days: 7
+      semver-patch-days: 30
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -90,6 +91,7 @@ updates:
           - "patch"
     cooldown:
       default-days: 7
+      semver-patch-days: 30
 
   - package-ecosystem: "github-actions"
     # Scan composite actions too — their SHA-pinned `uses:` refs need update
@@ -116,3 +118,4 @@ updates:
           - "major"
     cooldown:
       default-days: 7
+      semver-patch-days: 30


### PR DESCRIPTION
## Proposed Changes

Adds a 30-day cooldown for patch-level dependency updates across all three Dependabot ecosystems (npm, Composer, GitHub Actions). Patch bumps now wait 30 days after release before a PR opens, while minor and major updates keep the existing 7-day `default-days` cooldown. This cuts noise from rapid patch releases and lets unstable point releases settle before we pick them up.