### PR TITLE
Resolve HPPS storage configuration once

### DIFF
--- a/changelog/update-hpps-storage-configuration
+++ b/changelog/update-hpps-storage-configuration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Resolve HPPS storage configuration consistently across progress query services and repositories.

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -81,7 +81,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->course_id               = (int) $course_id;
 		$this->user_id                 = (int) $user_id;
 		$this->page_slug               = Sensei_Analysis::PAGE_SLUG;
-		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory() )->create_reports_listing_service();
+		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_reports_listing_service();
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
 			$this->view = sensei_request_text( $_GET['view'] );

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -40,7 +40,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$this->lesson_id               = intval( $lesson_id );
 		$this->course_id               = intval( get_post_meta( $this->lesson_id, '_lesson_course', true ) );
 		$this->page_slug               = Sensei_Analysis::PAGE_SLUG;
-		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory() )->create_reports_listing_service();
+		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_reports_listing_service();
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_lesson' );

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -38,7 +38,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 	public function __construct( $user_id = 0, ?Reports_Listing_Service_Interface $reports_listing_service = null ) {
 		$this->user_id                 = intval( $user_id );
 		$this->page_slug               = Sensei_Analysis::PAGE_SLUG;
-		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory() )->create_reports_listing_service();
+		$this->reports_listing_service = $reports_listing_service ?? ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_reports_listing_service();
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_user_profile' );

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -59,7 +59,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		}
 
 		$this->grading_listing_service = $grading_listing_service
-			?? ( new Progress_Query_Service_Factory() )->create_grading_listing_service();
+			?? ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_grading_listing_service();
 
 		// Load Parent token into constructor
 		parent::__construct( 'grading_main' );

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -89,7 +89,7 @@ class Sensei_Grading {
 	 * @return Progress_Aggregation_Service_Interface
 	 */
 	private static function get_aggregation_service(): Progress_Aggregation_Service_Interface {
-		return ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+		return ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_aggregation_service();
 	}
 
 	/**
@@ -100,7 +100,7 @@ class Sensei_Grading {
 	 * @return Grading_Stats_Service_Interface
 	 */
 	private static function get_grading_stats_service(): Grading_Stats_Service_Interface {
-		return ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		return ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_grading_stats_service();
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -21,7 +21,7 @@ use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Interface;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Interface;
-use Sensei\Internal\Services\Progress_Storage_Settings;
+use Sensei\Internal\Services\Progress_Storage_Configuration;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Factory;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Interface;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Factory;
@@ -125,6 +125,15 @@ class Sensei_Main {
 	 * @var Sensei_Settings
 	 */
 	public $settings;
+
+	/**
+	 * Resolved progress storage configuration.
+	 *
+	 * @since $$next-version$$
+	 * @psalm-suppress PropertyNotSetInConstructor
+	 * @var Progress_Storage_Configuration
+	 */
+	public $progress_storage_configuration;
 
 	/**
 	 * Script and stylesheet loading.
@@ -634,7 +643,13 @@ class Sensei_Main {
 	 */
 	public function initialize_global_objects() {
 		// Setup settings.
-		$this->settings = new Sensei_Settings();
+		$this->settings                       = new Sensei_Settings();
+		$this->progress_storage_configuration = Progress_Storage_Configuration::resolve( $this->settings->settings );
+
+		if ( $this->progress_storage_configuration->is_hpps_enabled() ) {
+			// Enable tables based progress feature flag.
+			add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
+		}
 
 		// Asset loading.
 		$this->assets = new Sensei_Assets( $this->plugin_url, $this->plugin_path, $this->version );
@@ -765,45 +780,20 @@ class Sensei_Main {
 		Sensei_Abilities::init();
 
 		// Student progress repositories.
-		$tables_feature_enabled = isset( $this->settings->settings['experimental_progress_storage'] )
-			&& ( true === $this->settings->settings['experimental_progress_storage'] );
-
-		if ( $tables_feature_enabled ) {
-			// Enable tables based progress feature flag.
-			add_filter( 'sensei_feature_flag_tables_based_progress', '__return_true' );
-		}
-
-		$tables_sync_enabled = $tables_feature_enabled
-			&& ( true === $this->settings->settings['experimental_progress_storage_synchronization'] );
-
-		$read_from_tables_setting = isset( $this->settings->settings['experimental_progress_storage_repository'] )
-			&& ( Progress_Storage_Settings::TABLES_STORAGE === $this->settings->settings['experimental_progress_storage_repository'] );
-
-		/**
-		 * Filter whether to read student progress from tables.
-		 *
-		 * @since 4.17.0
-		 *
-		 * @hook  sensei_student_progress_read_from_tables
-		 *
-		 * @param {bool} $read_from_tables Whether to read student progress from tables.
-		 * @return {bool} Whether to read student progress from tables.
-		 */
-		$read_from_tables                         = apply_filters( 'sensei_student_progress_read_from_tables', $read_from_tables_setting );
-		$this->course_progress_repository_factory = new Course_Progress_Repository_Factory( $tables_sync_enabled, $read_from_tables );
+		$this->course_progress_repository_factory = new Course_Progress_Repository_Factory( $this->progress_storage_configuration );
 		$this->course_progress_repository         = $this->course_progress_repository_factory->create();
-		$this->lesson_progress_repository_factory = new Lesson_Progress_Repository_Factory( $tables_sync_enabled, $read_from_tables );
+		$this->lesson_progress_repository_factory = new Lesson_Progress_Repository_Factory( $this->progress_storage_configuration );
 		$this->lesson_progress_repository         = $this->lesson_progress_repository_factory->create();
-		$this->quiz_progress_repository_factory   = new Quiz_Progress_Repository_Factory( $tables_sync_enabled, $read_from_tables );
+		$this->quiz_progress_repository_factory   = new Quiz_Progress_Repository_Factory( $this->progress_storage_configuration );
 		$this->quiz_progress_repository           = $this->quiz_progress_repository_factory->create();
 
 		// Quiz submission repositories.
-		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
-		$this->quiz_answer_repository     = ( new Answer_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
-		$this->quiz_grade_repository      = ( new Grade_Repository_Factory( $tables_sync_enabled, $read_from_tables ) )->create();
+		$this->quiz_submission_repository = ( new Submission_Repository_Factory( $this->progress_storage_configuration ) )->create();
+		$this->quiz_answer_repository     = ( new Answer_Repository_Factory( $this->progress_storage_configuration ) )->create();
+		$this->quiz_grade_repository      = ( new Grade_Repository_Factory( $this->progress_storage_configuration ) )->create();
 
 		// Progress tables eraser.
-		if ( $tables_feature_enabled ) {
+		if ( $this->progress_storage_configuration->is_hpps_enabled() ) {
 			( new Progress_Tables_Eraser() )->init();
 		}
 
@@ -812,7 +802,7 @@ class Sensei_Main {
 		}
 
 		// Student progress migration.
-		if ( $tables_feature_enabled && $this->action_scheduler ) {
+		if ( $this->progress_storage_configuration->is_hpps_enabled() && $this->action_scheduler ) {
 			$this->init_migration_scheduler();
 		}
 

--- a/includes/internal/quiz-submission/answer/repositories/class-answer-repository-factory.php
+++ b/includes/internal/quiz-submission/answer/repositories/class-answer-repository-factory.php
@@ -9,6 +9,7 @@ namespace Sensei\Internal\Quiz_Submission\Answer\Repositories;
 
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
+use Sensei\Internal\Services\Progress_Storage_Configuration;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -24,18 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Answer_Repository_Factory {
 
 	/**
-	 * Is tables based progress feature flag enabled.
+	 * Resolved progress storage configuration.
 	 *
-	 * @var bool
+	 * @var Progress_Storage_Configuration
 	 */
-	private $tables_enabled;
-
-	/**
-	 * Read from tables.
-	 *
-	 * @var bool
-	 */
-	private $read_tables;
+	private $storage_configuration;
 
 
 	/**
@@ -43,12 +37,10 @@ class Answer_Repository_Factory {
 	 *
 	 * @internal
 	 *
-	 * @param bool $tables_enabled Is tables based progress feature flag enabled.
-	 * @param bool $read_tables    Read from tables.
+	 * @param Progress_Storage_Configuration $storage_configuration Resolved progress storage configuration.
 	 */
-	public function __construct( bool $tables_enabled, bool $read_tables ) {
-		$this->tables_enabled = $tables_enabled;
-		$this->read_tables    = $read_tables;
+	public function __construct( Progress_Storage_Configuration $storage_configuration ) {
+		$this->storage_configuration = $storage_configuration;
 	}
 
 
@@ -62,11 +54,11 @@ class Answer_Repository_Factory {
 	public function create(): Answer_Repository_Interface {
 		global $wpdb;
 
-		if ( ! $this->tables_enabled ) {
+		if ( ! $this->storage_configuration->is_dual_write_enabled() ) {
 			return new Comments_Based_Answer_Repository();
 		}
 
-		if ( ! $this->read_tables ) {
+		if ( ! $this->storage_configuration->is_reading_from_tables() ) {
 			return new Comment_Reading_Aggregate_Answer_Repository(
 				new Comments_Based_Answer_Repository(),
 				new Tables_Based_Answer_Repository( $wpdb ),

--- a/includes/internal/quiz-submission/grade/repositories/class-grade-repository-factory.php
+++ b/includes/internal/quiz-submission/grade/repositories/class-grade-repository-factory.php
@@ -11,6 +11,7 @@ use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Re
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Tables_Based_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Tables_Based_Submission_Repository;
+use Sensei\Internal\Services\Progress_Storage_Configuration;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -26,30 +27,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Grade_Repository_Factory {
 
 	/**
-	 * Is tables based progress feature flag enabled.
+	 * Resolved progress storage configuration.
 	 *
-	 * @var bool
+	 * @var Progress_Storage_Configuration
 	 */
-	private $tables_enabled;
-
-	/**
-	 * Read from tables.
-	 *
-	 * @var bool
-	 */
-	private $read_tables;
+	private $storage_configuration;
 
 	/**
 	 * Grade_Repository_Factory constructor.
 	 *
 	 * @internal
 	 *
-	 * @param bool $tables_enabled Is tables based progress feature flag enabled.
-	 * @param bool $read_tables    Read from tables.
+	 * @param Progress_Storage_Configuration $storage_configuration Resolved progress storage configuration.
 	 */
-	public function __construct( bool $tables_enabled, bool $read_tables ) {
-		$this->tables_enabled = $tables_enabled;
-		$this->read_tables    = $read_tables;
+	public function __construct( Progress_Storage_Configuration $storage_configuration ) {
+		$this->storage_configuration = $storage_configuration;
 	}
 
 	/**
@@ -62,11 +54,11 @@ class Grade_Repository_Factory {
 	public function create(): Grade_Repository_Interface {
 		global $wpdb;
 
-		if ( ! $this->tables_enabled ) {
+		if ( ! $this->storage_configuration->is_dual_write_enabled() ) {
 			return new Comments_Based_Grade_Repository();
 		}
 
-		if ( ! $this->read_tables ) {
+		if ( ! $this->storage_configuration->is_reading_from_tables() ) {
 			return new Comment_Reading_Aggregate_Grade_Repository(
 				new Comments_Based_Grade_Repository(),
 				new Tables_Based_Grade_Repository( $wpdb ),

--- a/includes/internal/quiz-submission/submission/repositories/class-submission-repository-factory.php
+++ b/includes/internal/quiz-submission/submission/repositories/class-submission-repository-factory.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Quiz_Submission\Submission\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -21,28 +23,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Submission_Repository_Factory {
 
 	/**
-	 * Is tables based progress feature flag enabled.
+	 * Resolved progress storage configuration.
 	 *
-	 * @var bool
+	 * @var Progress_Storage_Configuration
 	 */
-	private $tables_enabled;
-
-	/**
-	 * Read from tables.
-	 *
-	 * @var bool
-	 */
-	private $read_tables;
+	private $storage_configuration;
 
 	/**
 	 * Submission_Repository_Factory constructor.
 	 *
-	 * @param bool $tables_enabled Is tables based progress feature flag enabled.
-	 * @param bool $read_tables    Read from tables.
+	 * @param Progress_Storage_Configuration $storage_configuration Resolved progress storage configuration.
 	 */
-	public function __construct( bool $tables_enabled, bool $read_tables ) {
-		$this->tables_enabled = $tables_enabled;
-		$this->read_tables    = $read_tables;
+	public function __construct( Progress_Storage_Configuration $storage_configuration ) {
+		$this->storage_configuration = $storage_configuration;
 	}
 
 	/**
@@ -55,11 +48,11 @@ class Submission_Repository_Factory {
 	public function create(): Submission_Repository_Interface {
 		global $wpdb;
 
-		if ( ! $this->tables_enabled ) {
+		if ( ! $this->storage_configuration->is_dual_write_enabled() ) {
 			return new Comments_Based_Submission_Repository();
 		}
 
-		if ( ! $this->read_tables ) {
+		if ( ! $this->storage_configuration->is_reading_from_tables() ) {
 			return new Comment_Reading_Aggregate_Submission_Repository(
 				new Comments_Based_Submission_Repository(),
 				new Tables_Based_Submission_Repository( $wpdb )

--- a/includes/internal/services/class-progress-query-service-factory.php
+++ b/includes/internal/services/class-progress-query-service-factory.php
@@ -14,14 +14,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class Progress_Query_Service_Factory.
  *
- * Factory that returns the correct progress service implementations (clauses and aggregation)
- * based on the current progress storage settings.
+ * Factory that returns the correct progress query service implementations
+ * based on the resolved progress storage configuration.
  *
  * @internal
  *
  * @since 4.26.0
  */
 class Progress_Query_Service_Factory {
+	/**
+	 * Resolved progress storage configuration.
+	 *
+	 * @var Progress_Storage_Configuration
+	 */
+	private $storage_configuration;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Progress_Storage_Configuration $storage_configuration Resolved progress storage configuration.
+	 */
+	public function __construct( Progress_Storage_Configuration $storage_configuration ) {
+		$this->storage_configuration = $storage_configuration;
+	}
 
 	/**
 	 * Create a Progress_Clauses_Service_Interface instance.
@@ -36,7 +51,7 @@ class Progress_Query_Service_Factory {
 	public function create_clauses_service(): Progress_Clauses_Service_Interface {
 		global $wpdb;
 
-		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+		if ( $this->storage_configuration->is_reading_from_tables() ) {
 			return new Tables_Based_Progress_Clauses_Service( $wpdb );
 		}
 
@@ -53,7 +68,7 @@ class Progress_Query_Service_Factory {
 	public function create_grading_listing_service(): Grading_Listing_Service_Interface {
 		global $wpdb;
 
-		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+		if ( $this->storage_configuration->is_reading_from_tables() ) {
 			return new Tables_Based_Grading_Listing_Service( $wpdb );
 		}
 
@@ -73,7 +88,7 @@ class Progress_Query_Service_Factory {
 	public function create_grading_stats_service(): Grading_Stats_Service_Interface {
 		global $wpdb;
 
-		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+		if ( $this->storage_configuration->is_reading_from_tables() ) {
 			return new Tables_Based_Grading_Stats_Service( $wpdb );
 		}
 
@@ -90,7 +105,7 @@ class Progress_Query_Service_Factory {
 	public function create_reports_listing_service(): Reports_Listing_Service_Interface {
 		global $wpdb;
 
-		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+		if ( $this->storage_configuration->is_reading_from_tables() ) {
 			return new Tables_Based_Reports_Listing_Service( $wpdb );
 		}
 
@@ -110,7 +125,7 @@ class Progress_Query_Service_Factory {
 	public function create_aggregation_service(): Progress_Aggregation_Service_Interface {
 		global $wpdb;
 
-		if ( Progress_Storage_Settings::is_hpps_enabled() && Progress_Storage_Settings::is_tables_repository() ) {
+		if ( $this->storage_configuration->is_reading_from_tables() ) {
 			return new Tables_Based_Progress_Aggregation_Service( $wpdb );
 		}
 

--- a/includes/internal/services/class-progress-storage-configuration.php
+++ b/includes/internal/services/class-progress-storage-configuration.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * File containing the Progress_Storage_Configuration class.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Internal\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Immutable resolved progress storage configuration.
+ *
+ * @internal
+ *
+ * @since $$next-version$$
+ */
+final class Progress_Storage_Configuration {
+	/**
+	 * Comments read backend.
+	 *
+	 * @var string
+	 */
+	public const COMMENTS_BACKEND = 'comments';
+
+	/**
+	 * Tables read backend.
+	 *
+	 * @var string
+	 */
+	public const TABLES_BACKEND = 'tables';
+
+	/**
+	 * Whether the HPPS feature is enabled.
+	 *
+	 * @var bool
+	 */
+	private $hpps_enabled;
+
+	/**
+	 * The authoritative read backend.
+	 *
+	 * @var string
+	 */
+	private $read_backend;
+
+	/**
+	 * Whether writes are synchronized to both backends.
+	 *
+	 * @var bool
+	 */
+	private $dual_write_enabled;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param bool   $hpps_enabled      Whether the HPPS feature is enabled.
+	 * @param string $read_backend      The authoritative read backend.
+	 * @param bool   $dual_write_enabled Whether writes are synchronized to both backends.
+	 */
+	private function __construct( bool $hpps_enabled, string $read_backend, bool $dual_write_enabled ) {
+		$this->hpps_enabled       = $hpps_enabled;
+		$this->read_backend       = $read_backend;
+		$this->dual_write_enabled = $dual_write_enabled;
+	}
+
+	/**
+	 * Resolve a valid configuration from raw settings and compatibility filters.
+	 *
+	 * Tables reads require both HPPS and dual writes. Invalid configurations fall
+	 * back to comments reads and comments-only writes.
+	 *
+	 * @param array $settings Raw Sensei settings.
+	 * @return self
+	 */
+	public static function resolve( array $settings ): self {
+		$hpps_enabled       = true === ( $settings['experimental_progress_storage'] ?? false );
+		$dual_write_enabled = $hpps_enabled && true === ( $settings['experimental_progress_storage_synchronization'] ?? false );
+		$read_from_tables   = Progress_Storage_Settings::TABLES_STORAGE === ( $settings['experimental_progress_storage_repository'] ?? Progress_Storage_Settings::COMMENTS_STORAGE );
+
+		/**
+		 * Filter whether to read student progress from tables.
+		 *
+		 * @since 4.17.0
+		 *
+		 * @hook sensei_student_progress_read_from_tables
+		 *
+		 * @param {bool} $read_from_tables Whether to read student progress from tables.
+		 * @return {bool} Whether to read student progress from tables.
+		 */
+		$read_from_tables = (bool) apply_filters( 'sensei_student_progress_read_from_tables', $read_from_tables );
+		$read_backend     = $hpps_enabled && $dual_write_enabled && $read_from_tables
+			? self::TABLES_BACKEND
+			: self::COMMENTS_BACKEND;
+
+		return new self( $hpps_enabled, $read_backend, $dual_write_enabled );
+	}
+
+	/**
+	 * Returns whether the HPPS feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_hpps_enabled(): bool {
+		return $this->hpps_enabled;
+	}
+
+	/**
+	 * Returns the authoritative read backend.
+	 *
+	 * @return string
+	 */
+	public function get_read_backend(): string {
+		return $this->read_backend;
+	}
+
+	/**
+	 * Returns whether tables are authoritative for reads.
+	 *
+	 * @return bool
+	 */
+	public function is_reading_from_tables(): bool {
+		return self::TABLES_BACKEND === $this->read_backend;
+	}
+
+	/**
+	 * Returns whether writes are synchronized to both backends.
+	 *
+	 * @return bool
+	 */
+	public function is_dual_write_enabled(): bool {
+		return $this->dual_write_enabled;
+	}
+}

--- a/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-factory.php
+++ b/includes/internal/student-progress/course-progress/repositories/class-course-progress-repository-factory.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Student_Progress\Course_Progress\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -21,28 +23,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Course_Progress_Repository_Factory {
 
 	/**
-	 * Is tables based progress feature flag enabled.
+	 * Resolved progress storage configuration.
 	 *
-	 * @var bool
+	 * @var Progress_Storage_Configuration
 	 */
-	private $tables_enabled;
-
-	/**
-	 * Read from tables.
-	 *
-	 * @var bool
-	 */
-	private $read_tables;
+	private $storage_configuration;
 
 	/**
 	 * Course_Progress_Repository_Factory constructor.
 	 *
-	 * @param bool $tables_enabled Is tables based progress feature flag enabled.
-	 * @param bool $read_tables    Read from tables.
+	 * @param Progress_Storage_Configuration $storage_configuration Resolved progress storage configuration.
 	 */
-	public function __construct( bool $tables_enabled, bool $read_tables ) {
-		$this->tables_enabled = $tables_enabled;
-		$this->read_tables    = $read_tables;
+	public function __construct( Progress_Storage_Configuration $storage_configuration ) {
+		$this->storage_configuration = $storage_configuration;
 	}
 
 	/**
@@ -58,11 +51,11 @@ class Course_Progress_Repository_Factory {
 		$comments_based = $this->create_comments_based_repository();
 		$tables_based   = new Tables_Based_Course_Progress_Repository( $wpdb );
 
-		if ( ! $this->tables_enabled ) {
+		if ( ! $this->storage_configuration->is_dual_write_enabled() ) {
 			return $comments_based;
 		}
 
-		if ( ! $this->read_tables ) {
+		if ( ! $this->storage_configuration->is_reading_from_tables() ) {
 			return new Comment_Reading_Aggregate_Course_Progress_Repository( $comments_based, $tables_based );
 		}
 

--- a/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-factory.php
+++ b/includes/internal/student-progress/lesson-progress/repositories/class-lesson-progress-repository-factory.php
@@ -7,6 +7,8 @@
 
 namespace Sensei\Internal\Student_Progress\Lesson_Progress\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -20,28 +22,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Lesson_Progress_Repository_Factory {
 	/**
-	 * Is tables based progress feature flag enabled.
+	 * Resolved progress storage configuration.
 	 *
-	 * @var bool
+	 * @var Progress_Storage_Configuration
 	 */
-	private $tables_enabled;
-
-	/**
-	 * Read from tables flag.
-	 *
-	 * @var bool
-	 */
-	private $read_tables;
+	private $storage_configuration;
 
 	/**
 	 * Lesson_Progress_Repository_Factory constructor.
 	 *
-	 * @param bool $tables_enabled Is tables based progress feature flag enabled.
-	 * @param bool $read_tables Read from tables flag.
+	 * @param Progress_Storage_Configuration $storage_configuration Resolved progress storage configuration.
 	 */
-	public function __construct( bool $tables_enabled, bool $read_tables ) {
-		$this->tables_enabled = $tables_enabled;
-		$this->read_tables    = $read_tables;
+	public function __construct( Progress_Storage_Configuration $storage_configuration ) {
+		$this->storage_configuration = $storage_configuration;
 	}
 
 	/**
@@ -54,11 +47,11 @@ class Lesson_Progress_Repository_Factory {
 	public function create(): Lesson_Progress_Repository_Interface {
 		global $wpdb;
 
-		if ( ! $this->tables_enabled ) {
+		if ( ! $this->storage_configuration->is_dual_write_enabled() ) {
 			return new Comments_Based_Lesson_Progress_Repository();
 		}
 
-		if ( ! $this->read_tables ) {
+		if ( ! $this->storage_configuration->is_reading_from_tables() ) {
 			return new Comment_Reading_Aggregate_Lesson_Progress_Repository(
 				new Comments_Based_Lesson_Progress_Repository(),
 				new Tables_Based_Lesson_Progress_Repository( $wpdb )

--- a/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
+++ b/includes/internal/student-progress/quiz-progress/repositories/class-quiz-progress-repository-factory.php
@@ -7,6 +7,7 @@
 
 namespace Sensei\Internal\Student_Progress\Quiz_Progress\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comments_Based_Lesson_Progress_Repository;
 
 /**
@@ -19,28 +20,19 @@ use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comments_Based
 class Quiz_Progress_Repository_Factory {
 
 	/**
-	 * The flag if the tables based implementation is available for use.
+	 * Resolved progress storage configuration.
 	 *
-	 * @var bool
+	 * @var Progress_Storage_Configuration
 	 */
-	private $tables_enabled;
-
-	/**
-	 * The flag if we read progress from tables.
-	 *
-	 * @var bool
-	 */
-	private $read_tables;
+	private $storage_configuration;
 
 	/**
 	 * Quiz_Progress_Repository_Factory constructor.
 	 *
-	 * @param bool $tables_enabled Is tables based progress enabled.
-	 * @param bool $read_tables Is reading from tables enabled.
+	 * @param Progress_Storage_Configuration $storage_configuration Resolved progress storage configuration.
 	 */
-	public function __construct( bool $tables_enabled, bool $read_tables ) {
-		$this->tables_enabled = $tables_enabled;
-		$this->read_tables    = $read_tables;
+	public function __construct( Progress_Storage_Configuration $storage_configuration ) {
+		$this->storage_configuration = $storage_configuration;
 	}
 
 	/**
@@ -53,11 +45,11 @@ class Quiz_Progress_Repository_Factory {
 	public function create(): Quiz_Progress_Repository_Interface {
 		global $wpdb;
 
-		if ( ! $this->tables_enabled ) {
+		if ( ! $this->storage_configuration->is_dual_write_enabled() ) {
 			return new Comments_Based_Quiz_Progress_Repository();
 		}
 
-		if ( ! $this->read_tables ) {
+		if ( ! $this->storage_configuration->is_reading_from_tables() ) {
 			return new Comment_Reading_Aggregate_Quiz_Progress_Repository(
 				new Comments_Based_Quiz_Progress_Repository(),
 				new Tables_Based_Quiz_Progress_Repository( $wpdb )

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
@@ -56,7 +56,7 @@ class Sensei_Reports_Overview_Data_Provider_Courses implements Sensei_Reports_Ov
 	 */
 	public function __construct( ?Progress_Clauses_Service_Interface $progress_clauses_service = null ) {
 		$this->progress_clauses_service = $progress_clauses_service
-			?? ( new Progress_Query_Service_Factory() )->create_clauses_service();
+			?? ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_clauses_service();
 	}
 
 	/**

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -48,7 +48,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 	public function __construct( Sensei_Course $course, ?Progress_Clauses_Service_Interface $progress_clauses_service = null ) {
 		$this->course                   = $course;
 		$this->progress_clauses_service = $progress_clauses_service
-			?? ( new Progress_Query_Service_Factory() )->create_clauses_service();
+			?? ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_clauses_service();
 	}
 
 	/**

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-factory.php
@@ -28,7 +28,7 @@ class Sensei_Reports_Overview_List_Table_Factory {
 	 * @throws InvalidArgumentException If the report type is not supported.
 	 */
 	public function create( string $type ) {
-		$query_service_factory = new Progress_Query_Service_Factory();
+		$query_service_factory = new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration );
 
 		switch ( $type ) {
 			case 'users':

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -46,7 +46,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 		parent::__construct( 'lessons', $data_provider );
 		$this->course              = $course;
 		$this->aggregation_service = $aggregation_service
-			?? ( new Progress_Query_Service_Factory() )->create_aggregation_service();
+			?? ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_aggregation_service();
 
 		add_filter( 'sensei_analysis_overview_columns', array( $this, 'add_totals_to_report_column_headers' ) );
 	}

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -92,7 +92,7 @@ class Sensei_Reports_Overview_Service_Courses {
 			return 0;
 		}
 
-		return ( new Progress_Query_Service_Factory() )->create_grading_stats_service()->get_courses_average_grade( $course_ids );
+		return ( new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration ) )->create_grading_stats_service()->get_courses_average_grade( $course_ids );
 	}
 
 	/**

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -52,8 +52,9 @@ class Sensei_Reports_Overview_Service_Students {
 	 * @param Grading_Stats_Service_Interface|null        $grading_stats_service Grading stats service.
 	 */
 	public function __construct( ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
-		$this->aggregation_service   = $aggregation_service ?? ( new Progress_Query_Service_Factory() )->create_aggregation_service();
-		$this->grading_stats_service = $grading_stats_service ?? ( new Progress_Query_Service_Factory() )->create_grading_stats_service();
+		$query_service_factory       = new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration );
+		$this->aggregation_service   = $aggregation_service ?? $query_service_factory->create_aggregation_service();
+		$this->grading_stats_service = $grading_stats_service ?? $query_service_factory->create_grading_stats_service();
 	}
 
 	/**

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -52,9 +52,14 @@ class Sensei_Reports_Overview_Service_Students {
 	 * @param Grading_Stats_Service_Interface|null        $grading_stats_service Grading stats service.
 	 */
 	public function __construct( ?Progress_Aggregation_Service_Interface $aggregation_service = null, ?Grading_Stats_Service_Interface $grading_stats_service = null ) {
-		$query_service_factory       = new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration );
-		$this->aggregation_service   = $aggregation_service ?? $query_service_factory->create_aggregation_service();
-		$this->grading_stats_service = $grading_stats_service ?? $query_service_factory->create_grading_stats_service();
+		if ( null === $aggregation_service || null === $grading_stats_service ) {
+			$query_service_factory = new Progress_Query_Service_Factory( Sensei()->progress_storage_configuration );
+			$aggregation_service   = $aggregation_service ?? $query_service_factory->create_aggregation_service();
+			$grading_stats_service = $grading_stats_service ?? $query_service_factory->create_grading_stats_service();
+		}
+
+		$this->aggregation_service   = $aggregation_service;
+		$this->grading_stats_service = $grading_stats_service;
 	}
 
 	/**

--- a/tests/framework/trait-sensei-hpps-helpers.php
+++ b/tests/framework/trait-sensei-hpps-helpers.php
@@ -69,7 +69,15 @@ trait Sensei_HPPS_Helpers {
 	 */
 	private $_quiz_grade_repository;
 
+	/**
+	 * Original raw progress storage repository setting, captured before enable_hpps_tables_repository() switches it.
+	 *
+	 * @var string
+	 */
+	private $_original_progress_storage_repository = Progress_Storage_Settings::COMMENTS_STORAGE;
+
 	private function enable_hpps_tables_repository() {
+		$this->_original_progress_storage_repository = Sensei()->settings->settings['experimental_progress_storage_repository'] ?? Progress_Storage_Settings::COMMENTS_STORAGE;
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::TABLES_STORAGE;
 		$storage_configuration                   = Progress_Storage_Configuration::resolve(
 			array(
@@ -96,7 +104,7 @@ trait Sensei_HPPS_Helpers {
 	}
 
 	private function reset_hpps_repository() {
-		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
+		Sensei()->settings->settings['experimental_progress_storage_repository'] = $this->_original_progress_storage_repository;
 		Sensei()->progress_storage_configuration                                 = Progress_Storage_Configuration::resolve( Sensei()->settings->settings );
 
 		Sensei()->course_progress_repository = $this->_course_progress_repository;

--- a/tests/framework/trait-sensei-hpps-helpers.php
+++ b/tests/framework/trait-sensei-hpps-helpers.php
@@ -71,13 +71,14 @@ trait Sensei_HPPS_Helpers {
 
 	private function enable_hpps_tables_repository() {
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::TABLES_STORAGE;
-		$storage_configuration = Progress_Storage_Configuration::resolve(
+		$storage_configuration                   = Progress_Storage_Configuration::resolve(
 			array(
 				'experimental_progress_storage'            => true,
 				'experimental_progress_storage_repository' => Progress_Storage_Settings::TABLES_STORAGE,
 				'experimental_progress_storage_synchronization' => true,
 			)
 		);
+		Sensei()->progress_storage_configuration = $storage_configuration;
 
 		$this->_course_progress_repository = Sensei()->course_progress_repository;
 		$this->_lesson_progress_repository = Sensei()->lesson_progress_repository;
@@ -96,6 +97,7 @@ trait Sensei_HPPS_Helpers {
 
 	private function reset_hpps_repository() {
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
+		Sensei()->progress_storage_configuration                                 = Progress_Storage_Configuration::resolve( Sensei()->settings->settings );
 
 		Sensei()->course_progress_repository = $this->_course_progress_repository;
 		Sensei()->lesson_progress_repository = $this->_lesson_progress_repository;

--- a/tests/framework/trait-sensei-hpps-helpers.php
+++ b/tests/framework/trait-sensei-hpps-helpers.php
@@ -11,6 +11,7 @@
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory;
+use Sensei\Internal\Services\Progress_Storage_Configuration;
 use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Course_Progress_Repository_Factory;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Factory;
@@ -70,6 +71,13 @@ trait Sensei_HPPS_Helpers {
 
 	private function enable_hpps_tables_repository() {
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::TABLES_STORAGE;
+		$storage_configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => true,
+				'experimental_progress_storage_repository' => Progress_Storage_Settings::TABLES_STORAGE,
+				'experimental_progress_storage_synchronization' => true,
+			)
+		);
 
 		$this->_course_progress_repository = Sensei()->course_progress_repository;
 		$this->_lesson_progress_repository = Sensei()->lesson_progress_repository;
@@ -78,12 +86,12 @@ trait Sensei_HPPS_Helpers {
 		$this->_quiz_answer_repository     = Sensei()->quiz_answer_repository;
 		$this->_quiz_grade_repository      = Sensei()->quiz_grade_repository;
 
-		Sensei()->course_progress_repository = ( new Course_Progress_Repository_Factory( true, true ) )->create();
-		Sensei()->lesson_progress_repository = ( new Lesson_Progress_Repository_Factory( true, true ) )->create();
-		Sensei()->quiz_progress_repository   = ( new Quiz_Progress_Repository_Factory( true, true ) )->create();
-		Sensei()->quiz_submission_repository = ( new Submission_Repository_Factory( true, true ) )->create();
-		Sensei()->quiz_answer_repository     = ( new Answer_Repository_Factory( true, true ) )->create();
-		Sensei()->quiz_grade_repository      = ( new Grade_Repository_Factory( true, true ) )->create();
+		Sensei()->course_progress_repository = ( new Course_Progress_Repository_Factory( $storage_configuration ) )->create();
+		Sensei()->lesson_progress_repository = ( new Lesson_Progress_Repository_Factory( $storage_configuration ) )->create();
+		Sensei()->quiz_progress_repository   = ( new Quiz_Progress_Repository_Factory( $storage_configuration ) )->create();
+		Sensei()->quiz_submission_repository = ( new Submission_Repository_Factory( $storage_configuration ) )->create();
+		Sensei()->quiz_answer_repository     = ( new Answer_Repository_Factory( $storage_configuration ) )->create();
+		Sensei()->quiz_grade_repository      = ( new Grade_Repository_Factory( $storage_configuration ) )->create();
 	}
 
 	private function reset_hpps_repository() {

--- a/tests/framework/trait-sensei-hpps-helpers.php
+++ b/tests/framework/trait-sensei-hpps-helpers.php
@@ -69,15 +69,7 @@ trait Sensei_HPPS_Helpers {
 	 */
 	private $_quiz_grade_repository;
 
-	/**
-	 * Original raw progress storage repository setting, captured before enable_hpps_tables_repository() switches it.
-	 *
-	 * @var string
-	 */
-	private $_original_progress_storage_repository = Progress_Storage_Settings::COMMENTS_STORAGE;
-
 	private function enable_hpps_tables_repository() {
-		$this->_original_progress_storage_repository = Sensei()->settings->settings['experimental_progress_storage_repository'] ?? Progress_Storage_Settings::COMMENTS_STORAGE;
 		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::TABLES_STORAGE;
 		$storage_configuration                   = Progress_Storage_Configuration::resolve(
 			array(
@@ -104,7 +96,7 @@ trait Sensei_HPPS_Helpers {
 	}
 
 	private function reset_hpps_repository() {
-		Sensei()->settings->settings['experimental_progress_storage_repository'] = $this->_original_progress_storage_repository;
+		Sensei()->settings->settings['experimental_progress_storage_repository'] = Progress_Storage_Settings::COMMENTS_STORAGE;
 		Sensei()->progress_storage_configuration                                 = Progress_Storage_Configuration::resolve( Sensei()->settings->settings );
 
 		Sensei()->course_progress_repository = $this->_course_progress_repository;

--- a/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-answer-repository-factory.php
+++ b/tests/unit-tests/internal/quiz-submission/answer/repositories/test-class-answer-repository-factory.php
@@ -2,6 +2,8 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Answer\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comment_Reading_Aggregate_Answer_Repository;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Answer_Repository_Factory;
 use Sensei\Internal\Quiz_Submission\Answer\Repositories\Comments_Based_Answer_Repository;
@@ -19,9 +21,16 @@ class Answer_Repository_Factory_Test extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider providerCreate_WhenCalled_ReturnsAnswerRepository
 	 */
-	public function testCreate_WhenCalled_ReturnsAnswerRepository( bool $tables_enabled, bool $read_tables, string $expected ): void {
+	public function testCreate_WhenCalled_ReturnsAnswerRepository( bool $hpps_enabled, string $read_backend, bool $dual_write_enabled, string $expected ): void {
 		/* Arrange. */
-		$factory = new Answer_Repository_Factory( $tables_enabled, $read_tables );
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => $hpps_enabled,
+				'experimental_progress_storage_repository' => $read_backend,
+				'experimental_progress_storage_synchronization' => $dual_write_enabled,
+			)
+		);
+		$factory       = new Answer_Repository_Factory( $configuration );
 
 		/* Act. */
 		$actual = $factory->create();
@@ -32,10 +41,10 @@ class Answer_Repository_Factory_Test extends \WP_UnitTestCase {
 
 	public function providerCreate_WhenCalled_ReturnsAnswerRepository(): array {
 		return array(
-			'tables disabled, don\'t read tables' => array( false, false, Comments_Based_Answer_Repository::class ),
-			'tables disabled, read tables'        => array( false, true, Comments_Based_Answer_Repository::class ),
-			'tables enabled, don\'t read tables'  => array( true, false, Comment_Reading_Aggregate_Answer_Repository::class ),
-			'tables enabled, read tables'         => array( true, true, Table_Reading_Aggregate_Answer_Repository::class ),
+			'hpps disabled, tables selected, synchronization enabled' => array( false, Progress_Storage_Settings::TABLES_STORAGE, true, Comments_Based_Answer_Repository::class ),
+			'hpps enabled, tables selected, synchronization disabled' => array( true, Progress_Storage_Settings::TABLES_STORAGE, false, Comments_Based_Answer_Repository::class ),
+			'hpps enabled, comments reads, dual writes enabled'       => array( true, Progress_Storage_Settings::COMMENTS_STORAGE, true, Comment_Reading_Aggregate_Answer_Repository::class ),
+			'hpps enabled, tables reads, dual writes enabled'         => array( true, Progress_Storage_Settings::TABLES_STORAGE, true, Table_Reading_Aggregate_Answer_Repository::class ),
 		);
 	}
 }

--- a/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-grade-repository-factory.php
+++ b/tests/unit-tests/internal/quiz-submission/grade/repositories/test-class-grade-repository-factory.php
@@ -2,6 +2,8 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Grade\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comment_Reading_Aggregate_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Comments_Based_Grade_Repository;
 use Sensei\Internal\Quiz_Submission\Grade\Repositories\Grade_Repository_Factory;
@@ -19,9 +21,16 @@ class Grade_Repository_Factory_Test extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider providerCreate_WhenCalled_ReturnsGradeRepository
 	 */
-	public function testCreate_WhenCalled_ReturnsGradeRepository( bool $tables_enabled, bool $read_tables, string $expected ): void {
+	public function testCreate_WhenCalled_ReturnsGradeRepository( bool $hpps_enabled, string $read_backend, bool $dual_write_enabled, string $expected ): void {
 		/* Arrange. */
-		$factory = new Grade_Repository_Factory( $tables_enabled, $read_tables );
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => $hpps_enabled,
+				'experimental_progress_storage_repository' => $read_backend,
+				'experimental_progress_storage_synchronization' => $dual_write_enabled,
+			)
+		);
+		$factory       = new Grade_Repository_Factory( $configuration );
 
 		/* Act. */
 		$actual = $factory->create();
@@ -32,10 +41,10 @@ class Grade_Repository_Factory_Test extends \WP_UnitTestCase {
 
 	public function providerCreate_WhenCalled_ReturnsGradeRepository(): array {
 		return array(
-			'tables disabled, don\'t read tables' => array( false, false, Comments_Based_Grade_Repository::class ),
-			'tables disabled, read tables'        => array( false, true, Comments_Based_Grade_Repository::class ),
-			'tables enabled, don\'t read tables'  => array( true, false, Comment_Reading_Aggregate_Grade_Repository::class ),
-			'tables enabled, read tables'         => array( true, true, Table_Reading_Aggregate_Grade_Repository::class ),
+			'hpps disabled, tables selected, synchronization enabled' => array( false, Progress_Storage_Settings::TABLES_STORAGE, true, Comments_Based_Grade_Repository::class ),
+			'hpps enabled, tables selected, synchronization disabled' => array( true, Progress_Storage_Settings::TABLES_STORAGE, false, Comments_Based_Grade_Repository::class ),
+			'hpps enabled, comments reads, dual writes enabled'       => array( true, Progress_Storage_Settings::COMMENTS_STORAGE, true, Comment_Reading_Aggregate_Grade_Repository::class ),
+			'hpps enabled, tables reads, dual writes enabled'         => array( true, Progress_Storage_Settings::TABLES_STORAGE, true, Table_Reading_Aggregate_Grade_Repository::class ),
 		);
 	}
 }

--- a/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-submission-repository-factory.php
+++ b/tests/unit-tests/internal/quiz-submission/submission/repositories/test-class-submission-repository-factory.php
@@ -2,6 +2,8 @@
 
 namespace SenseiTest\Internal\Quiz_Submission\Submission\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comment_Reading_Aggregate_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Comments_Based_Submission_Repository;
 use Sensei\Internal\Quiz_Submission\Submission\Repositories\Submission_Repository_Factory;
@@ -19,9 +21,16 @@ class Submission_Repository_Factory_Test extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider providerCreate_WhenCalled_ReturnsSubmissionRepository
 	 */
-	public function testCreate_WhenCalled_ReturnsSubmissionRepository( bool $tables_enabled, bool $read_tables, string $expected ): void {
+	public function testCreate_WhenCalled_ReturnsSubmissionRepository( bool $hpps_enabled, string $read_backend, bool $dual_write_enabled, string $expected ): void {
 		/* Arrange. */
-		$factory = new Submission_Repository_Factory( $tables_enabled, $read_tables );
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => $hpps_enabled,
+				'experimental_progress_storage_repository' => $read_backend,
+				'experimental_progress_storage_synchronization' => $dual_write_enabled,
+			)
+		);
+		$factory       = new Submission_Repository_Factory( $configuration );
 
 		/* Act. */
 		$actual = $factory->create();
@@ -31,11 +40,11 @@ class Submission_Repository_Factory_Test extends \WP_UnitTestCase {
 	}
 
 	public function providerCreate_WhenCalled_ReturnsSubmissionRepository(): array {
-		return [
-			'tables disabled, don\'t read tables' => [ false, false, Comments_Based_Submission_Repository::class ],
-			'tables disabled, read tables'        => [ false, true, Comments_Based_Submission_Repository::class ],
-			'tables enabled, don\'t read tables'  => [ true, false, Comment_Reading_Aggregate_Submission_Repository::class ],
-			'tables enabled, read tables'         => [ true, true, Table_Reading_Aggregate_Submission_Repository::class ],
-		];
+		return array(
+			'hpps disabled, tables selected, synchronization enabled' => array( false, Progress_Storage_Settings::TABLES_STORAGE, true, Comments_Based_Submission_Repository::class ),
+			'hpps enabled, tables selected, synchronization disabled' => array( true, Progress_Storage_Settings::TABLES_STORAGE, false, Comments_Based_Submission_Repository::class ),
+			'hpps enabled, comments reads, dual writes enabled'       => array( true, Progress_Storage_Settings::COMMENTS_STORAGE, true, Comment_Reading_Aggregate_Submission_Repository::class ),
+			'hpps enabled, tables reads, dual writes enabled'         => array( true, Progress_Storage_Settings::TABLES_STORAGE, true, Table_Reading_Aggregate_Submission_Repository::class ),
+		);
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-progress-query-service-factory.php
+++ b/tests/unit-tests/internal/services/test-class-progress-query-service-factory.php
@@ -3,12 +3,18 @@
 namespace SenseiTest\Internal\Services;
 
 use Sensei\Internal\Services\Comments_Based_Grading_Listing_Service;
+use Sensei\Internal\Services\Comments_Based_Grading_Stats_Service;
 use Sensei\Internal\Services\Comments_Based_Progress_Aggregation_Service;
 use Sensei\Internal\Services\Comments_Based_Progress_Clauses_Service;
+use Sensei\Internal\Services\Comments_Based_Reports_Listing_Service;
 use Sensei\Internal\Services\Progress_Query_Service_Factory;
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Services\Tables_Based_Grading_Listing_Service;
+use Sensei\Internal\Services\Tables_Based_Grading_Stats_Service;
 use Sensei\Internal\Services\Tables_Based_Progress_Aggregation_Service;
 use Sensei\Internal\Services\Tables_Based_Progress_Clauses_Service;
+use Sensei\Internal\Services\Tables_Based_Reports_Listing_Service;
 
 /**
  * Class Progress_Query_Service_Factory_Test.
@@ -19,9 +25,7 @@ class Progress_Query_Service_Factory_Test extends \WP_UnitTestCase {
 
 	public function testCreateClausesService_WhenHppsDisabled_ReturnsCommentsBased(): void {
 		/* Arrange. */
-		\Sensei()->settings->settings['experimental_progress_storage']            = false;
-		\Sensei()->settings->settings['experimental_progress_storage_repository'] = 'comments';
-		$factory = new Progress_Query_Service_Factory();
+		$factory = $this->create_factory( false, Progress_Storage_Settings::COMMENTS_STORAGE, false );
 
 		/* Act. */
 		$service = $factory->create_clauses_service();
@@ -32,9 +36,7 @@ class Progress_Query_Service_Factory_Test extends \WP_UnitTestCase {
 
 	public function testCreateClausesService_WhenHppsEnabled_ReturnsTablesBased(): void {
 		/* Arrange. */
-		\Sensei()->settings->settings['experimental_progress_storage']            = true;
-		\Sensei()->settings->settings['experimental_progress_storage_repository'] = 'custom_tables';
-		$factory = new Progress_Query_Service_Factory();
+		$factory = $this->create_factory( true, Progress_Storage_Settings::TABLES_STORAGE, true );
 
 		/* Act. */
 		$service = $factory->create_clauses_service();
@@ -45,9 +47,7 @@ class Progress_Query_Service_Factory_Test extends \WP_UnitTestCase {
 
 	public function testCreateAggregationService_WhenHppsDisabled_ReturnsCommentsBased(): void {
 		/* Arrange. */
-		\Sensei()->settings->settings['experimental_progress_storage']            = false;
-		\Sensei()->settings->settings['experimental_progress_storage_repository'] = 'comments';
-		$factory = new Progress_Query_Service_Factory();
+		$factory = $this->create_factory( false, Progress_Storage_Settings::COMMENTS_STORAGE, false );
 
 		/* Act. */
 		$service = $factory->create_aggregation_service();
@@ -58,9 +58,7 @@ class Progress_Query_Service_Factory_Test extends \WP_UnitTestCase {
 
 	public function testCreateAggregationService_WhenHppsEnabled_ReturnsTablesBased(): void {
 		/* Arrange. */
-		\Sensei()->settings->settings['experimental_progress_storage']            = true;
-		\Sensei()->settings->settings['experimental_progress_storage_repository'] = 'custom_tables';
-		$factory = new Progress_Query_Service_Factory();
+		$factory = $this->create_factory( true, Progress_Storage_Settings::TABLES_STORAGE, true );
 
 		/* Act. */
 		$service = $factory->create_aggregation_service();
@@ -71,9 +69,7 @@ class Progress_Query_Service_Factory_Test extends \WP_UnitTestCase {
 
 	public function testCreateGradingListingService_WhenHppsDisabled_ReturnsCommentsBased(): void {
 		/* Arrange. */
-		\Sensei()->settings->settings['experimental_progress_storage']            = false;
-		\Sensei()->settings->settings['experimental_progress_storage_repository'] = 'comments';
-		$factory = new Progress_Query_Service_Factory();
+		$factory = $this->create_factory( false, Progress_Storage_Settings::COMMENTS_STORAGE, false );
 
 		/* Act. */
 		$service = $factory->create_grading_listing_service();
@@ -84,14 +80,76 @@ class Progress_Query_Service_Factory_Test extends \WP_UnitTestCase {
 
 	public function testCreateGradingListingService_WhenHppsEnabled_ReturnsTablesBased(): void {
 		/* Arrange. */
-		\Sensei()->settings->settings['experimental_progress_storage']            = true;
-		\Sensei()->settings->settings['experimental_progress_storage_repository'] = 'custom_tables';
-		$factory = new Progress_Query_Service_Factory();
+		$factory = $this->create_factory( true, Progress_Storage_Settings::TABLES_STORAGE, true );
 
 		/* Act. */
 		$service = $factory->create_grading_listing_service();
 
 		/* Assert. */
 		$this->assertInstanceOf( Tables_Based_Grading_Listing_Service::class, $service );
+	}
+
+	public function testCreateGradingStatsService_WhenCommentsAreAuthoritative_ReturnsCommentsBased(): void {
+		/* Arrange. */
+		$factory = $this->create_factory( true, Progress_Storage_Settings::COMMENTS_STORAGE, true );
+
+		/* Act. */
+		$service = $factory->create_grading_stats_service();
+
+		/* Assert. */
+		$this->assertInstanceOf( Comments_Based_Grading_Stats_Service::class, $service );
+	}
+
+	public function testCreateGradingStatsService_WhenTablesAreAuthoritative_ReturnsTablesBased(): void {
+		/* Arrange. */
+		$factory = $this->create_factory( true, Progress_Storage_Settings::TABLES_STORAGE, true );
+
+		/* Act. */
+		$service = $factory->create_grading_stats_service();
+
+		/* Assert. */
+		$this->assertInstanceOf( Tables_Based_Grading_Stats_Service::class, $service );
+	}
+
+	public function testCreateReportsListingService_WhenCommentsAreAuthoritative_ReturnsCommentsBased(): void {
+		/* Arrange. */
+		$factory = $this->create_factory( true, Progress_Storage_Settings::COMMENTS_STORAGE, true );
+
+		/* Act. */
+		$service = $factory->create_reports_listing_service();
+
+		/* Assert. */
+		$this->assertInstanceOf( Comments_Based_Reports_Listing_Service::class, $service );
+	}
+
+	public function testCreateReportsListingService_WhenTablesAreAuthoritative_ReturnsTablesBased(): void {
+		/* Arrange. */
+		$factory = $this->create_factory( true, Progress_Storage_Settings::TABLES_STORAGE, true );
+
+		/* Act. */
+		$service = $factory->create_reports_listing_service();
+
+		/* Assert. */
+		$this->assertInstanceOf( Tables_Based_Reports_Listing_Service::class, $service );
+	}
+
+	/**
+	 * Creates a query service factory for the requested raw settings.
+	 *
+	 * @param bool   $hpps_enabled            Whether HPPS is enabled.
+	 * @param string $selected_repository     The selected repository setting.
+	 * @param bool   $synchronization_enabled Whether synchronization is enabled.
+	 * @return Progress_Query_Service_Factory
+	 */
+	private function create_factory( bool $hpps_enabled, string $selected_repository, bool $synchronization_enabled ): Progress_Query_Service_Factory {
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => $hpps_enabled,
+				'experimental_progress_storage_repository' => $selected_repository,
+				'experimental_progress_storage_synchronization' => $synchronization_enabled,
+			)
+		);
+
+		return new Progress_Query_Service_Factory( $configuration );
 	}
 }

--- a/tests/unit-tests/internal/services/test-class-progress-storage-configuration.php
+++ b/tests/unit-tests/internal/services/test-class-progress-storage-configuration.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace SenseiTest\Internal\Services;
+
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
+
+/**
+ * Tests for the Progress_Storage_Configuration class.
+ *
+ * @covers \Sensei\Internal\Services\Progress_Storage_Configuration
+ */
+class Progress_Storage_Configuration_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Tests that all storage setting combinations resolve safely.
+	 *
+	 * @dataProvider providerResolve_SettingsGiven_ReturnsExpectedConfiguration
+	 */
+	public function testResolve_SettingsGiven_ReturnsExpectedConfiguration(
+		bool $hpps_enabled,
+		string $selected_repository,
+		bool $synchronization_enabled,
+		string $expected_read_backend,
+		bool $expected_dual_write_enabled
+	): void {
+		/* Arrange. */
+		$settings = array(
+			'experimental_progress_storage'            => $hpps_enabled,
+			'experimental_progress_storage_repository' => $selected_repository,
+			'experimental_progress_storage_synchronization' => $synchronization_enabled,
+		);
+
+		/* Act. */
+		$configuration = Progress_Storage_Configuration::resolve( $settings );
+
+		/* Assert. */
+		self::assertSame(
+			array( $hpps_enabled, $expected_read_backend, $expected_dual_write_enabled ),
+			array( $configuration->is_hpps_enabled(), $configuration->get_read_backend(), $configuration->is_dual_write_enabled() )
+		);
+	}
+
+	public function providerResolve_SettingsGiven_ReturnsExpectedConfiguration(): array {
+		return array(
+			'hpps disabled, comments selected, synchronization disabled' => array( false, Progress_Storage_Settings::COMMENTS_STORAGE, false, Progress_Storage_Configuration::COMMENTS_BACKEND, false ),
+			'hpps disabled, comments selected, synchronization enabled'  => array( false, Progress_Storage_Settings::COMMENTS_STORAGE, true, Progress_Storage_Configuration::COMMENTS_BACKEND, false ),
+			'hpps disabled, tables selected, synchronization disabled'   => array( false, Progress_Storage_Settings::TABLES_STORAGE, false, Progress_Storage_Configuration::COMMENTS_BACKEND, false ),
+			'hpps disabled, tables selected, synchronization enabled'    => array( false, Progress_Storage_Settings::TABLES_STORAGE, true, Progress_Storage_Configuration::COMMENTS_BACKEND, false ),
+			'hpps enabled, comments selected, synchronization disabled'  => array( true, Progress_Storage_Settings::COMMENTS_STORAGE, false, Progress_Storage_Configuration::COMMENTS_BACKEND, false ),
+			'hpps enabled, comments selected, synchronization enabled'   => array( true, Progress_Storage_Settings::COMMENTS_STORAGE, true, Progress_Storage_Configuration::COMMENTS_BACKEND, true ),
+			'hpps enabled, tables selected, synchronization disabled'    => array( true, Progress_Storage_Settings::TABLES_STORAGE, false, Progress_Storage_Configuration::COMMENTS_BACKEND, false ),
+			'hpps enabled, tables selected, synchronization enabled'     => array( true, Progress_Storage_Settings::TABLES_STORAGE, true, Progress_Storage_Configuration::TABLES_BACKEND, true ),
+		);
+	}
+
+	public function testResolve_SettingsMissing_ReturnsSafeDefaults(): void {
+		/* Act. */
+		$configuration = Progress_Storage_Configuration::resolve( array() );
+
+		/* Assert. */
+		self::assertSame(
+			array( false, Progress_Storage_Configuration::COMMENTS_BACKEND, false ),
+			array( $configuration->is_hpps_enabled(), $configuration->get_read_backend(), $configuration->is_dual_write_enabled() )
+		);
+	}
+
+	public function testResolve_UnknownRepositoryGiven_ReturnsCommentsBackend(): void {
+		/* Arrange. */
+		$settings = array(
+			'experimental_progress_storage'            => true,
+			'experimental_progress_storage_repository' => 'unknown',
+			'experimental_progress_storage_synchronization' => true,
+		);
+
+		/* Act. */
+		$configuration = Progress_Storage_Configuration::resolve( $settings );
+
+		/* Assert. */
+		self::assertSame( Progress_Storage_Configuration::COMMENTS_BACKEND, $configuration->get_read_backend() );
+	}
+
+	public function testResolve_FilterDisablesTablesReads_ReturnsCommentsBackend(): void {
+		/* Arrange. */
+		$settings = array(
+			'experimental_progress_storage'            => true,
+			'experimental_progress_storage_repository' => Progress_Storage_Settings::TABLES_STORAGE,
+			'experimental_progress_storage_synchronization' => true,
+		);
+		add_filter( 'sensei_student_progress_read_from_tables', '__return_false' );
+
+		/* Act. */
+		$configuration = Progress_Storage_Configuration::resolve( $settings );
+
+		/* Assert. */
+		self::assertSame( Progress_Storage_Configuration::COMMENTS_BACKEND, $configuration->get_read_backend() );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_student_progress_read_from_tables', '__return_false' );
+	}
+
+	public function testResolve_FilterEnablesTablesReadsWithSynchronization_ReturnsTablesBackend(): void {
+		/* Arrange. */
+		$settings = array(
+			'experimental_progress_storage'            => true,
+			'experimental_progress_storage_repository' => Progress_Storage_Settings::COMMENTS_STORAGE,
+			'experimental_progress_storage_synchronization' => true,
+		);
+		add_filter( 'sensei_student_progress_read_from_tables', '__return_true' );
+
+		/* Act. */
+		$configuration = Progress_Storage_Configuration::resolve( $settings );
+
+		/* Assert. */
+		self::assertSame( Progress_Storage_Configuration::TABLES_BACKEND, $configuration->get_read_backend() );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_student_progress_read_from_tables', '__return_true' );
+	}
+
+	public function testResolve_FilterEnablesTablesReadsWithoutSynchronization_ReturnsCommentsBackend(): void {
+		/* Arrange. */
+		$settings = array(
+			'experimental_progress_storage'            => true,
+			'experimental_progress_storage_repository' => Progress_Storage_Settings::COMMENTS_STORAGE,
+			'experimental_progress_storage_synchronization' => false,
+		);
+		add_filter( 'sensei_student_progress_read_from_tables', '__return_true' );
+
+		/* Act. */
+		$configuration = Progress_Storage_Configuration::resolve( $settings );
+
+		/* Assert. */
+		self::assertSame( Progress_Storage_Configuration::COMMENTS_BACKEND, $configuration->get_read_backend() );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_student_progress_read_from_tables', '__return_true' );
+	}
+
+	public function testResolve_FilterEnablesTablesReadsWithHppsDisabled_ReturnsCommentsBackend(): void {
+		/* Arrange. */
+		$settings = array(
+			'experimental_progress_storage'            => false,
+			'experimental_progress_storage_repository' => Progress_Storage_Settings::COMMENTS_STORAGE,
+			'experimental_progress_storage_synchronization' => true,
+		);
+		add_filter( 'sensei_student_progress_read_from_tables', '__return_true' );
+
+		/* Act. */
+		$configuration = Progress_Storage_Configuration::resolve( $settings );
+
+		/* Assert. */
+		self::assertSame( Progress_Storage_Configuration::COMMENTS_BACKEND, $configuration->get_read_backend() );
+
+		/* Cleanup. */
+		remove_filter( 'sensei_student_progress_read_from_tables', '__return_true' );
+	}
+}

--- a/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-course-progress-repository-factory.php
+++ b/tests/unit-tests/internal/student-progress/course-progress/repositories/test-class-course-progress-repository-factory.php
@@ -2,6 +2,8 @@
 
 namespace SenseiTest\Internal\Student_Progress\Course_Progress\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Aggregate_Course_Progress_Repository;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Comment_Reading_Aggregate_Course_Progress_Repository;
 use Sensei\Internal\Student_Progress\Course_Progress\Repositories\Comments_Based_Course_Progress_Repository;
@@ -19,9 +21,16 @@ class Course_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider providerCreate_WhenCalled_ReturnsCourseProgressRepository
 	 */
-	public function testCreate_WhenCalled_ReturnsCourseProgressRepository( bool $tables_enabled, bool $read_tables, string $expected ): void {
+	public function testCreate_WhenCalled_ReturnsCourseProgressRepository( bool $hpps_enabled, string $read_backend, bool $dual_write_enabled, string $expected ): void {
 		/* Arrange. */
-		$factory = new Course_Progress_Repository_Factory( $tables_enabled, $read_tables );
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => $hpps_enabled,
+				'experimental_progress_storage_repository' => $read_backend,
+				'experimental_progress_storage_synchronization' => $dual_write_enabled,
+			)
+		);
+		$factory       = new Course_Progress_Repository_Factory( $configuration );
 
 		/* Act. */
 		$actual = $factory->create();
@@ -32,24 +41,28 @@ class Course_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 
 	public function providerCreate_WhenCalled_ReturnsCourseProgressRepository(): array {
 		return array(
-			'tables enabled, reading disabled'  => array(
+			'hpps enabled, comments reads, dual writes enabled' => array(
 				true,
-				false,
+				Progress_Storage_Settings::COMMENTS_STORAGE,
+				true,
 				Comment_Reading_Aggregate_Course_Progress_Repository::class,
 			),
-			'tables enabled, reading enabled'   => array(
+			'hpps enabled, tables reads, dual writes enabled'   => array(
 				true,
+				Progress_Storage_Settings::TABLES_STORAGE,
 				true,
 				Table_Reading_Aggregate_Course_Progress_Repository::class,
 			),
-			'tables disabled, reading disabled' => array(
+			'hpps disabled, tables selected, synchronization enabled' => array(
 				false,
-				false,
+				Progress_Storage_Settings::TABLES_STORAGE,
+				true,
 				Comments_Based_Course_Progress_Repository::class,
 			),
-			'tables disabled, reading enabled'  => array(
-				false,
+			'hpps enabled, tables selected, synchronization disabled' => array(
 				true,
+				Progress_Storage_Settings::TABLES_STORAGE,
+				false,
 				Comments_Based_Course_Progress_Repository::class,
 			),
 		);

--- a/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-lesson-progress-repository-factory.php
+++ b/tests/unit-tests/internal/student-progress/lesson-progress/repositories/test-class-lesson-progress-repository-factory.php
@@ -2,6 +2,8 @@
 
 namespace SenseiTest\Internal\Student_Progress\Lesson_Progress\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comment_Reading_Aggregate_Lesson_Progress_Repository;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Comments_Based_Lesson_Progress_Repository;
 use Sensei\Internal\Student_Progress\Lesson_Progress\Repositories\Lesson_Progress_Repository_Factory;
@@ -18,9 +20,16 @@ class Lesson_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider providerCreate_WhenCalled_ReturnsLessonProgressRepository
 	 */
-	public function testCreate_WhenCalled_ReturnsLessonProgressRepository( bool $tables_enabled, bool $read_tables, string $expected ): void {
+	public function testCreate_WhenCalled_ReturnsLessonProgressRepository( bool $hpps_enabled, string $read_backend, bool $dual_write_enabled, string $expected ): void {
 		/* Arrange. */
-		$factory = new Lesson_Progress_Repository_Factory( $tables_enabled, $read_tables );
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => $hpps_enabled,
+				'experimental_progress_storage_repository' => $read_backend,
+				'experimental_progress_storage_synchronization' => $dual_write_enabled,
+			)
+		);
+		$factory       = new Lesson_Progress_Repository_Factory( $configuration );
 
 		/* Act. */
 		$actual_repository = $factory->create();
@@ -30,27 +39,31 @@ class Lesson_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 	}
 
 	public function providerCreate_WhenCalled_ReturnsLessonProgressRepository(): array {
-		return [
-			'tables feature enabled, read enabled'   => array(
+		return array(
+			'hpps enabled, tables reads, dual writes enabled' => array(
 				true,
+				Progress_Storage_Settings::TABLES_STORAGE,
 				true,
 				Table_Reading_Aggregate_Lesson_Progress_Repository::class,
 			),
-			'tables feature enabled, read disabled'  => array(
+			'hpps enabled, comments reads, dual writes enabled' => array(
 				true,
-				false,
+				Progress_Storage_Settings::COMMENTS_STORAGE,
+				true,
 				Comment_Reading_Aggregate_Lesson_Progress_Repository::class,
 			),
-			'tables feature disabled, read enabled'  => array(
+			'hpps disabled, tables selected, synchronization enabled' => array(
 				false,
+				Progress_Storage_Settings::TABLES_STORAGE,
 				true,
 				Comments_Based_Lesson_Progress_Repository::class,
 			),
-			'tables feature disabled, read disabled' => array(
-				false,
+			'hpps enabled, tables selected, synchronization disabled' => array(
+				true,
+				Progress_Storage_Settings::TABLES_STORAGE,
 				false,
 				Comments_Based_Lesson_Progress_Repository::class,
 			),
-		];
+		);
 	}
 }

--- a/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-quiz-progress-repository-factory.php
+++ b/tests/unit-tests/internal/student-progress/quiz-progress/repositories/test-class-quiz-progress-repository-factory.php
@@ -2,6 +2,8 @@
 
 namespace SenseiTest\Internal\Student_Progress\Repositories;
 
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Comment_Reading_Aggregate_Quiz_Progress_Repository;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Comments_Based_Quiz_Progress_Repository;
 use Sensei\Internal\Student_Progress\Quiz_Progress\Repositories\Quiz_Progress_Repository_Factory;
@@ -20,9 +22,16 @@ class Quiz_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider providerCreate_WhenCalled_ReturnsQuizProgressRepository
 	 */
-	public function testCreate_WhenCalled_ReturnsQuizProgressRepository( bool $tables_enabled, bool $read_tables, string $expected ): void {
+	public function testCreate_WhenCalled_ReturnsQuizProgressRepository( bool $hpps_enabled, string $read_backend, bool $dual_write_enabled, string $expected ): void {
 		/* Arrange. */
-		$factory = new Quiz_Progress_Repository_Factory( $tables_enabled, $read_tables );
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => $hpps_enabled,
+				'experimental_progress_storage_repository' => $read_backend,
+				'experimental_progress_storage_synchronization' => $dual_write_enabled,
+			)
+		);
+		$factory       = new Quiz_Progress_Repository_Factory( $configuration );
 
 		/* Act. */
 		$actual_repository = $factory->create();
@@ -33,24 +42,28 @@ class Quiz_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 
 	public function providerCreate_WhenCalled_ReturnsQuizProgressRepository(): array {
 		return array(
-			'tables enabled, readig disabled'   => array(
+			'hpps enabled, comments reads, dual writes enabled' => array(
 				true,
-				false,
+				Progress_Storage_Settings::COMMENTS_STORAGE,
+				true,
 				Comment_Reading_Aggregate_Quiz_Progress_Repository::class,
 			),
-			'tables enabled, reading enabled'   => array(
+			'hpps enabled, tables reads, dual writes enabled' => array(
 				true,
+				Progress_Storage_Settings::TABLES_STORAGE,
 				true,
 				Table_Reading_Aggregate_Quiz_Progress_Repository::class,
 			),
-			'tables disabled, reading disabled' => array(
+			'hpps disabled, tables selected, synchronization enabled' => array(
 				false,
-				false,
+				Progress_Storage_Settings::TABLES_STORAGE,
+				true,
 				Comments_Based_Quiz_Progress_Repository::class,
 			),
-			'tables disabled, reading enabled'  => array(
-				false,
+			'hpps enabled, tables selected, synchronization disabled' => array(
 				true,
+				Progress_Storage_Settings::TABLES_STORAGE,
+				false,
 				Comments_Based_Quiz_Progress_Repository::class,
 			),
 		);
@@ -58,7 +71,14 @@ class Quiz_Progress_Repository_Factory_Test extends \WP_UnitTestCase {
 
 	public function testCreateTablesBasedRepository_Always_ReturnsTablesBasedRepository(): void {
 		/* Arrange. */
-		$factory = new Quiz_Progress_Repository_Factory( true, true );
+		$configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => true,
+				'experimental_progress_storage_repository' => Progress_Storage_Settings::TABLES_STORAGE,
+				'experimental_progress_storage_synchronization' => true,
+			)
+		);
+		$factory       = new Quiz_Progress_Repository_Factory( $configuration );
 
 		/* Act. */
 		$actual_repository = $factory->create_tables_based_repository();

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -69,7 +69,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			$course,
 			$data_provider,
 			$service,
-			( new Progress_Query_Service_Factory() )->create_aggregation_service()
+			( new Progress_Query_Service_Factory( \Sensei()->progress_storage_configuration ) )->create_aggregation_service()
 		);
 
 		$list_table->total_items = 1;
@@ -116,7 +116,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 			$course,
 			$data_provider,
 			$service,
-			( new Progress_Query_Service_Factory() )->create_aggregation_service()
+			( new Progress_Query_Service_Factory( \Sensei()->progress_storage_configuration ) )->create_aggregation_service()
 		);
 
 		/* Act. */

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-students.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-students.php
@@ -46,7 +46,7 @@ class Sensei_Reports_Overview_Service_Students_Test extends WP_UnitTestCase {
 	 * @return Sensei_Reports_Overview_Service_Students
 	 */
 	private function create_service(): Sensei_Reports_Overview_Service_Students {
-		$query_service_factory = new Progress_Query_Service_Factory();
+		$query_service_factory = new Progress_Query_Service_Factory( \Sensei()->progress_storage_configuration );
 
 		return new Sensei_Reports_Overview_Service_Students(
 			$query_service_factory->create_aggregation_service(),

--- a/tests/unit-tests/test-trait-sensei-hpps-helpers.php
+++ b/tests/unit-tests/test-trait-sensei-hpps-helpers.php
@@ -11,20 +11,23 @@ class Sensei_HPPS_Helpers_Test extends WP_UnitTestCase {
 
 	public function testEnableHppsTablesRepository_Called_SetsResolvedConfigurationToTables() {
 		/* Arrange. */
+		$original_repository            = Sensei()->settings->settings['experimental_progress_storage_repository'] ?? Progress_Storage_Settings::COMMENTS_STORAGE;
 		$original_storage_configuration = Sensei()->progress_storage_configuration;
 
 		/* Act. */
 		$this->enable_hpps_tables_repository();
 		$actual = Sensei()->progress_storage_configuration->is_reading_from_tables();
 		$this->reset_hpps_repository();
-		Sensei()->progress_storage_configuration = $original_storage_configuration;
+		Sensei()->settings->settings['experimental_progress_storage_repository'] = $original_repository;
+		Sensei()->progress_storage_configuration                                 = $original_storage_configuration;
 
 		/* Assert. */
 		self::assertTrue( $actual );
 	}
 
-	public function testResetHppsRepository_TablesConfigurationGiven_RestoresOriginalConfiguration() {
+	public function testResetHppsRepository_TablesConfigurationGiven_SetsResolvedConfigurationToComments() {
 		/* Arrange. */
+		$original_repository                     = Sensei()->settings->settings['experimental_progress_storage_repository'] ?? Progress_Storage_Settings::COMMENTS_STORAGE;
 		$original_storage_configuration          = Sensei()->progress_storage_configuration;
 		Sensei()->progress_storage_configuration = Progress_Storage_Configuration::resolve(
 			array(
@@ -37,10 +40,12 @@ class Sensei_HPPS_Helpers_Test extends WP_UnitTestCase {
 
 		/* Act. */
 		$this->reset_hpps_repository();
-		$actual                                  = Sensei()->progress_storage_configuration->is_reading_from_tables();
-		Sensei()->progress_storage_configuration = $original_storage_configuration;
+		$actual = Sensei()->progress_storage_configuration->is_reading_from_tables();
+
+		Sensei()->settings->settings['experimental_progress_storage_repository'] = $original_repository;
+		Sensei()->progress_storage_configuration                                 = $original_storage_configuration;
 
 		/* Assert. */
-		self::assertSame( $original_storage_configuration->is_reading_from_tables(), $actual );
+		self::assertFalse( $actual );
 	}
 }

--- a/tests/unit-tests/test-trait-sensei-hpps-helpers.php
+++ b/tests/unit-tests/test-trait-sensei-hpps-helpers.php
@@ -1,0 +1,46 @@
+<?php
+
+use Sensei\Internal\Services\Progress_Storage_Configuration;
+use Sensei\Internal\Services\Progress_Storage_Settings;
+
+/**
+ * Tests for Sensei_HPPS_Helpers.
+ */
+class Sensei_HPPS_Helpers_Test extends WP_UnitTestCase {
+	use Sensei_HPPS_Helpers;
+
+	public function testEnableHppsTablesRepository_Called_SetsResolvedConfigurationToTables() {
+		/* Arrange. */
+		$original_storage_configuration = Sensei()->progress_storage_configuration;
+
+		/* Act. */
+		$this->enable_hpps_tables_repository();
+		$actual = Sensei()->progress_storage_configuration->is_reading_from_tables();
+		$this->reset_hpps_repository();
+		Sensei()->progress_storage_configuration = $original_storage_configuration;
+
+		/* Assert. */
+		self::assertTrue( $actual );
+	}
+
+	public function testResetHppsRepository_TablesConfigurationGiven_SetsResolvedConfigurationToComments() {
+		/* Arrange. */
+		$original_storage_configuration          = Sensei()->progress_storage_configuration;
+		Sensei()->progress_storage_configuration = Progress_Storage_Configuration::resolve(
+			array(
+				'experimental_progress_storage'            => true,
+				'experimental_progress_storage_repository' => Progress_Storage_Settings::TABLES_STORAGE,
+				'experimental_progress_storage_synchronization' => true,
+			)
+		);
+		$this->enable_hpps_tables_repository();
+
+		/* Act. */
+		$this->reset_hpps_repository();
+		$actual                                  = Sensei()->progress_storage_configuration->is_reading_from_tables();
+		Sensei()->progress_storage_configuration = $original_storage_configuration;
+
+		/* Assert. */
+		self::assertFalse( $actual );
+	}
+}

--- a/tests/unit-tests/test-trait-sensei-hpps-helpers.php
+++ b/tests/unit-tests/test-trait-sensei-hpps-helpers.php
@@ -23,7 +23,7 @@ class Sensei_HPPS_Helpers_Test extends WP_UnitTestCase {
 		self::assertTrue( $actual );
 	}
 
-	public function testResetHppsRepository_TablesConfigurationGiven_SetsResolvedConfigurationToComments() {
+	public function testResetHppsRepository_TablesConfigurationGiven_RestoresOriginalConfiguration() {
 		/* Arrange. */
 		$original_storage_configuration          = Sensei()->progress_storage_configuration;
 		Sensei()->progress_storage_configuration = Progress_Storage_Configuration::resolve(
@@ -41,6 +41,6 @@ class Sensei_HPPS_Helpers_Test extends WP_UnitTestCase {
 		Sensei()->progress_storage_configuration = $original_storage_configuration;
 
 		/* Assert. */
-		self::assertFalse( $actual );
+		self::assertSame( $original_storage_configuration->is_reading_from_tables(), $actual );
 	}
 }


### PR DESCRIPTION
## Why

Before this change, repositories and reporting queries decided separately whether to read from comments or tables. Reporting queries did not honor the `sensei_student_progress_read_from_tables` filter, so a filter override could make different parts of Sensei read progress from different places. Resolving the configuration once gives every consumer the same authoritative backend and safely falls back to comments for invalid states.

| HPPS | Synchronization | Requested read backend | Reads from | Writes to |
| --- | --- | --- | --- | --- |
| Off | Any | Any | Comments | Comments |
| On | Off | Any | Comments | Comments |
| On | On | Comments | Comments | Comments and tables |
| On | On | Tables | Tables | Comments and tables |

The requested read backend is derived from the repository setting after applying `sensei_student_progress_read_from_tables`. Tables are authoritative only while synchronization is enabled; otherwise the resolved configuration uses comments reads and comments-only writes.

## Proposed Changes

* Add one immutable resolved configuration for HPPS enablement, authoritative read storage, and dual writes.
* Normalize invalid storage states, including table reads without synchronization, to comments reads.
* Use the resolved configuration for query-service and progress-repository construction.
* Remove duplicated storage-selection logic without migrating screen queries or changing service responsibilities.
* Add matrix coverage for storage states, filter behavior, query-service selection, and repository construction.

## Testing Instructions

1. With **High-Performance Progress Storage** disabled, create or update learner progress and a graded quiz submission. Confirm the expected status and grade appear in Reports and Grading.
2. Enable **High-Performance Progress Storage** and **Progress storage synchronization**, wait for migration to complete, and keep **WordPress comments based storage** selected. Create new learner progress and a graded quiz submission, then confirm Reports and Grading remain correct.
3. Select **High-Performance progress storage (experimental)** and save. Confirm the progress and grade created in step 2 still appear with the same values in Reports and Grading.

## New/Updated Hooks

* `sensei_student_progress_read_from_tables` continues to control the authoritative read backend. A tables selection is now normalized to comments when HPPS or synchronization is disabled.

## Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch - Backward-compatible bug fixes
- [ ] Minor - Add or deprecate functionality in a backward-compatible manner
- [ ] Major - Incompatible or breaking API changes

#### Type
- [ ] Added - Adds new functionality
- [x] Changed - Changes existing functionality
- [ ] Fixed - Fixes a bug
- [ ] Deprecated - Marks functionality as deprecated
- [ ] Removed - Removes functionality
- [ ] Security - Security-related change
- [ ] Development - Development or internal task

#### Message

Resolve HPPS storage configuration consistently across progress query services and repositories.

</details>
